### PR TITLE
[VAN-396][VAN-387] store return values in caller after a function call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,6 +262,7 @@ version = "2.1.3"
 dependencies = [
  "code_producers",
  "constant_tracking",
+ "either",
  "num-bigint-dig",
  "num-traits",
  "program_structure",

--- a/compiler-tests/arrays/array8.circom
+++ b/compiler-tests/arrays/array8.circom
@@ -1,0 +1,37 @@
+pragma circom 2.0.0;
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && circom --llvm -o %t %s
+
+// Arena layout (setup by caller):
+// | l   m   n |        ret        | j |
+// | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 |
+function return_array_A(l, m, n) {
+    var ret[5];
+    for (var j = 0; j < n; j++) {
+        ret[j] = 999;
+    }
+    return ret;
+}
+
+// Arena layout (setup by caller):
+// | n   m |        ret        |
+// | 0 | 1 | 2 | 3 | 4 | 5 | 6 |
+function return_array_B(n, m) {
+    var r[5] = return_array_A(12, m, n);
+    return r;
+}
+
+
+template ArrayReturnTemplate(n) {
+    var r[5] = return_array_B(n, 13);
+}
+
+component main = ArrayReturnTemplate(4);
+
+//CHECK-LABEL: define i256 @return_array_B
+//CHECK: call void @fr_copy_n(i256* %{{.*}}, i256* %{{.*}}, i32 5)
+//CHECK: }
+
+//CHECK-LABEL: define void @ArrayReturnTemplate
+//CHECK: call void @fr_copy_n(i256* %{{.*}}, i256* %{{.*}}, i32 5)
+//CHECK: }

--- a/compiler-tests/controlflow/van348F.circom
+++ b/compiler-tests/controlflow/van348F.circom
@@ -1,12 +1,6 @@
 pragma circom 2.0.0;
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && circom --llvm -o %t %s
-//
-// XFAIL: *
-// TODO: Failure occurs in https://github.com/Veridise/circom/pull/15
-//       due to an assertion that was added and unintentionally revealed
-//       that return values from call expressions are not stored.
-//
 
 function identity(n) {
    return n;

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -9,7 +9,7 @@ constant_tracking = {path = "../constant_tracking"}
 program_structure = {path = "../program_structure"}
 code_producers = {path = "../code_producers"}
 
+either = "1.8.0"
 num-bigint-dig = "0.6.0"
 num-traits = "0.2.6"
 rand = "0.8.5"
-

--- a/compiler/src/intermediate_representation/call_bucket.rs
+++ b/compiler/src/intermediate_representation/call_bucket.rs
@@ -1,3 +1,4 @@
+use either::Either;
 use super::ir_interface::*;
 use crate::translating_traits::*;
 use code_producers::c_elements::*;
@@ -132,19 +133,14 @@ impl WriteLLVMIR for CallBucket {
                         &[i32_type(producer).const_int(self.arguments.len() as u64, false)],
                     )
                 };
-                return StoreBucket {
-                    id: new_id(),
-                    source_file_id: self.source_file_id,
-                    line: self.line,
-                    message_id: self.message_id,
-                    context: InstrContext { size },
-                    dest_is_output: false,
-                    dest_address_type: data.dest_address_type.clone(),
-                    dest: data.dest.clone(),
-                    src: NopBucket { id: new_id() }.allocate(),
-                    bounded_fn: None,
-                }
-                .produce_llvm_ir_from_src(producer, source_of_store);
+                return StoreBucket::produce_llvm_ir(
+                    producer,
+                    Either::Left(source_of_store),
+                    &data.dest,
+                    &data.dest_address_type,
+                    InstrContext { size },
+                    &None,
+                );
             }
         };
     }

--- a/compiler/src/intermediate_representation/call_bucket.rs
+++ b/compiler/src/intermediate_representation/call_bucket.rs
@@ -2,12 +2,13 @@ use super::ir_interface::*;
 use crate::translating_traits::*;
 use code_producers::c_elements::*;
 use code_producers::llvm_elements::{LLVMInstruction, LLVMIRProducer, to_basic_metadata_enum};
-use code_producers::llvm_elements::instructions::{create_alloca, create_call, create_gep, create_store, pointer_cast};
-use code_producers::llvm_elements::types::bigint_type;
+use code_producers::llvm_elements::instructions::{
+    create_alloca, create_call, create_gep, create_store, pointer_cast,
+};
+use code_producers::llvm_elements::types::{bigint_type, i32_type};
 use code_producers::llvm_elements::values::{create_literal_u32, zero};
 use code_producers::wasm_elements::*;
-use crate::intermediate_representation::BucketId;
-
+use crate::intermediate_representation::{BucketId, new_id};
 
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct FinalData {
@@ -74,28 +75,78 @@ impl ToString for CallBucket {
 }
 
 impl WriteLLVMIR for CallBucket {
-    /// Since calls use the same internal IR than templates they expect the same memory layout
+    /// Since calls use the same internal IR as templates they expect the same memory layout.
     /// Any signal is copied previously to an arena and the function uses that arena
     /// as a set of local variables.
-    fn produce_llvm_ir<'a, 'b>(&self, producer: &'b dyn LLVMIRProducer<'a>) -> Option<LLVMInstruction<'a>> {
+    fn produce_llvm_ir<'a, 'b>(
+        &self,
+        producer: &'b dyn LLVMIRProducer<'a>,
+    ) -> Option<LLVMInstruction<'a>> {
         Self::manage_debug_loc_from_curr(producer, self);
 
         // Create array with arena_size size
         let bigint_arr = bigint_type(producer).array_type(self.arena_size as u32);
-        let arena = create_alloca(producer, bigint_arr.into(), format!("{}_arena", self.symbol).as_str());
+        let arena =
+            create_alloca(producer, bigint_arr.into(), format!("{}_arena", self.symbol).as_str());
 
         // Copy arguments into elements of the arena by indexing order (arg 0 -> arena 0, arg 1 -> arena 1, etc)
-        for (id, arg) in self.arguments.iter().map(|i|
-            i.produce_llvm_ir(producer).expect("Call arguments must produce a value!")
-        ).enumerate() {
+        for (id, arg) in self
+            .arguments
+            .iter()
+            .map(|i| i.produce_llvm_ir(producer).expect("Call arguments must produce a value!"))
+            .enumerate()
+        {
             let i = create_literal_u32(producer, id as u64);
             let ptr = create_gep(producer, arena.into_pointer_value(), &[zero(producer), i]);
             create_store(producer, ptr.into_pointer_value(), arg);
         }
 
-        let arena = pointer_cast(producer, arena.into_pointer_value(), bigint_type(producer).ptr_type(Default::default()));
+        let arena = pointer_cast(
+            producer,
+            arena.into_pointer_value(),
+            bigint_type(producer).ptr_type(Default::default()),
+        );
+
         // Call function passing the array as argument
-        Some(create_call(producer, self.symbol.as_str(), &[to_basic_metadata_enum(arena.into())]))
+        let call_ret_val = create_call(
+            producer,
+            self.symbol.as_str(),
+            &[to_basic_metadata_enum(arena.into())],
+        );
+
+        match &self.return_info {
+            ReturnType::Intermediate { op_aux_no } => {
+                todo!("ReturnType::Intermediate {:#?}", op_aux_no);
+            }
+            ReturnType::Final(data) => {
+                let size = data.context.size;
+                let source_of_store = if size == 1 {
+                    //For scalar returns, store the returned value to
+                    //  the proper index in the current function's arena.
+                    call_ret_val
+                } else {
+                    //For array returns, copy the data from the callee arena to the caller arena.
+                    create_gep(
+                        producer,
+                        arena,
+                        &[i32_type(producer).const_int(self.arguments.len() as u64, false)],
+                    )
+                };
+                return StoreBucket {
+                    id: new_id(),
+                    source_file_id: self.source_file_id,
+                    line: self.line,
+                    message_id: self.message_id,
+                    context: InstrContext { size },
+                    dest_is_output: false,
+                    dest_address_type: data.dest_address_type.clone(),
+                    dest: data.dest.clone(),
+                    src: NopBucket { id: new_id() }.allocate(),
+                    bounded_fn: None,
+                }
+                .produce_llvm_ir_from_src(producer, source_of_store);
+            }
+        };
     }
 }
 


### PR DESCRIPTION
I have handled storing the return value in the caller after a function call for both scalar and array returns. I did not change the return type to void for the array returns but that issue is non-breaking and distinct so I can address it later. I just wanted to get this PR started in the meantime.