### PR TITLE
[VAN-276] fix gep indexing for local variables

### DIFF
--- a/code_producers/src/llvm_elements/template.rs
+++ b/code_producers/src/llvm_elements/template.rs
@@ -121,7 +121,7 @@ impl<'a> TemplateCtx<'a> {
 impl<'a> BodyCtx<'a> for TemplateCtx<'a> {
     /// Returns a reference to the local variable associated to the index
     fn get_variable(&self, producer: &dyn LLVMIRProducer<'a>, index: IntValue<'a>) -> AnyValueEnum<'a> {
-        create_gep(producer, self.stack, &[index])
+        create_gep(producer, self.stack, &[zero(producer), index])
     }
 }
 


### PR DESCRIPTION
The initial 0 parameter was missing from the GEP instruction for indexing the local variable array leading to type mismatches caught by the verifier.