### PR TITLE
Add array constraint generation

### DIFF
--- a/circom/tests/subcmps/array_copy_constraints.circom
+++ b/circom/tests/subcmps/array_copy_constraints.circom
@@ -1,0 +1,73 @@
+pragma circom 2.0.0;
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llvm -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s
+
+template Sum(n) {
+    signal input inp[n];
+    signal output outp;
+
+    var acc = 0;
+    for (var i = 0; i < n; i++) {
+        acc += inp[i];
+    }
+
+    outp <== acc;
+}
+
+template Caller(n) {
+    signal input inp[n];
+    signal outp;
+
+    component op = Sum(n);
+    op.inp <== inp;
+
+    outp <== op.outp;
+}
+
+component main = Caller(5);
+
+//CHECK-LABEL: define void @Caller_{{[0-9]+}}_run
+//CHECK-SAME: ([0 x i256]* %0)
+//CHECK: store{{[0-9]+}}: ; preds = %create_cmp{{[0-9]+}}
+//CHECK: %[[SUBCMP_PTR:[0-9]+]] = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
+//CHECK: %[[SUBCMP_INP_ARR:[0-9]+]] = load [0 x i256]*, [0 x i256]** %[[SUBCMP_PTR]]
+//CHECK: %[[SUBCMP_INP_PTR:[0-9]+]] = getelementptr [0 x i256], [0 x i256]* %[[SUBCMP_INP_ARR]], i32 0, i32 1
+//CHECK: %[[INP_PTR:[0-9]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
+//CHECK: call void @fr_copy_n(i256* %[[INP_PTR]], i256* %[[SUBCMP_INP_PTR]], i32 5)
+//CHECK: %decrement.counter = sub i32 %load.subcmp.counter, 5
+//CHECK: call void @Sum_{{[0-9]+}}_run([0 x i256]* %{{[0-9]+}})
+
+//CHECK: %[[INP_PTR_0:[0-9]+]] = getelementptr i256, i256* %[[INP_PTR]], i32 0
+//CHECK: %[[INP_0:[0-9]+]] = load i256, i256* %[[INP_PTR_0]]
+//CHECK: %[[SUBCMP_INP_PTR_0:[0-9]+]] = getelementptr i256, i256* %[[SUBCMP_INP_PTR]], i32 0
+//CHECK: %[[SUBCMP_INP_0:[0-9]+]] = load i256, i256* %[[SUBCMP_INP_PTR_0]]
+//CHECK: %constraint_0 = alloca i1
+//CHECK: call void @__constraint_values(i256 %[[INP_0]], i256 %[[SUBCMP_INP_0]], i1* %constraint_0)
+
+//CHECK: %[[INP_PTR_1:[0-9]+]] = getelementptr i256, i256* %[[INP_PTR]], i32 1
+//CHECK: %[[INP_1:[0-9]+]] = load i256, i256* %[[INP_PTR_1]]
+//CHECK: %[[SUBCMP_INP_PTR_1:[0-9]+]] = getelementptr i256, i256* %[[SUBCMP_INP_PTR]], i32 1
+//CHECK: %[[SUBCMP_INP_1:[0-9]+]] = load i256, i256* %[[SUBCMP_INP_PTR_1]]
+//CHECK: %constraint_1 = alloca i1
+//CHECK: call void @__constraint_values(i256 %[[INP_1]], i256 %[[SUBCMP_INP_1]], i1* %constraint_1)
+
+//CHECK: %[[INP_PTR_2:[0-9]+]] = getelementptr i256, i256* %[[INP_PTR]], i32 2
+//CHECK: %[[INP_2:[0-9]+]] = load i256, i256* %[[INP_PTR_2]]
+//CHECK: %[[SUBCMP_INP_PTR_2:[0-9]+]] = getelementptr i256, i256* %[[SUBCMP_INP_PTR]], i32 2
+//CHECK: %[[SUBCMP_INP_2:[0-9]+]] = load i256, i256* %[[SUBCMP_INP_PTR_2]]
+//CHECK: %constraint_2 = alloca i1
+//CHECK: call void @__constraint_values(i256 %[[INP_2]], i256 %[[SUBCMP_INP_2]], i1* %constraint_2)
+
+//CHECK: %[[INP_PTR_3:[0-9]+]] = getelementptr i256, i256* %[[INP_PTR]], i32 3
+//CHECK: %[[INP_3:[0-9]+]] = load i256, i256* %[[INP_PTR_3]]
+//CHECK: %[[SUBCMP_INP_PTR_3:[0-9]+]] = getelementptr i256, i256* %[[SUBCMP_INP_PTR]], i32 3
+//CHECK: %[[SUBCMP_INP_3:[0-9]+]] = load i256, i256* %[[SUBCMP_INP_PTR_3]]
+//CHECK: %constraint_3 = alloca i1
+//CHECK: call void @__constraint_values(i256 %[[INP_3]], i256 %[[SUBCMP_INP_3]], i1* %constraint_3)
+
+//CHECK: %[[INP_PTR_4:[0-9]+]] = getelementptr i256, i256* %[[INP_PTR]], i32 4
+//CHECK: %[[INP_4:[0-9]+]] = load i256, i256* %[[INP_PTR_4]]
+//CHECK: %[[SUBCMP_INP_PTR_4:[0-9]+]] = getelementptr i256, i256* %[[SUBCMP_INP_PTR]], i32 4
+//CHECK: %[[SUBCMP_INP_4:[0-9]+]] = load i256, i256* %[[SUBCMP_INP_PTR_4]]
+//CHECK: %constraint_4 = alloca i1
+//CHECK: call void @__constraint_values(i256 %[[INP_4]], i256 %[[SUBCMP_INP_4]], i1* %constraint_4)

--- a/code_producers/src/llvm_elements/mod.rs
+++ b/code_producers/src/llvm_elements/mod.rs
@@ -155,8 +155,8 @@ impl<'a> TopLevelLLVMIRProducer<'a> {
 pub type LLVMAdapter<'a> = &'a Rc<RefCell<LLVM<'a>>>;
 pub type BigIntType<'a> = IntType<'a>; // i256
 
-pub fn new_constraint<'a>(producer: &dyn LLVMIRProducer<'a>) -> AnyValueEnum<'a> {
-    let alloca = create_alloca(producer, bool_type(producer).into(), "constraint");
+pub fn new_constraint_with_name<'a>(producer: &dyn LLVMIRProducer<'a>, name: &str) -> AnyValueEnum<'a> {
+    let alloca = create_alloca(producer, bool_type(producer).into(), name);
     let s = producer.context().metadata_string("constraint");
     let kind = producer.context().get_kind_id("constraint");
     let node = producer.context().metadata_node(&[s.into()]);
@@ -167,6 +167,10 @@ pub fn new_constraint<'a>(producer: &dyn LLVMIRProducer<'a>) -> AnyValueEnum<'a>
         .set_metadata(node, kind)
         .expect("Could not setup metadata marker for constraint value");
     alloca
+}
+
+pub fn new_constraint<'a>(producer: &dyn LLVMIRProducer<'a>) -> AnyValueEnum<'a> {
+    new_constraint_with_name(producer, "constraint")
 }
 
 #[inline]

--- a/compiler/src/intermediate_representation/constraint_bucket.rs
+++ b/compiler/src/intermediate_representation/constraint_bucket.rs
@@ -116,10 +116,7 @@ impl WriteLLVMIR for ConstraintBucket {
         match self {
             ConstraintBucket::Substitution(i) => {
                 let size = match i.as_ref() {
-                    Instruction::Value(_) => todo!(),
-                    Instruction::Load(_) => todo!(),
                     Instruction::Store(b) => b.context.size,
-                    Instruction::Compute(_) => todo!(),
                     Instruction::Call(b) => {
                         for arg_ty in &b.argument_types {
                             if arg_ty.size > 1 {
@@ -129,15 +126,7 @@ impl WriteLLVMIR for ConstraintBucket {
                         }
                         1
                     },
-                    Instruction::Branch(_) => todo!(),
-                    Instruction::Return(_) => todo!(),
-                    Instruction::Assert(_) => todo!(),
-                    Instruction::Log(_) => todo!(),
-                    Instruction::Loop(_) => todo!(),
-                    Instruction::CreateCmp(_) => todo!(),
-                    Instruction::Constraint(_) => todo!(),
-                    Instruction::Block(_) => todo!(),
-                    Instruction::Nop(_) => todo!(),
+                    _ => unreachable!("Instruction {:#?} should not be used for constraint substitution", i),
                 };
                 assert_ne!(0, size, "must have non-zero size");
                 if size == 1 {

--- a/compiler/src/intermediate_representation/store_bucket.rs
+++ b/compiler/src/intermediate_representation/store_bucket.rs
@@ -106,6 +106,7 @@ impl StoreBucket{
         // If we have bounds for an unknown index, we will get the base address and let the function check the bounds
         let store = match &bounded_fn {
             Some(name) => {
+                assert_eq!(1, context.size, "unhandled array store");
                 let arr_ptr = match &dest_address_type {
                     AddressType::Variable => producer.body_ctx().get_variable_array(producer),
                     AddressType::Signal => producer.template_ctx().get_signal_array(producer),
@@ -168,13 +169,12 @@ impl StoreBucket{
             }
         };
 
-        // If we have a subcomponent storage decrement the counter
+        // If we have a subcomponent storage decrement the counter by the size of the store (i.e., context.size)
         if let AddressType::SubcmpSignal { cmp_address, .. } = &dest_address_type {
             let addr = cmp_address.produce_llvm_ir(producer).expect("The address of a subcomponent must yield a value!");
             let counter = producer.template_ctx().load_subcmp_counter(producer, addr);
             let value = create_load_with_name(producer, counter, "load.subcmp.counter");
-            let new_value = create_sub_with_name(producer, value.into_int_value(), create_literal_u32(producer, 1), "decrement.counter");
-            assert_eq!(1, context.size, "unhandled array store");
+            let new_value = create_sub_with_name(producer, value.into_int_value(), create_literal_u32(producer, context.size as u64), "decrement.counter");
             create_store(producer, counter, new_value);
         }
 


### PR DESCRIPTION
Generates constraints for each array element when `fr_copy_n` is used. For an array of N elements, this will create N calls to `__constraint_values`.