### PR TITLE
[VAN-833] Correct handling of insertions from extracted location updater

### DIFF
--- a/circom/tests/zzz/VAN-833.circom
+++ b/circom/tests/zzz/VAN-833.circom
@@ -1,0 +1,26 @@
+pragma circom 2.0.6;
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llvm -o %t %s
+
+template SMTProcessorSM() {
+  signal input prev_new1;
+  signal input prev_na;
+}
+
+template SMTProcessor(nLevels) {
+    signal input enabled;
+
+    component sm[nLevels];
+    for (var i=0; i<nLevels; i++) {
+        sm[i] = SMTProcessorSM();
+        if (i==0) {
+            sm[i].prev_new1 <-- 0;
+            sm[i].prev_na <-- 1 - enabled;
+        } else {
+            sm[i].prev_new1 <-- 0;
+            sm[i].prev_na <-- 0;
+        }
+    }
+}
+
+component main = SMTProcessor(2);

--- a/circuit_passes/src/passes/loop_unroll/body_extractor.rs
+++ b/circuit_passes/src/passes/loop_unroll/body_extractor.rs
@@ -266,8 +266,8 @@ impl LoopBodyExtractor {
             //  after the current statement and insert them after the updated statement.
             //NOTE: nothing will be updated or added if 'bucket_to_args' is empty so skip.
             if !bucket_to_args.is_empty() {
-                let mut upd = ExtractedFunctionLocationUpdater::new();
-                upd.check_instructions(&mut copy, &mut bucket_to_args, true);
+                let mut upd = ExtractedFunctionLocationUpdater::new(&mut bucket_to_args);
+                upd.check_instructions(&mut copy);
             }
             for mut s in copy.drain(..) {
                 s.update_id();


### PR DESCRIPTION
The old approach would append the `insert_after` list at the tail of the existing `InstructionList` once all instructions were processed but that would cause an assertion failure in some cases and was actually not quite correct to do. The new approach inserts the current `insert_after` list immediately following each instruction as they are processed.