### PR TITLE
[VAN-348] Fix LLVM IR verification errors

### DIFF
--- a/code_producers/src/llvm_elements/mod.rs
+++ b/code_producers/src/llvm_elements/mod.rs
@@ -1,5 +1,4 @@
 use std::cell::RefCell;
-
 use std::convert::TryFrom;
 use std::rc::Rc;
 use ansi_term::Colour;
@@ -9,15 +8,15 @@ use inkwell::builder::Builder;
 use inkwell::context::{Context, ContextRef};
 use inkwell::module::Module;
 use inkwell::types::{AnyTypeEnum, BasicType, BasicTypeEnum, IntType};
-use inkwell::values::{AnyValueEnum, ArrayValue, BasicMetadataValueEnum, BasicValueEnum, IntValue};
+use inkwell::values::{ArrayValue, BasicMetadataValueEnum, BasicValueEnum, IntValue};
 use inkwell::values::FunctionValue;
 
 use template::TemplateCtx;
 
+use crate::llvm_elements::instructions::create_alloca;
 use crate::llvm_elements::types::bool_type;
 pub use inkwell::types::AnyType;
-pub use inkwell::values::AnyValue;
-use crate::llvm_elements::instructions::create_alloca;
+pub use inkwell::values::{AnyValue, AnyValueEnum, InstructionOpcode};
 
 pub mod stdlib;
 pub mod template;
@@ -94,7 +93,9 @@ impl<'a> LLVMIRProducer<'a> for TopLevelLLVMIRProducer<'a> {
     }
 
     fn get_template_mem_arg(&self, _run_fn: FunctionValue<'a>) -> ArrayValue<'a> {
-        panic!("The top level llvm producer can't extract the template argument of a run function!");
+        panic!(
+            "The top level llvm producer can't extract the template argument of a run function!"
+        );
     }
 }
 
@@ -121,14 +122,17 @@ impl<'a> TopLevelLLVMIRProducer<'a> {
 pub type LLVMAdapter<'a> = &'a Rc<RefCell<LLVM<'a>>>;
 pub type BigIntType<'a> = IntType<'a>; // i256
 
-
-
 pub fn new_constraint<'a>(producer: &dyn LLVMIRProducer<'a>) -> AnyValueEnum<'a> {
     let alloca = create_alloca(producer, bool_type(producer).into(), "constraint");
     let s = producer.context().metadata_string("constraint");
     let kind = producer.context().get_kind_id("constraint");
     let node = producer.context().metadata_node(&[s.into()]);
-    alloca.into_pointer_value().as_instruction().unwrap().set_metadata(node, kind).expect("Could not setup metadata marker for constraint value");
+    alloca
+        .into_pointer_value()
+        .as_instruction()
+        .unwrap()
+        .set_metadata(node, kind)
+        .expect("Could not setup metadata marker for constraint value");
     alloca
 }
 
@@ -182,16 +186,17 @@ pub struct LLVM<'a> {
 
 impl<'a> LLVM<'a> {
     pub fn from_context(context: &'a Context, name: &str) -> Self {
-        LLVM {
-            module: context.create_module(name),
-            builder: context.create_builder(),
-        }
+        LLVM { module: context.create_module(name), builder: context.create_builder() }
     }
 
     pub fn write_to_file(&self, path: &str) -> Result<(), ()> {
         // Run module verification
         self.module.verify().map_err(|llvm_err| {
-            eprintln!("{}: {}", Colour::Red.paint("LLVM Module verification failed"), llvm_err.to_string());
+            eprintln!(
+                "{}: {}",
+                Colour::Red.paint("LLVM Module verification failed"),
+                llvm_err.to_string()
+            );
             eprintln!("Generated LLVM:");
             self.module.print_to_stderr();
         })?;
@@ -217,7 +222,11 @@ impl<'a> LLVM<'a> {
         }
         // Write the output to file
         self.module.print_to_file(path).map_err(|llvm_err| {
-            eprintln!("{}: {}", Colour::Red.paint("Writing LLVM Module failed"), llvm_err.to_string());
+            eprintln!(
+                "{}: {}",
+                Colour::Red.paint("Writing LLVM Module failed"),
+                llvm_err.to_string()
+            );
         })
     }
 }

--- a/compiler/src/intermediate_representation/branch_bucket.rs
+++ b/compiler/src/intermediate_representation/branch_bucket.rs
@@ -1,9 +1,12 @@
 use super::ir_interface::*;
 use crate::translating_traits::*;
 use code_producers::c_elements::*;
-use code_producers::llvm_elements::{LLVMInstruction, any_value_wraps_basic_value, any_value_to_basic, to_enum, LLVMIRProducer};
+use code_producers::llvm_elements::{
+    any_value_wraps_basic_value, LLVMInstruction, LLVMIRProducer, AnyValue,
+};
+use code_producers::llvm_elements::{AnyValueEnum, InstructionOpcode}; //from inkwell via "pub use" in mod.rs
 use code_producers::llvm_elements::functions::create_bb;
-use code_producers::llvm_elements::instructions::{create_br, create_conditional_branch, create_phi};
+use code_producers::llvm_elements::instructions::{create_br, create_conditional_branch};
 use code_producers::wasm_elements::*;
 
 #[derive(Clone)]
@@ -56,67 +59,68 @@ impl ToString for BranchBucket {
 }
 
 impl WriteLLVMIR for BranchBucket {
-    fn produce_llvm_ir<'a, 'b>(&self, producer: &'b dyn LLVMIRProducer<'a>) -> Option<LLVMInstruction<'a>> {
+    fn produce_llvm_ir<'a, 'b>(
+        &self,
+        producer: &'b dyn LLVMIRProducer<'a>,
+    ) -> Option<LLVMInstruction<'a>> {
         println!("{}\n", self.to_string());
         // Necessary basic blocks
         let current_function = producer.current_function();
         let then_bb = create_bb(producer, current_function, "if.then");
         let else_bb = create_bb(producer, current_function, "if.else");
         let merge_bb = create_bb(producer, current_function, "if.merge");
-        // Check of the condition
-        let cond_code = self.cond.produce_llvm_ir(producer)
-            .expect("Cond instruction must produce a value!");
+
+        // Generate check of the condition and the conditional jump in the current block
+        let cond_code =
+            self.cond.produce_llvm_ir(producer).expect("Cond instruction must produce a value!");
         create_conditional_branch(producer, cond_code.into_int_value(), then_bb, else_bb);
+
+        // Define helper to process the body of the given branch of the if-statement.
+        // If needed, it will produce an unconditional jump to the "merge" basic block.
+        // Returns true iff the unconditional jump was produced.
+        let process_body = |branch_body: &InstructionList| {
+            let mut last_inst = None;
+            for inst in branch_body {
+                last_inst = inst.produce_llvm_ir(producer);
+            }
+            if let Some(inst) = last_inst {
+                //The final instruction will never be a BasicValueEnum. Even the
+                //  ternary conditional operator will be desugared to a normal
+                //  if-statement that stores to a temporary variable.
+                assert!(!any_value_wraps_basic_value(inst));
+                //Special case: Should not branch after a branch, return, or unreachable
+                if let AnyValueEnum::InstructionValue(v) = inst {
+                    match v.get_opcode() {
+                        InstructionOpcode::Unreachable
+                        | InstructionOpcode::Return
+                        | InstructionOpcode::Br => {
+                            return false;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            //Any other case
+            create_br(producer, merge_bb);
+            return true;
+        };
+
         // Then branch
         producer.set_current_bb(then_bb);
-        let mut then_last_inst = None;
-        for inst in &self.if_branch {
-            then_last_inst = inst.produce_llvm_ir(producer);
-            if let Some(inst) = then_last_inst {
-                if !any_value_wraps_basic_value(inst) {
-                    then_last_inst = None
-                }
-            }
-        }
-        create_br(producer, merge_bb);
+        let jump_from_if = process_body(&self.if_branch);
         // Else branch
         producer.set_current_bb(else_bb);
-        let mut else_last_inst = None;
-        for inst in &self.else_branch {
-            else_last_inst = inst.produce_llvm_ir(producer);
-            if let Some(inst) = else_last_inst {
-                if !any_value_wraps_basic_value(inst) {
-                    else_last_inst = None
-                }
-            }
-        }
-        create_br(producer, merge_bb);
-        // Merge results
+        let jump_from_else = process_body(&self.else_branch);
+        // Merge block (where the function body continues)
         producer.set_current_bb(merge_bb);
-        match (then_last_inst, else_last_inst) {
-            (None, None) => {
-                None
-            }
-            (Some(then), None) => {
-                let phi = create_phi(producer,then.get_type(), "if.merge.phi");
-                let then = any_value_to_basic(then);
-                phi.add_incoming_as_enum(&[(then, then_bb)]);
-                Some(to_enum(phi))
-            }
-            (None, Some(else_)) => {
-                let phi = create_phi(producer, else_.get_type(), "if.merge.phi");
-                let else_ = any_value_to_basic(else_);
-                phi.add_incoming_as_enum(&[(else_, else_bb)]);
-                Some(to_enum(phi))
-            }
-            (Some(then), Some(else_)) => {
-                assert_eq!(then.get_type(), else_.get_type(), "Types of the two branches of if statement must be of the same type!");
-                let phi = create_phi(producer,then.get_type(), "if.merge.phi");
-                let then = any_value_to_basic(then);
-                let else_ = any_value_to_basic(else_);
-                phi.add_incoming_as_enum(&[(then, then_bb), (else_, else_bb)]);
-                Some(to_enum(phi))
-            }
+
+
+        //If there are no jumps to the merge block, it is unreachable.
+        if !jump_from_if && !jump_from_else {
+            let u = producer.builder().build_unreachable();
+            Some(u.as_any_value_enum())
+        } else {
+            None //merge block is empty
         }
     }
 }

--- a/compiler/src/intermediate_representation/ir_interface.rs
+++ b/compiler/src/intermediate_representation/ir_interface.rs
@@ -132,6 +132,7 @@ impl WriteWasm for Instruction {
 }
 
 impl WriteLLVMIR for Instruction {
+    /// This must always return the final statement in the current BasicBlock or None if empty.
     fn produce_llvm_ir<'a, 'b>(&self, producer: &'b dyn LLVMIRProducer<'a>) -> Option<LLVMInstruction<'a>> {
         use Instruction::*;
         match self {

--- a/compiler/src/intermediate_representation/loop_bucket.rs
+++ b/compiler/src/intermediate_representation/loop_bucket.rs
@@ -49,33 +49,39 @@ impl ToString for LoopBucket {
 }
 
 impl WriteLLVMIR for LoopBucket {
-    fn produce_llvm_ir<'a, 'b>(&self, producer: &'b dyn LLVMIRProducer<'a>) -> Option<LLVMInstruction<'a>> {
+    fn produce_llvm_ir<'a, 'b>(
+        &self,
+        producer: &'b dyn LLVMIRProducer<'a>,
+    ) -> Option<LLVMInstruction<'a>> {
         let current_function = producer.current_function();
-        let cond_bb = create_bb(producer, current_function, "loop.cond.0");
-        let body_bb = create_bb(producer, current_function, "loop.body.0");
-        let end_bb = create_bb(producer, current_function, "loop.end.0");
+        let cond_bb = create_bb(producer, current_function, "loop.cond");
+        let body_bb = create_bb(producer, current_function, "loop.body");
+        let end_bb = create_bb(producer, current_function, "loop.end");
+        // Generate jump from current block to the new condition block
         create_br(producer, cond_bb);
         producer.set_current_bb(cond_bb);
         // Cond logic
         let cond_res = self.continue_condition.produce_llvm_ir(producer);
         // XXX: Assumption: If the value is 0 the we go to the end block
-        let cond = create_conditional_branch(
+        create_conditional_branch(
             producer,
             cond_res.expect("Conditional check expression must produce a value").into_int_value(),
             body_bb,
-            end_bb
+            end_bb,
         );
 
+        // Body contents and branch back to header to check condition
         producer.set_current_bb(body_bb);
-        // Body logic
         for stmt in &self.body {
             stmt.produce_llvm_ir(producer);
         }
         create_br(producer, cond_bb);
+
+        //
         producer.set_current_bb(end_bb);
 
-        // Returns the condition code
-        Some(cond)
+        // Returns None since the current block "end_bb" is empty
+        None
     }
 }
 

--- a/compiler/src/translating_traits/mod.rs
+++ b/compiler/src/translating_traits/mod.rs
@@ -31,6 +31,7 @@ pub trait WriteWasm {
 }
 
 pub trait WriteLLVMIR {
+    /// This must always return the final statement in the current BasicBlock or None if empty.
     fn produce_llvm_ir<'a, 'b>(&self, producer: &'b dyn LLVMIRProducer<'a>) -> Option<LLVMInstruction<'a>>;
     fn write_llvm_ir(&self, llvm_path: &str, data: &LLVMCircuitData) -> Result<(), ()> {
         let context = Box::new(create_context());


### PR DESCRIPTION
The construction of looping and branching statements had some cases where a block in the LLVM IR did not end with a terminator or had multiple terminators (i.e. return followed by jump).