### PR TITLE
move error printout to the end (after code dump)

### DIFF
--- a/circuit_passes/src/bucket_interpreter/env.rs
+++ b/circuit_passes/src/bucket_interpreter/env.rs
@@ -238,7 +238,7 @@ impl<'a> Env<'a> {
         observe: bool,
     ) -> Value {
         if cfg!(debug_assertions) {
-            println!("Running {}", name);
+            println!("Running function {}", name);
         }
         let code = &self.functions_library[name].body;
         let mut function_env =

--- a/circuit_passes/src/passes/memory.rs
+++ b/circuit_passes/src/passes/memory.rs
@@ -48,7 +48,7 @@ impl PassMemory {
     pub fn run_template(&self, observer: &dyn InterpreterObserver, template: &TemplateCode) {
         assert!(!self.current_scope.is_empty());
         if cfg!(debug_assertions) {
-            println!("Running {}", self.current_scope);
+            println!("Running template {}", self.current_scope);
         }
         let interpreter = self.build_interpreter(observer);
         let env = Env::new(&self.templates_library, &self.functions_library, self);

--- a/code_producers/src/llvm_elements/mod.rs
+++ b/code_producers/src/llvm_elements/mod.rs
@@ -43,10 +43,7 @@ pub trait BodyCtx<'a> {
         index: IntValue<'a>,
     ) -> AnyValueEnum<'a>;
 
-    fn get_variable_array(
-        &self,
-        producer: &dyn LLVMIRProducer<'a>,
-    ) -> AnyValueEnum<'a>;
+    fn get_variable_array(&self, producer: &dyn LLVMIRProducer<'a>) -> AnyValueEnum<'a>;
 }
 
 pub trait LLVMIRProducer<'a> {
@@ -62,7 +59,6 @@ pub trait LLVMIRProducer<'a> {
 }
 
 pub type IndexMapping = HashMap<usize, Range<usize>>;
-
 
 #[derive(Default, Eq, PartialEq, Debug)]
 pub struct LLVMCircuitData {
@@ -294,13 +290,13 @@ impl<'a> LLVM<'a> {
         }
         // Run module verification
         self.module.verify().map_err(|llvm_err| {
+            eprintln!("Generated LLVM:");
+            self.module.print_to_stderr();
             eprintln!(
                 "{}: {}",
                 Colour::Red.paint("LLVM Module verification failed"),
                 llvm_err.to_string()
             );
-            eprintln!("Generated LLVM:");
-            self.module.print_to_stderr();
         })?;
         // Verify that bitcode can be written, parsed, and re-verified
         {


### PR DESCRIPTION
also add template vs. function to the "Running" debug line