### PR TITLE
[VAN-611] Fill in fr_copy_n, also apply to arguments

### DIFF
--- a/circom/tests/calls/call_with_array.circom
+++ b/circom/tests/calls/call_with_array.circom
@@ -1,7 +1,6 @@
 pragma circom 2.0.0;
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llvm -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s
-// XFAIL: .*
 
 function sum(a) {
     return a[0] + a[1] + a[2] + a[3];
@@ -16,6 +15,40 @@ template CallWithArray() {
 
 component main = CallWithArray();
 
+//CHECK-LABEL: define void @fr_copy_n
+//CHECK-SAME: (i256* %[[SRC:[0-9]+]], i256* %[[DST:[0-9]+]], i32 %[[LEN:[0-9]+]])
+//CHECK: [[ENTRY_BB:.*]]:
+//CHECK: %[[I:.*]] = alloca i32
+//CHECK: store i32 0, i32* %[[I]]
+//CHECK: br label %[[COND_BB:.*]]
+//CHECK: [[COND_BB]]:
+//CHECK-SAME: preds = %[[BODY_BB:.*]], %[[ENTRY_BB]]
+//CHECK: %[[IDX:.*]] = load i32, i32* %[[I]]
+//CHECK: %[[COND:.*]] = icmp slt i32 %[[IDX]], %[[LEN]]
+//CHECK: br i1 %[[COND]], label %[[BODY_BB]], label %[[END_BB:.*]]
+//CHECK: [[BODY_BB]]:
+//CHECK-SAME: preds = %[[COND_BB]]
+//CHECK: %[[CUR_IDX:.*]] = load i32, i32* %[[I]]
+//CHECK: %[[SRC_PTR:.*]] = getelementptr i256, i256* %[[SRC]], i32 %[[CUR_IDX]]
+//CHECK: %[[SRC_VAL:.*]] = load i256, i256* %[[SRC_PTR]]
+//CHECK: %[[DST_PTR:.*]] = getelementptr i256, i256* %[[DST]], i32 %[[CUR_IDX]]
+//CHECK: store i256 %[[SRC_VAL]], i256* %[[DST_PTR]]
+//CHECK: %[[NXT_IDX:.*]] = add i32 %[[CUR_IDX]], 1
+//CHECK: store i32 %[[NXT_IDX]], i32* %[[I]]
+//CHECK: br label %[[COND_BB]]
+//CHECK: [[END_BB]]:
+//CHECK-SAME: preds = %[[COND_BB]]
+//CHECK: ret void
+
 //CHECK-LABEL: define void @CallWithArray_{{[0-9]+}}_run
 //CHECK-SAME: ([0 x i256]* %[[ARG:[0-9]+]])
-//CHECK: TODO: Code produced currently is incorrect! See https://veridise.atlassian.net/browse/VAN-611
+//CHECK: call1:
+//CHECK: %[[ARENA:sum_.*_arena]] = alloca [4 x i256]
+//CHECK: %[[DST:[0-9]+]] = getelementptr [4 x i256], [4 x i256]* %[[ARENA]], i32 0, i32 0
+//CHECK: %[[SRC:[0-9]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i32 1
+//CHECK: call void @fr_copy_n(i256* %[[SRC]], i256* %[[DST]], i32 4)
+//CHECK: %[[ARENA_PTR:.*]] = bitcast [4 x i256]* %[[ARENA]] to i256*
+//CHECK: %call.[[SUM:sum_[0-9]+]] = call i256 @[[SUM]](i256* %[[ARENA_PTR]])
+//CHECK: %[[OUT:[0-9]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i32 0
+//CHECK: store i256 %call.[[SUM]], i256* %[[OUT]]
+//CHECK: br label %prologue

--- a/circom/tests/calls/call_with_array_and_scalar.circom
+++ b/circom/tests/calls/call_with_array_and_scalar.circom
@@ -1,0 +1,33 @@
+pragma circom 2.0.0;
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llvm -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s
+
+function sum(x, a, y) {
+    return x + a[0] + a[1] + a[2] + a[3] + y;
+}
+
+template CallWithArray() {
+    signal input x[4];
+    signal output y;
+
+    y <-- sum(77, x, 99);
+}
+
+component main = CallWithArray();
+
+//CHECK-LABEL: define void @CallWithArray_{{[0-9]+}}_run
+//CHECK-SAME: ([0 x i256]* %[[ARG:[0-9]+]])
+//CHECK: call1:
+//CHECK: %[[ARENA:sum_.*_arena]] = alloca [6 x i256]
+//CHECK: %[[X_PTR:[0-9]+]] = getelementptr [6 x i256], [6 x i256]* %[[ARENA]], i32 0, i32 0
+//CHECK: store i256 77, i256* %[[X_PTR]]
+//CHECK: %[[DST:[0-9]+]] = getelementptr [6 x i256], [6 x i256]* %[[ARENA]], i32 0, i32 1
+//CHECK: %[[SRC:[0-9]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i32 1
+//CHECK: call void @fr_copy_n(i256* %[[SRC]], i256* %[[DST]], i32 4)
+//CHECK: %[[Y_PTR:[0-9]+]] = getelementptr [6 x i256], [6 x i256]* %[[ARENA]], i32 0, i32 5
+//CHECK: store i256 99, i256* %[[Y_PTR]]
+//CHECK: %[[ARENA_PTR:.*]] = bitcast [6 x i256]* %[[ARENA]] to i256*
+//CHECK: %call.[[SUM:sum_[0-9]+]] = call i256 @[[SUM]](i256* %[[ARENA_PTR]])
+//CHECK: %[[OUT:[0-9]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i32 0
+//CHECK: store i256 %call.[[SUM]], i256* %[[OUT]]
+//CHECK: br label %prologue

--- a/code_producers/src/llvm_elements/fr.rs
+++ b/code_producers/src/llvm_elements/fr.rs
@@ -9,6 +9,7 @@ use crate::llvm_elements::instructions::{
 };
 use crate::llvm_elements::types::{bigint_type, bool_type, i32_type, void_type};
 
+use super::instructions::create_array_copy;
 use super::instructions::{create_inv, create_return_void};
 
 pub const FR_ADD_FN_NAME: &str = "fr_add";
@@ -261,7 +262,12 @@ pub fn array_copy_fn<'a>(producer: &dyn LLVMIRProducer<'a>) {
     );
     let main = create_bb(producer, func, FR_ARRAY_COPY_FN_NAME);
     producer.set_current_bb(main);
-    //TODO: may need to implement the body of this method
+
+    let src = func.get_nth_param(0).unwrap();
+    let dst = func.get_nth_param(1).unwrap();
+    let len = func.get_nth_param(2).unwrap();
+    create_array_copy(producer, func, src.into_pointer_value(), dst.into_pointer_value(), len.into_int_value());
+
     create_return_void(producer);
 }
 

--- a/compiler/src/intermediate_representation/call_bucket.rs
+++ b/compiler/src/intermediate_representation/call_bucket.rs
@@ -1,3 +1,4 @@
+use code_producers::llvm_elements::fr::FR_ARRAY_COPY_FN_NAME;
 use either::Either;
 use super::ir_interface::*;
 use crate::translating_traits::*;
@@ -111,16 +112,45 @@ impl WriteLLVMIR for CallBucket {
         let arena =
             create_alloca(producer, bigint_arr.into(), format!("{}_arena", self.symbol).as_str());
 
+        // Get the offsets based on the sizes of the arguments
+        let offsets: Vec<usize> = self.argument_types.iter().scan(0, |state, arg_ty| {
+            let curr_offset = *state;
+            *state = *state + arg_ty.size;
+            Some(curr_offset)
+        }).collect();
+
         // Copy arguments into elements of the arena by indexing order (arg 0 -> arena 0, arg 1 -> arena 1, etc)
-        for (id, arg) in self
+        for ((arg, arg_ty), offset) in self
             .arguments
             .iter()
-            .map(|i| i.produce_llvm_ir(producer).expect("Call arguments must produce a value!"))
-            .enumerate()
+            .zip(&self.argument_types)
+            .zip(offsets)
         {
-            let i = create_literal_u32(producer, id as u64);
-            let ptr = create_gep(producer, arena.into_pointer_value(), &[zero(producer), i]);
-            create_store(producer, ptr.into_pointer_value(), arg);
+            let i = create_literal_u32(producer, offset as u64);
+            let ptr = create_gep(producer, arena.into_pointer_value(), &[zero(producer), i]).into_pointer_value();
+            if arg_ty.size > 1 {
+                let src_arg = match arg.as_ref() {
+                    Instruction::Load(v) => {
+                        let index = v.src.produce_llvm_ir(producer).expect("We need to produce some kind of instruction!").into_int_value();
+                        let gep = match &v.address_type {
+                            AddressType::Variable => producer.body_ctx().get_variable(producer, index),
+                            AddressType::Signal => producer.template_ctx().get_signal(producer, index),
+                            AddressType::SubcmpSignal { cmp_address, ..  } => {
+                                let addr = cmp_address.produce_llvm_ir(producer).expect("The address of a subcomponent must yield a value!");
+                                let subcmp = producer.template_ctx().load_subcmp_addr(producer, addr);
+                                create_gep(producer, subcmp, &[zero(producer), index])
+                            }
+                        }.into_pointer_value();
+                        gep
+                    },
+                    _ => unreachable!(),
+                };
+                let len_arg = create_literal_u32(producer, arg_ty.size as u64);
+                create_call(producer, FR_ARRAY_COPY_FN_NAME, &[src_arg.into(), ptr.into(), len_arg.into()]);
+            } else {
+                let arg_load = arg.produce_llvm_ir(producer).expect("Call arguments must produce a value!");
+                create_store(producer, ptr, arg_load);
+            }
         }
 
         let arena = pointer_cast(


### PR DESCRIPTION
- The implementation of fr_copy_n was "todo", so I added the array copying logic for it.
- Also applied array copying for function arguments based on the argument type size available in call bucket