### PR TITLE
[VAN-405] Unknown signal propagation fix

### DIFF
--- a/circuit_passes/src/bucket_interpreter/mod.rs
+++ b/circuit_passes/src/bucket_interpreter/mod.rs
@@ -86,8 +86,13 @@ impl<'a> BucketInterpreter<'a> {
                     LocationRule::Indexed { location, .. } => self.execute_instruction(location, env, continue_observing),
                     LocationRule::Mapped { .. } => unreachable!()
                 };
-                let idx = idx.expect("Indexed location must produce a value!").get_u32();
-                (Some(env.get_var(idx)), env)
+
+                let idx_value = idx.expect("Indexed location must produce a value!");
+                if (idx_value.is_unknown()) {
+                    (Some(Unknown), env)
+                } else {
+                    (Some(env.get_var(idx_value.get_u32())), env)
+                }
             },
             AddressType::Signal => {
                 let continue_observing =
@@ -96,8 +101,13 @@ impl<'a> BucketInterpreter<'a> {
                     LocationRule::Indexed { location, .. } => self.execute_instruction(location, env, continue_observing),
                     LocationRule::Mapped { .. } => unreachable!()
                 };
-                let idx = idx.expect("Indexed location must produce a value!").get_u32();
-                (Some(env.get_signal(idx)), env)
+
+                let idx_value = idx.expect("Indexed location must produce a value!");
+                if (idx_value.is_unknown()) {
+                    (Some(Unknown), env)
+                } else {
+                    (Some(env.get_var(idx_value.get_u32())), env)
+                }
             },
             AddressType::SubcmpSignal { cmp_address, .. } => {
                 let (addr, env) = self.execute_instruction(cmp_address, env, observe);

--- a/circuit_passes/src/bucket_interpreter/mod.rs
+++ b/circuit_passes/src/bucket_interpreter/mod.rs
@@ -106,7 +106,7 @@ impl<'a> BucketInterpreter<'a> {
                 if (idx_value.is_unknown()) {
                     (Some(Unknown), env)
                 } else {
-                    (Some(env.get_var(idx_value.get_u32())), env)
+                    (Some(env.get_signal(idx_value.get_u32())), env)
                 }
             },
             AddressType::SubcmpSignal { cmp_address, .. } => {

--- a/circuit_passes/src/bucket_interpreter/mod.rs
+++ b/circuit_passes/src/bucket_interpreter/mod.rs
@@ -88,7 +88,7 @@ impl<'a> BucketInterpreter<'a> {
                 };
 
                 let idx_value = idx.expect("Indexed location must produce a value!");
-                if (idx_value.is_unknown()) {
+                if idx_value.is_unknown() {
                     (Some(Unknown), env)
                 } else {
                     (Some(env.get_var(idx_value.get_u32())), env)
@@ -103,7 +103,7 @@ impl<'a> BucketInterpreter<'a> {
                 };
 
                 let idx_value = idx.expect("Indexed location must produce a value!");
-                if (idx_value.is_unknown()) {
+                if idx_value.is_unknown() {
                     (Some(Unknown), env)
                 } else {
                     (Some(env.get_signal(idx_value.get_u32())), env)
@@ -157,8 +157,14 @@ impl<'a> BucketInterpreter<'a> {
                     LocationRule::Indexed { location, .. } => self.execute_instruction(location, env, continue_observing),
                     LocationRule::Mapped { .. } => unreachable!()
                 };
-                let idx = idx.expect("Indexed location must produce a value!").get_u32();
-                env.set_var(idx, value)
+
+                let idx_value = idx.expect("Indexed location must produce a value!");
+                if !idx_value.is_unknown() {
+                    let idx = idx_value.get_u32();
+                    env.set_var(idx, value)
+                } else {
+                    env
+                }
             },
             AddressType::Signal => {
                 let continue_observing =
@@ -167,8 +173,14 @@ impl<'a> BucketInterpreter<'a> {
                     LocationRule::Indexed { location, .. } => self.execute_instruction(location, env, continue_observing),
                     LocationRule::Mapped { .. } => unreachable!()
                 };
-                let idx = idx.expect("Indexed location must produce a value!").get_u32();
-                env.set_signal(idx, value)
+
+                let idx_value = idx.expect("Indexed location must produce a value!");
+                if !idx_value.is_unknown() {
+                    let idx = idx_value.get_u32();
+                    env.set_signal(idx, value)
+                } else {
+                    env
+                }
             },
             AddressType::SubcmpSignal { cmp_address, input_information, .. } => {
                 let (addr, env) = self.execute_instruction(cmp_address, env, observe);


### PR DESCRIPTION
- Handle unknown values in load and store buckets
- ~~Fix LoadBucket issue which fetched known variables instead of known signals (`get_var` vs `get_signal`)~~ (apparently this was my own copy-paste issue that I introduced)