### PR TITLE
[VAN-417] Add load/store functions that perform bounds checks on unknown indices

### DIFF
--- a/circom/src/compilation_user.rs
+++ b/circom/src/compilation_user.rs
@@ -67,6 +67,7 @@ pub fn compile(config: CompilerConfig, program_archive: ProgramArchive, prime: &
             .schedule_loop_unroll_pass(prime)
             .schedule_conditional_flattening_pass(prime)
             .schedule_mapped_to_indexed_pass(prime)
+            .schedule_unknown_index_sanitization_pass(prime)
             .schedule_simplification_pass(prime)
             .schedule_deterministic_subcmp_invoke_pass(prime)
             .transform_circuit(circuit);

--- a/circuit_passes/src/bucket_interpreter/mod.rs
+++ b/circuit_passes/src/bucket_interpreter/mod.rs
@@ -276,8 +276,14 @@ impl<'a> BucketInterpreter<'a> {
                     LocationRule::Indexed { location, .. } => self.execute_instruction(location, env, continue_observing),
                     LocationRule::Mapped { .. } => unreachable!()
                 };
-                let idx = idx.expect("Indexed location must produce a value!").get_u32();
-                env.set_var(idx, value)
+
+                let idx_value = idx.expect("Indexed location must produce a value!");
+                if !idx_value.is_unknown() {
+                    let idx = idx_value.get_u32();
+                    env.set_var(idx, value)
+                } else {
+                    env
+                }
             },
             AddressType::Signal => {
                 let continue_observing =
@@ -286,8 +292,14 @@ impl<'a> BucketInterpreter<'a> {
                     LocationRule::Indexed { location, .. } => self.execute_instruction(location, env, continue_observing),
                     LocationRule::Mapped { .. } => unreachable!()
                 };
-                let idx = idx.expect("Indexed location must produce a value!").get_u32();
-                env.set_signal(idx, value)
+
+                let idx_value = idx.expect("Indexed location must produce a value!");
+                if !idx_value.is_unknown() {
+                    let idx = idx_value.get_u32();
+                    env.set_signal(idx, value)
+                } else {
+                    env
+                }
             },
             AddressType::SubcmpSignal { cmp_address, input_information, .. } => {
                 let (addr, env) = self.execute_instruction(cmp_address, env, observe);

--- a/circuit_passes/src/passes/loop_unroll.rs
+++ b/circuit_passes/src/passes/loop_unroll.rs
@@ -226,7 +226,8 @@ mod test {
                             parse_as: ValueType::U32,
                             op_aux_no: 0,
                             value: 0,
-                        }
+                        },
+                        bounded_fn: None,
                         .allocate(),
                     }
                     .allocate(),
@@ -259,6 +260,7 @@ mod test {
                             value: 0,
                         }
                         .allocate(),
+                        bounded_fn: None,
                     }
                     .allocate(),
                     // (loop (compute le (load 1) 5) (
@@ -290,6 +292,7 @@ mod test {
                                         .allocate(),
                                         template_header: Some("test_0".to_string()),
                                     },
+                                    bounded_fn: None,
                                 }
                                 .allocate(),
                                 ValueBucket {
@@ -349,6 +352,7 @@ mod test {
                                                 .allocate(),
                                                 template_header: Some("test_0".to_string()),
                                             },
+                                            bounded_fn: None,
                                         }
                                         .allocate(),
                                         ValueBucket {
@@ -363,6 +367,7 @@ mod test {
                                     ],
                                 }
                                 .allocate(),
+                                bounded_fn: None,
                             }
                             .allocate(),
                             //   (store 1 (compute add (load 1) 1))
@@ -409,6 +414,7 @@ mod test {
                                                 .allocate(),
                                                 template_header: Some("test_0".to_string()),
                                             },
+                                            bounded_fn: None,
                                         }
                                         .allocate(),
                                         ValueBucket {
@@ -423,6 +429,7 @@ mod test {
                                     ],
                                 }
                                 .allocate(),
+                                bounded_fn: None,
                             }
                             .allocate(),
                         ],

--- a/circuit_passes/src/passes/loop_unroll.rs
+++ b/circuit_passes/src/passes/loop_unroll.rs
@@ -226,9 +226,9 @@ mod test {
                             parse_as: ValueType::U32,
                             op_aux_no: 0,
                             value: 0,
-                        },
-                        bounded_fn: None,
+                        }
                         .allocate(),
+                        bounded_fn: None,
                     }
                     .allocate(),
                     // (store 1 0)

--- a/circuit_passes/src/passes/mod.rs
+++ b/circuit_passes/src/passes/mod.rs
@@ -181,6 +181,7 @@ pub trait CircuitTransformationPass {
             message_id: bucket.message_id,
             address_type: self.transform_address_type(&bucket.address_type),
             src: self.transform_location_rule(&bucket.src),
+            bounded_fn: bucket.bounded_fn.clone(),
         }
         .allocate()
     }
@@ -195,6 +196,7 @@ pub trait CircuitTransformationPass {
             dest_address_type: self.transform_address_type(&bucket.dest_address_type),
             dest: self.transform_location_rule(&bucket.dest),
             src: self.transform_instruction(&bucket.src),
+            bounded_fn: bucket.bounded_fn.clone(),
         }
         .allocate()
     }

--- a/circuit_passes/src/passes/mod.rs
+++ b/circuit_passes/src/passes/mod.rs
@@ -13,11 +13,14 @@ use compiler::intermediate_representation::ir_interface::{
     StoreBucket, BlockBucket, ValueBucket, AddressType, ReturnType, FinalData, LogBucketArg,
 };
 
-use crate::passes::loop_unroll::LoopUnrollPass;
-use crate::passes::conditional_flattening::ConditionalFlattening;
-use crate::passes::deterministic_subcomponent_invocation::DeterministicSubCmpInvokePass;
-use crate::passes::simplification::SimplificationPass;
-use crate::passes::mapped_to_indexed::MappedToIndexedPass;
+use crate::passes::{
+    conditional_flattening::ConditionalFlattening,
+    deterministic_subcomponent_invocation::DeterministicSubCmpInvokePass,
+    loop_unroll::LoopUnrollPass,
+    mapped_to_indexed::MappedToIndexedPass,
+    simplification::SimplificationPass,
+    unknown_index_sanitization::UnknownIndexSanitizationPass,
+};
 
 mod conditional_flattening;
 mod loop_unroll;
@@ -25,6 +28,7 @@ mod memory;
 mod simplification;
 mod deterministic_subcomponent_invocation;
 mod mapped_to_indexed;
+mod unknown_index_sanitization;
 
 macro_rules! pre_hook {
     ($name: ident, $bucket_ty: ty) => {
@@ -406,6 +410,11 @@ impl PassManager {
 
     pub fn schedule_mapped_to_indexed_pass(&self, prime: &String) -> &Self {
         self.passes.borrow_mut().push(Box::new(MappedToIndexedPass::new(prime)));
+        self
+    }
+
+    pub fn schedule_unknown_index_sanitization_pass(&self, prime: &String) -> &Self {
+        self.passes.borrow_mut().push(Box::new(UnknownIndexSanitizationPass::new(prime)));
         self
     }
 

--- a/circuit_passes/src/passes/unknown_index_sanitization.rs
+++ b/circuit_passes/src/passes/unknown_index_sanitization.rs
@@ -1,0 +1,193 @@
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+
+use compiler::circuit_design::template::TemplateCode;
+use compiler::compiler_interface::Circuit;
+use compiler::intermediate_representation::{InstructionPointer};
+use compiler::intermediate_representation::ir_interface::{AddressType, Allocate, AssertBucket, BlockBucket, BranchBucket, CallBucket, ComputeBucket, ConstraintBucket, CreateCmpBucket, LoadBucket, LocationRule, LogBucket, LoopBucket, NopBucket, ReturnBucket, StoreBucket, ValueBucket};
+
+use crate::bucket_interpreter::env::Env;
+use crate::bucket_interpreter::BucketInterpreter;
+use crate::bucket_interpreter::observer::InterpreterObserver;
+use crate::bucket_interpreter::value::Value::KnownU32;
+use crate::passes::CircuitTransformationPass;
+use crate::passes::memory::PassMemory;
+
+pub struct UnknownIndexSanitizationPass {
+    // Wrapped in a RefCell because the reference to the static analysis is immutable but we need mutability
+    memory: RefCell<PassMemory>,
+    replacements: RefCell<BTreeMap<LocationRule, LocationRule>>,
+}
+
+
+/**
+ * The goal of this pass is to
+ */
+impl UnknownIndexSanitizationPass {
+    pub fn new(prime: &String) -> Self {
+        UnknownIndexSanitizationPass { memory: PassMemory::new_cell(prime, "".to_string(), Default::default()), replacements: Default::default() }
+    }
+
+    fn transform_mapped_loc_to_indexed_loc(&self,
+        cmp_address: &InstructionPointer, indexes: &Vec<InstructionPointer>, signal_code: usize, env: &Env) -> LocationRule {
+
+        let mem = self.memory.borrow();
+        let interpreter = BucketInterpreter::init(&mem.current_scope, &mem.prime, &mem.constant_fields, self, &mem.io_map);
+
+        let (resolved_addr, acc_env) = interpreter.execute_instruction(cmp_address, env.clone(), false);
+
+        let resolved_addr = resolved_addr
+            .expect("cmp_address instruction in SubcmpSignal must produce a value!")
+            .get_u32();
+
+        let name = acc_env.get_subcmp_name(resolved_addr).clone();
+        let mut indexes_values = vec![];
+        let mut acc_env = acc_env;
+        for i in indexes {
+            let (val, new_env) = interpreter.execute_instruction(i, acc_env, false);
+            indexes_values.push(val.expect("Mapped location must produce a value!").get_u32());
+            acc_env = new_env;
+        }
+
+        if indexes.len() > 0 {
+            if indexes.len() == 1 {
+                let map_access = &mem.io_map[&acc_env.get_subcmp_template_id(resolved_addr)][signal_code].offset;
+                let value = map_access + indexes_values[0];
+                let mut unused = vec![];
+                LocationRule::Indexed { location: KnownU32(value).to_value_bucket(&mut unused).allocate(), template_header: Some(name) }
+            } else {
+                todo!()
+            }
+        } else {
+            unreachable!()
+        }
+    }
+
+    fn maybe_transform_index_computation(&self, address: &AddressType, location: &LocationRule, env: &Env) -> bool {
+        // println!("\tlocation: {:?}", location);
+        true
+
+        // match address {
+        //     AddressType::Variable | AddressType::Signal => {
+        //         match location {
+        //             LocationRule::Indexed { .. } => true,
+        //             LocationRule::Mapped { .. } => unreachable!()
+        //         }
+        //     },
+        //     AddressType::SubcmpSignal { cmp_address, .. } => {
+        //         match location {
+        //             LocationRule::Indexed { .. } => true,
+        //             LocationRule::Mapped { indexes, signal_code } => {
+        //                 let indexed_rule = self.transform_mapped_loc_to_indexed_loc(cmp_address, indexes, *signal_code, env);
+        //                 self.replacements.borrow_mut().insert(location.clone(), indexed_rule);
+        //                 true
+        //             }
+        //         }
+        //     }
+        // }
+    }
+}
+
+impl InterpreterObserver for UnknownIndexSanitizationPass {
+    fn on_value_bucket(&self, _bucket: &ValueBucket, _env: &Env) -> bool {
+        true
+    }
+
+    fn on_load_bucket(&self, bucket: &LoadBucket, env: &Env) -> bool {
+        // println!("load bucket: {:?}", bucket);
+        self.maybe_transform_index_computation(&bucket.address_type, &bucket.src, env)
+    }
+
+    fn on_store_bucket(&self, bucket: &StoreBucket, env: &Env) -> bool {
+        // println!("store bucket: {:?}", bucket);
+        self.maybe_transform_index_computation(&bucket.dest_address_type, &bucket.dest, env)
+    }
+
+    fn on_compute_bucket(&self, _bucket: &ComputeBucket, _env: &Env) -> bool {
+        true
+    }
+
+    fn on_assert_bucket(&self, _bucket: &AssertBucket, _env: &Env) -> bool {
+        true
+    }
+
+    fn on_loop_bucket(&self, _bucket: &LoopBucket, _env: &Env) -> bool {
+        true
+    }
+
+    fn on_create_cmp_bucket(&self, _bucket: &CreateCmpBucket, _env: &Env) -> bool {
+        true
+    }
+
+    fn on_constraint_bucket(&self, _bucket: &ConstraintBucket, _env: &Env) -> bool {
+        true
+    }
+
+    fn on_block_bucket(&self, _bucket: &BlockBucket, _env: &Env) -> bool {
+        true
+    }
+
+    fn on_nop_bucket(&self, _bucket: &NopBucket, _env: &Env) -> bool {
+        true
+    }
+
+    fn on_location_rule(&self, _location_rule: &LocationRule, _env: &Env) -> bool {
+        true
+    }
+
+    fn on_call_bucket(&self, _bucket: &CallBucket, _env: &Env) -> bool {
+        true
+    }
+
+    fn on_branch_bucket(&self, _bucket: &BranchBucket, _env: &Env) -> bool {
+        true
+    }
+
+    fn on_return_bucket(&self, _bucket: &ReturnBucket, _env: &Env) -> bool {
+        true
+    }
+
+    fn on_log_bucket(&self, _bucket: &LogBucket, _env: &Env) -> bool {
+        true
+    }
+
+    fn ignore_function_calls(&self) -> bool {
+        true
+    }
+
+    fn ignore_subcmp_calls(&self) -> bool {
+        true
+    }
+}
+
+impl CircuitTransformationPass for UnknownIndexSanitizationPass {
+    fn get_updated_field_constants(&self) -> Vec<String> {
+        self.memory.borrow().constant_fields.clone()
+    }
+
+    /*
+        iangneal: Let the interpreter run to see if we can find any replacements.
+        If so, yield the replacement. Else, just give the default transformation
+    */
+    fn transform_location_rule(&self, location_rule: &LocationRule) -> LocationRule {
+        // If the interpreter found a viable transformation, do that.
+        if let Some(indexed_rule) = self.replacements.borrow().get(&location_rule) {
+            return indexed_rule.clone();
+        }
+        match location_rule {
+            LocationRule::Indexed { location, template_header } => LocationRule::Indexed {
+                location: self.transform_instruction(location),
+                template_header: template_header.clone(),
+            },
+            LocationRule::Mapped { .. } => unreachable!()
+        }
+    }
+
+    fn pre_hook_circuit(&self, circuit: &Circuit) {
+        self.memory.borrow_mut().fill_from_circuit(circuit);
+    }
+
+    fn pre_hook_template(&self, template: &TemplateCode) {
+        self.memory.borrow().run_template(self, template);
+    }
+}

--- a/circuit_passes/src/passes/unknown_index_sanitization.rs
+++ b/circuit_passes/src/passes/unknown_index_sanitization.rs
@@ -154,6 +154,9 @@ impl UnknownIndexSanitizationPass {
          *      (base_offset + (mul_offset * UNKNOWN))
          * So, if we set the unknown value to 0, we will compute the base offset,
          * which will let us look up the range of the underlying array.
+         *
+         * This specifically tackles 1-D arrays (what we currently deal with), but could be
+         * extended to arbitrary dimensions if needed.
          */
         match location {
             LocationRule::Indexed { location, .. } => {

--- a/circuit_passes/src/passes/unknown_index_sanitization.rs
+++ b/circuit_passes/src/passes/unknown_index_sanitization.rs
@@ -155,8 +155,8 @@ impl UnknownIndexSanitizationPass {
          * So, if we set the unknown value to 0, we will compute the base offset,
          * which will let us look up the range of the underlying array.
          *
-         * This specifically tackles 1-D arrays (what we currently deal with), but could be
-         * extended to arbitrary dimensions if needed.
+         * The expression above is for 1-D arrays, multidimensional arrays follow 
+         * a similar pattern that is also handled here.
          */
         match location {
             LocationRule::Indexed { location, .. } => {

--- a/circuit_passes/src/passes/unknown_index_sanitization.rs
+++ b/circuit_passes/src/passes/unknown_index_sanitization.rs
@@ -283,6 +283,7 @@ impl CircuitTransformationPass for UnknownIndexSanitizationPass {
         };
         LoadBucket {
             id: new_id(),
+            source_file_id: bucket.source_file_id.clone(),
             line: bucket.line,
             message_id: bucket.message_id,
             address_type: self.transform_address_type(&bucket.address_type),
@@ -299,6 +300,7 @@ impl CircuitTransformationPass for UnknownIndexSanitizationPass {
         };
         StoreBucket {
             id: new_id(),
+            source_file_id: bucket.source_file_id.clone(),
             line: bucket.line,
             message_id: bucket.message_id,
             context: bucket.context.clone(),

--- a/code_producers/src/llvm_elements/array_switch.rs
+++ b/code_producers/src/llvm_elements/array_switch.rs
@@ -1,0 +1,133 @@
+use crate::llvm_elements::LLVMIRProducer;
+use std::ops::Range;
+
+mod array_switch {
+    use std::borrow::Borrow;
+    use std::convert::TryInto;
+    use std::fmt::format;
+    use std::ops::Range;
+
+    use inkwell::values::AnyValue;
+
+    use crate::llvm_elements::functions::{create_bb, create_function};
+    use crate::llvm_elements::instructions::{
+        create_br, create_call, create_conditional_branch, create_eq, create_return_void,
+        create_store, create_gep, create_load, create_return, create_switch,
+    };
+    use crate::llvm_elements::stdlib::{
+        ASSERT_FN_NAME, CONSTRAINT_VALUE_FN_NAME, CONSTRAINT_VALUES_FN_NAME,
+    };
+    use crate::llvm_elements::LLVMIRProducer;
+    use crate::llvm_elements::types::{bigint_type, bool_type, i32_type, void_type};
+
+
+    pub fn get_load_symbol(index_range: &Range<usize>) -> String {
+        format!("__array_load__{}_to_{}", index_range.start, index_range.end)
+    }
+
+    pub fn get_store_symbol(index_range: &Range<usize>) -> String {
+        format!("__array_store__{}_to_{}", index_range.start, index_range.end)
+    }
+
+    pub fn create_array_load_fn<'a>(producer: &dyn LLVMIRProducer<'a>, index_range: &Range<usize>) {
+        // args: array, index
+        // return: bigint loaded from array
+        let bool_ty = bool_type(producer);
+        let bigint_ty = bigint_type(producer);
+        let i32_ty = i32_type(producer);
+        let args = &[
+            bigint_ty.ptr_type(Default::default()).into(),
+            i32_ty.into(),
+        ];
+
+        let func = create_function(producer, &get_load_symbol(index_range), bigint_ty.fn_type(args, false));
+        let main = create_bb(producer, func, "main");
+
+        let arr = func.get_nth_param(0).unwrap().into_pointer_value();
+        let arr_idx = func.get_nth_param(1).unwrap().into_int_value();
+
+        // build the switch cases
+        let mut cases = vec![];
+        for idx in index_range.clone().into_iter() {
+            let case_val = i32_ty.const_int(idx.try_into().unwrap(), false);
+            let case_bb = create_bb(producer, func, format!("case_{}", idx).as_str());
+            producer.set_current_bb(case_bb);
+
+            let ptr = create_gep(producer, arr, &[case_val]).into_pointer_value();
+            let val = create_load(producer, ptr).into_int_value();
+            create_return(producer, val);
+
+            cases.push((case_val, case_bb));
+        }
+        // -- else case
+        let else_bb = create_bb(producer, func, "else");
+        producer.set_current_bb(else_bb);
+        create_call(producer, ASSERT_FN_NAME, &[bool_ty.const_zero().into()]);
+        create_return(producer, bigint_ty.const_zero());
+
+        producer.set_current_bb(main);
+
+        create_switch(producer, arr_idx, else_bb, &cases);
+
+    }
+
+    pub fn create_array_store_fn<'a>(producer: &dyn LLVMIRProducer<'a>, index_range: &Range<usize>) {
+        // args: array, index, value
+        // return: void
+        let bool_ty = bool_type(producer);
+        let bigint_ty = bigint_type(producer);
+        let i32_ty = i32_type(producer);
+        let void_ty = void_type(producer);
+        let args = &[
+            bigint_ty.ptr_type(Default::default()).into(),
+            i32_ty.into(),
+            bigint_ty.into(),
+        ];
+        let void_ty = void_type(producer);
+
+        let func = create_function(producer, &get_store_symbol(index_range), void_ty.fn_type(args, false));
+        let main = create_bb(producer, func, "main");
+
+        let arr = func.get_nth_param(0).unwrap().into_pointer_value();
+        let arr_idx = func.get_nth_param(1).unwrap().into_int_value();
+        let val = func.get_nth_param(2).unwrap();
+
+        // build the switch cases
+        let mut cases = vec![];
+        for idx in index_range.clone().into_iter() {
+            let case_val = i32_ty.const_int(idx.try_into().unwrap(), false);
+            let case_bb = create_bb(producer, func, format!("case_{}", idx).as_str());
+            producer.set_current_bb(case_bb);
+
+            let ptr = create_gep(producer, arr, &[case_val]).into_pointer_value();
+            create_store(producer, ptr, val.into());
+            create_return_void(producer);
+
+            cases.push((case_val, case_bb));
+        }
+        // -- else case
+        let else_bb = create_bb(producer, func, "else");
+        producer.set_current_bb(else_bb);
+        create_call(producer, ASSERT_FN_NAME, &[bool_ty.const_zero().into()]);
+        create_return_void(producer);
+
+        producer.set_current_bb(main);
+
+        create_switch(producer, arr_idx, else_bb, &cases);
+    }
+
+
+}
+
+pub fn load_array_switch<'a>(producer: &dyn LLVMIRProducer<'a>, index_range: &Range<usize>) {
+    array_switch::create_array_load_fn(producer, index_range);
+    array_switch::create_array_store_fn(producer, index_range);
+}
+
+pub fn get_array_load_symbol(index_range: &Range<usize>) -> String {
+    array_switch::get_load_symbol(index_range)
+}
+
+pub fn get_array_store_symbol(index_range: &Range<usize>) -> String {
+    array_switch::get_store_symbol(index_range)
+}

--- a/code_producers/src/llvm_elements/array_switch.rs
+++ b/code_producers/src/llvm_elements/array_switch.rs
@@ -40,7 +40,7 @@ mod array_switch {
             i32_ty.into(),
         ];
 
-        let func = create_function(producer, &get_load_symbol(index_range), bigint_ty.fn_type(args, false));
+        let func = create_function(producer, &None, 0, "", &get_load_symbol(index_range), bigint_ty.fn_type(args, false));
         let main = create_bb(producer, func, "main");
 
         let arr = func.get_nth_param(0).unwrap().into_pointer_value();
@@ -85,7 +85,7 @@ mod array_switch {
         ];
         let void_ty = void_type(producer);
 
-        let func = create_function(producer, &get_store_symbol(index_range), void_ty.fn_type(args, false));
+        let func = create_function(producer, &None, 0, "", &get_store_symbol(index_range), void_ty.fn_type(args, false));
         let main = create_bb(producer, func, "main");
 
         let arr = func.get_nth_param(0).unwrap().into_pointer_value();

--- a/code_producers/src/llvm_elements/functions.rs
+++ b/code_producers/src/llvm_elements/functions.rs
@@ -130,4 +130,11 @@ impl<'a> BodyCtx<'a> for FunctionCtx<'a> {
     ) -> AnyValueEnum<'a> {
         create_gep(producer, self.arena, &[index])
     }
+
+    fn get_variable_array(
+        &self,
+        producer: &dyn LLVMIRProducer<'a>,
+    ) -> AnyValueEnum<'a> {
+        self.arena.into()
+    }
 }

--- a/code_producers/src/llvm_elements/instructions.rs
+++ b/code_producers/src/llvm_elements/instructions.rs
@@ -695,3 +695,12 @@ pub fn pointer_cast<'a>(
 ) -> PointerValue<'a> {
     producer.builder().build_pointer_cast(from, to, "")
 }
+
+pub fn create_switch<'a>(
+    producer: &dyn LLVMIRProducer<'a>,
+    value: IntValue<'a>,
+    else_block: BasicBlock<'a>,
+    cases: &[(IntValue<'a>, BasicBlock<'a>)],
+) -> InstructionValue<'a> {
+    producer.builder().build_switch(value, else_block, cases)
+}

--- a/code_producers/src/llvm_elements/mod.rs
+++ b/code_producers/src/llvm_elements/mod.rs
@@ -29,6 +29,7 @@ pub mod functions;
 pub mod instructions;
 pub mod fr;
 pub mod values;
+pub mod array_switch;
 
 pub type LLVMInstruction<'a> = AnyValueEnum<'a>;
 
@@ -61,7 +62,7 @@ pub struct LLVMCircuitData {
     pub io_map: TemplateInstanceIOMap,
     pub signal_index_mapping: HashMap<String, IndexMapping>,
     pub variable_index_mapping: HashMap<String, IndexMapping>,
-    pub component_index_mapping: HashMap<String, IndexMapping>
+    pub component_index_mapping: HashMap<String, IndexMapping>,
 }
 
 impl LLVMCircuitData {

--- a/code_producers/src/llvm_elements/mod.rs
+++ b/code_producers/src/llvm_elements/mod.rs
@@ -42,6 +42,11 @@ pub trait BodyCtx<'a> {
         producer: &dyn LLVMIRProducer<'a>,
         index: IntValue<'a>,
     ) -> AnyValueEnum<'a>;
+
+    fn get_variable_array(
+        &self,
+        producer: &dyn LLVMIRProducer<'a>,
+    ) -> AnyValueEnum<'a>;
 }
 
 pub trait LLVMIRProducer<'a> {

--- a/code_producers/src/llvm_elements/template.rs
+++ b/code_producers/src/llvm_elements/template.rs
@@ -165,6 +165,15 @@ impl<'a> TemplateCtx<'a> {
         let signals = self.current_function.get_nth_param(self.signals_arg_offset as u32).unwrap();
         create_gep(producer, signals.into_pointer_value(), &[zero(producer), index])
     }
+
+    /// Returns a pointer to the signal array
+    pub fn get_signal_array(
+        &self,
+        producer: &dyn LLVMIRProducer<'a>,
+    ) -> AnyValueEnum<'a> {
+        let signals = self.current_function.get_nth_param(self.signals_arg_offset as u32).unwrap();
+        signals.into_pointer_value().into()
+    }
 }
 
 impl<'a> BodyCtx<'a> for TemplateCtx<'a> {
@@ -175,6 +184,13 @@ impl<'a> BodyCtx<'a> for TemplateCtx<'a> {
         index: IntValue<'a>,
     ) -> AnyValueEnum<'a> {
         create_gep(producer, self.stack, &[zero(producer), index])
+    }
+
+    fn get_variable_array(
+        &self,
+        producer: &dyn LLVMIRProducer<'a>,
+    ) -> AnyValueEnum<'a> {
+        self.stack.into()
     }
 }
 

--- a/compiler-tests/arrays/unknown_index_load_store.circom
+++ b/compiler-tests/arrays/unknown_index_load_store.circom
@@ -1,0 +1,16 @@
+pragma circom 2.0.0;
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && circom --llvm -o %t %s
+
+template UnknownIndexLoadStore() {
+    signal input in;
+    signal output out[10];
+
+    var arr1[10] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+    var arr2[10] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+    var arr3[10] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+    out[in] <-- arr2[in];
+}
+
+component main = UnknownIndexLoadStore();

--- a/compiler/src/intermediate_representation/load_bucket.rs
+++ b/compiler/src/intermediate_representation/load_bucket.rs
@@ -2,7 +2,7 @@ use super::ir_interface::*;
 use crate::translating_traits::*;
 use code_producers::c_elements::*;
 use code_producers::llvm_elements::{LLVMInstruction, LLVMIRProducer};
-use code_producers::llvm_elements::instructions::{create_gep, create_load};
+use code_producers::llvm_elements::instructions::{create_gep, create_load, create_call};
 use code_producers::llvm_elements::values::zero;
 use code_producers::wasm_elements::*;
 use crate::intermediate_representation::BucketId;
@@ -15,6 +15,7 @@ pub struct LoadBucket {
     pub message_id: usize,
     pub address_type: AddressType,
     pub src: LocationRule,
+    pub bounded_fn: Option<String>,
 }
 
 impl IntoInstruction for LoadBucket {
@@ -55,18 +56,28 @@ impl WriteLLVMIR for LoadBucket {
     fn produce_llvm_ir<'a, 'b>(&self, producer: &'b dyn LLVMIRProducer<'a>) -> Option<LLVMInstruction<'a>> {
         // Generate the code of the location and use the last value as the reference
         let index = self.src.produce_llvm_ir(producer).expect("We need to produce some kind of instruction!").into_int_value();
+
+        // If we have bounds for an unknown index, we will get the base address and let the function check the bounds
+        let gep_index = match self.bounded_fn {
+            Some(_) => zero(producer),
+            None => index,
+        };
+
         let gep = match &self.address_type {
-            AddressType::Variable => producer.body_ctx().get_variable(producer, index),
+            AddressType::Variable => producer.body_ctx().get_variable(producer, gep_index),
             AddressType::Signal => {
-                producer.template_ctx().get_signal(producer, index)
+                producer.template_ctx().get_signal(producer, gep_index)
             },
             AddressType::SubcmpSignal { cmp_address, ..  } => {
                 let addr = cmp_address.produce_llvm_ir(producer).expect("The address of a subcomponent must yield a value!");
                 let subcmp = producer.template_ctx().load_subcmp_addr(producer, addr);
-                create_gep(producer, subcmp, &[zero(producer), index])
+                create_gep(producer, subcmp, &[zero(producer), gep_index])
             }
         };
-        let load = create_load(producer, gep.into_pointer_value());
+        let load = match &self.bounded_fn {
+            Some(name) => create_call(producer, name.as_str(), &[gep.into_pointer_value().into(), index.into()]),
+            None => create_load(producer, gep.into_pointer_value()),
+        };
         Some(load)
     }
 }

--- a/compiler/src/intermediate_representation/load_bucket.rs
+++ b/compiler/src/intermediate_representation/load_bucket.rs
@@ -1,8 +1,9 @@
 use super::ir_interface::*;
 use crate::translating_traits::*;
 use code_producers::c_elements::*;
+use code_producers::llvm_elements::array_switch::array_ptr_ty;
 use code_producers::llvm_elements::{LLVMInstruction, LLVMIRProducer};
-use code_producers::llvm_elements::instructions::{create_gep, create_load, create_call};
+use code_producers::llvm_elements::instructions::{create_gep, create_load, create_call, pointer_cast};
 use code_producers::llvm_elements::values::zero;
 use code_producers::wasm_elements::*;
 use crate::intermediate_representation::BucketId;
@@ -69,20 +70,34 @@ impl WriteLLVMIR for LoadBucket {
             None => index,
         };
 
-        let gep = match &self.address_type {
-            AddressType::Variable => producer.body_ctx().get_variable(producer, gep_index),
-            AddressType::Signal => {
-                producer.template_ctx().get_signal(producer, gep_index)
-            },
-            AddressType::SubcmpSignal { cmp_address, ..  } => {
-                let addr = cmp_address.produce_llvm_ir(producer).expect("The address of a subcomponent must yield a value!");
-                let subcmp = producer.template_ctx().load_subcmp_addr(producer, addr);
-                create_gep(producer, subcmp, &[zero(producer), gep_index])
-            }
-        };
         let load = match &self.bounded_fn {
-            Some(name) => create_call(producer, name.as_str(), &[gep.into_pointer_value().into(), index.into()]),
-            None => create_load(producer, gep.into_pointer_value()),
+            Some(name) => {
+                let arr_ptr = match &self.address_type {
+                    AddressType::Variable => producer.body_ctx().get_variable_array(producer),
+                    AddressType::Signal => producer.template_ctx().get_signal_array(producer),
+                    AddressType::SubcmpSignal { cmp_address, .. } => {
+                        let addr = cmp_address.produce_llvm_ir(producer).expect("The address of a subcomponent must yield a value!");
+                        let subcmp = producer.template_ctx().load_subcmp_addr(producer, addr);
+                        create_gep(producer, subcmp, &[zero(producer)])
+                    },
+                }.into_pointer_value();
+                let arr_ptr = pointer_cast(producer, arr_ptr, array_ptr_ty(producer));
+                create_call(producer, name.as_str(), &[arr_ptr.into(), index.into()])
+            },
+            None => {
+                let gep = match &self.address_type {
+                    AddressType::Variable => producer.body_ctx().get_variable(producer, index),
+                    AddressType::Signal => {
+                        producer.template_ctx().get_signal(producer, index)
+                    },
+                    AddressType::SubcmpSignal { cmp_address, ..  } => {
+                        let addr = cmp_address.produce_llvm_ir(producer).expect("The address of a subcomponent must yield a value!");
+                        let subcmp = producer.template_ctx().load_subcmp_addr(producer, addr);
+                        create_gep(producer, subcmp, &[zero(producer), index])
+                    }
+                }.into_pointer_value();
+                create_load(producer, gep)
+            },
         };
         Some(load)
     }

--- a/compiler/src/intermediate_representation/store_bucket.rs
+++ b/compiler/src/intermediate_representation/store_bucket.rs
@@ -1,8 +1,9 @@
 use super::ir_interface::*;
 use crate::translating_traits::*;
 use code_producers::c_elements::*;
+use code_producers::llvm_elements::array_switch::array_ptr_ty;
 use code_producers::llvm_elements::{LLVMInstruction, to_enum, LLVMIRProducer};
-use code_producers::llvm_elements::instructions::{create_call, create_gep, create_load_with_name, create_store, create_sub_with_name};
+use code_producers::llvm_elements::instructions::{create_call, create_gep, create_load_with_name, create_store, create_sub_with_name, pointer_cast};
 use code_producers::llvm_elements::run_fn_name;
 use code_producers::llvm_elements::values::{create_literal_u32, zero};
 use code_producers::wasm_elements::*;
@@ -68,29 +69,36 @@ impl WriteLLVMIR for StoreBucket {
         // A store instruction has a source instruction that states the origin of the value that is going to be stored
         let index =  self.dest.produce_llvm_ir(producer).expect("We need to produce some kind of instruction!").into_int_value();
 
-        // If we have bounds for an unknown index, we will get the base address and let the function check the bounds
-        let gep_index = match self.bounded_fn {
-            Some(_) => zero(producer),
-            None => index,
-        };
-
         // Extract the source and store the result in the destination
         let source = to_enum(self.src.produce_llvm_ir(producer).unwrap());
 
-        let gep = match &self.dest_address_type {
-            AddressType::Variable => producer.body_ctx().get_variable(producer, gep_index),
-            AddressType::Signal => producer.template_ctx().get_signal(producer, gep_index),
-            AddressType::SubcmpSignal { cmp_address, .. } => {
-                let addr = cmp_address.produce_llvm_ir(producer).expect("The address of a subcomponent must yield a value!");
-                let subcmp = producer.template_ctx().load_subcmp_addr(producer, addr);
-                create_gep(producer, subcmp, &[zero(producer), gep_index])
-            }
-        }.into_pointer_value();
-
-        // If we have bounds to check, wrap the store in a switch function
+        // If we have bounds for an unknown index, we will get the base address and let the function check the bounds
         let store = match &self.bounded_fn {
-            Some(name) => create_call(producer, name.as_str(), &[gep.into(), index.into(), source.into_int_value().into()]),
-            None => create_store(producer,gep, source),
+            Some(name) => {
+                let arr_ptr = match &self.dest_address_type {
+                    AddressType::Variable => producer.body_ctx().get_variable_array(producer),
+                    AddressType::Signal => producer.template_ctx().get_signal_array(producer),
+                    AddressType::SubcmpSignal { cmp_address, .. } => {
+                        let addr = cmp_address.produce_llvm_ir(producer).expect("The address of a subcomponent must yield a value!");
+                        let subcmp = producer.template_ctx().load_subcmp_addr(producer, addr);
+                        create_gep(producer, subcmp, &[zero(producer)])
+                    }
+                }.into_pointer_value();
+                let arr_ptr = pointer_cast(producer, arr_ptr, array_ptr_ty(producer));
+                create_call(producer, name.as_str(), &[arr_ptr.into(), index.into(), source.into_int_value().into()])
+            },
+            None => {
+                let gep = match &self.dest_address_type {
+                    AddressType::Variable => producer.body_ctx().get_variable(producer, index),
+                    AddressType::Signal => producer.template_ctx().get_signal(producer, index),
+                    AddressType::SubcmpSignal { cmp_address, .. } => {
+                        let addr = cmp_address.produce_llvm_ir(producer).expect("The address of a subcomponent must yield a value!");
+                        let subcmp = producer.template_ctx().load_subcmp_addr(producer, addr);
+                        create_gep(producer, subcmp, &[zero(producer), index])
+                    }
+                }.into_pointer_value();
+                create_store(producer,gep, source)
+            },
         };
 
         // If we have a subcomponent storage decrement the counter

--- a/compiler/src/intermediate_representation/translate.rs
+++ b/compiler/src/intermediate_representation/translate.rs
@@ -341,6 +341,7 @@ fn initialize_constants(state: &mut State, constants: Vec<Argument>, stmt: &Stat
                 dest: LocationRule::Indexed { location: full_address, template_header: None },
                 context: InstrContext { size: 1 },
                 src: content,
+                bounded_fn: None,
             }
             .allocate();
             state.code.push(store_instruction);
@@ -1211,6 +1212,7 @@ impl ProcessedSymbol {
                 context: InstrContext { size: self.length },
                 dest_is_output: false,
                 dest_address_type: dest_type,
+                bounded_fn: None,
             }
             .allocate()
         } else {
@@ -1228,6 +1230,7 @@ impl ProcessedSymbol {
                 dest_is_output: self.signal_type.map_or(false, |t| t == SignalType::Output),
                 dest: LocationRule::Indexed { location: address, template_header: None },
                 context: InstrContext { size: self.length },
+                bounded_fn: None,
             }
             .allocate()
         }
@@ -1250,6 +1253,7 @@ impl ProcessedSymbol {
                 line: self.line,
                 message_id: self.message_id,
                 address_type: dest_type,
+                bounded_fn: None,
             }
             .allocate()
         } else {
@@ -1264,6 +1268,7 @@ impl ProcessedSymbol {
                 address_type: xtype,
                 message_id: self.message_id,
                 src: LocationRule::Indexed { location: address, template_header: None },
+                bounded_fn: None,
             }
             .allocate()
         }


### PR DESCRIPTION
This is done by adding some information to `StoreBucket` and `LoadBucket`. If this information (function name) is present, it changes the normal LLVM IR generation to generate a function call rather than a direct load/store.

(Note: I considered adding this as transformation from a `LoadBucket`/`StoreBucket` -> `CallBucket`, but there's no way to get a pointer argument for a function in circom, since the idea of a "pointer" doesn't exist in circom. So, you can't pass a pointer to a signal to another function this way, unless it's just in the LLVM IR generation.)