### PR TITLE
Run LLVM verification

### DIFF
--- a/code_producers/src/llvm_elements/mod.rs
+++ b/code_producers/src/llvm_elements/mod.rs
@@ -184,6 +184,8 @@ impl<'a> LLVM<'a> {
 
     pub fn write_to_file(&self, path: &str) -> Result<(), ()> {
         // self.module.print_to_stderr();
+        let res = self.module.verify();
+        println!("Verification result: {:#?}", res);
         self.module.print_to_file(path).map_err(|_| {})
     }
 

--- a/code_producers/src/llvm_elements/mod.rs
+++ b/code_producers/src/llvm_elements/mod.rs
@@ -183,10 +183,12 @@ impl<'a> LLVM<'a> {
     }
 
     pub fn write_to_file(&self, path: &str) -> Result<(), ()> {
-        // self.module.print_to_stderr();
-        let res = self.module.verify();
-        println!("Verification result: {:#?}", res);
-        self.module.print_to_file(path).map_err(|_| {})
+        self.module.verify().map_err(|llvm_err| {
+            eprintln!("{}: {}", Colour::Red.paint("LLVM Module verification failed"), llvm_err);
+        })?;
+        self.module.print_to_file(path).map_err(|llvm_err| {
+            eprintln!("{}: {}", Colour::Red.paint("Writing LLVM Module failed"), llvm_err);
+        })
     }
 
     pub fn bigint_type(&self) -> BigIntType<'a> {

--- a/compiler/src/intermediate_representation/branch_bucket.rs
+++ b/compiler/src/intermediate_representation/branch_bucket.rs
@@ -3,7 +3,7 @@ use crate::translating_traits::*;
 use code_producers::c_elements::*;
 use code_producers::llvm_elements::{LLVMInstruction, any_value_wraps_basic_value, any_value_to_basic, to_enum, LLVMIRProducer};
 use code_producers::llvm_elements::functions::create_bb;
-use code_producers::llvm_elements::instructions::{create_conditional_branch, create_phi};
+use code_producers::llvm_elements::instructions::{create_br, create_conditional_branch, create_phi};
 use code_producers::wasm_elements::*;
 
 #[derive(Clone)]
@@ -77,6 +77,7 @@ impl WriteLLVMIR for BranchBucket {
                 }
             }
         }
+        create_br(producer, merge_bb);
         // Else branch
         producer.set_current_bb(else_bb);
         let mut else_last_inst = None;
@@ -88,6 +89,7 @@ impl WriteLLVMIR for BranchBucket {
                 }
             }
         }
+        create_br(producer, merge_bb);
         // Merge results
         producer.set_current_bb(merge_bb);
         match (then_last_inst, else_last_inst) {


### PR DESCRIPTION
Call the LLVM verifier on the module before writing the LLVM IR to the output file. Currently, it just prints the verification result to stdout but we could make it terminate the build if there are an errors in the generated LLVM.