### PR TITLE
[VAN-503] Convert to/from i1 as needed

### DIFF
--- a/circom/tests/type_conversions/bool_1.circom
+++ b/circom/tests/type_conversions/bool_1.circom
@@ -1,0 +1,22 @@
+pragma circom 2.0.0;
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llvm -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck --enable-var-scope %s
+
+function binop_comp(a, b) {
+  return a > b;
+}
+
+template A(x) {
+  signal input in;
+  signal output out;
+
+  out <-- binop_comp(in, x);
+}
+
+component main = A(5);
+
+//CHECK-LABEL: define i256 @binop_comp_{{[0-9]+}}
+//CHECK-SAME: (i256* %0)
+//CHECK: %call.fr_gt = call i1 @fr_gt(i256 %{{[0-9]+}}, i256 %{{[0-9]+}})
+//CHECK: %[[RET:[0-9]+]] = zext i1 %call.fr_gt to i256
+//CHECK: ret i256 %[[RET]]

--- a/circom/tests/type_conversions/bool_2.circom
+++ b/circom/tests/type_conversions/bool_2.circom
@@ -1,0 +1,31 @@
+pragma circom 2.0.0;
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llvm -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck --enable-var-scope %s
+
+function binop_bool(a, b) {
+  return a || b;
+}
+
+template A(x) {
+  signal input in;
+  signal output out;
+
+  var temp;
+  if (binop_bool(in, x)) {
+    temp = 1;
+  } else {
+    temp = 0;
+  }
+  out <-- temp;
+
+  //Essentially equivalent code:
+  // out <-- binop_bool(in, x);
+}
+
+component main = A(555);
+
+//CHECK-LABEL: define i256 @binop_bool_{{[0-9]+}}
+//CHECK-SAME: (i256* %0)
+//CHECK: %call.fr_logic_or = call i1 @fr_logic_or(i1 %{{[0-9]+}}, i1 %{{[0-9]+}})
+//CHECK: %[[RET:[0-9]+]] = zext i1 %call.fr_logic_or to i256
+//CHECK: ret i256 %[[RET]]

--- a/circom/tests/type_conversions/bool_3.circom
+++ b/circom/tests/type_conversions/bool_3.circom
@@ -1,0 +1,24 @@
+pragma circom 2.0.0;
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llvm -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck --enable-var-scope %s
+
+template A(x) {
+  signal input in;
+  signal output out;
+
+  var z = 0;
+  if (in || x) {
+    z = 1;
+  }
+  out <-- z;
+}
+
+component main = A(99);
+
+//CHECK-LABEL: define void @A_{{[0-9]+}}_run
+//CHECK-SAME: ([0 x i256]* %0)
+//CHECK: branch{{[0-9]+}}:
+//CHECK: %[[VAL_PTR:[0-9]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 1
+//CHECK: %[[VAL:[0-9]+]] = load i256, i256* %[[VAL_PTR]]
+//CHECK: %[[BOOL:[0-9]+]] = icmp ne i256 %[[VAL]], 0
+//CHECK: %call.fr_logic_or = call i1 @fr_logic_or(i1 %[[BOOL]], i1 true)

--- a/circom/tests/type_conversions/bool_3.circom
+++ b/circom/tests/type_conversions/bool_3.circom
@@ -22,3 +22,4 @@ component main = A(99);
 //CHECK: %[[VAL:[0-9]+]] = load i256, i256* %[[VAL_PTR]]
 //CHECK: %[[BOOL:[0-9]+]] = icmp ne i256 %[[VAL]], 0
 //CHECK: %call.fr_logic_or = call i1 @fr_logic_or(i1 %[[BOOL]], i1 true)
+//CHECK: br i1 %call.fr_logic_or, label %if.then, label %if.else

--- a/circom/tests/type_conversions/bool_4.circom
+++ b/circom/tests/type_conversions/bool_4.circom
@@ -1,0 +1,27 @@
+pragma circom 2.0.0;
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llvm -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck --enable-var-scope %s
+
+function binop_bool_array(a, b) {
+  var arr[10];
+  for (var i = 0; i < 10; i++) {
+    arr[i] = a[i] || b[i];
+  }
+  return arr;
+}
+
+template A() {
+  signal input in1[10];
+  signal input in2[10];
+  signal output out[10];
+
+  out <-- binop_bool_array(in1, in2);
+}
+
+component main = A();
+
+//CHECK-LABEL: define void @binop_bool_array_{{[0-9]+}}
+//CHECK-SAME: (i256* %0)
+//CHECK: %call.fr_logic_or = call i1 @fr_logic_or(i1 %{{[0-9]+}}, i1 %{{[0-9]+}})
+//CHECK: %[[VAL:[0-9]+]] = zext i1 %call.fr_logic_or to i256
+//CHECK: store i256 %[[VAL]], i256* %{{[0-9]+}}

--- a/code_producers/src/llvm_elements/instructions.rs
+++ b/code_producers/src/llvm_elements/instructions.rs
@@ -490,25 +490,13 @@ pub fn ensure_int_type_match<'a>(
     }
 }
 
-macro_rules! conditional_name {
-    ($fmt: expr, $name: expr) => {{
-        if $name.is_empty() { $name.to_string() } else { format!($fmt, $name) }.as_ref()
-    }};
-}
-
 pub fn create_logic_and_with_name<'a, T: IntMathValue<'a>>(
     producer: &dyn LLVMIRProducer<'a>,
     lhs: T,
     rhs: T,
     name: &str,
 ) -> AnyValueEnum<'a> {
-    let bool_lhs =
-        ensure_bool_with_name(producer, lhs, conditional_name!("bool_cast_lhs.{}", name))
-            .into_int_value();
-    let bool_rhs =
-        ensure_bool_with_name(producer, rhs, conditional_name!("bool_cast_rhs.{}", name))
-            .into_int_value();
-    producer.llvm().builder.build_and(bool_lhs, bool_rhs, name).as_any_value_enum()
+    producer.llvm().builder.build_and(lhs, rhs, name).as_any_value_enum()
 }
 
 pub fn create_logic_and<'a, T: IntMathValue<'a>>(
@@ -525,13 +513,7 @@ pub fn create_logic_or_with_name<'a, T: IntMathValue<'a>>(
     rhs: T,
     name: &str,
 ) -> AnyValueEnum<'a> {
-    let bool_lhs =
-        ensure_bool_with_name(producer, lhs, conditional_name!("bool_cast_lhs.{}", name))
-            .into_int_value();
-    let bool_rhs =
-        ensure_bool_with_name(producer, rhs, conditional_name!("bool_cast_rhs.{}", name))
-            .into_int_value();
-    producer.llvm().builder.build_or(bool_lhs, bool_rhs, name).as_any_value_enum()
+    producer.llvm().builder.build_or(lhs, rhs, name).as_any_value_enum()
 }
 
 pub fn create_logic_or<'a, T: IntMathValue<'a>>(
@@ -547,9 +529,7 @@ pub fn create_logic_not_with_name<'a, T: IntMathValue<'a>>(
     val: T,
     name: &str,
 ) -> AnyValueEnum<'a> {
-    let bool_val = ensure_bool_with_name(producer, val, conditional_name!("bool_cast.{}", name))
-        .into_int_value();
-    producer.llvm().builder.build_not(bool_val, name).as_any_value_enum()
+    producer.llvm().builder.build_not(val, name).as_any_value_enum()
 }
 
 pub fn create_logic_not<'a, T: IntMathValue<'a>>(

--- a/code_producers/src/llvm_elements/instructions.rs
+++ b/code_producers/src/llvm_elements/instructions.rs
@@ -447,13 +447,9 @@ pub fn ensure_bool_with_name<'a, T: IntMathValue<'a>>(
     val: T,
     name: &str,
 ) -> AnyValueEnum<'a> {
-    if val.as_basic_value_enum().into_int_value().get_type() != bool_type(producer) {
-        create_neq_with_name(
-            producer,
-            val.as_basic_value_enum().into_int_value(),
-            bigint_type(producer).const_zero(),
-            name,
-        )
+    let int_val = val.as_basic_value_enum().into_int_value();
+    if int_val.get_type() != bool_type(producer) {
+        create_neq_with_name(producer, int_val, bigint_type(producer).const_zero(), name)
     } else {
         val.as_any_value_enum()
     }


### PR DESCRIPTION
The logic functions (`fr_logic_*`), the library functions (like constraints and assertions), and branch instructions require `i1` (i.e., boolean) arguments. So, when storing the results of logic operations to a regular variable (which is always a bigint, i.e. `i256`) or implicitly converting a regular variable into a boolean (e.g., `if (foo)`), a conversion needs to occur in the LLVM IR. I've implemented the following changes:

- When creating a call, store, or return with boolean arguments, automatically add a conversion to boolean if the provided argument is a non-boolean integer (by adding a computation of `val != 0`). 
- When creating a call, store, or return with an integer argument, automatically add a conversion to the non-boolean integer if the provided argument is a boolean  (by adding a zext instruction).
- When creating a branch, ensure that the value is converted to a boolean using the above methods.

I also added 4 test cases (3 from the original issue, one that I added during debugging).