### PR TITLE
Fix a regression and refactor some functions to a better location

### DIFF
--- a/circuit_passes/src/bucket_interpreter/env/standard_env.rs
+++ b/circuit_passes/src/bucket_interpreter/env/standard_env.rs
@@ -4,8 +4,8 @@ use std::fmt::{Display, Formatter};
 use compiler::circuit_design::function::FunctionCode;
 use compiler::circuit_design::template::TemplateCode;
 use compiler::intermediate_representation::BucketId;
-use crate::bucket_interpreter::error::BadInterp;
-use crate::bucket_interpreter::{BucketInterpreter, new_inconsistency_err};
+use crate::bucket_interpreter::error::{BadInterp, new_inconsistency_err};
+use crate::bucket_interpreter::BucketInterpreter;
 use crate::bucket_interpreter::value::Value;
 use super::{SubcmpEnv, LibraryAccess};
 

--- a/circuit_passes/src/bucket_interpreter/error.rs
+++ b/circuit_passes/src/bucket_interpreter/error.rs
@@ -79,3 +79,30 @@ impl BadInterp {
         res
     }
 }
+
+#[inline]
+pub fn new_compute_err<S: ToString>(msg: S) -> BadInterp {
+    BadInterp::error(msg.to_string(), ReportCode::NonComputableExpression)
+}
+
+#[inline]
+pub fn new_compute_err_result<S: ToString, R>(msg: S) -> Result<R, BadInterp> {
+    Err(new_compute_err(msg))
+}
+
+#[inline]
+pub fn new_inconsistency_err<S: ToString>(msg: S) -> BadInterp {
+    BadInterp::error(msg.to_string(), ReportCode::InconsistentStaticInformation)
+}
+
+#[inline]
+pub fn add_loc_if_err<R, B: ObtainMeta>(
+    report: Result<R, BadInterp>,
+    loc: &B,
+) -> Result<R, BadInterp> {
+    report.map_err(|r| {
+        let mut new_r = r;
+        new_r.add_location(loc);
+        new_r
+    })
+}

--- a/circuit_passes/src/bucket_interpreter/operations.rs
+++ b/circuit_passes/src/bucket_interpreter/operations.rs
@@ -1,9 +1,7 @@
 use circom_algebra::num_bigint::BigInt;
 use compiler::intermediate_representation::ir_interface::{ComputeBucket, OperatorType};
-use crate::bucket_interpreter::{value, new_inconsistency_err};
-use crate::bucket_interpreter::value::{resolve_operation, Value};
-use crate::bucket_interpreter::value::Value::KnownU32;
-use super::error::BadInterp;
+use super::error::{BadInterp, new_inconsistency_err};
+use super::value::{self, resolve_operation, Value, Value::KnownU32};
 
 pub fn compute_operation(
     bucket: &ComputeBucket,

--- a/circuit_passes/src/passes/loop_unroll/loop_env_recorder.rs
+++ b/circuit_passes/src/passes/loop_unroll/loop_env_recorder.rs
@@ -147,9 +147,13 @@ impl<'a, 'd> EnvRecorder<'a, 'd> {
         let interp = self.mem.build_interpreter(self.global_data, self);
         let (idx_loc, _) = interp.execute_instruction(location, env.clone(), false)?;
         if let Some(idx_loc) = idx_loc {
-            let (idx_header, _) =
-                interp.execute_instruction(location, self.get_header_env_clone(), false)?;
-            if let Some(idx_header) = idx_header {
+            // NOTE: It's possible for the interpreter to run into problems evaluating the location
+            //  using the header Env. For example, a value may not have been defined yet so address
+            //  computations on that value could give out of range results for the 'usize' type.
+            //  Thus, these errors should be ignored and fall through into the Ok(Unknown) case.
+            let header_res =
+                interp.execute_instruction(location, self.get_header_env_clone(), false);
+            if let Ok((Some(idx_header), _)) = header_res {
                 if Value::eq(&idx_header, &idx_loc) {
                     return Ok(idx_loc);
                 }

--- a/circuit_passes/src/passes/unknown_index_sanitization.rs
+++ b/circuit_passes/src/passes/unknown_index_sanitization.rs
@@ -9,11 +9,11 @@ use compiler::num_bigint::BigInt;
 use code_producers::llvm_elements::array_switch::{get_array_load_name, get_array_store_name};
 use program_structure::constants::UsefulConstants;
 use crate::bucket_interpreter::env::Env;
-use crate::bucket_interpreter::error::BadInterp;
+use crate::bucket_interpreter::error::{BadInterp, add_loc_if_err};
 use crate::bucket_interpreter::memory::PassMemory;
 use crate::bucket_interpreter::observer::Observer;
 use crate::bucket_interpreter::operations::compute_operation;
-use crate::bucket_interpreter::{R, to_bigint, add_loc_if_err, into_result};
+use crate::bucket_interpreter::{R, to_bigint, into_result};
 use crate::bucket_interpreter::value::Value::{KnownU32, KnownBigInt};
 use crate::{
     default__get_updated_field_constants, default__name, default__pre_hook_template,


### PR DESCRIPTION
1. Fix regression introduced when converting panics to meaningful error messages. There was one location where the panic was caught and ignored so a Result::Err should have also been ignored in that location but was not.
2. Move helper functions for creating error messages into the error.rs file instead of the module file for the interpreter.