### PR TITLE
[VAN-278] Generate FF to int cast for addresses

### DIFF
--- a/code_producers/src/llvm_elements/instructions.rs
+++ b/code_producers/src/llvm_elements/instructions.rs
@@ -1,7 +1,7 @@
 use inkwell::basic_block::BasicBlock;
 use inkwell::IntPredicate::{EQ, NE, SLT, SGT, SLE, SGE};
 use inkwell::types::{AnyTypeEnum, BasicType, PointerType};
-use inkwell::values::{AnyValue, AnyValueEnum, ArrayValue, BasicMetadataValueEnum, BasicValue, BasicValueEnum, FunctionValue, InstructionValue, IntMathValue, IntValue, PhiValue, PointerValue};
+use inkwell::values::{AnyValue, AnyValueEnum, ArrayValue, BasicMetadataValueEnum, BasicValue, BasicValueEnum, FunctionValue, InstructionOpcode, InstructionValue, IntMathValue, IntValue, PhiValue, PointerValue};
 use crate::llvm_elements::{LLVMIRProducer, to_basic_enum, to_type_enum};
 use crate::llvm_elements::fr::{FR_MUL_FN_NAME, FR_LT_FN_NAME};
 use crate::llvm_elements::functions::create_bb;
@@ -651,6 +651,25 @@ pub fn get_instruction_arg(inst: InstructionValue, idx: u32) -> AnyValueEnum {
     } else {
         r.unwrap_right().get_last_instruction().unwrap().as_any_value_enum()
     }
+}
+
+pub fn create_cast_to_addr_with_name<'a, T: IntMathValue<'a>>(
+    producer: &dyn LLVMIRProducer<'a>,
+    val: T,
+    name: &str,
+) -> AnyValueEnum<'a> {
+    producer
+        .llvm()
+        .builder
+        .build_cast(InstructionOpcode::Trunc, val, i32_type(producer), name)
+        .as_any_value_enum()
+}
+
+pub fn create_cast_to_addr<'a, T: IntMathValue<'a>>(
+    producer: &dyn LLVMIRProducer<'a>,
+    val: T,
+) -> AnyValueEnum<'a> {
+    create_cast_to_addr_with_name(producer, val, "")
 }
 
 pub fn pointer_cast_with_name<'a>(

--- a/compiler/src/intermediate_representation/compute_bucket.rs
+++ b/compiler/src/intermediate_representation/compute_bucket.rs
@@ -7,7 +7,7 @@ use code_producers::llvm_elements::fr::{
     FR_EQ_FN_NAME, FR_NEQ_FN_NAME, FR_LT_FN_NAME, FR_GT_FN_NAME, FR_LE_FN_NAME, FR_GE_FN_NAME,
     FR_NEG_FN_NAME, FR_SHL_FN_NAME, FR_SHR_FN_NAME,
     FR_BITAND_FN_NAME, FR_BITOR_FN_NAME, FR_BITXOR_FN_NAME, FR_BITFLIP_FN_NAME,
-    FR_LAND_FN_NAME, FR_LOR_FN_NAME, FR_LNOT_FN_NAME
+    FR_LAND_FN_NAME, FR_LOR_FN_NAME, FR_LNOT_FN_NAME, FR_ADDR_CAST_FN_NAME
 };
 use code_producers::llvm_elements::instructions::{create_add_with_name, create_call, create_mul_with_name};
 use code_producers::wasm_elements::*;
@@ -227,7 +227,7 @@ impl WriteLLVMIR for ComputeBucket {
                 create_call(producer, FR_BITFLIP_FN_NAME, &args)
             }
             OperatorType::ToAddress => {
-                to_enum(args[0])
+                create_call(producer,FR_ADDR_CAST_FN_NAME, &args)
             }
             OperatorType::MulAddress => {
                 let lhs = args[0].into_int_value();


### PR DESCRIPTION
Implement `OperatorType::ToAddress` transformation based on C code implementation which performs a cast from the finite field data type to the int data type. Thus, pointer/address computations uses int instead of finite field operations.