### PR TITLE
Update inkwell dependency to latest release from upstream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -653,8 +653,8 @@ dependencies = [
 
 [[package]]
 name = "inkwell"
-version = "0.1.1"
-source = "git+https://github.com/Veridise/inkwell?branch=master#828650aed2077753a74dad9a6d81188ad271e078"
+version = "0.2.0"
+source = "git+https://github.com/TheDan64/inkwell?tag=0.2.0#04fac601505b572e1b0af2890dfb262f40afe814"
 dependencies = [
  "either",
  "inkwell_internals",
@@ -666,12 +666,12 @@ dependencies = [
 
 [[package]]
 name = "inkwell_internals"
-version = "0.7.0"
-source = "git+https://github.com/Veridise/inkwell?branch=master#828650aed2077753a74dad9a6d81188ad271e078"
+version = "0.8.0"
+source = "git+https://github.com/TheDan64/inkwell?tag=0.2.0#04fac601505b572e1b0af2890dfb262f40afe814"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -990,7 +990,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn",
 ]
 
 [[package]]
@@ -1333,7 +1333,7 @@ checksum = "a3385e45322e8f9931410f01b3031ec534c3947d0e94c18049af4d9f9907d4e0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn",
 ]
 
 [[package]]
@@ -1405,17 +1405,6 @@ dependencies = [
  "program_structure",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
 ]
 
 [[package]]
@@ -1494,7 +1483,7 @@ checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn",
 ]
 
 [[package]]

--- a/code_producers/Cargo.toml
+++ b/code_producers/Cargo.toml
@@ -13,9 +13,9 @@ handlebars = "4.1.3"
 lz_fnv = "0.1.2"
 num-bigint-dig = "0.6.0"
 serde_json = "1.0.68"
-inkwell = { git = "https://github.com/Veridise/inkwell", branch = "master", features = ["llvm13-0"] }
+inkwell = { git = "https://github.com/TheDan64/inkwell", tag = "0.2.0", features = ["llvm13-0"] }
 # Cause llvm-sys to link against LLVM dynamically if possible. This helps prevent some linker errors on macOS.
-# TODO: update our fork of inkwell since upstream has a feature flag for this now.
+# NOTE: inkwell has the "llvm13-0-prefer-dynamic" feature flag for this if we update to commit 4030f764f1c889f36429ac02ef32e04fcfa8ce33.
 llvm-sys = { version = "130", features = ["prefer-dynamic"] }
 ansi_term = "0.12.1"
 uuid = "1.3.4"


### PR DESCRIPTION
The Veridise fork of inkwell contained only a single function addition which we don't use any longer so migrating back to the upstream repo.