### PR TITLE
Allow dumb terminals to not have color

### DIFF
--- a/program_structure/src/program_library/error_definition.rs
+++ b/program_structure/src/program_library/error_definition.rs
@@ -52,7 +52,7 @@ impl Report {
     }
     pub fn print_reports(reports: &[Report], file_library: &FileLibrary) {
         use codespan_reporting::term::termcolor::{ColorChoice, StandardStream};
-        let writer = StandardStream::stderr(ColorChoice::Always);
+        let writer = StandardStream::stderr(ColorChoice::Auto);
         let config = term::Config::default();
         let mut diagnostics = Vec::new();
         let files = file_library.to_storage();


### PR DESCRIPTION
![image](https://github.com/iden3/circom/assets/3696828/9fd76b3f-b3a4-44bf-ae1e-e99febbef72a)
