### PR TITLE
[VAN-846] use External linkage kind on all template functions

### DIFF
--- a/compiler/src/circuit_design/template.rs
+++ b/compiler/src/circuit_design/template.rs
@@ -151,10 +151,8 @@ impl WriteLLVMIR for TemplateCodeInfo {
         build_function.set_section(Some(&self.name));
 
         // Set External linkage so main template functions are not removed by global DCE
-        if self.header.eq(producer.get_main_template_header()) {
-            run_function.set_linkage(Linkage::External);
-            build_function.set_linkage(Linkage::External);
-        }
+        run_function.set_linkage(Linkage::External);
+        build_function.set_linkage(Linkage::External);
         Some(ret)
     }
 }


### PR DESCRIPTION
This forces the identical function merging pass to retain all `build` and `run` function definitions but the ones that would have been removed (due to being identical to some other function) will instead be converted into a delegating function like the following:
```
define dso_local void @MixS_8_build({ [0 x i256]*, i32 }* %0) section ",MixS" {
  tail call void @MixS_10_build({ [0 x i256]*, i32 }* %0)
  ret void
}
```