### PR TITLE
Avoid generating dead code and update tests

### DIFF
--- a/circom/tests/arrays/unknown_index_unconstrained.circom
+++ b/circom/tests/arrays/unknown_index_unconstrained.circom
@@ -19,7 +19,7 @@ component main = UnknownIndex();
 //CHECK-LABEL: define{{.*}} i256 @__array_load__0_to_10([0 x i256]* %0, i32 %1) {
 //
 //CHECK-LABEL: define{{.*}} void @UnknownIndex_{{[0-9]+}}_run([0 x i256]* %0){{.*}} {
+//CHECK:        %[[T04:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
 //CHECK:        %[[T03:[0-9a-zA-Z_.]+]] = call i256 @__array_load__0_to_10([0 x i256]* %{{[0-9a-zA-Z_.]+}}, i32 %{{[0-9a-zA-Z_.]+}})
-//CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
 //CHECK-NEXT:   store i256 %[[T03]], i256* %[[T04]], align 4
 //CHECK-NEXT:   br label %prologue

--- a/circom/tests/calls/call_arg_arraymulti.circom
+++ b/circom/tests/calls/call_arg_arraymulti.circom
@@ -26,75 +26,75 @@ component main = CallArgTest();
 //CHECK-NEXT:   br label %store1
 //CHECK-EMPTY:
 //CHECK-NEXT: store1:
-//CHECK-NEXT:   %1 = getelementptr i256, i256* %0, i32 6
-//CHECK-NEXT:   store i256 0, i256* %1, align 4
+//CHECK-NEXT:   %[[T01:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 6
+//CHECK-NEXT:   store i256 0, i256* %[[T01]], align 4
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY:
 //CHECK-NEXT: store2:
-//CHECK-NEXT:   %2 = getelementptr i256, i256* %0, i32 7
-//CHECK-NEXT:   store i256 0, i256* %2, align 4
+//CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 7
+//CHECK-NEXT:   store i256 0, i256* %[[T02]], align 4
 //CHECK-NEXT:   br label %loop3
 //CHECK-EMPTY:
 //CHECK-NEXT: loop3:
 //CHECK-NEXT:   br label %loop.cond
 //CHECK-EMPTY:
 //CHECK-NEXT: loop.cond:
-//CHECK-NEXT:   %3 = getelementptr i256, i256* %0, i32 7
-//CHECK-NEXT:   %4 = load i256, i256* %3, align 4
-//CHECK-NEXT:   %call.fr_lt = call i1 @fr_lt(i256 %4, i256 3)
+//CHECK-NEXT:   %[[T03:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 7
+//CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T03]], align 4
+//CHECK-NEXT:   %call.fr_lt = call i1 @fr_lt(i256 %[[T04]], i256 3)
 //CHECK-NEXT:   br i1 %call.fr_lt, label %loop.body, label %loop.end
 //CHECK-EMPTY:
 //CHECK-NEXT: loop.body:
-//CHECK-NEXT:   %5 = getelementptr i256, i256* %0, i32 8
-//CHECK-NEXT:   store i256 0, i256* %5, align 4
+//CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 8
+//CHECK-NEXT:   store i256 0, i256* %[[T05]], align 4
 //CHECK-NEXT:   br label %loop.cond1
 //CHECK-EMPTY:
 //CHECK-NEXT: loop.end:
 //CHECK-NEXT:   br label %return10
 //CHECK-EMPTY:
 //CHECK-NEXT: loop.cond1:
-//CHECK-NEXT:   %6 = getelementptr i256, i256* %0, i32 8
-//CHECK-NEXT:   %7 = load i256, i256* %6, align 4
-//CHECK-NEXT:   %call.fr_lt4 = call i1 @fr_lt(i256 %7, i256 2)
+//CHECK-NEXT:   %[[T06:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 8
+//CHECK-NEXT:   %[[T07:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T06]], align 4
+//CHECK-NEXT:   %call.fr_lt4 = call i1 @fr_lt(i256 %[[T07]], i256 2)
 //CHECK-NEXT:   br i1 %call.fr_lt4, label %loop.body2, label %loop.end3
 //CHECK-EMPTY:
 //CHECK-NEXT: loop.body2:
-//CHECK-NEXT:   %8 = getelementptr i256, i256* %0, i32 6
-//CHECK-NEXT:   %9 = load i256, i256* %8, align 4
-//CHECK-NEXT:   %10 = getelementptr i256, i256* %0, i32 7
-//CHECK-NEXT:   %11 = load i256, i256* %10, align 4
-//CHECK-NEXT:   %call.fr_cast_to_addr = call i32 @fr_cast_to_addr(i256 %11)
+//CHECK-NEXT:   %[[T16:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 6
+//CHECK-NEXT:   %[[T08:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 6
+//CHECK-NEXT:   %[[T09:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T08]], align 4
+//CHECK-NEXT:   %[[T10:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 7
+//CHECK-NEXT:   %[[T11:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T10]], align 4
+//CHECK-NEXT:   %call.fr_cast_to_addr = call i32 @fr_cast_to_addr(i256 %[[T11]])
 //CHECK-NEXT:   %mul_addr = mul i32 2, %call.fr_cast_to_addr
-//CHECK-NEXT:   %12 = getelementptr i256, i256* %0, i32 8
-//CHECK-NEXT:   %13 = load i256, i256* %12, align 4
-//CHECK-NEXT:   %call.fr_cast_to_addr5 = call i32 @fr_cast_to_addr(i256 %13)
+//CHECK-NEXT:   %[[T12:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 8
+//CHECK-NEXT:   %[[T13:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T12]], align 4
+//CHECK-NEXT:   %call.fr_cast_to_addr5 = call i32 @fr_cast_to_addr(i256 %[[T13]])
 //CHECK-NEXT:   %mul_addr6 = mul i32 1, %call.fr_cast_to_addr5
 //CHECK-NEXT:   %add_addr = add i32 %mul_addr, %mul_addr6
 //CHECK-NEXT:   %add_addr7 = add i32 %add_addr, 0
-//CHECK-NEXT:   %14 = getelementptr i256, i256* %0, i32 %add_addr7
-//CHECK-NEXT:   %15 = load i256, i256* %14, align 4
-//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %9, i256 %15)
-//CHECK-NEXT:   %16 = getelementptr i256, i256* %0, i32 6
-//CHECK-NEXT:   store i256 %call.fr_add, i256* %16, align 4
-//CHECK-NEXT:   %17 = getelementptr i256, i256* %0, i32 8
-//CHECK-NEXT:   %18 = load i256, i256* %17, align 4
-//CHECK-NEXT:   %call.fr_add8 = call i256 @fr_add(i256 %18, i256 1)
-//CHECK-NEXT:   %19 = getelementptr i256, i256* %0, i32 8
-//CHECK-NEXT:   store i256 %call.fr_add8, i256* %19, align 4
+//CHECK-NEXT:   %[[T14:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 %add_addr7
+//CHECK-NEXT:   %[[T15:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T14]], align 4
+//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %[[T09]], i256 %[[T15]])
+//CHECK-NEXT:   store i256 %call.fr_add, i256* %[[T16]], align 4
+//CHECK-NEXT:   %[[T19:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 8
+//CHECK-NEXT:   %[[T17:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 8
+//CHECK-NEXT:   %[[T18:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T17]], align 4
+//CHECK-NEXT:   %call.fr_add8 = call i256 @fr_add(i256 %[[T18]], i256 1)
+//CHECK-NEXT:   store i256 %call.fr_add8, i256* %[[T19]], align 4
 //CHECK-NEXT:   br label %loop.cond1
 //CHECK-EMPTY:
 //CHECK-NEXT: loop.end3:
-//CHECK-NEXT:   %20 = getelementptr i256, i256* %0, i32 7
-//CHECK-NEXT:   %21 = load i256, i256* %20, align 4
-//CHECK-NEXT:   %call.fr_add9 = call i256 @fr_add(i256 %21, i256 1)
-//CHECK-NEXT:   %22 = getelementptr i256, i256* %0, i32 7
-//CHECK-NEXT:   store i256 %call.fr_add9, i256* %22, align 4
+//CHECK-NEXT:   %[[T22:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 7
+//CHECK-NEXT:   %[[T20:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 7
+//CHECK-NEXT:   %[[T21:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T20]], align 4
+//CHECK-NEXT:   %call.fr_add9 = call i256 @fr_add(i256 %[[T21]], i256 1)
+//CHECK-NEXT:   store i256 %call.fr_add9, i256* %[[T22]], align 4
 //CHECK-NEXT:   br label %loop.cond
 //CHECK-EMPTY:
 //CHECK-NEXT: return10:
-//CHECK-NEXT:   %23 = getelementptr i256, i256* %0, i32 6
-//CHECK-NEXT:   %24 = load i256, i256* %23, align 4
-//CHECK-NEXT:   ret i256 %24
+//CHECK-NEXT:   %[[T23:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 6
+//CHECK-NEXT:   %[[T24:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T23]], align 4
+//CHECK-NEXT:   ret i256 %[[T24]]
 //CHECK-NEXT: }
 //
 //CHECK-LABEL: define{{.*}} void @CallArgTest_0_run([0 x i256]* %0){{.*}} {
@@ -105,13 +105,13 @@ component main = CallArgTest();
 //CHECK-EMPTY:
 //CHECK-NEXT: call1:
 //CHECK-NEXT:   %sum_0_arena = alloca [9 x i256], align 8
-//CHECK-NEXT:   %1 = getelementptr [9 x i256], [9 x i256]* %sum_0_arena, i32 0, i32 0
-//CHECK-NEXT:   %2 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 1
-//CHECK-NEXT:   call void @fr_copy_n(i256* %2, i256* %1, i32 6)
-//CHECK-NEXT:   %3 = bitcast [9 x i256]* %sum_0_arena to i256*
-//CHECK-NEXT:   %call.sum_0 = call i256 @sum_0(i256* %3)
-//CHECK-NEXT:   %4 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
-//CHECK-NEXT:   store i256 %call.sum_0, i256* %4, align 4
+//CHECK-NEXT:   %[[T01:[0-9a-zA-Z_.]+]] = getelementptr [9 x i256], [9 x i256]* %sum_0_arena, i32 0, i32 0
+//CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 1
+//CHECK-NEXT:   call void @fr_copy_n(i256* %[[T02]], i256* %[[T01]], i32 6)
+//CHECK-NEXT:   %[[T03:[0-9a-zA-Z_.]+]] = bitcast [9 x i256]* %sum_0_arena to i256*
+//CHECK-NEXT:   %call.sum_0 = call i256 @sum_0(i256* %[[T03]])
+//CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
+//CHECK-NEXT:   store i256 %call.sum_0, i256* %[[T04]], align 4
 //CHECK-NEXT:   br label %prologue
 //CHECK-EMPTY:
 //CHECK-NEXT: prologue:

--- a/circom/tests/calls/call_arg_arraymulti_arraymulti.circom
+++ b/circom/tests/calls/call_arg_arraymulti_arraymulti.circom
@@ -27,88 +27,88 @@ component main = CallArgTest();
 //CHECK-NEXT:   br label %store1
 //CHECK-EMPTY:
 //CHECK-NEXT: store1:
-//CHECK-NEXT:   %1 = getelementptr i256, i256* %0, i32 12
-//CHECK-NEXT:   store i256 0, i256* %1, align 4
+//CHECK-NEXT:   %[[T01:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 12
+//CHECK-NEXT:   store i256 0, i256* %[[T01]], align 4
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY:
 //CHECK-NEXT: store2:
-//CHECK-NEXT:   %2 = getelementptr i256, i256* %0, i32 13
-//CHECK-NEXT:   store i256 0, i256* %2, align 4
+//CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 13
+//CHECK-NEXT:   store i256 0, i256* %[[T02]], align 4
 //CHECK-NEXT:   br label %loop3
 //CHECK-EMPTY:
 //CHECK-NEXT: loop3:
 //CHECK-NEXT:   br label %loop.cond
 //CHECK-EMPTY:
 //CHECK-NEXT: loop.cond:
-//CHECK-NEXT:   %3 = getelementptr i256, i256* %0, i32 13
-//CHECK-NEXT:   %4 = load i256, i256* %3, align 4
-//CHECK-NEXT:   %call.fr_lt = call i1 @fr_lt(i256 %4, i256 3)
+//CHECK-NEXT:   %[[T03:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 13
+//CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T03]], align 4
+//CHECK-NEXT:   %call.fr_lt = call i1 @fr_lt(i256 %[[T04]], i256 3)
 //CHECK-NEXT:   br i1 %call.fr_lt, label %loop.body, label %loop.end
 //CHECK-EMPTY:
 //CHECK-NEXT: loop.body:
-//CHECK-NEXT:   %5 = getelementptr i256, i256* %0, i32 14
-//CHECK-NEXT:   store i256 0, i256* %5, align 4
+//CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 14
+//CHECK-NEXT:   store i256 0, i256* %[[T05]], align 4
 //CHECK-NEXT:   br label %loop.cond1
 //CHECK-EMPTY:
 //CHECK-NEXT: loop.end:
 //CHECK-NEXT:   br label %return10
 //CHECK-EMPTY:
 //CHECK-NEXT: loop.cond1:
-//CHECK-NEXT:   %6 = getelementptr i256, i256* %0, i32 14
-//CHECK-NEXT:   %7 = load i256, i256* %6, align 4
-//CHECK-NEXT:   %call.fr_lt4 = call i1 @fr_lt(i256 %7, i256 2)
+//CHECK-NEXT:   %[[T06:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 14
+//CHECK-NEXT:   %[[T07:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T06]], align 4
+//CHECK-NEXT:   %call.fr_lt4 = call i1 @fr_lt(i256 %[[T07]], i256 2)
 //CHECK-NEXT:   br i1 %call.fr_lt4, label %loop.body2, label %loop.end3
 //CHECK-EMPTY:
 //CHECK-NEXT: loop.body2:
-//CHECK-NEXT:   %8 = getelementptr i256, i256* %0, i32 12
-//CHECK-NEXT:   %9 = load i256, i256* %8, align 4
-//CHECK-NEXT:   %10 = getelementptr i256, i256* %0, i32 13
-//CHECK-NEXT:   %11 = load i256, i256* %10, align 4
-//CHECK-NEXT:   %call.fr_cast_to_addr = call i32 @fr_cast_to_addr(i256 %11)
+//CHECK-NEXT:   %[[T22:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 12
+//CHECK-NEXT:   %[[T08:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 12
+//CHECK-NEXT:   %[[T09:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T08]], align 4
+//CHECK-NEXT:   %[[T10:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 13
+//CHECK-NEXT:   %[[T11:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T10]], align 4
+//CHECK-NEXT:   %call.fr_cast_to_addr = call i32 @fr_cast_to_addr(i256 %[[T11]])
 //CHECK-NEXT:   %mul_addr = mul i32 2, %call.fr_cast_to_addr
-//CHECK-NEXT:   %12 = getelementptr i256, i256* %0, i32 14
-//CHECK-NEXT:   %13 = load i256, i256* %12, align 4
-//CHECK-NEXT:   %call.fr_cast_to_addr5 = call i32 @fr_cast_to_addr(i256 %13)
+//CHECK-NEXT:   %[[T12:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 14
+//CHECK-NEXT:   %[[T13:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T12]], align 4
+//CHECK-NEXT:   %call.fr_cast_to_addr5 = call i32 @fr_cast_to_addr(i256 %[[T13]])
 //CHECK-NEXT:   %mul_addr6 = mul i32 1, %call.fr_cast_to_addr5
 //CHECK-NEXT:   %add_addr = add i32 %mul_addr, %mul_addr6
 //CHECK-NEXT:   %add_addr7 = add i32 %add_addr, 0
-//CHECK-NEXT:   %14 = getelementptr i256, i256* %0, i32 %add_addr7
-//CHECK-NEXT:   %15 = load i256, i256* %14, align 4
-//CHECK-NEXT:   %16 = getelementptr i256, i256* %0, i32 13
-//CHECK-NEXT:   %17 = load i256, i256* %16, align 4
-//CHECK-NEXT:   %call.fr_cast_to_addr8 = call i32 @fr_cast_to_addr(i256 %17)
+//CHECK-NEXT:   %[[T14:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 %add_addr7
+//CHECK-NEXT:   %[[T15:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T14]], align 4
+//CHECK-NEXT:   %[[T16:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 13
+//CHECK-NEXT:   %[[T17:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T16]], align 4
+//CHECK-NEXT:   %call.fr_cast_to_addr8 = call i32 @fr_cast_to_addr(i256 %[[T17]])
 //CHECK-NEXT:   %mul_addr9 = mul i32 2, %call.fr_cast_to_addr8
-//CHECK-NEXT:   %18 = getelementptr i256, i256* %0, i32 14
-//CHECK-NEXT:   %19 = load i256, i256* %18, align 4
-//CHECK-NEXT:   %call.fr_cast_to_addr10 = call i32 @fr_cast_to_addr(i256 %19)
+//CHECK-NEXT:   %[[T18:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 14
+//CHECK-NEXT:   %[[T19:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T18]], align 4
+//CHECK-NEXT:   %call.fr_cast_to_addr10 = call i32 @fr_cast_to_addr(i256 %[[T19]])
 //CHECK-NEXT:   %mul_addr11 = mul i32 1, %call.fr_cast_to_addr10
 //CHECK-NEXT:   %add_addr12 = add i32 %mul_addr9, %mul_addr11
 //CHECK-NEXT:   %add_addr13 = add i32 %add_addr12, 6
-//CHECK-NEXT:   %20 = getelementptr i256, i256* %0, i32 %add_addr13
-//CHECK-NEXT:   %21 = load i256, i256* %20, align 4
-//CHECK-NEXT:   %call.fr_sub = call i256 @fr_sub(i256 %15, i256 %21)
-//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %9, i256 %call.fr_sub)
-//CHECK-NEXT:   %22 = getelementptr i256, i256* %0, i32 12
-//CHECK-NEXT:   store i256 %call.fr_add, i256* %22, align 4
-//CHECK-NEXT:   %23 = getelementptr i256, i256* %0, i32 14
-//CHECK-NEXT:   %24 = load i256, i256* %23, align 4
-//CHECK-NEXT:   %call.fr_add14 = call i256 @fr_add(i256 %24, i256 1)
-//CHECK-NEXT:   %25 = getelementptr i256, i256* %0, i32 14
-//CHECK-NEXT:   store i256 %call.fr_add14, i256* %25, align 4
+//CHECK-NEXT:   %[[T20:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 %add_addr13
+//CHECK-NEXT:   %[[T21:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T20]], align 4
+//CHECK-NEXT:   %call.fr_sub = call i256 @fr_sub(i256 %[[T15]], i256 %[[T21]])
+//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %[[T09]], i256 %call.fr_sub)
+//CHECK-NEXT:   store i256 %call.fr_add, i256* %[[T22]], align 4
+//CHECK-NEXT:   %[[T25:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 14
+//CHECK-NEXT:   %[[T23:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 14
+//CHECK-NEXT:   %[[T24:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T23]], align 4
+//CHECK-NEXT:   %call.fr_add14 = call i256 @fr_add(i256 %[[T24]], i256 1)
+//CHECK-NEXT:   store i256 %call.fr_add14, i256* %[[T25]], align 4
 //CHECK-NEXT:   br label %loop.cond1
 //CHECK-EMPTY:
 //CHECK-NEXT: loop.end3:
-//CHECK-NEXT:   %26 = getelementptr i256, i256* %0, i32 13
-//CHECK-NEXT:   %27 = load i256, i256* %26, align 4
-//CHECK-NEXT:   %call.fr_add15 = call i256 @fr_add(i256 %27, i256 1)
-//CHECK-NEXT:   %28 = getelementptr i256, i256* %0, i32 13
-//CHECK-NEXT:   store i256 %call.fr_add15, i256* %28, align 4
+//CHECK-NEXT:   %[[T28:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 13
+//CHECK-NEXT:   %[[T26:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 13
+//CHECK-NEXT:   %[[T27:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T26]], align 4
+//CHECK-NEXT:   %call.fr_add15 = call i256 @fr_add(i256 %[[T27]], i256 1)
+//CHECK-NEXT:   store i256 %call.fr_add15, i256* %[[T28]], align 4
 //CHECK-NEXT:   br label %loop.cond
 //CHECK-EMPTY:
 //CHECK-NEXT: return10:
-//CHECK-NEXT:   %29 = getelementptr i256, i256* %0, i32 12
-//CHECK-NEXT:   %30 = load i256, i256* %29, align 4
-//CHECK-NEXT:   ret i256 %30
+//CHECK-NEXT:   %[[T29:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 12
+//CHECK-NEXT:   %[[T30:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T29]], align 4
+//CHECK-NEXT:   ret i256 %[[T30]]
 //CHECK-NEXT: }
 //
 //CHECK-LABEL: define{{.*}} void @CallArgTest_0_run([0 x i256]* %0){{.*}} {
@@ -119,16 +119,16 @@ component main = CallArgTest();
 //CHECK-EMPTY:
 //CHECK-NEXT: call1:
 //CHECK-NEXT:   %sum_0_arena = alloca [15 x i256], align 8
-//CHECK-NEXT:   %1 = getelementptr [15 x i256], [15 x i256]* %sum_0_arena, i32 0, i32 0
-//CHECK-NEXT:   %2 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 1
-//CHECK-NEXT:   call void @fr_copy_n(i256* %2, i256* %1, i32 6)
-//CHECK-NEXT:   %3 = getelementptr [15 x i256], [15 x i256]* %sum_0_arena, i32 0, i32 6
-//CHECK-NEXT:   %4 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 7
-//CHECK-NEXT:   call void @fr_copy_n(i256* %4, i256* %3, i32 6)
-//CHECK-NEXT:   %5 = bitcast [15 x i256]* %sum_0_arena to i256*
-//CHECK-NEXT:   %call.sum_0 = call i256 @sum_0(i256* %5)
-//CHECK-NEXT:   %6 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
-//CHECK-NEXT:   store i256 %call.sum_0, i256* %6, align 4
+//CHECK-NEXT:   %[[T01:[0-9a-zA-Z_.]+]] = getelementptr [15 x i256], [15 x i256]* %sum_0_arena, i32 0, i32 0
+//CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 1
+//CHECK-NEXT:   call void @fr_copy_n(i256* %[[T02]], i256* %[[T01]], i32 6)
+//CHECK-NEXT:   %[[T03:[0-9a-zA-Z_.]+]] = getelementptr [15 x i256], [15 x i256]* %sum_0_arena, i32 0, i32 6
+//CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 7
+//CHECK-NEXT:   call void @fr_copy_n(i256* %[[T04]], i256* %[[T03]], i32 6)
+//CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = bitcast [15 x i256]* %sum_0_arena to i256*
+//CHECK-NEXT:   %call.sum_0 = call i256 @sum_0(i256* %[[T05]])
+//CHECK-NEXT:   %[[T06:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
+//CHECK-NEXT:   store i256 %call.sum_0, i256* %[[T06]], align 4
 //CHECK-NEXT:   br label %prologue
 //CHECK-EMPTY:
 //CHECK-NEXT: prologue:

--- a/circom/tests/calls/call_arg_arrays_complex_A.circom
+++ b/circom/tests/calls/call_arg_arrays_complex_A.circom
@@ -18,14 +18,14 @@ template CallArgTest() {
 component main = CallArgTest();
 
 //CHECK-LABEL: define{{.*}} i256* @sum_0(i256* %0){{.*}} {
-//CHECK:        %3 = getelementptr i256, i256* %0, i32 0
-//CHECK-NEXT:   %4 = getelementptr i256, i256* %0, i32 9
-//CHECK-NEXT:   call void @fr_copy_n(i256* %4, i256* %3, i32 3)
+//CHECK:        %[[T03:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 0
+//CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 9
+//CHECK-NEXT:   call void @fr_copy_n(i256* %[[T04]], i256* %[[T03]], i32 3)
 //CHECK-NEXT:   br label %return2
 //CHECK-EMPTY:
 //CHECK-NEXT: return2:
-//CHECK-NEXT:   %5 = getelementptr i256, i256* %0, i32 6
-//CHECK-NEXT:   ret i256* %5
+//CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 6
+//CHECK-NEXT:   ret i256* %[[T05]]
 //CHECK-NEXT: }
 //
 //CHECK-LABEL: define{{.*}} void @CallArgTest_0_run([0 x i256]* %0){{.*}} {
@@ -36,16 +36,16 @@ component main = CallArgTest();
 //CHECK-EMPTY:
 //CHECK-NEXT: call1:
 //CHECK-NEXT:   %sum_0_arena = alloca [12 x i256], align 8
-//CHECK-NEXT:   %1 = getelementptr [12 x i256], [12 x i256]* %sum_0_arena, i32 0, i32 0
-//CHECK-NEXT:   %2 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 6
-//CHECK-NEXT:   call void @fr_copy_n(i256* %2, i256* %1, i32 6)
-//CHECK-NEXT:   %3 = getelementptr [12 x i256], [12 x i256]* %sum_0_arena, i32 0, i32 6
-//CHECK-NEXT:   %4 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 12
-//CHECK-NEXT:   call void @fr_copy_n(i256* %4, i256* %3, i32 6)
-//CHECK-NEXT:   %5 = bitcast [12 x i256]* %sum_0_arena to i256*
-//CHECK-NEXT:   %call.sum_0 = call i256* @sum_0(i256* %5)
-//CHECK-NEXT:   %6 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
-//CHECK-NEXT:   call void @fr_copy_n(i256* %call.sum_0, i256* %6, i32 6)
+//CHECK-NEXT:   %[[T01:[0-9a-zA-Z_.]+]] = getelementptr [12 x i256], [12 x i256]* %sum_0_arena, i32 0, i32 0
+//CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 6
+//CHECK-NEXT:   call void @fr_copy_n(i256* %[[T02]], i256* %[[T01]], i32 6)
+//CHECK-NEXT:   %[[T03:[0-9a-zA-Z_.]+]] = getelementptr [12 x i256], [12 x i256]* %sum_0_arena, i32 0, i32 6
+//CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 12
+//CHECK-NEXT:   call void @fr_copy_n(i256* %[[T04]], i256* %[[T03]], i32 6)
+//CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = bitcast [12 x i256]* %sum_0_arena to i256*
+//CHECK-NEXT:   %call.sum_0 = call i256* @sum_0(i256* %[[T05]])
+//CHECK-NEXT:   %[[T06:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
+//CHECK-NEXT:   call void @fr_copy_n(i256* %call.sum_0, i256* %[[T06]], i32 6)
 //CHECK-NEXT:   br label %prologue
 //CHECK-EMPTY:
 //CHECK-NEXT: prologue:

--- a/circom/tests/calls/call_arg_arrays_complex_B.circom
+++ b/circom/tests/calls/call_arg_arrays_complex_B.circom
@@ -20,20 +20,20 @@ component main = CallArgTest();
 
 //CHECK-LABEL: define{{.*}} i256* @sum_0(i256* %0){{.*}} {
 //CHECK:      store1:
-//CHECK:        %3 = getelementptr i256, i256* %0, i32 6
-//CHECK-NEXT:   %4 = getelementptr i256, i256* %0, i32 3
-//CHECK-NEXT:   call void @fr_copy_n(i256* %4, i256* %3, i32 3)
+//CHECK:        %[[T03:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 6
+//CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 3
+//CHECK-NEXT:   call void @fr_copy_n(i256* %[[T04]], i256* %[[T03]], i32 3)
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY:
 //CHECK:      store2:
-//CHECK:        %7 = getelementptr i256, i256* %0, i32 9
-//CHECK-NEXT:   %8 = getelementptr i256, i256* %0, i32 0
-//CHECK-NEXT:   call void @fr_copy_n(i256* %8, i256* %7, i32 3)
+//CHECK:        %[[T07:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 9
+//CHECK-NEXT:   %[[T08:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 0
+//CHECK-NEXT:   call void @fr_copy_n(i256* %[[T08]], i256* %[[T07]], i32 3)
 //CHECK-NEXT:   br label %return3
 //CHECK-EMPTY:
 //CHECK-NEXT: return3:
-//CHECK-NEXT:   %9 = getelementptr i256, i256* %0, i32 6
-//CHECK-NEXT:   ret i256* %9
+//CHECK-NEXT:   %[[T09:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 6
+//CHECK-NEXT:   ret i256* %[[T09]]
 //CHECK-NEXT: }
 //
 //CHECK-LABEL: define{{.*}} void @CallArgTest_0_run([0 x i256]* %0){{.*}} {
@@ -43,48 +43,44 @@ component main = CallArgTest();
 //CHECK-NEXT:   br label %store1
 //CHECK-EMPTY:
 //CHECK-NEXT: store1:
-//CHECK-NEXT:   %1 = getelementptr [9 x i256], [9 x i256]* %lvars, i32 0, i32 6
-//CHECK-NEXT:   store i256 0, i256* %1, align 4
+//CHECK-NEXT:   %[[T01:[0-9a-zA-Z_.]+]] = getelementptr [9 x i256], [9 x i256]* %lvars, i32 0, i32 6
+//CHECK-NEXT:   store i256 0, i256* %[[T01]], align 4
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY:
 //CHECK-NEXT: store2:
-//CHECK-NEXT:   %2 = getelementptr [9 x i256], [9 x i256]* %lvars, i32 0, i32 7
-//CHECK-NEXT:   store i256 0, i256* %2, align 4
+//CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr [9 x i256], [9 x i256]* %lvars, i32 0, i32 7
+//CHECK-NEXT:   store i256 0, i256* %[[T02]], align 4
 //CHECK-NEXT:   br label %store3
 //CHECK-EMPTY:
 //CHECK-NEXT: store3:
-//CHECK-NEXT:   %3 = getelementptr [9 x i256], [9 x i256]* %lvars, i32 0, i32 8
-//CHECK-NEXT:   store i256 0, i256* %3, align 4
+//CHECK-NEXT:   %[[T03:[0-9a-zA-Z_.]+]] = getelementptr [9 x i256], [9 x i256]* %lvars, i32 0, i32 8
+//CHECK-NEXT:   store i256 0, i256* %[[T03]], align 4
 //CHECK-NEXT:   br label %store4
 //CHECK-EMPTY:
 //CHECK-NEXT: store4:
-//CHECK-NEXT:   %4 = getelementptr [9 x i256], [9 x i256]* %lvars, i32 0, i32 6
-//CHECK-NEXT:   %5 = load i256, i256* %4, align 4
-//CHECK-NEXT:   %6 = getelementptr [9 x i256], [9 x i256]* %lvars, i32 0, i32 0
-//CHECK-NEXT:   %7 = getelementptr [9 x i256], [9 x i256]* %lvars, i32 0, i32 6
-//CHECK-NEXT:   call void @fr_copy_n(i256* %7, i256* %6, i32 3)
+//CHECK-NEXT:   %[[T06:[0-9a-zA-Z_.]+]] = getelementptr [9 x i256], [9 x i256]* %lvars, i32 0, i32 0
+//CHECK-NEXT:   %[[T07:[0-9a-zA-Z_.]+]] = getelementptr [9 x i256], [9 x i256]* %lvars, i32 0, i32 6
+//CHECK-NEXT:   call void @fr_copy_n(i256* %[[T07]], i256* %[[T06]], i32 3)
 //CHECK-NEXT:   br label %store5
 //CHECK-EMPTY:
 //CHECK-NEXT: store5:
-//CHECK-NEXT:   %8 = getelementptr [9 x i256], [9 x i256]* %lvars, i32 0, i32 6
-//CHECK-NEXT:   %9 = load i256, i256* %8, align 4
-//CHECK-NEXT:   %10 = getelementptr [9 x i256], [9 x i256]* %lvars, i32 0, i32 3
-//CHECK-NEXT:   %11 = getelementptr [9 x i256], [9 x i256]* %lvars, i32 0, i32 6
-//CHECK-NEXT:   call void @fr_copy_n(i256* %11, i256* %10, i32 3)
+//CHECK-NEXT:   %[[T10:[0-9a-zA-Z_.]+]] = getelementptr [9 x i256], [9 x i256]* %lvars, i32 0, i32 3
+//CHECK-NEXT:   %[[T11:[0-9a-zA-Z_.]+]] = getelementptr [9 x i256], [9 x i256]* %lvars, i32 0, i32 6
+//CHECK-NEXT:   call void @fr_copy_n(i256* %[[T11]], i256* %[[T10]], i32 3)
 //CHECK-NEXT:   br label %call6
 //CHECK-EMPTY:
 //CHECK-NEXT: call6:
 //CHECK-NEXT:   %sum_0_arena = alloca [12 x i256], align 8
-//CHECK-NEXT:   %12 = getelementptr [12 x i256], [12 x i256]* %sum_0_arena, i32 0, i32 0
-//CHECK-NEXT:   %13 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 6
-//CHECK-NEXT:   call void @fr_copy_n(i256* %13, i256* %12, i32 6)
-//CHECK-NEXT:   %14 = getelementptr [12 x i256], [12 x i256]* %sum_0_arena, i32 0, i32 6
-//CHECK-NEXT:   %15 = getelementptr [9 x i256], [9 x i256]* %lvars, i32 0, i32 0
-//CHECK-NEXT:   call void @fr_copy_n(i256* %15, i256* %14, i32 6)
-//CHECK-NEXT:   %16 = bitcast [12 x i256]* %sum_0_arena to i256*
-//CHECK-NEXT:   %call.sum_0 = call i256* @sum_0(i256* %16)
-//CHECK-NEXT:   %17 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
-//CHECK-NEXT:   call void @fr_copy_n(i256* %call.sum_0, i256* %17, i32 6)
+//CHECK-NEXT:   %[[T12:[0-9a-zA-Z_.]+]] = getelementptr [12 x i256], [12 x i256]* %sum_0_arena, i32 0, i32 0
+//CHECK-NEXT:   %[[T13:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 6
+//CHECK-NEXT:   call void @fr_copy_n(i256* %[[T13]], i256* %[[T12]], i32 6)
+//CHECK-NEXT:   %[[T14:[0-9a-zA-Z_.]+]] = getelementptr [12 x i256], [12 x i256]* %sum_0_arena, i32 0, i32 6
+//CHECK-NEXT:   %[[T15:[0-9a-zA-Z_.]+]] = getelementptr [9 x i256], [9 x i256]* %lvars, i32 0, i32 0
+//CHECK-NEXT:   call void @fr_copy_n(i256* %[[T15]], i256* %[[T14]], i32 6)
+//CHECK-NEXT:   %[[T16:[0-9a-zA-Z_.]+]] = bitcast [12 x i256]* %sum_0_arena to i256*
+//CHECK-NEXT:   %call.sum_0 = call i256* @sum_0(i256* %[[T16]])
+//CHECK-NEXT:   %[[T17:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
+//CHECK-NEXT:   call void @fr_copy_n(i256* %call.sum_0, i256* %[[T17]], i32 6)
 //CHECK-NEXT:   br label %prologue
 //CHECK-EMPTY:
 //CHECK-NEXT: prologue:

--- a/circom/tests/calls/call_arg_arrays_complex_C.circom
+++ b/circom/tests/calls/call_arg_arrays_complex_C.circom
@@ -22,21 +22,21 @@ component main = CallArgTest();
 
 //CHECK-LABEL: define{{.*}} i256 @sum_0(i256* %0){{.*}} {
 //CHECK:      store1:
-//CHECK:        %3 = getelementptr i256, i256* %0, i32 6
-//CHECK-NEXT:   %4 = getelementptr i256, i256* %0, i32 3
-//CHECK-NEXT:   call void @fr_copy_n(i256* %4, i256* %3, i32 3)
+//CHECK:        %[[T03:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 6
+//CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 3
+//CHECK-NEXT:   call void @fr_copy_n(i256* %[[T04]], i256* %[[T03]], i32 3)
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY:
 //CHECK:      store2:
-//CHECK:        %7 = getelementptr i256, i256* %0, i32 9
-//CHECK-NEXT:   %8 = getelementptr i256, i256* %0, i32 0
-//CHECK-NEXT:   call void @fr_copy_n(i256* %8, i256* %7, i32 3)
+//CHECK:        %[[T07:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 9
+//CHECK-NEXT:   %[[T08:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 0
+//CHECK-NEXT:   call void @fr_copy_n(i256* %[[T08]], i256* %[[T07]], i32 3)
 //CHECK-NEXT:   br label %return3
 //CHECK-EMPTY:
 //CHECK-NEXT: return3:
-//CHECK-NEXT:   %9 = getelementptr i256, i256* %0, i32 0
-//CHECK-NEXT:   %10 = load i256, i256* %9, align 4
-//CHECK-NEXT:   ret i256 %10
+//CHECK-NEXT:   %[[T09:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 0
+//CHECK-NEXT:   %[[T10:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T09]], align 4
+//CHECK-NEXT:   ret i256 %[[T10]]
 //CHECK-NEXT: }
 //
 //CHECK-LABEL: define{{.*}} void @CallArgTest_0_run([0 x i256]* %0){{.*}} {
@@ -47,16 +47,16 @@ component main = CallArgTest();
 //CHECK-EMPTY:
 //CHECK-NEXT: call1:
 //CHECK-NEXT:   %sum_0_arena = alloca [12 x i256], align 8
-//CHECK-NEXT:   %1 = getelementptr [12 x i256], [12 x i256]* %sum_0_arena, i32 0, i32 0
-//CHECK-NEXT:   %2 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 7
-//CHECK-NEXT:   call void @fr_copy_n(i256* %2, i256* %1, i32 6)
-//CHECK-NEXT:   %3 = getelementptr [12 x i256], [12 x i256]* %sum_0_arena, i32 0, i32 6
-//CHECK-NEXT:   %4 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 13
-//CHECK-NEXT:   call void @fr_copy_n(i256* %4, i256* %3, i32 6)
-//CHECK-NEXT:   %5 = bitcast [12 x i256]* %sum_0_arena to i256*
-//CHECK-NEXT:   %call.sum_0 = call i256 @sum_0(i256* %5)
-//CHECK-NEXT:   %6 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 6
-//CHECK-NEXT:   store i256 %call.sum_0, i256* %6, align 4
+//CHECK-NEXT:   %[[T01:[0-9a-zA-Z_.]+]] = getelementptr [12 x i256], [12 x i256]* %sum_0_arena, i32 0, i32 0
+//CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 7
+//CHECK-NEXT:   call void @fr_copy_n(i256* %[[T02]], i256* %[[T01]], i32 6)
+//CHECK-NEXT:   %[[T03:[0-9a-zA-Z_.]+]] = getelementptr [12 x i256], [12 x i256]* %sum_0_arena, i32 0, i32 6
+//CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 13
+//CHECK-NEXT:   call void @fr_copy_n(i256* %[[T04]], i256* %[[T03]], i32 6)
+//CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = bitcast [12 x i256]* %sum_0_arena to i256*
+//CHECK-NEXT:   %call.sum_0 = call i256 @sum_0(i256* %[[T05]])
+//CHECK-NEXT:   %[[T06:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 6
+//CHECK-NEXT:   store i256 %call.sum_0, i256* %[[T06]], align 4
 //CHECK-NEXT:   br label %prologue
 //CHECK-EMPTY: 
 //CHECK-NEXT: prologue:

--- a/circom/tests/calls/call_arg_arrays_complex_D.circom
+++ b/circom/tests/calls/call_arg_arrays_complex_D.circom
@@ -29,31 +29,31 @@ component main = CallArgTest();
 //CHECK-NEXT:   br label %branch1
 //CHECK-EMPTY:
 //CHECK-NEXT: branch1:
-//CHECK-NEXT:   %1 = getelementptr i256, i256* %0, i32 0
-//CHECK-NEXT:   %2 = load i256, i256* %1, align 4
-//CHECK-NEXT:   %call.fr_lt = call i1 @fr_lt(i256 %2, i256 7)
+//CHECK-NEXT:   %[[T01:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 0
+//CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T01]], align 4
+//CHECK-NEXT:   %call.fr_lt = call i1 @fr_lt(i256 %[[T02]], i256 7)
 //CHECK-NEXT:   br i1 %call.fr_lt, label %if.then, label %if.else
 //CHECK-EMPTY:
 //CHECK-NEXT: if.then:
-//CHECK-NEXT:   %3 = getelementptr i256, i256* %0, i32 1
-//CHECK-NEXT:   ret i256* %3
+//CHECK-NEXT:   %[[T03:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 1
+//CHECK-NEXT:   ret i256* %[[T03]]
 //CHECK-EMPTY:
 //CHECK-NEXT: if.else:
-//CHECK-NEXT:   %4 = getelementptr i256, i256* %0, i32 0
-//CHECK-NEXT:   %5 = load i256, i256* %4, align 4
-//CHECK-NEXT:   %call.fr_gt = call i1 @fr_gt(i256 %5, i256 12)
+//CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 0
+//CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T04]], align 4
+//CHECK-NEXT:   %call.fr_gt = call i1 @fr_gt(i256 %[[T05]], i256 12)
 //CHECK-NEXT:   br i1 %call.fr_gt, label %if.then1, label %if.else2
 //CHECK-EMPTY:
 //CHECK-NEXT: if.merge:
 //CHECK-NEXT:   unreachable
 //CHECK-EMPTY:
 //CHECK-NEXT: if.then1:
-//CHECK-NEXT:   %6 = getelementptr i256, i256* %0, i32 7
-//CHECK-NEXT:   ret i256* %6
+//CHECK-NEXT:   %[[T06:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 7
+//CHECK-NEXT:   ret i256* %[[T06]]
 //CHECK-EMPTY:
 //CHECK-NEXT: if.else2:
-//CHECK-NEXT:   %7 = getelementptr i256, i256* %0, i32 13
-//CHECK-NEXT:   ret i256* %7
+//CHECK-NEXT:   %[[T07:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 13
+//CHECK-NEXT:   ret i256* %[[T07]]
 //CHECK-EMPTY:
 //CHECK-NEXT: if.merge3:
 //CHECK-NEXT:   unreachable
@@ -67,23 +67,23 @@ component main = CallArgTest();
 //CHECK-EMPTY:
 //CHECK-NEXT: call1:
 //CHECK-NEXT:   %sum_0_arena = alloca [19 x i256], align 8
-//CHECK-NEXT:   %1 = getelementptr [19 x i256], [19 x i256]* %sum_0_arena, i32 0, i32 0
-//CHECK-NEXT:   %2 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 6
-//CHECK-NEXT:   %3 = load i256, i256* %2, align 4
-//CHECK-NEXT:   store i256 %3, i256* %1, align 4
-//CHECK-NEXT:   %4 = getelementptr [19 x i256], [19 x i256]* %sum_0_arena, i32 0, i32 1
-//CHECK-NEXT:   %5 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 7
-//CHECK-NEXT:   call void @fr_copy_n(i256* %5, i256* %4, i32 6)
-//CHECK-NEXT:   %6 = getelementptr [19 x i256], [19 x i256]* %sum_0_arena, i32 0, i32 7
-//CHECK-NEXT:   %7 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 13
-//CHECK-NEXT:   call void @fr_copy_n(i256* %7, i256* %6, i32 6)
-//CHECK-NEXT:   %8 = getelementptr [19 x i256], [19 x i256]* %sum_0_arena, i32 0, i32 13
-//CHECK-NEXT:   %9 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 19
-//CHECK-NEXT:   call void @fr_copy_n(i256* %9, i256* %8, i32 6)
-//CHECK-NEXT:   %10 = bitcast [19 x i256]* %sum_0_arena to i256*
-//CHECK-NEXT:   %call.sum_0 = call i256* @sum_0(i256* %10)
-//CHECK-NEXT:   %11 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
-//CHECK-NEXT:   call void @fr_copy_n(i256* %call.sum_0, i256* %11, i32 6)
+//CHECK-NEXT:   %[[T01:[0-9a-zA-Z_.]+]] = getelementptr [19 x i256], [19 x i256]* %sum_0_arena, i32 0, i32 0
+//CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 6
+//CHECK-NEXT:   %[[T03:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T02]], align 4
+//CHECK-NEXT:   store i256 %[[T03]], i256* %[[T01]], align 4
+//CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = getelementptr [19 x i256], [19 x i256]* %sum_0_arena, i32 0, i32 1
+//CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 7
+//CHECK-NEXT:   call void @fr_copy_n(i256* %[[T05]], i256* %[[T04]], i32 6)
+//CHECK-NEXT:   %[[T06:[0-9a-zA-Z_.]+]] = getelementptr [19 x i256], [19 x i256]* %sum_0_arena, i32 0, i32 7
+//CHECK-NEXT:   %[[T07:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 13
+//CHECK-NEXT:   call void @fr_copy_n(i256* %[[T07]], i256* %[[T06]], i32 6)
+//CHECK-NEXT:   %[[T08:[0-9a-zA-Z_.]+]] = getelementptr [19 x i256], [19 x i256]* %sum_0_arena, i32 0, i32 13
+//CHECK-NEXT:   %[[T09:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 19
+//CHECK-NEXT:   call void @fr_copy_n(i256* %[[T09]], i256* %[[T08]], i32 6)
+//CHECK-NEXT:   %[[T10:[0-9a-zA-Z_.]+]] = bitcast [19 x i256]* %sum_0_arena to i256*
+//CHECK-NEXT:   %call.sum_0 = call i256* @sum_0(i256* %[[T10]])
+//CHECK-NEXT:   %[[T11:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
+//CHECK-NEXT:   call void @fr_copy_n(i256* %call.sum_0, i256* %[[T11]], i32 6)
 //CHECK-NEXT:   br label %prologue
 //CHECK-EMPTY:
 //CHECK-NEXT: prologue:

--- a/circom/tests/calls/call_ret_array.circom
+++ b/circom/tests/calls/call_ret_array.circom
@@ -21,16 +21,14 @@ component main = CallRetTest();
 //CHECK-NEXT:   br label %store1
 //CHECK-EMPTY:
 //CHECK-NEXT: store1:
-//CHECK-NEXT:   %1 = getelementptr i256, i256* %0, i32 0
-//CHECK-NEXT:   %2 = load i256, i256* %1, align 4
-//CHECK-NEXT:   %3 = getelementptr i256, i256* %0, i32 4
-//CHECK-NEXT:   %4 = getelementptr i256, i256* %0, i32 0
-//CHECK-NEXT:   call void @fr_copy_n(i256* %4, i256* %3, i32 4)
+//CHECK-NEXT:   %[[T03:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 4
+//CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 0
+//CHECK-NEXT:   call void @fr_copy_n(i256* %[[T04]], i256* %[[T03]], i32 4)
 //CHECK-NEXT:   br label %return2
 //CHECK-EMPTY:
 //CHECK-NEXT: return2:
-//CHECK-NEXT:   %5 = getelementptr i256, i256* %0, i32 4
-//CHECK-NEXT:   ret i256* %5
+//CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 4
+//CHECK-NEXT:   ret i256* %[[T05]]
 //CHECK-NEXT: }
 //
 //CHECK-LABEL: define{{.*}} void @CallRetTest_0_run([0 x i256]* %0){{.*}} {
@@ -41,13 +39,13 @@ component main = CallRetTest();
 //CHECK-EMPTY:
 //CHECK-NEXT: call1:
 //CHECK-NEXT:   %sum_0_arena = alloca [8 x i256], align 8
-//CHECK-NEXT:   %1 = getelementptr [8 x i256], [8 x i256]* %sum_0_arena, i32 0, i32 0
-//CHECK-NEXT:   %2 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 4
-//CHECK-NEXT:   call void @fr_copy_n(i256* %2, i256* %1, i32 4)
-//CHECK-NEXT:   %3 = bitcast [8 x i256]* %sum_0_arena to i256*
-//CHECK-NEXT:   %call.sum_0 = call i256* @sum_0(i256* %3)
-//CHECK-NEXT:   %4 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
-//CHECK-NEXT:   call void @fr_copy_n(i256* %call.sum_0, i256* %4, i32 4)
+//CHECK-NEXT:   %[[T01:[0-9a-zA-Z_.]+]] = getelementptr [8 x i256], [8 x i256]* %sum_0_arena, i32 0, i32 0
+//CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 4
+//CHECK-NEXT:   call void @fr_copy_n(i256* %[[T02]], i256* %[[T01]], i32 4)
+//CHECK-NEXT:   %[[T03:[0-9a-zA-Z_.]+]] = bitcast [8 x i256]* %sum_0_arena to i256*
+//CHECK-NEXT:   %call.sum_0 = call i256* @sum_0(i256* %[[T03]])
+//CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
+//CHECK-NEXT:   call void @fr_copy_n(i256* %call.sum_0, i256* %[[T04]], i32 4)
 //CHECK-NEXT:   br label %prologue
 //CHECK-EMPTY:
 //CHECK-NEXT: prologue:

--- a/circom/tests/calls/call_ret_arraymulti.circom
+++ b/circom/tests/calls/call_ret_arraymulti.circom
@@ -21,16 +21,14 @@ component main = CallRetTest();
 //CHECK-NEXT:   br label %store1
 //CHECK-EMPTY:
 //CHECK-NEXT: store1:
-//CHECK-NEXT:   %1 = getelementptr i256, i256* %0, i32 0
-//CHECK-NEXT:   %2 = load i256, i256* %1, align 4
-//CHECK-NEXT:   %3 = getelementptr i256, i256* %0, i32 24
-//CHECK-NEXT:   %4 = getelementptr i256, i256* %0, i32 0
-//CHECK-NEXT:   call void @fr_copy_n(i256* %4, i256* %3, i32 24)
+//CHECK-NEXT:   %[[T03:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 24
+//CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 0
+//CHECK-NEXT:   call void @fr_copy_n(i256* %[[T04]], i256* %[[T03]], i32 24)
 //CHECK-NEXT:   br label %return2
 //CHECK-EMPTY:
 //CHECK-NEXT: return2:
-//CHECK-NEXT:   %5 = getelementptr i256, i256* %0, i32 24
-//CHECK-NEXT:   ret i256* %5
+//CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 24
+//CHECK-NEXT:   ret i256* %[[T05]]
 //CHECK-NEXT: }
 //
 //CHECK-LABEL: define{{.*}} void @CallRetTest_0_run([0 x i256]* %0){{.*}} {
@@ -41,13 +39,13 @@ component main = CallRetTest();
 //CHECK-EMPTY:
 //CHECK-NEXT: call1:
 //CHECK-NEXT:   %sum_0_arena = alloca [48 x i256], align 8
-//CHECK-NEXT:   %1 = getelementptr [48 x i256], [48 x i256]* %sum_0_arena, i32 0, i32 0
-//CHECK-NEXT:   %2 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 24
-//CHECK-NEXT:   call void @fr_copy_n(i256* %2, i256* %1, i32 24)
-//CHECK-NEXT:   %3 = bitcast [48 x i256]* %sum_0_arena to i256*
-//CHECK-NEXT:   %call.sum_0 = call i256* @sum_0(i256* %3)
-//CHECK-NEXT:   %4 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
-//CHECK-NEXT:   call void @fr_copy_n(i256* %call.sum_0, i256* %4, i32 24)
+//CHECK-NEXT:   %[[T01:[0-9a-zA-Z_.]+]] = getelementptr [48 x i256], [48 x i256]* %sum_0_arena, i32 0, i32 0
+//CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 24
+//CHECK-NEXT:   call void @fr_copy_n(i256* %[[T02]], i256* %[[T01]], i32 24)
+//CHECK-NEXT:   %[[T03:[0-9a-zA-Z_.]+]] = bitcast [48 x i256]* %sum_0_arena to i256*
+//CHECK-NEXT:   %call.sum_0 = call i256* @sum_0(i256* %[[T03]])
+//CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
+//CHECK-NEXT:   call void @fr_copy_n(i256* %call.sum_0, i256* %[[T04]], i32 24)
 //CHECK-NEXT:   br label %prologue
 //CHECK-EMPTY:
 //CHECK-NEXT: prologue:

--- a/circom/tests/calls/call_without_arena_gotcha.circom
+++ b/circom/tests/calls/call_without_arena_gotcha.circom
@@ -24,25 +24,25 @@ component main = Gotcha();
 //CHECK-NEXT:   br label %store1
 //CHECK-EMPTY:
 //CHECK-NEXT: store1:
-//CHECK-NEXT:   %1 = getelementptr i256, i256* %0, i32 3
-//CHECK-NEXT:   %2 = load i256, i256* %1, align 4
-//CHECK-NEXT:   %3 = getelementptr i256, i256* %0, i32 0
-//CHECK-NEXT:   store i256 %2, i256* %3, align 4
+//CHECK-NEXT:   %[[T03:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 0
+//CHECK-NEXT:   %[[T01:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 3
+//CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T01]], align 4
+//CHECK-NEXT:   store i256 %[[T02]], i256* %[[T03]], align 4
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY:
 //CHECK-NEXT: store2:
-//CHECK-NEXT:   %4 = getelementptr i256, i256* %0, i32 2
-//CHECK-NEXT:   %5 = load i256, i256* %4, align 4
-//CHECK-NEXT:   %6 = getelementptr i256, i256* %0, i32 1
-//CHECK-NEXT:   store i256 %5, i256* %6, align 4
+//CHECK-NEXT:   %[[T06:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 1
+//CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 2
+//CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T04]], align 4
+//CHECK-NEXT:   store i256 %[[T05]], i256* %[[T06]], align 4
 //CHECK-NEXT:   br label %return3
 //CHECK-EMPTY:
 //CHECK-NEXT: return3:
-//CHECK-NEXT:   %7 = getelementptr i256, i256* %0, i32 0
-//CHECK-NEXT:   %8 = load i256, i256* %7, align 4
-//CHECK-NEXT:   %9 = getelementptr i256, i256* %0, i32 1
-//CHECK-NEXT:   %10 = load i256, i256* %9, align 4
-//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %8, i256 %10)
+//CHECK-NEXT:   %[[T07:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 0
+//CHECK-NEXT:   %[[T08:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T07]], align 4
+//CHECK-NEXT:   %[[T09:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %0, i32 1
+//CHECK-NEXT:   %[[T10:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T09]], align 4
+//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %[[T08]], i256 %[[T10]])
 //CHECK-NEXT:   ret i256 %call.fr_add
 //CHECK-NEXT: }
 //
@@ -57,19 +57,19 @@ component main = Gotcha();
 //CHECK-EMPTY:
 //CHECK-NEXT: call2:
 //CHECK-NEXT:   %overwrite_0_arena = alloca [4 x i256], align 8
-//CHECK-NEXT:   %1 = getelementptr [4 x i256], [4 x i256]* %overwrite_0_arena, i32 0, i32 0
-//CHECK-NEXT:   %2 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 1
-//CHECK-NEXT:   call void @fr_copy_n(i256* %2, i256* %1, i32 2)
-//CHECK-NEXT:   %3 = getelementptr [4 x i256], [4 x i256]* %overwrite_0_arena, i32 0, i32 2
-//CHECK-NEXT:   %4 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 3
-//CHECK-NEXT:   call void @fr_copy_n(i256* %4, i256* %3, i32 2)
-//CHECK-NEXT:   %5 = bitcast [4 x i256]* %overwrite_0_arena to i256*
-//CHECK-NEXT:   %call.overwrite_0 = call i256 @overwrite_0(i256* %5)
-//CHECK-NEXT:   %6 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
-//CHECK-NEXT:   store i256 %call.overwrite_0, i256* %6, align 4
-//CHECK-NEXT:   %7 = load i256, i256* %6, align 4
+//CHECK-NEXT:   %[[T01:[0-9a-zA-Z_.]+]] = getelementptr [4 x i256], [4 x i256]* %overwrite_0_arena, i32 0, i32 0
+//CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 1
+//CHECK-NEXT:   call void @fr_copy_n(i256* %[[T02]], i256* %[[T01]], i32 2)
+//CHECK-NEXT:   %[[T03:[0-9a-zA-Z_.]+]] = getelementptr [4 x i256], [4 x i256]* %overwrite_0_arena, i32 0, i32 2
+//CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 3
+//CHECK-NEXT:   call void @fr_copy_n(i256* %[[T04]], i256* %[[T03]], i32 2)
+//CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = bitcast [4 x i256]* %overwrite_0_arena to i256*
+//CHECK-NEXT:   %call.overwrite_0 = call i256 @overwrite_0(i256* %[[T05]])
+//CHECK-NEXT:   %[[T06:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
+//CHECK-NEXT:   store i256 %call.overwrite_0, i256* %[[T06]], align 4
+//CHECK-NEXT:   %[[T07:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T06]], align 4
 //CHECK-NEXT:   %constraint = alloca i1, align 1
-//CHECK-NEXT:   call void @__constraint_values(i256 %call.overwrite_0, i256 %7, i1* %constraint)
+//CHECK-NEXT:   call void @__constraint_values(i256 %call.overwrite_0, i256 %[[T07]], i1* %constraint)
 //CHECK-NEXT:   br label %log3
 //CHECK-EMPTY:
 //CHECK-NEXT: log3:

--- a/circom/tests/constraints/arr_cpy_store.circom
+++ b/circom/tests/constraints/arr_cpy_store.circom
@@ -26,21 +26,19 @@ component main = Foo(2);
 //CHECK-NEXT:   br label %store1
 //CHECK-EMPTY:
 //CHECK-NEXT: store1:
-//CHECK-NEXT:   %0 = getelementptr [0 x i256], [0 x i256]* %signals, i32 0, i32 0
-//CHECK-NEXT:   %1 = load i256, i256* %0, align 4
-//CHECK-NEXT:   %2 = getelementptr i256, i256* %subsig_0, i32 0
-//CHECK-NEXT:   %3 = getelementptr [0 x i256], [0 x i256]* %signals, i32 0, i32 0
-//CHECK-NEXT:   call void @fr_copy_n(i256* %3, i256* %2, i32 2)
-//CHECK-NEXT:   %4 = getelementptr [0 x i256], [0 x i256]* %signals, i32 0, i32 0
-//CHECK-NEXT:   %5 = load i256, i256* %4, align 4
-//CHECK-NEXT:   %6 = getelementptr i256, i256* %subsig_0, i32 0
-//CHECK-NEXT:   %7 = load i256, i256* %6, align 4
+//CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subsig_0, i32 0
+//CHECK-NEXT:   %[[T03:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %signals, i32 0, i32 0
+//CHECK-NEXT:   call void @fr_copy_n(i256* %[[T03]], i256* %[[T02]], i32 2)
+//CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %signals, i32 0, i32 0
+//CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T04]], align 4
+//CHECK-NEXT:   %[[T06:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subsig_0, i32 0
+//CHECK-NEXT:   %[[T07:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T06]], align 4
 //CHECK-NEXT:   %constraint_0 = alloca i1, align 1
-//CHECK-NEXT:   call void @__constraint_values(i256 %5, i256 %7, i1* %constraint_0)
-//CHECK-NEXT:   %8 = getelementptr [0 x i256], [0 x i256]* %signals, i32 0, i32 1
-//CHECK-NEXT:   %9 = load i256, i256* %8, align 4
-//CHECK-NEXT:   %10 = getelementptr i256, i256* %subsig_0, i32 1
-//CHECK-NEXT:   %11 = load i256, i256* %10, align 4
+//CHECK-NEXT:   call void @__constraint_values(i256 %[[T05]], i256 %[[T07]], i1* %constraint_0)
+//CHECK-NEXT:   %[[T08:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %signals, i32 0, i32 1
+//CHECK-NEXT:   %[[T09:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T08]], align 4
+//CHECK-NEXT:   %[[T10:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subsig_0, i32 1
+//CHECK-NEXT:   %[[T11:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T10]], align 4
 //CHECK-NEXT:   %constraint_1 = alloca i1, align 1
-//CHECK-NEXT:   call void @__constraint_values(i256 %9, i256 %11, i1* %constraint_1)
+//CHECK-NEXT:   call void @__constraint_values(i256 %[[T09]], i256 %[[T11]], i1* %constraint_1)
 //CHECK-NEXT:   br label %store2

--- a/circom/tests/constraints/known5.circom
+++ b/circom/tests/constraints/known5.circom
@@ -15,10 +15,10 @@ component main = A();
 //CHECK-LABEL: define{{.*}} void @A_{{[0-9]+}}_run([0 x i256]* %0){{.*}} {
 //CHECK: store{{[0-9]+}}:{{.*}}
 //CHECK: store{{[0-9]+}}:{{.*}}
+//CHECK:   %[[T4:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 1
 //CHECK:   %[[T1:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
 //CHECK:   %[[T2:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T1]], align 4
 //CHECK:   %[[T3:[0-9a-zA-Z_.]+]] = call i256 @fr_mul(i256 %[[T2]], i256 1)
-//CHECK:   %[[T4:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 1
 //CHECK:   store i256 %[[T3]], i256* %[[T4]], align 4
 //CHECK:   %[[T5:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T4]], align 4
 //CHECK:   %constraint = alloca i1, align 1

--- a/circom/tests/constraints/missed_index_simpl.circom
+++ b/circom/tests/constraints/missed_index_simpl.circom
@@ -32,31 +32,31 @@ component main = Good(2);
 //CHECK-NEXT:   br label %store1
 //CHECK-EMPTY: 
 //CHECK-NEXT: store1:
-//CHECK-NEXT:   %0 = getelementptr i256, i256* %sig_[[X2]], i32 0
-//CHECK-NEXT:   %1 = load i256, i256* %0, align 4
-//CHECK-NEXT:   %2 = getelementptr i256, i256* %subsig_[[X1]], i32 0
-//CHECK-NEXT:   store i256 %1, i256* %2, align 4
-//CHECK-NEXT:   %3 = load i256, i256* %2, align 4
+//CHECK-NEXT:   %[[T002:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subsig_[[X1]], i32 0
+//CHECK-NEXT:   %[[T000:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_[[X2]], i32 0
+//CHECK-NEXT:   %[[T001:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T000]], align 4
+//CHECK-NEXT:   store i256 %[[T001]], i256* %[[T002]], align 4
+//CHECK-NEXT:   %[[T003:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T002]], align 4
 //CHECK-NEXT:   %constraint = alloca i1, align 1
-//CHECK-NEXT:   call void @__constraint_values(i256 %1, i256 %3, i1* %constraint)
+//CHECK-NEXT:   call void @__constraint_values(i256 %[[T001]], i256 %[[T003]], i1* %constraint)
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY: 
 //CHECK-NEXT: store2:
-//CHECK-NEXT:   %4 = load i256, i256* %subc_[[X1]], align 4
-//CHECK-NEXT:   %call.fr_sub = call i256 @fr_sub(i256 %4, i256 1)
-//CHECK-NEXT:   %5 = getelementptr i256, i256* %subc_[[X1]], i32 0
-//CHECK-NEXT:   store i256 %call.fr_sub, i256* %5, align 4
+//CHECK-NEXT:   %[[T005:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subc_[[X1]], i32 0
+//CHECK-NEXT:   %[[T004:[0-9a-zA-Z_.]+]] = load i256, i256* %subc_[[X1]], align 4
+//CHECK-NEXT:   %call.fr_sub = call i256 @fr_sub(i256 %[[T004]], i256 1)
+//CHECK-NEXT:   store i256 %call.fr_sub, i256* %[[T005]], align 4
 //CHECK-NEXT:   br label %fold_false3
 //CHECK-EMPTY: 
 //CHECK-NEXT: fold_false3:
 //CHECK-NEXT:   br label %store4
 //CHECK-EMPTY: 
 //CHECK-NEXT: store4:
-//CHECK-NEXT:   %6 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
-//CHECK-NEXT:   %7 = load i256, i256* %6, align 4
-//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %7, i256 1)
-//CHECK-NEXT:   %8 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
-//CHECK-NEXT:   store i256 %call.fr_add, i256* %8, align 4
+//CHECK-NEXT:   %[[T008:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
+//CHECK-NEXT:   %[[T006:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
+//CHECK-NEXT:   %[[T007:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T006]], align 4
+//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %[[T007]], i256 1)
+//CHECK-NEXT:   store i256 %call.fr_add, i256* %[[T008]], align 4
 //CHECK-NEXT:   br label %return5
 //CHECK-EMPTY: 
 //CHECK-NEXT: return5:
@@ -69,20 +69,20 @@ component main = Good(2);
 //CHECK-NEXT:   br label %store1
 //CHECK-EMPTY: 
 //CHECK-NEXT: store1:
-//CHECK-NEXT:   %0 = getelementptr i256, i256* %sig_[[X2]], i32 0
-//CHECK-NEXT:   %1 = load i256, i256* %0, align 4
-//CHECK-NEXT:   %2 = getelementptr i256, i256* %subsig_[[X1]], i32 0
-//CHECK-NEXT:   store i256 %1, i256* %2, align 4
-//CHECK-NEXT:   %3 = load i256, i256* %2, align 4
+//CHECK-NEXT:   %[[T002:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subsig_[[X1]], i32 0
+//CHECK-NEXT:   %[[T000:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_[[X2]], i32 0
+//CHECK-NEXT:   %[[T001:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T000]], align 4
+//CHECK-NEXT:   store i256 %[[T001]], i256* %[[T002]], align 4
+//CHECK-NEXT:   %[[T003:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T002]], align 4
 //CHECK-NEXT:   %constraint = alloca i1, align 1
-//CHECK-NEXT:   call void @__constraint_values(i256 %1, i256 %3, i1* %constraint)
+//CHECK-NEXT:   call void @__constraint_values(i256 %[[T001]], i256 %[[T003]], i1* %constraint)
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY: 
 //CHECK-NEXT: store2:
-//CHECK-NEXT:   %4 = load i256, i256* %subc_[[X1]], align 4
-//CHECK-NEXT:   %call.fr_sub = call i256 @fr_sub(i256 %4, i256 1)
-//CHECK-NEXT:   %5 = getelementptr i256, i256* %subc_[[X1]], i32 0
-//CHECK-NEXT:   store i256 %call.fr_sub, i256* %5, align 4
+//CHECK-NEXT:   %[[T005:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subc_[[X1]], i32 0
+//CHECK-NEXT:   %[[T004:[0-9a-zA-Z_.]+]] = load i256, i256* %subc_[[X1]], align 4
+//CHECK-NEXT:   %call.fr_sub = call i256 @fr_sub(i256 %[[T004]], i256 1)
+//CHECK-NEXT:   store i256 %call.fr_sub, i256* %[[T005]], align 4
 //CHECK-NEXT:   br label %fold_true3
 //CHECK-EMPTY: 
 //CHECK-NEXT: fold_true3:
@@ -90,113 +90,114 @@ component main = Good(2);
 //CHECK-NEXT:   br label %store4
 //CHECK-EMPTY: 
 //CHECK-NEXT: store4:
-//CHECK-NEXT:   %6 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
-//CHECK-NEXT:   %7 = load i256, i256* %6, align 4
-//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %7, i256 1)
-//CHECK-NEXT:   %8 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
-//CHECK-NEXT:   store i256 %call.fr_add, i256* %8, align 4
+//CHECK-NEXT:   %[[T008:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
+//CHECK-NEXT:   %[[T006:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
+//CHECK-NEXT:   %[[T007:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T006]], align 4
+//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %[[T007]], i256 1)
+//CHECK-NEXT:   store i256 %call.fr_add, i256* %[[T008]], align 4
 //CHECK-NEXT:   br label %return5
 //CHECK-EMPTY: 
 //CHECK-NEXT: return5:
 //CHECK-NEXT:   ret void
 //CHECK-NEXT: }
 //
-//CHECK-LABEL: define{{.*}} void @Good_{{[0-9]+}}_run([0 x i256]* %0){{.*}} {
+//CHECK-LABEL: define{{.*}} void @Good_{{[0-9]+}}_run
+//CHECK-SAME: ([0 x i256]* %[[ARENA:[0-9a-zA-Z_.]+]]){{.*}} {
 //CHECK-NEXT: prelude:
 //CHECK-NEXT:   %lvars = alloca [3 x i256], align 8
 //CHECK-NEXT:   %subcmps = alloca [2 x { [0 x i256]*, i32 }], align 8
 //CHECK-NEXT:   br label %store1
 //CHECK-EMPTY: 
 //CHECK-NEXT: store1:
-//CHECK-NEXT:   %1 = getelementptr [3 x i256], [3 x i256]* %lvars, i32 0, i32 0
-//CHECK-NEXT:   store i256 2, i256* %1, align 4
+//CHECK-NEXT:   %[[T001:[0-9a-zA-Z_.]+]] = getelementptr [3 x i256], [3 x i256]* %lvars, i32 0, i32 0
+//CHECK-NEXT:   store i256 2, i256* %[[T001]], align 4
 //CHECK-NEXT:   br label %create_cmp2
 //CHECK-EMPTY: 
 //CHECK-NEXT: create_cmp2:
-//CHECK-NEXT:   %2 = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0
-//CHECK-NEXT:   call void @Mult_0_build({ [0 x i256]*, i32 }* %2)
-//CHECK-NEXT:   %3 = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1
-//CHECK-NEXT:   call void @Mult_0_build({ [0 x i256]*, i32 }* %3)
+//CHECK-NEXT:   %[[T002:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0
+//CHECK-NEXT:   call void @Mult_0_build({ [0 x i256]*, i32 }* %[[T002]])
+//CHECK-NEXT:   %[[T003:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1
+//CHECK-NEXT:   call void @Mult_0_build({ [0 x i256]*, i32 }* %[[T003]])
 //CHECK-NEXT:   br label %store3
 //CHECK-EMPTY: 
 //CHECK-NEXT: store3:
-//CHECK-NEXT:   %4 = getelementptr [3 x i256], [3 x i256]* %lvars, i32 0, i32 1
-//CHECK-NEXT:   store i256 0, i256* %4, align 4
+//CHECK-NEXT:   %[[T004:[0-9a-zA-Z_.]+]] = getelementptr [3 x i256], [3 x i256]* %lvars, i32 0, i32 1
+//CHECK-NEXT:   store i256 0, i256* %[[T004]], align 4
 //CHECK-NEXT:   br label %unrolled_loop4
 //CHECK-EMPTY: 
 //CHECK-NEXT: unrolled_loop4:
-//CHECK-NEXT:   %5 = getelementptr [3 x i256], [3 x i256]* %lvars, i32 0, i32 2
-//CHECK-NEXT:   store i256 0, i256* %5, align 4
-//CHECK-NEXT:   %6 = bitcast [3 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %7 = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
-//CHECK-NEXT:   %8 = load [0 x i256]*, [0 x i256]** %7, align 8
-//CHECK-NEXT:   %9 = getelementptr [0 x i256], [0 x i256]* %8, i32 0
-//CHECK-NEXT:   %10 = getelementptr [0 x i256], [0 x i256]* %9, i32 0, i256 1
-//CHECK-NEXT:   %11 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 0
-//CHECK-NEXT:   %12 = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
-//CHECK-NEXT:   %13 = load [0 x i256]*, [0 x i256]** %12, align 8
-//CHECK-NEXT:   %14 = getelementptr [0 x i256], [0 x i256]* %13, i32 0
-//CHECK-NEXT:   %15 = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 1
-//CHECK-NEXT:   %16 = bitcast i32* %15 to i256*
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %6, [0 x i256]* %0, i256* %10, i256* %11, [0 x i256]* %14, i256* %16)
-//CHECK-NEXT:   %17 = bitcast [3 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %18 = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
-//CHECK-NEXT:   %19 = load [0 x i256]*, [0 x i256]** %18, align 8
-//CHECK-NEXT:   %20 = getelementptr [0 x i256], [0 x i256]* %19, i32 0
-//CHECK-NEXT:   %21 = getelementptr [0 x i256], [0 x i256]* %20, i32 0, i256 2
-//CHECK-NEXT:   %22 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 1
-//CHECK-NEXT:   %23 = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
-//CHECK-NEXT:   %24 = load [0 x i256]*, [0 x i256]** %23, align 8
-//CHECK-NEXT:   %25 = getelementptr [0 x i256], [0 x i256]* %24, i32 0
-//CHECK-NEXT:   %26 = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 1
-//CHECK-NEXT:   %27 = bitcast i32* %26 to i256*
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_2]]([0 x i256]* %17, [0 x i256]* %0, i256* %21, i256* %22, [0 x i256]* %25, i256* %27)
-//CHECK-NEXT:   %28 = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
-//CHECK-NEXT:   %29 = load [0 x i256]*, [0 x i256]** %28, align 8
-//CHECK-NEXT:   %30 = getelementptr [0 x i256], [0 x i256]* %29, i32 0, i32 0
-//CHECK-NEXT:   %31 = load i256, i256* %30, align 4
-//CHECK-NEXT:   %call.fr_eq = call i1 @fr_eq(i256 %31, i256 77)
+//CHECK-NEXT:   %[[T005:[0-9a-zA-Z_.]+]] = getelementptr [3 x i256], [3 x i256]* %lvars, i32 0, i32 2
+//CHECK-NEXT:   store i256 0, i256* %[[T005]], align 4
+//CHECK-NEXT:   %[[T006:[0-9a-zA-Z_.]+]] = bitcast [3 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T007:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
+//CHECK-NEXT:   %[[T008:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T007]], align 8
+//CHECK-NEXT:   %[[T009:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T008]], i32 0
+//CHECK-NEXT:   %[[T010:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T009]], i32 0, i256 1
+//CHECK-NEXT:   %[[T011:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARENA]], i32 0, i256 0
+//CHECK-NEXT:   %[[T012:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
+//CHECK-NEXT:   %[[T013:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T012]], align 8
+//CHECK-NEXT:   %[[T014:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T013]], i32 0
+//CHECK-NEXT:   %[[T015:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 1
+//CHECK-NEXT:   %[[T016:[0-9a-zA-Z_.]+]] = bitcast i32* %[[T015]] to i256*
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %[[T006]], [0 x i256]* %[[ARENA]], i256* %[[T010]], i256* %[[T011]], [0 x i256]* %[[T014]], i256* %[[T016]])
+//CHECK-NEXT:   %[[T017:[0-9a-zA-Z_.]+]] = bitcast [3 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T018:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
+//CHECK-NEXT:   %[[T019:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T018]], align 8
+//CHECK-NEXT:   %[[T020:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T019]], i32 0
+//CHECK-NEXT:   %[[T021:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T020]], i32 0, i256 2
+//CHECK-NEXT:   %[[T022:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARENA]], i32 0, i256 1
+//CHECK-NEXT:   %[[T023:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
+//CHECK-NEXT:   %[[T024:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T023]], align 8
+//CHECK-NEXT:   %[[T025:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T024]], i32 0
+//CHECK-NEXT:   %[[T026:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 1
+//CHECK-NEXT:   %[[T027:[0-9a-zA-Z_.]+]] = bitcast i32* %[[T026]] to i256*
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_2]]([0 x i256]* %[[T017]], [0 x i256]* %[[ARENA]], i256* %[[T021]], i256* %[[T022]], [0 x i256]* %[[T025]], i256* %[[T027]])
+//CHECK-NEXT:   %[[T028:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
+//CHECK-NEXT:   %[[T029:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T028]], align 8
+//CHECK-NEXT:   %[[T030:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T029]], i32 0, i32 0
+//CHECK-NEXT:   %[[T031:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T030]], align 4
+//CHECK-NEXT:   %call.fr_eq = call i1 @fr_eq(i256 %[[T031]], i256 77)
 //CHECK-NEXT:   call void @__assert(i1 %call.fr_eq)
 //CHECK-NEXT:   %constraint = alloca i1, align 1
 //CHECK-NEXT:   call void @__constraint_value(i1 %call.fr_eq, i1* %constraint)
-//CHECK-NEXT:   %32 = getelementptr [3 x i256], [3 x i256]* %lvars, i32 0, i32 1
-//CHECK-NEXT:   store i256 1, i256* %32, align 4
-//CHECK-NEXT:   %33 = getelementptr [3 x i256], [3 x i256]* %lvars, i32 0, i32 2
-//CHECK-NEXT:   store i256 0, i256* %33, align 4
-//CHECK-NEXT:   %34 = bitcast [3 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %35 = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 0
-//CHECK-NEXT:   %36 = load [0 x i256]*, [0 x i256]** %35, align 8
-//CHECK-NEXT:   %37 = getelementptr [0 x i256], [0 x i256]* %36, i32 0
-//CHECK-NEXT:   %38 = getelementptr [0 x i256], [0 x i256]* %37, i32 0, i256 1
-//CHECK-NEXT:   %39 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 2
-//CHECK-NEXT:   %40 = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 0
-//CHECK-NEXT:   %41 = load [0 x i256]*, [0 x i256]** %40, align 8
-//CHECK-NEXT:   %42 = getelementptr [0 x i256], [0 x i256]* %41, i32 0
-//CHECK-NEXT:   %43 = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 1
-//CHECK-NEXT:   %44 = bitcast i32* %43 to i256*
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %34, [0 x i256]* %0, i256* %38, i256* %39, [0 x i256]* %42, i256* %44)
-//CHECK-NEXT:   %45 = bitcast [3 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %46 = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 0
-//CHECK-NEXT:   %47 = load [0 x i256]*, [0 x i256]** %46, align 8
-//CHECK-NEXT:   %48 = getelementptr [0 x i256], [0 x i256]* %47, i32 0
-//CHECK-NEXT:   %49 = getelementptr [0 x i256], [0 x i256]* %48, i32 0, i256 2
-//CHECK-NEXT:   %50 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 3
-//CHECK-NEXT:   %51 = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 0
-//CHECK-NEXT:   %52 = load [0 x i256]*, [0 x i256]** %51, align 8
-//CHECK-NEXT:   %53 = getelementptr [0 x i256], [0 x i256]* %52, i32 0
-//CHECK-NEXT:   %54 = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 1
-//CHECK-NEXT:   %55 = bitcast i32* %54 to i256*
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_2]]([0 x i256]* %45, [0 x i256]* %0, i256* %49, i256* %50, [0 x i256]* %53, i256* %55)
-//CHECK-NEXT:   %56 = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 0
-//CHECK-NEXT:   %57 = load [0 x i256]*, [0 x i256]** %56, align 8
-//CHECK-NEXT:   %58 = getelementptr [0 x i256], [0 x i256]* %57, i32 0, i32 0
-//CHECK-NEXT:   %59 = load i256, i256* %58, align 4
-//CHECK-NEXT:   %call.fr_eq22 = call i1 @fr_eq(i256 %59, i256 77)
+//CHECK-NEXT:   %[[T032:[0-9a-zA-Z_.]+]] = getelementptr [3 x i256], [3 x i256]* %lvars, i32 0, i32 1
+//CHECK-NEXT:   store i256 1, i256* %[[T032]], align 4
+//CHECK-NEXT:   %[[T033:[0-9a-zA-Z_.]+]] = getelementptr [3 x i256], [3 x i256]* %lvars, i32 0, i32 2
+//CHECK-NEXT:   store i256 0, i256* %[[T033]], align 4
+//CHECK-NEXT:   %[[T034:[0-9a-zA-Z_.]+]] = bitcast [3 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T035:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 0
+//CHECK-NEXT:   %[[T036:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T035]], align 8
+//CHECK-NEXT:   %[[T037:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T036]], i32 0
+//CHECK-NEXT:   %[[T038:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T037]], i32 0, i256 1
+//CHECK-NEXT:   %[[T039:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARENA]], i32 0, i256 2
+//CHECK-NEXT:   %[[T040:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 0
+//CHECK-NEXT:   %[[T041:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T040]], align 8
+//CHECK-NEXT:   %[[T042:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T041]], i32 0
+//CHECK-NEXT:   %[[T043:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 1
+//CHECK-NEXT:   %[[T044:[0-9a-zA-Z_.]+]] = bitcast i32* %[[T043]] to i256*
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %[[T034]], [0 x i256]* %[[ARENA]], i256* %[[T038]], i256* %[[T039]], [0 x i256]* %[[T042]], i256* %[[T044]])
+//CHECK-NEXT:   %[[T045:[0-9a-zA-Z_.]+]] = bitcast [3 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T046:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 0
+//CHECK-NEXT:   %[[T047:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T046]], align 8
+//CHECK-NEXT:   %[[T048:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T047]], i32 0
+//CHECK-NEXT:   %[[T049:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T048]], i32 0, i256 2
+//CHECK-NEXT:   %[[T050:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARENA]], i32 0, i256 3
+//CHECK-NEXT:   %[[T051:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 0
+//CHECK-NEXT:   %[[T052:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T051]], align 8
+//CHECK-NEXT:   %[[T053:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T052]], i32 0
+//CHECK-NEXT:   %[[T054:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 1
+//CHECK-NEXT:   %[[T055:[0-9a-zA-Z_.]+]] = bitcast i32* %[[T054]] to i256*
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_2]]([0 x i256]* %[[T045]], [0 x i256]* %[[ARENA]], i256* %[[T049]], i256* %[[T050]], [0 x i256]* %[[T053]], i256* %[[T055]])
+//CHECK-NEXT:   %[[T056:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 0
+//CHECK-NEXT:   %[[T057:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T056]], align 8
+//CHECK-NEXT:   %[[T058:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T057]], i32 0, i32 0
+//CHECK-NEXT:   %[[T059:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T058]], align 4
+//CHECK-NEXT:   %call.fr_eq22 = call i1 @fr_eq(i256 %[[T059]], i256 77)
 //CHECK-NEXT:   call void @__assert(i1 %call.fr_eq22)
 //CHECK-NEXT:   %constraint23 = alloca i1, align 1
 //CHECK-NEXT:   call void @__constraint_value(i1 %call.fr_eq22, i1* %constraint23)
-//CHECK-NEXT:   %60 = getelementptr [3 x i256], [3 x i256]* %lvars, i32 0, i32 1
-//CHECK-NEXT:   store i256 2, i256* %60, align 4
+//CHECK-NEXT:   %[[T060:[0-9a-zA-Z_.]+]] = getelementptr [3 x i256], [3 x i256]* %lvars, i32 0, i32 1
+//CHECK-NEXT:   store i256 2, i256* %[[T060]], align 4
 //CHECK-NEXT:   br label %prologue
 //CHECK-EMPTY: 
 //CHECK-NEXT: prologue:

--- a/circom/tests/loops/assign_in_loop_1.circom
+++ b/circom/tests/loops/assign_in_loop_1.circom
@@ -30,17 +30,17 @@ component main = Num2Bits(3);
 //CHECK-NEXT:   br label %store1
 //CHECK-EMPTY: 
 //CHECK-NEXT: store1:
-//CHECK-NEXT:   %0 = getelementptr [0 x i256], [0 x i256]* %signals, i32 0, i32 3
-//CHECK-NEXT:   %1 = load i256, i256* %0, align 4
-//CHECK-NEXT:   %2 = getelementptr i256, i256* %subsig_[[X1]], i32 0
-//CHECK-NEXT:   store i256 %1, i256* %2, align 4
+//CHECK-NEXT:   %[[T002:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subsig_[[X1]], i32 0
+//CHECK-NEXT:   %[[T000:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %signals, i32 0, i32 3
+//CHECK-NEXT:   %[[T001:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T000]], align 4
+//CHECK-NEXT:   store i256 %[[T001]], i256* %[[T002]], align 4
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY: 
 //CHECK-NEXT: store2:
-//CHECK-NEXT:   %3 = load i256, i256* %subc_[[X3]], align 4
-//CHECK-NEXT:   %call.fr_sub = call i256 @fr_sub(i256 %3, i256 1)
-//CHECK-NEXT:   %4 = getelementptr i256, i256* %subc_[[X3]], i32 0
-//CHECK-NEXT:   store i256 %call.fr_sub, i256* %4, align 4
+//CHECK-NEXT:   %[[T004:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subc_[[X3]], i32 0
+//CHECK-NEXT:   %[[T003:[0-9a-zA-Z_.]+]] = load i256, i256* %subc_[[X3]], align 4
+//CHECK-NEXT:   %call.fr_sub = call i256 @fr_sub(i256 %[[T003]], i256 1)
+//CHECK-NEXT:   store i256 %call.fr_sub, i256* %[[T004]], align 4
 //CHECK-NEXT:   br label %fold_true3
 //CHECK-EMPTY: 
 //CHECK-NEXT: fold_true3:
@@ -48,98 +48,99 @@ component main = Num2Bits(3);
 //CHECK-NEXT:   br label %store4
 //CHECK-EMPTY: 
 //CHECK-NEXT: store4:
-//CHECK-NEXT:   %5 = getelementptr i256, i256* %subsig_[[X3]], i32 0
-//CHECK-NEXT:   %6 = load i256, i256* %5, align 4
-//CHECK-NEXT:   %7 = getelementptr i256, i256* %sig_[[X2]], i32 0
-//CHECK-NEXT:   store i256 %6, i256* %7, align 4
+//CHECK-NEXT:   %[[T007:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_[[X2]], i32 0
+//CHECK-NEXT:   %[[T005:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subsig_[[X3]], i32 0
+//CHECK-NEXT:   %[[T006:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T005]], align 4
+//CHECK-NEXT:   store i256 %[[T006]], i256* %[[T007]], align 4
 //CHECK-NEXT:   br label %store5
 //CHECK-EMPTY: 
 //CHECK-NEXT: store5:
-//CHECK-NEXT:   %8 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
-//CHECK-NEXT:   %9 = load i256, i256* %8, align 4
-//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %9, i256 1)
-//CHECK-NEXT:   %10 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
-//CHECK-NEXT:   store i256 %call.fr_add, i256* %10, align 4
+//CHECK-NEXT:   %[[T010:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
+//CHECK-NEXT:   %[[T008:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
+//CHECK-NEXT:   %[[T009:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T008]], align 4
+//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %[[T009]], i256 1)
+//CHECK-NEXT:   store i256 %call.fr_add, i256* %[[T010]], align 4
 //CHECK-NEXT:   br label %return6
 //CHECK-EMPTY: 
 //CHECK-NEXT: return6:
 //CHECK-NEXT:   ret void
 //CHECK-NEXT: }
 //
-//CHECK-LABEL: define{{.*}} void @Num2Bits_{{[0-9]+}}_run([0 x i256]* %0){{.*}} {
+//CHECK-LABEL: define{{.*}} void @Num2Bits_{{[0-9]+}}_run
+//CHECK-SAME: ([0 x i256]* %[[ARG:[0-9a-zA-Z_.]+]]){{.*}} {
 //CHECK-NEXT: prelude:
 //CHECK-NEXT:   %lvars = alloca [2 x i256], align 8
 //CHECK-NEXT:   %subcmps = alloca [3 x { [0 x i256]*, i32 }], align 8
 //CHECK-NEXT:   br label %store1
 //CHECK-EMPTY: 
 //CHECK-NEXT: store1:
-//CHECK-NEXT:   %1 = getelementptr [2 x i256], [2 x i256]* %lvars, i32 0, i32 0
-//CHECK-NEXT:   store i256 3, i256* %1, align 4
+//CHECK-NEXT:   %[[T001:[0-9a-zA-Z_.]+]] = getelementptr [2 x i256], [2 x i256]* %lvars, i32 0, i32 0
+//CHECK-NEXT:   store i256 3, i256* %[[T001]], align 4
 //CHECK-NEXT:   br label %create_cmp2
 //CHECK-EMPTY: 
 //CHECK-NEXT: create_cmp2:
-//CHECK-NEXT:   %2 = getelementptr [3 x { [0 x i256]*, i32 }], [3 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0
-//CHECK-NEXT:   call void @Inner_0_build({ [0 x i256]*, i32 }* %2)
-//CHECK-NEXT:   %3 = getelementptr [3 x { [0 x i256]*, i32 }], [3 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1
-//CHECK-NEXT:   call void @Inner_0_build({ [0 x i256]*, i32 }* %3)
-//CHECK-NEXT:   %4 = getelementptr [3 x { [0 x i256]*, i32 }], [3 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 2
-//CHECK-NEXT:   call void @Inner_0_build({ [0 x i256]*, i32 }* %4)
+//CHECK-NEXT:   %[[T002:[0-9a-zA-Z_.]+]] = getelementptr [3 x { [0 x i256]*, i32 }], [3 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0
+//CHECK-NEXT:   call void @Inner_0_build({ [0 x i256]*, i32 }* %[[T002]])
+//CHECK-NEXT:   %[[T003:[0-9a-zA-Z_.]+]] = getelementptr [3 x { [0 x i256]*, i32 }], [3 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1
+//CHECK-NEXT:   call void @Inner_0_build({ [0 x i256]*, i32 }* %[[T003]])
+//CHECK-NEXT:   %[[T004:[0-9a-zA-Z_.]+]] = getelementptr [3 x { [0 x i256]*, i32 }], [3 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 2
+//CHECK-NEXT:   call void @Inner_0_build({ [0 x i256]*, i32 }* %[[T004]])
 //CHECK-NEXT:   br label %store3
 //CHECK-EMPTY: 
 //CHECK-NEXT: store3:
-//CHECK-NEXT:   %5 = getelementptr [2 x i256], [2 x i256]* %lvars, i32 0, i32 1
-//CHECK-NEXT:   store i256 0, i256* %5, align 4
+//CHECK-NEXT:   %[[T005:[0-9a-zA-Z_.]+]] = getelementptr [2 x i256], [2 x i256]* %lvars, i32 0, i32 1
+//CHECK-NEXT:   store i256 0, i256* %[[T005]], align 4
 //CHECK-NEXT:   br label %unrolled_loop4
 //CHECK-EMPTY: 
 //CHECK-NEXT: unrolled_loop4:
-//CHECK-NEXT:   %6 = bitcast [2 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %7 = getelementptr [3 x { [0 x i256]*, i32 }], [3 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
-//CHECK-NEXT:   %8 = load [0 x i256]*, [0 x i256]** %7, align 8
-//CHECK-NEXT:   %9 = getelementptr [0 x i256], [0 x i256]* %8, i32 0
-//CHECK-NEXT:   %10 = getelementptr [0 x i256], [0 x i256]* %9, i32 0, i256 1
-//CHECK-NEXT:   %11 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 0
-//CHECK-NEXT:   %12 = getelementptr [3 x { [0 x i256]*, i32 }], [3 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
-//CHECK-NEXT:   %13 = load [0 x i256]*, [0 x i256]** %12, align 8
-//CHECK-NEXT:   %14 = getelementptr [0 x i256], [0 x i256]* %13, i32 0
-//CHECK-NEXT:   %15 = getelementptr [0 x i256], [0 x i256]* %14, i32 0, i256 0
-//CHECK-NEXT:   %16 = getelementptr [3 x { [0 x i256]*, i32 }], [3 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
-//CHECK-NEXT:   %17 = load [0 x i256]*, [0 x i256]** %16, align 8
-//CHECK-NEXT:   %18 = getelementptr [0 x i256], [0 x i256]* %17, i32 0
-//CHECK-NEXT:   %19 = getelementptr [3 x { [0 x i256]*, i32 }], [3 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 1
-//CHECK-NEXT:   %20 = bitcast i32* %19 to i256*
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %6, [0 x i256]* %0, i256* %10, i256* %11, i256* %15, [0 x i256]* %18, i256* %20)
-//CHECK-NEXT:   %21 = bitcast [2 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %22 = getelementptr [3 x { [0 x i256]*, i32 }], [3 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 0
-//CHECK-NEXT:   %23 = load [0 x i256]*, [0 x i256]** %22, align 8
-//CHECK-NEXT:   %24 = getelementptr [0 x i256], [0 x i256]* %23, i32 0
-//CHECK-NEXT:   %25 = getelementptr [0 x i256], [0 x i256]* %24, i32 0, i256 1
-//CHECK-NEXT:   %26 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 1
-//CHECK-NEXT:   %27 = getelementptr [3 x { [0 x i256]*, i32 }], [3 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 0
-//CHECK-NEXT:   %28 = load [0 x i256]*, [0 x i256]** %27, align 8
-//CHECK-NEXT:   %29 = getelementptr [0 x i256], [0 x i256]* %28, i32 0
-//CHECK-NEXT:   %30 = getelementptr [0 x i256], [0 x i256]* %29, i32 0, i256 0
-//CHECK-NEXT:   %31 = getelementptr [3 x { [0 x i256]*, i32 }], [3 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 0
-//CHECK-NEXT:   %32 = load [0 x i256]*, [0 x i256]** %31, align 8
-//CHECK-NEXT:   %33 = getelementptr [0 x i256], [0 x i256]* %32, i32 0
-//CHECK-NEXT:   %34 = getelementptr [3 x { [0 x i256]*, i32 }], [3 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 1
-//CHECK-NEXT:   %35 = bitcast i32* %34 to i256*
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %21, [0 x i256]* %0, i256* %25, i256* %26, i256* %30, [0 x i256]* %33, i256* %35)
-//CHECK-NEXT:   %36 = bitcast [2 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %37 = getelementptr [3 x { [0 x i256]*, i32 }], [3 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 2, i32 0
-//CHECK-NEXT:   %38 = load [0 x i256]*, [0 x i256]** %37, align 8
-//CHECK-NEXT:   %39 = getelementptr [0 x i256], [0 x i256]* %38, i32 0
-//CHECK-NEXT:   %40 = getelementptr [0 x i256], [0 x i256]* %39, i32 0, i256 1
-//CHECK-NEXT:   %41 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 2
-//CHECK-NEXT:   %42 = getelementptr [3 x { [0 x i256]*, i32 }], [3 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 2, i32 0
-//CHECK-NEXT:   %43 = load [0 x i256]*, [0 x i256]** %42, align 8
-//CHECK-NEXT:   %44 = getelementptr [0 x i256], [0 x i256]* %43, i32 0
-//CHECK-NEXT:   %45 = getelementptr [0 x i256], [0 x i256]* %44, i32 0, i256 0
-//CHECK-NEXT:   %46 = getelementptr [3 x { [0 x i256]*, i32 }], [3 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 2, i32 0
-//CHECK-NEXT:   %47 = load [0 x i256]*, [0 x i256]** %46, align 8
-//CHECK-NEXT:   %48 = getelementptr [0 x i256], [0 x i256]* %47, i32 0
-//CHECK-NEXT:   %49 = getelementptr [3 x { [0 x i256]*, i32 }], [3 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 2, i32 1
-//CHECK-NEXT:   %50 = bitcast i32* %49 to i256*
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %36, [0 x i256]* %0, i256* %40, i256* %41, i256* %45, [0 x i256]* %48, i256* %50)
+//CHECK-NEXT:   %[[T006:[0-9a-zA-Z_.]+]] = bitcast [2 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T007:[0-9a-zA-Z_.]+]] = getelementptr [3 x { [0 x i256]*, i32 }], [3 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
+//CHECK-NEXT:   %[[T008:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T007]], align 8
+//CHECK-NEXT:   %[[T009:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T008]], i32 0
+//CHECK-NEXT:   %[[T010:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T009]], i32 0, i256 1
+//CHECK-NEXT:   %[[T011:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 0
+//CHECK-NEXT:   %[[T012:[0-9a-zA-Z_.]+]] = getelementptr [3 x { [0 x i256]*, i32 }], [3 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
+//CHECK-NEXT:   %[[T013:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T012]], align 8
+//CHECK-NEXT:   %[[T014:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T013]], i32 0
+//CHECK-NEXT:   %[[T015:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T014]], i32 0, i256 0
+//CHECK-NEXT:   %[[T016:[0-9a-zA-Z_.]+]] = getelementptr [3 x { [0 x i256]*, i32 }], [3 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
+//CHECK-NEXT:   %[[T017:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T016]], align 8
+//CHECK-NEXT:   %[[T018:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T017]], i32 0
+//CHECK-NEXT:   %[[T019:[0-9a-zA-Z_.]+]] = getelementptr [3 x { [0 x i256]*, i32 }], [3 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 1
+//CHECK-NEXT:   %[[T020:[0-9a-zA-Z_.]+]] = bitcast i32* %[[T019]] to i256*
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %[[T006]], [0 x i256]* %[[ARG]], i256* %[[T010]], i256* %[[T011]], i256* %[[T015]], [0 x i256]* %[[T018]], i256* %[[T020]])
+//CHECK-NEXT:   %[[T021:[0-9a-zA-Z_.]+]] = bitcast [2 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T022:[0-9a-zA-Z_.]+]] = getelementptr [3 x { [0 x i256]*, i32 }], [3 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 0
+//CHECK-NEXT:   %[[T023:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T022]], align 8
+//CHECK-NEXT:   %[[T024:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T023]], i32 0
+//CHECK-NEXT:   %[[T025:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T024]], i32 0, i256 1
+//CHECK-NEXT:   %[[T026:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 1
+//CHECK-NEXT:   %[[T027:[0-9a-zA-Z_.]+]] = getelementptr [3 x { [0 x i256]*, i32 }], [3 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 0
+//CHECK-NEXT:   %[[T028:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T027]], align 8
+//CHECK-NEXT:   %[[T029:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T028]], i32 0
+//CHECK-NEXT:   %[[T030:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T029]], i32 0, i256 0
+//CHECK-NEXT:   %[[T031:[0-9a-zA-Z_.]+]] = getelementptr [3 x { [0 x i256]*, i32 }], [3 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 0
+//CHECK-NEXT:   %[[T032:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T031]], align 8
+//CHECK-NEXT:   %[[T033:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T032]], i32 0
+//CHECK-NEXT:   %[[T034:[0-9a-zA-Z_.]+]] = getelementptr [3 x { [0 x i256]*, i32 }], [3 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 1
+//CHECK-NEXT:   %[[T035:[0-9a-zA-Z_.]+]] = bitcast i32* %[[T034]] to i256*
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %[[T021]], [0 x i256]* %[[ARG]], i256* %[[T025]], i256* %[[T026]], i256* %[[T030]], [0 x i256]* %[[T033]], i256* %[[T035]])
+//CHECK-NEXT:   %[[T036:[0-9a-zA-Z_.]+]] = bitcast [2 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T037:[0-9a-zA-Z_.]+]] = getelementptr [3 x { [0 x i256]*, i32 }], [3 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 2, i32 0
+//CHECK-NEXT:   %[[T038:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T037]], align 8
+//CHECK-NEXT:   %[[T039:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T038]], i32 0
+//CHECK-NEXT:   %[[T040:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T039]], i32 0, i256 1
+//CHECK-NEXT:   %[[T041:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 2
+//CHECK-NEXT:   %[[T042:[0-9a-zA-Z_.]+]] = getelementptr [3 x { [0 x i256]*, i32 }], [3 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 2, i32 0
+//CHECK-NEXT:   %[[T043:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T042]], align 8
+//CHECK-NEXT:   %[[T044:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T043]], i32 0
+//CHECK-NEXT:   %[[T045:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T044]], i32 0, i256 0
+//CHECK-NEXT:   %[[T046:[0-9a-zA-Z_.]+]] = getelementptr [3 x { [0 x i256]*, i32 }], [3 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 2, i32 0
+//CHECK-NEXT:   %[[T047:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T046]], align 8
+//CHECK-NEXT:   %[[T048:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T047]], i32 0
+//CHECK-NEXT:   %[[T049:[0-9a-zA-Z_.]+]] = getelementptr [3 x { [0 x i256]*, i32 }], [3 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 2, i32 1
+//CHECK-NEXT:   %[[T050:[0-9a-zA-Z_.]+]] = bitcast i32* %[[T049]] to i256*
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %[[T036]], [0 x i256]* %[[ARG]], i256* %[[T040]], i256* %[[T041]], i256* %[[T045]], [0 x i256]* %[[T048]], i256* %[[T050]])
 //CHECK-NEXT:   br label %prologue
 //CHECK-EMPTY: 
 //CHECK-NEXT: prologue:

--- a/circom/tests/loops/call_inside_loop.circom
+++ b/circom/tests/loops/call_inside_loop.circom
@@ -50,19 +50,19 @@ component main = CallInLoop(2, 3);
 //CHECK-NEXT:   br label %store1
 //CHECK-EMPTY: 
 //CHECK-NEXT: store1:
-//CHECK-NEXT:   %0 = getelementptr [0 x i256], [0 x i256]* %signals, i32 0, i32 1
-//CHECK-NEXT:   %1 = load i256, i256* %0, align 4
-//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 3, i256 %1)
-//CHECK-NEXT:   %2 = getelementptr i256, i256* %var_0, i32 0
-//CHECK-NEXT:   store i256 %call.fr_add, i256* %2, align 4
+//CHECK-NEXT:   %[[T002:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %var_0, i32 0
+//CHECK-NEXT:   %[[T000:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %signals, i32 0, i32 1
+//CHECK-NEXT:   %[[T001:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T000]], align 4
+//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 3, i256 %[[T001]])
+//CHECK-NEXT:   store i256 %call.fr_add, i256* %[[T002]], align 4
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY: 
 //CHECK-NEXT: store2:
-//CHECK-NEXT:   %3 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 4
-//CHECK-NEXT:   %4 = load i256, i256* %3, align 4
-//CHECK-NEXT:   %call.fr_add1 = call i256 @fr_add(i256 %4, i256 1)
-//CHECK-NEXT:   %5 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 4
-//CHECK-NEXT:   store i256 %call.fr_add1, i256* %5, align 4
+//CHECK-NEXT:   %[[T005:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 4
+//CHECK-NEXT:   %[[T003:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 4
+//CHECK-NEXT:   %[[T004:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T003]], align 4
+//CHECK-NEXT:   %call.fr_add1 = call i256 @fr_add(i256 %[[T004]], i256 1)
+//CHECK-NEXT:   store i256 %call.fr_add1, i256* %[[T005]], align 4
 //CHECK-NEXT:   br label %return3
 //CHECK-EMPTY: 
 //CHECK-NEXT: return3:
@@ -76,114 +76,115 @@ component main = CallInLoop(2, 3);
 //CHECK-EMPTY: 
 //CHECK-NEXT: call1:
 //CHECK-NEXT:   %fun_0_arena = alloca [15 x i256], align 8
-//CHECK-NEXT:   %0 = getelementptr [15 x i256], [15 x i256]* %fun_0_arena, i32 0, i32 0
-//CHECK-NEXT:   %1 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
-//CHECK-NEXT:   call void @fr_copy_n(i256* %1, i256* %0, i32 2)
-//CHECK-NEXT:   %2 = getelementptr [15 x i256], [15 x i256]* %fun_0_arena, i32 0, i32 2
-//CHECK-NEXT:   store i256 2, i256* %2, align 4
-//CHECK-NEXT:   %3 = getelementptr [15 x i256], [15 x i256]* %fun_0_arena, i32 0, i32 3
-//CHECK-NEXT:   store i256 3, i256* %3, align 4
-//CHECK-NEXT:   %4 = getelementptr [15 x i256], [15 x i256]* %fun_0_arena, i32 0, i32 4
-//CHECK-NEXT:   store i256 3, i256* %4, align 4
-//CHECK-NEXT:   %5 = getelementptr [15 x i256], [15 x i256]* %fun_0_arena, i32 0, i32 5
-//CHECK-NEXT:   store i256 3, i256* %5, align 4
-//CHECK-NEXT:   %6 = getelementptr [15 x i256], [15 x i256]* %fun_0_arena, i32 0, i32 6
-//CHECK-NEXT:   store i256 3, i256* %6, align 4
-//CHECK-NEXT:   %7 = getelementptr [15 x i256], [15 x i256]* %fun_0_arena, i32 0, i32 7
-//CHECK-NEXT:   store i256 3, i256* %7, align 4
-//CHECK-NEXT:   %8 = getelementptr [15 x i256], [15 x i256]* %fun_0_arena, i32 0, i32 8
-//CHECK-NEXT:   store i256 3, i256* %8, align 4
-//CHECK-NEXT:   %9 = bitcast [15 x i256]* %fun_0_arena to i256*
-//CHECK-NEXT:   %call.fun_0 = call i256 @fun_0(i256* %9)
-//CHECK-NEXT:   %10 = getelementptr i256, i256* %var_0, i32 0
-//CHECK-NEXT:   store i256 %call.fun_0, i256* %10, align 4
+//CHECK-NEXT:   %[[T000:[0-9a-zA-Z_.]+]] = getelementptr [15 x i256], [15 x i256]* %fun_0_arena, i32 0, i32 0
+//CHECK-NEXT:   %[[T001:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
+//CHECK-NEXT:   call void @fr_copy_n(i256* %[[T001]], i256* %[[T000]], i32 2)
+//CHECK-NEXT:   %[[T002:[0-9a-zA-Z_.]+]] = getelementptr [15 x i256], [15 x i256]* %fun_0_arena, i32 0, i32 2
+//CHECK-NEXT:   store i256 2, i256* %[[T002]], align 4
+//CHECK-NEXT:   %[[T003:[0-9a-zA-Z_.]+]] = getelementptr [15 x i256], [15 x i256]* %fun_0_arena, i32 0, i32 3
+//CHECK-NEXT:   store i256 3, i256* %[[T003]], align 4
+//CHECK-NEXT:   %[[T004:[0-9a-zA-Z_.]+]] = getelementptr [15 x i256], [15 x i256]* %fun_0_arena, i32 0, i32 4
+//CHECK-NEXT:   store i256 3, i256* %[[T004]], align 4
+//CHECK-NEXT:   %[[T005:[0-9a-zA-Z_.]+]] = getelementptr [15 x i256], [15 x i256]* %fun_0_arena, i32 0, i32 5
+//CHECK-NEXT:   store i256 3, i256* %[[T005]], align 4
+//CHECK-NEXT:   %[[T006:[0-9a-zA-Z_.]+]] = getelementptr [15 x i256], [15 x i256]* %fun_0_arena, i32 0, i32 6
+//CHECK-NEXT:   store i256 3, i256* %[[T006]], align 4
+//CHECK-NEXT:   %[[T007:[0-9a-zA-Z_.]+]] = getelementptr [15 x i256], [15 x i256]* %fun_0_arena, i32 0, i32 7
+//CHECK-NEXT:   store i256 3, i256* %[[T007]], align 4
+//CHECK-NEXT:   %[[T008:[0-9a-zA-Z_.]+]] = getelementptr [15 x i256], [15 x i256]* %fun_0_arena, i32 0, i32 8
+//CHECK-NEXT:   store i256 3, i256* %[[T008]], align 4
+//CHECK-NEXT:   %[[T009:[0-9a-zA-Z_.]+]] = bitcast [15 x i256]* %fun_0_arena to i256*
+//CHECK-NEXT:   %call.fun_0 = call i256 @fun_0(i256* %[[T009]])
+//CHECK-NEXT:   %[[T010:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %var_0, i32 0
+//CHECK-NEXT:   store i256 %call.fun_0, i256* %[[T010]], align 4
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY: 
 //CHECK-NEXT: store2:
-//CHECK-NEXT:   %11 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 6
-//CHECK-NEXT:   %12 = load i256, i256* %11, align 4
-//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %12, i256 1)
-//CHECK-NEXT:   %13 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 6
-//CHECK-NEXT:   store i256 %call.fr_add, i256* %13, align 4
+//CHECK-NEXT:   %[[T013:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 6
+//CHECK-NEXT:   %[[T011:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 6
+//CHECK-NEXT:   %[[T012:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T011]], align 4
+//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %[[T012]], i256 1)
+//CHECK-NEXT:   store i256 %call.fr_add, i256* %[[T013]], align 4
 //CHECK-NEXT:   br label %return3
 //CHECK-EMPTY: 
 //CHECK-NEXT: return3:
 //CHECK-NEXT:   ret void
 //CHECK-NEXT: }
 //
-//CHECK-LABEL: define{{.*}} void @CallInLoop_{{[0-9]+}}_run([0 x i256]* %0){{.*}} {
+//CHECK-LABEL: define{{.*}} void @CallInLoop_{{[0-9]+}}_run
+//CHECK-SAME: ([0 x i256]* %[[ARG:[0-9a-zA-Z_.]+]]){{.*}} {
 //CHECK-NEXT: prelude:
 //CHECK-NEXT:   %lvars = alloca [7 x i256], align 8
 //CHECK-NEXT:   %subcmps = alloca [0 x { [0 x i256]*, i32 }], align 8
 //CHECK-NEXT:   br label %store1
 //CHECK-EMPTY: 
 //CHECK-NEXT: store1:
-//CHECK-NEXT:   %1 = getelementptr [7 x i256], [7 x i256]* %lvars, i32 0, i32 0
-//CHECK-NEXT:   store i256 3, i256* %1, align 4
+//CHECK-NEXT:   %[[T001:[0-9a-zA-Z_.]+]] = getelementptr [7 x i256], [7 x i256]* %lvars, i32 0, i32 0
+//CHECK-NEXT:   store i256 3, i256* %[[T001]], align 4
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY: 
 //CHECK-NEXT: store2:
-//CHECK-NEXT:   %2 = getelementptr [7 x i256], [7 x i256]* %lvars, i32 0, i32 1
-//CHECK-NEXT:   store i256 2, i256* %2, align 4
+//CHECK-NEXT:   %[[T002:[0-9a-zA-Z_.]+]] = getelementptr [7 x i256], [7 x i256]* %lvars, i32 0, i32 1
+//CHECK-NEXT:   store i256 2, i256* %[[T002]], align 4
 //CHECK-NEXT:   br label %store3
 //CHECK-EMPTY: 
 //CHECK-NEXT: store3:
-//CHECK-NEXT:   %3 = getelementptr [7 x i256], [7 x i256]* %lvars, i32 0, i32 2
-//CHECK-NEXT:   store i256 0, i256* %3, align 4
+//CHECK-NEXT:   %[[T003:[0-9a-zA-Z_.]+]] = getelementptr [7 x i256], [7 x i256]* %lvars, i32 0, i32 2
+//CHECK-NEXT:   store i256 0, i256* %[[T003]], align 4
 //CHECK-NEXT:   br label %store4
 //CHECK-EMPTY: 
 //CHECK-NEXT: store4:
-//CHECK-NEXT:   %4 = getelementptr [7 x i256], [7 x i256]* %lvars, i32 0, i32 3
-//CHECK-NEXT:   store i256 0, i256* %4, align 4
+//CHECK-NEXT:   %[[T004:[0-9a-zA-Z_.]+]] = getelementptr [7 x i256], [7 x i256]* %lvars, i32 0, i32 3
+//CHECK-NEXT:   store i256 0, i256* %[[T004]], align 4
 //CHECK-NEXT:   br label %store5
 //CHECK-EMPTY: 
 //CHECK-NEXT: store5:
-//CHECK-NEXT:   %5 = getelementptr [7 x i256], [7 x i256]* %lvars, i32 0, i32 4
-//CHECK-NEXT:   store i256 0, i256* %5, align 4
+//CHECK-NEXT:   %[[T005:[0-9a-zA-Z_.]+]] = getelementptr [7 x i256], [7 x i256]* %lvars, i32 0, i32 4
+//CHECK-NEXT:   store i256 0, i256* %[[T005]], align 4
 //CHECK-NEXT:   br label %unrolled_loop6
 //CHECK-EMPTY: 
 //CHECK-NEXT: unrolled_loop6:
-//CHECK-NEXT:   %6 = bitcast [7 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %7 = bitcast [7 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %8 = getelementptr [0 x i256], [0 x i256]* %7, i32 0, i256 2
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %6, [0 x i256]* %0, i256* %8)
-//CHECK-NEXT:   %9 = bitcast [7 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %10 = bitcast [7 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %11 = getelementptr [0 x i256], [0 x i256]* %10, i32 0, i256 3
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %9, [0 x i256]* %0, i256* %11)
+//CHECK-NEXT:   %[[T006:[0-9a-zA-Z_.]+]] = bitcast [7 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T007:[0-9a-zA-Z_.]+]] = bitcast [7 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T008:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T007]], i32 0, i256 2
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %[[T006]], [0 x i256]* %[[ARG]], i256* %[[T008]])
+//CHECK-NEXT:   %[[T009:[0-9a-zA-Z_.]+]] = bitcast [7 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T010:[0-9a-zA-Z_.]+]] = bitcast [7 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T011:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T010]], i32 0, i256 3
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %[[T009]], [0 x i256]* %[[ARG]], i256* %[[T011]])
 //CHECK-NEXT:   br label %store7
 //CHECK-EMPTY: 
 //CHECK-NEXT: store7:
-//CHECK-NEXT:   %12 = getelementptr [7 x i256], [7 x i256]* %lvars, i32 0, i32 4
-//CHECK-NEXT:   store i256 0, i256* %12, align 4
+//CHECK-NEXT:   %[[T012:[0-9a-zA-Z_.]+]] = getelementptr [7 x i256], [7 x i256]* %lvars, i32 0, i32 4
+//CHECK-NEXT:   store i256 0, i256* %[[T012]], align 4
 //CHECK-NEXT:   br label %store8
 //CHECK-EMPTY: 
 //CHECK-NEXT: store8:
-//CHECK-NEXT:   %13 = getelementptr [7 x i256], [7 x i256]* %lvars, i32 0, i32 5
-//CHECK-NEXT:   store i256 0, i256* %13, align 4
+//CHECK-NEXT:   %[[T013:[0-9a-zA-Z_.]+]] = getelementptr [7 x i256], [7 x i256]* %lvars, i32 0, i32 5
+//CHECK-NEXT:   store i256 0, i256* %[[T013]], align 4
 //CHECK-NEXT:   br label %store9
 //CHECK-EMPTY: 
 //CHECK-NEXT: store9:
-//CHECK-NEXT:   %14 = getelementptr [7 x i256], [7 x i256]* %lvars, i32 0, i32 6
-//CHECK-NEXT:   store i256 0, i256* %14, align 4
+//CHECK-NEXT:   %[[T014:[0-9a-zA-Z_.]+]] = getelementptr [7 x i256], [7 x i256]* %lvars, i32 0, i32 6
+//CHECK-NEXT:   store i256 0, i256* %[[T014]], align 4
 //CHECK-NEXT:   br label %unrolled_loop10
 //CHECK-EMPTY: 
 //CHECK-NEXT: unrolled_loop10:
-//CHECK-NEXT:   %15 = bitcast [7 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %16 = bitcast [7 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %17 = getelementptr [0 x i256], [0 x i256]* %16, i32 0, i256 4
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_2]]([0 x i256]* %15, [0 x i256]* %0, i256* %17)
-//CHECK-NEXT:   %18 = bitcast [7 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %19 = bitcast [7 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %20 = getelementptr [0 x i256], [0 x i256]* %19, i32 0, i256 5
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_2]]([0 x i256]* %18, [0 x i256]* %0, i256* %20)
+//CHECK-NEXT:   %[[T015:[0-9a-zA-Z_.]+]] = bitcast [7 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T016:[0-9a-zA-Z_.]+]] = bitcast [7 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T017:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T016]], i32 0, i256 4
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_2]]([0 x i256]* %[[T015]], [0 x i256]* %[[ARG]], i256* %[[T017]])
+//CHECK-NEXT:   %[[T018:[0-9a-zA-Z_.]+]] = bitcast [7 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T019:[0-9a-zA-Z_.]+]] = bitcast [7 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T020:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T019]], i32 0, i256 5
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_2]]([0 x i256]* %[[T018]], [0 x i256]* %[[ARG]], i256* %[[T020]])
 //CHECK-NEXT:   br label %store11
 //CHECK-EMPTY: 
 //CHECK-NEXT: store11:
-//CHECK-NEXT:   %21 = getelementptr [7 x i256], [7 x i256]* %lvars, i32 0, i32 4
-//CHECK-NEXT:   %22 = load i256, i256* %21, align 4
-//CHECK-NEXT:   %23 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
-//CHECK-NEXT:   store i256 %22, i256* %23, align 4
+//CHECK-NEXT:   %[[T023:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i32 0
+//CHECK-NEXT:   %[[T021:[0-9a-zA-Z_.]+]] = getelementptr [7 x i256], [7 x i256]* %lvars, i32 0, i32 4
+//CHECK-NEXT:   %[[T022:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T021]], align 4
+//CHECK-NEXT:   store i256 %[[T022]], i256* %[[T023]], align 4
 //CHECK-NEXT:   br label %prologue
 //CHECK-EMPTY: 
 //CHECK-NEXT: prologue:

--- a/circom/tests/loops/fixed_idx_nested_lhs.circom
+++ b/circom/tests/loops/fixed_idx_nested_lhs.circom
@@ -19,74 +19,75 @@ component main = FixIdxNested();
 //CHECK-NEXT:   br label %store1
 //CHECK-EMPTY: 
 //CHECK-NEXT: store1:
-//CHECK-NEXT:   %0 = getelementptr i256, i256* %var_1, i32 0
-//CHECK-NEXT:   %1 = load i256, i256* %0, align 4
-//CHECK-NEXT:   %2 = getelementptr i256, i256* %sig_0, i32 0
-//CHECK-NEXT:   store i256 %1, i256* %2, align 4
+//CHECK-NEXT:   %[[T002:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_0, i32 0
+//CHECK-NEXT:   %[[T000:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %var_1, i32 0
+//CHECK-NEXT:   %[[T001:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T000]], align 4
+//CHECK-NEXT:   store i256 %[[T001]], i256* %[[T002]], align 4
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY: 
 //CHECK-NEXT: store2:
-//CHECK-NEXT:   %3 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 9
-//CHECK-NEXT:   %4 = load i256, i256* %3, align 4
-//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %4, i256 1)
-//CHECK-NEXT:   %5 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 9
-//CHECK-NEXT:   store i256 %call.fr_add, i256* %5, align 4
+//CHECK-NEXT:   %[[T005:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 9
+//CHECK-NEXT:   %[[T003:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 9
+//CHECK-NEXT:   %[[T004:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T003]], align 4
+//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %[[T004]], i256 1)
+//CHECK-NEXT:   store i256 %call.fr_add, i256* %[[T005]], align 4
 //CHECK-NEXT:   br label %return3
 //CHECK-EMPTY: 
 //CHECK-NEXT: return3:
 //CHECK-NEXT:   ret void
 //CHECK-NEXT: }
 
-//CHECK-LABEL: define{{.*}} void @FixIdxNested_0_run([0 x i256]* %0){{.*}} {
+//CHECK-LABEL: define{{.*}} void @FixIdxNested_0_run
+//CHECK-SAME: ([0 x i256]* %[[ARG:[0-9a-zA-Z_.]+]]){{.*}} {
 //CHECK-NEXT: prelude:
 //CHECK-NEXT:   %lvars = alloca [10 x i256], align 8
 //CHECK-NEXT:   %subcmps = alloca [0 x { [0 x i256]*, i32 }], align 8
 //CHECK-NEXT:   br label %store1
 //CHECK-EMPTY:
 //CHECK:      unrolled_loop11:
-//CHECK-NEXT:   %11 = bitcast [10 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %12 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 8
-//CHECK-NEXT:   %13 = bitcast [10 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %14 = getelementptr [0 x i256], [0 x i256]* %13, i32 0, i256 0
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %11, [0 x i256]* %0, i256* %12, i256* %14)
-//CHECK-NEXT:   %15 = bitcast [10 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %16 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 7
-//CHECK-NEXT:   %17 = bitcast [10 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %18 = getelementptr [0 x i256], [0 x i256]* %17, i32 0, i256 1
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %15, [0 x i256]* %0, i256* %16, i256* %18)
-//CHECK-NEXT:   %19 = bitcast [10 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %20 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 6
-//CHECK-NEXT:   %21 = bitcast [10 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %22 = getelementptr [0 x i256], [0 x i256]* %21, i32 0, i256 2
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %19, [0 x i256]* %0, i256* %20, i256* %22)
-//CHECK-NEXT:   %23 = bitcast [10 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %24 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 5
-//CHECK-NEXT:   %25 = bitcast [10 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %26 = getelementptr [0 x i256], [0 x i256]* %25, i32 0, i256 3
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %23, [0 x i256]* %0, i256* %24, i256* %26)
-//CHECK-NEXT:   %27 = bitcast [10 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %28 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 4
-//CHECK-NEXT:   %29 = bitcast [10 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %30 = getelementptr [0 x i256], [0 x i256]* %29, i32 0, i256 4
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %27, [0 x i256]* %0, i256* %28, i256* %30)
-//CHECK-NEXT:   %31 = bitcast [10 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %32 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 3
-//CHECK-NEXT:   %33 = bitcast [10 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %34 = getelementptr [0 x i256], [0 x i256]* %33, i32 0, i256 5
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %31, [0 x i256]* %0, i256* %32, i256* %34)
-//CHECK-NEXT:   %35 = bitcast [10 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %36 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 2
-//CHECK-NEXT:   %37 = bitcast [10 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %38 = getelementptr [0 x i256], [0 x i256]* %37, i32 0, i256 6
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %35, [0 x i256]* %0, i256* %36, i256* %38)
-//CHECK-NEXT:   %39 = bitcast [10 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %40 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 1
-//CHECK-NEXT:   %41 = bitcast [10 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %42 = getelementptr [0 x i256], [0 x i256]* %41, i32 0, i256 7
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %39, [0 x i256]* %0, i256* %40, i256* %42)
-//CHECK-NEXT:   %43 = bitcast [10 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %44 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 0
-//CHECK-NEXT:   %45 = bitcast [10 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %46 = getelementptr [0 x i256], [0 x i256]* %45, i32 0, i256 8
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %43, [0 x i256]* %0, i256* %44, i256* %46)
+//CHECK-NEXT:   %[[T011:[0-9a-zA-Z_.]+]] = bitcast [10 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T012:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 8
+//CHECK-NEXT:   %[[T013:[0-9a-zA-Z_.]+]] = bitcast [10 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T014:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T013]], i32 0, i256 0
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %[[T011]], [0 x i256]* %[[ARG]], i256* %[[T012]], i256* %[[T014]])
+//CHECK-NEXT:   %[[T015:[0-9a-zA-Z_.]+]] = bitcast [10 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T016:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 7
+//CHECK-NEXT:   %[[T017:[0-9a-zA-Z_.]+]] = bitcast [10 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T018:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T017]], i32 0, i256 1
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %[[T015]], [0 x i256]* %[[ARG]], i256* %[[T016]], i256* %[[T018]])
+//CHECK-NEXT:   %[[T019:[0-9a-zA-Z_.]+]] = bitcast [10 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T020:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 6
+//CHECK-NEXT:   %[[T021:[0-9a-zA-Z_.]+]] = bitcast [10 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T022:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T021]], i32 0, i256 2
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %[[T019]], [0 x i256]* %[[ARG]], i256* %[[T020]], i256* %[[T022]])
+//CHECK-NEXT:   %[[T023:[0-9a-zA-Z_.]+]] = bitcast [10 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T024:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 5
+//CHECK-NEXT:   %[[T025:[0-9a-zA-Z_.]+]] = bitcast [10 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T026:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T025]], i32 0, i256 3
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %[[T023]], [0 x i256]* %[[ARG]], i256* %[[T024]], i256* %[[T026]])
+//CHECK-NEXT:   %[[T027:[0-9a-zA-Z_.]+]] = bitcast [10 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T028:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 4
+//CHECK-NEXT:   %[[T029:[0-9a-zA-Z_.]+]] = bitcast [10 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T030:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T029]], i32 0, i256 4
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %[[T027]], [0 x i256]* %[[ARG]], i256* %[[T028]], i256* %[[T030]])
+//CHECK-NEXT:   %[[T031:[0-9a-zA-Z_.]+]] = bitcast [10 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T032:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 3
+//CHECK-NEXT:   %[[T033:[0-9a-zA-Z_.]+]] = bitcast [10 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T034:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T033]], i32 0, i256 5
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %[[T031]], [0 x i256]* %[[ARG]], i256* %[[T032]], i256* %[[T034]])
+//CHECK-NEXT:   %[[T035:[0-9a-zA-Z_.]+]] = bitcast [10 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T036:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 2
+//CHECK-NEXT:   %[[T037:[0-9a-zA-Z_.]+]] = bitcast [10 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T038:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T037]], i32 0, i256 6
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %[[T035]], [0 x i256]* %[[ARG]], i256* %[[T036]], i256* %[[T038]])
+//CHECK-NEXT:   %[[T039:[0-9a-zA-Z_.]+]] = bitcast [10 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T040:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 1
+//CHECK-NEXT:   %[[T041:[0-9a-zA-Z_.]+]] = bitcast [10 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T042:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T041]], i32 0, i256 7
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %[[T039]], [0 x i256]* %[[ARG]], i256* %[[T040]], i256* %[[T042]])
+//CHECK-NEXT:   %[[T043:[0-9a-zA-Z_.]+]] = bitcast [10 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T044:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 0
+//CHECK-NEXT:   %[[T045:[0-9a-zA-Z_.]+]] = bitcast [10 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T046:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T045]], i32 0, i256 8
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %[[T043]], [0 x i256]* %[[ARG]], i256* %[[T044]], i256* %[[T046]])
 //CHECK-NEXT:   br label %prologue

--- a/circom/tests/loops/fixed_idx_nested_rhs.circom
+++ b/circom/tests/loops/fixed_idx_nested_rhs.circom
@@ -24,96 +24,97 @@ component main = FixIdxNested();
 //CHECK-NEXT:   br label %store1
 //CHECK-EMPTY: 
 //CHECK-NEXT: store1:
-//CHECK-NEXT:   %0 = getelementptr i256, i256* %sig_1, i32 0
-//CHECK-NEXT:   %1 = load i256, i256* %0, align 4
-//CHECK-NEXT:   %2 = getelementptr i256, i256* %sig_0, i32 0
-//CHECK-NEXT:   store i256 %1, i256* %2, align 4
-//CHECK-NEXT:   %3 = load i256, i256* %2, align 4
+//CHECK-NEXT:   %[[T002:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_0, i32 0
+//CHECK-NEXT:   %[[T000:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_1, i32 0
+//CHECK-NEXT:   %[[T001:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T000]], align 4
+//CHECK-NEXT:   store i256 %[[T001]], i256* %[[T002]], align 4
+//CHECK-NEXT:   %[[T003:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T002]], align 4
 //CHECK-NEXT:   %constraint = alloca i1, align 1
-//CHECK-NEXT:   call void @__constraint_values(i256 %1, i256 %3, i1* %constraint)
+//CHECK-NEXT:   call void @__constraint_values(i256 %[[T001]], i256 %[[T003]], i1* %constraint)
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY: 
 //CHECK-NEXT: store2:
-//CHECK-NEXT:   %4 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 16
-//CHECK-NEXT:   %5 = load i256, i256* %4, align 4
-//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %5, i256 1)
-//CHECK-NEXT:   %6 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 16
-//CHECK-NEXT:   store i256 %call.fr_add, i256* %6, align 4
+//CHECK-NEXT:   %[[T006:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 16
+//CHECK-NEXT:   %[[T004:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 16
+//CHECK-NEXT:   %[[T005:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T004]], align 4
+//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %[[T005]], i256 1)
+//CHECK-NEXT:   store i256 %call.fr_add, i256* %[[T006]], align 4
 //CHECK-NEXT:   br label %return3
 //CHECK-EMPTY: 
 //CHECK-NEXT: return3:
 //CHECK-NEXT:   ret void
 //CHECK-NEXT: }
 //
-//CHECK-LABEL: define{{.*}} void @FixIdxNested_0_run([0 x i256]* %0){{.*}} {
+//CHECK-LABEL: define{{.*}} void @FixIdxNested_0_run
+//CHECK-SAME: ([0 x i256]* %[[ARG:[0-9a-zA-Z_.]+]]){{.*}} {
 //CHECK-NEXT: prelude:
 //CHECK-NEXT:   %lvars = alloca [17 x i256], align 8
 //CHECK-NEXT:   %subcmps = alloca [0 x { [0 x i256]*, i32 }], align 8
 //CHECK-NEXT:   br label %store1
 //CHECK-EMPTY:
 //CHECK:      unrolled_loop18:
-//CHECK-NEXT:   %18 = bitcast [17 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %19 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 0
-//CHECK-NEXT:   %20 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 16
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %18, [0 x i256]* %0, i256* %19, i256* %20)
-//CHECK-NEXT:   %21 = bitcast [17 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %22 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 1
-//CHECK-NEXT:   %23 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 21
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %21, [0 x i256]* %0, i256* %22, i256* %23)
-//CHECK-NEXT:   %24 = bitcast [17 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %25 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 2
-//CHECK-NEXT:   %26 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 26
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %24, [0 x i256]* %0, i256* %25, i256* %26)
-//CHECK-NEXT:   %27 = bitcast [17 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %28 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 3
-//CHECK-NEXT:   %29 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 31
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %27, [0 x i256]* %0, i256* %28, i256* %29)
-//CHECK-NEXT:   %30 = bitcast [17 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %31 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 4
-//CHECK-NEXT:   %32 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 20
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %30, [0 x i256]* %0, i256* %31, i256* %32)
-//CHECK-NEXT:   %33 = bitcast [17 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %34 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 5
-//CHECK-NEXT:   %35 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 25
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %33, [0 x i256]* %0, i256* %34, i256* %35)
-//CHECK-NEXT:   %36 = bitcast [17 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %37 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 6
-//CHECK-NEXT:   %38 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 30
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %36, [0 x i256]* %0, i256* %37, i256* %38)
-//CHECK-NEXT:   %39 = bitcast [17 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %40 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 7
-//CHECK-NEXT:   %41 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 19
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %39, [0 x i256]* %0, i256* %40, i256* %41)
-//CHECK-NEXT:   %42 = bitcast [17 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %43 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 8
-//CHECK-NEXT:   %44 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 24
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %42, [0 x i256]* %0, i256* %43, i256* %44)
-//CHECK-NEXT:   %45 = bitcast [17 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %46 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 9
-//CHECK-NEXT:   %47 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 29
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %45, [0 x i256]* %0, i256* %46, i256* %47)
-//CHECK-NEXT:   %48 = bitcast [17 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %49 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 10
-//CHECK-NEXT:   %50 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 18
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %48, [0 x i256]* %0, i256* %49, i256* %50)
-//CHECK-NEXT:   %51 = bitcast [17 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %52 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 11
-//CHECK-NEXT:   %53 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 23
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %51, [0 x i256]* %0, i256* %52, i256* %53)
-//CHECK-NEXT:   %54 = bitcast [17 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %55 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 12
-//CHECK-NEXT:   %56 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 28
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %54, [0 x i256]* %0, i256* %55, i256* %56)
-//CHECK-NEXT:   %57 = bitcast [17 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %58 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 13
-//CHECK-NEXT:   %59 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 17
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %57, [0 x i256]* %0, i256* %58, i256* %59)
-//CHECK-NEXT:   %60 = bitcast [17 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %61 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 14
-//CHECK-NEXT:   %62 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 22
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %60, [0 x i256]* %0, i256* %61, i256* %62)
-//CHECK-NEXT:   %63 = bitcast [17 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %64 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 15
-//CHECK-NEXT:   %65 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 27
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %63, [0 x i256]* %0, i256* %64, i256* %65)
+//CHECK-NEXT:   %[[T018:[0-9a-zA-Z_.]+]] = bitcast [17 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T019:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 0
+//CHECK-NEXT:   %[[T020:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 16
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %[[T018]], [0 x i256]* %[[ARG]], i256* %[[T019]], i256* %[[T020]])
+//CHECK-NEXT:   %[[T021:[0-9a-zA-Z_.]+]] = bitcast [17 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T022:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 1
+//CHECK-NEXT:   %[[T023:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 21
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %[[T021]], [0 x i256]* %[[ARG]], i256* %[[T022]], i256* %[[T023]])
+//CHECK-NEXT:   %[[T024:[0-9a-zA-Z_.]+]] = bitcast [17 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T025:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 2
+//CHECK-NEXT:   %[[T026:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 26
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %[[T024]], [0 x i256]* %[[ARG]], i256* %[[T025]], i256* %[[T026]])
+//CHECK-NEXT:   %[[T027:[0-9a-zA-Z_.]+]] = bitcast [17 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T028:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 3
+//CHECK-NEXT:   %[[T029:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 31
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %[[T027]], [0 x i256]* %[[ARG]], i256* %[[T028]], i256* %[[T029]])
+//CHECK-NEXT:   %[[T030:[0-9a-zA-Z_.]+]] = bitcast [17 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T031:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 4
+//CHECK-NEXT:   %[[T032:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 20
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %[[T030]], [0 x i256]* %[[ARG]], i256* %[[T031]], i256* %[[T032]])
+//CHECK-NEXT:   %[[T033:[0-9a-zA-Z_.]+]] = bitcast [17 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T034:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 5
+//CHECK-NEXT:   %[[T035:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 25
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %[[T033]], [0 x i256]* %[[ARG]], i256* %[[T034]], i256* %[[T035]])
+//CHECK-NEXT:   %[[T036:[0-9a-zA-Z_.]+]] = bitcast [17 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T037:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 6
+//CHECK-NEXT:   %[[T038:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 30
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %[[T036]], [0 x i256]* %[[ARG]], i256* %[[T037]], i256* %[[T038]])
+//CHECK-NEXT:   %[[T039:[0-9a-zA-Z_.]+]] = bitcast [17 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T040:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 7
+//CHECK-NEXT:   %[[T041:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 19
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %[[T039]], [0 x i256]* %[[ARG]], i256* %[[T040]], i256* %[[T041]])
+//CHECK-NEXT:   %[[T042:[0-9a-zA-Z_.]+]] = bitcast [17 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T043:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 8
+//CHECK-NEXT:   %[[T044:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 24
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %[[T042]], [0 x i256]* %[[ARG]], i256* %[[T043]], i256* %[[T044]])
+//CHECK-NEXT:   %[[T045:[0-9a-zA-Z_.]+]] = bitcast [17 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T046:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 9
+//CHECK-NEXT:   %[[T047:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 29
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %[[T045]], [0 x i256]* %[[ARG]], i256* %[[T046]], i256* %[[T047]])
+//CHECK-NEXT:   %[[T048:[0-9a-zA-Z_.]+]] = bitcast [17 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T049:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 10
+//CHECK-NEXT:   %[[T050:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 18
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %[[T048]], [0 x i256]* %[[ARG]], i256* %[[T049]], i256* %[[T050]])
+//CHECK-NEXT:   %[[T051:[0-9a-zA-Z_.]+]] = bitcast [17 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T052:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 11
+//CHECK-NEXT:   %[[T053:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 23
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %[[T051]], [0 x i256]* %[[ARG]], i256* %[[T052]], i256* %[[T053]])
+//CHECK-NEXT:   %[[T054:[0-9a-zA-Z_.]+]] = bitcast [17 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T055:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 12
+//CHECK-NEXT:   %[[T056:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 28
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %[[T054]], [0 x i256]* %[[ARG]], i256* %[[T055]], i256* %[[T056]])
+//CHECK-NEXT:   %[[T057:[0-9a-zA-Z_.]+]] = bitcast [17 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T058:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 13
+//CHECK-NEXT:   %[[T059:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 17
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %[[T057]], [0 x i256]* %[[ARG]], i256* %[[T058]], i256* %[[T059]])
+//CHECK-NEXT:   %[[T060:[0-9a-zA-Z_.]+]] = bitcast [17 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T061:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 14
+//CHECK-NEXT:   %[[T062:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 22
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %[[T060]], [0 x i256]* %[[ARG]], i256* %[[T061]], i256* %[[T062]])
+//CHECK-NEXT:   %[[T063:[0-9a-zA-Z_.]+]] = bitcast [17 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T064:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 15
+//CHECK-NEXT:   %[[T065:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 27
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %[[T063]], [0 x i256]* %[[ARG]], i256* %[[T064]], i256* %[[T065]])
 //CHECK-NEXT:   br label %prologue

--- a/circom/tests/loops/inner_conditional_1.circom
+++ b/circom/tests/loops/inner_conditional_1.circom
@@ -37,20 +37,20 @@ component main = InnerConditional1(10);
 //CHECK-NEXT:   br label %fold_true1
 //CHECK-EMPTY: 
 //CHECK-NEXT: fold_true1:
+//CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
 //CHECK-NEXT:   %[[T00:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
 //CHECK-NEXT:   %[[T01:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T00]], align 4
 //CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
 //CHECK-NEXT:   %[[T03:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T02]], align 4
 //CHECK-NEXT:   %[[C01:[0-9a-zA-Z_.]+]] = call i256 @fr_add(i256 %[[T01]], i256 %[[T03]])
-//CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
 //CHECK-NEXT:   store i256 %[[C01]], i256* %[[T04]], align 4
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY: 
 //CHECK-NEXT: store2:
+//CHECK-NEXT:   %[[T07:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
 //CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
 //CHECK-NEXT:   %[[T06:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T05]], align 4
 //CHECK-NEXT:   %[[C02:[0-9a-zA-Z_.]+]] = call i256 @fr_add(i256 %[[T06]], i256 1)
-//CHECK-NEXT:   %[[T07:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
 //CHECK-NEXT:   store i256 %[[C02]], i256* %[[T07]], align 4
 //CHECK-NEXT:   br label %return3
 //CHECK-EMPTY: 
@@ -63,20 +63,20 @@ component main = InnerConditional1(10);
 //CHECK-NEXT:   br label %fold_false1
 //CHECK-EMPTY: 
 //CHECK-NEXT: fold_false1:
+//CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
 //CHECK-NEXT:   %[[T00:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
 //CHECK-NEXT:   %[[T01:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T00]], align 4
 //CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
 //CHECK-NEXT:   %[[T03:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T02]], align 4
 //CHECK-NEXT:   %[[C01:[0-9a-zA-Z_.]+]] = call i256 @fr_sub(i256 %[[T01]], i256 %[[T03]])
-//CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
 //CHECK-NEXT:   store i256 %[[C01]], i256* %[[T04]], align 4
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY: 
 //CHECK-NEXT: store2:
+//CHECK-NEXT:   %[[T07:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
 //CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
 //CHECK-NEXT:   %[[T06:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T05]], align 4
 //CHECK-NEXT:   %[[C02:[0-9a-zA-Z_.]+]] = call i256 @fr_add(i256 %[[T06]], i256 1)
-//CHECK-NEXT:   %[[T07:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
 //CHECK-NEXT:   store i256 %[[C02]], i256* %[[T07]], align 4
 //CHECK-NEXT:   br label %return3
 //CHECK-EMPTY: 

--- a/circom/tests/loops/inner_conditional_10.circom
+++ b/circom/tests/loops/inner_conditional_10.circom
@@ -47,11 +47,11 @@ component main = Poseidon();
 //CHECK-NEXT: unrolled_loop3:
 //CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = getelementptr [2 x i256], [2 x i256]* %lvars, i32 0, i32 1
 //CHECK-NEXT:   store i256 0, i256* %[[T04]], align 4
-//CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
-//CHECK-NEXT:   %[[T06:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T05]], align 4
 //CHECK-NEXT:   %[[T07:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
 //CHECK-NEXT:   %[[T08:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T07]], align 8
 //CHECK-NEXT:   %[[T09:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T08]], i32 0, i32 1
+//CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
+//CHECK-NEXT:   %[[T06:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T05]], align 4
 //CHECK-NEXT:   store i256 %[[T06]], i256* %[[T09]], align 4
 //CHECK-NEXT:   %[[T10:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 1
 //CHECK-NEXT:   %load.subcmp.counter = load i32, i32* %[[T10]], align 4
@@ -71,11 +71,11 @@ component main = Poseidon();
 //CHECK-NEXT:   store i256 3, i256* %[[T16]], align 4
 //CHECK-NEXT:   %[[T17:[0-9a-zA-Z_.]+]] = getelementptr [2 x i256], [2 x i256]* %lvars, i32 0, i32 1
 //CHECK-NEXT:   store i256 1, i256* %[[T17]], align 4
-//CHECK-NEXT:   %[[T18:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
-//CHECK-NEXT:   %[[T19:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T18]], align 4
 //CHECK-NEXT:   %[[T20:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 0
 //CHECK-NEXT:   %[[T21:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T20]], align 8
 //CHECK-NEXT:   %[[T22:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T21]], i32 0, i32 1
+//CHECK-NEXT:   %[[T18:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
+//CHECK-NEXT:   %[[T19:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T18]], align 4
 //CHECK-NEXT:   store i256 %[[T19]], i256* %[[T22]], align 4
 //CHECK-NEXT:   %[[T23:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 1
 //CHECK-NEXT:   %load.subcmp.counter1 = load i32, i32* %[[T23]], align 4

--- a/circom/tests/loops/inner_conditional_11.circom
+++ b/circom/tests/loops/inner_conditional_11.circom
@@ -32,25 +32,25 @@ component main = Poseidon();
 //CHECK-NEXT:   br label %fold_true1
 //CHECK-EMPTY: 
 //CHECK-NEXT: fold_true1:
+//CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subsig_[[X1]], i32 0
 //CHECK-NEXT:   %[[T00:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %signals, i32 0, i32 0
 //CHECK-NEXT:   %[[T01:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T00]], align 4
-//CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subsig_[[X1]], i32 0
 //CHECK-NEXT:   store i256 %[[T01]], i256* %[[T02]], align 4
 //CHECK-NEXT:   %[[T03:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T02]], align 4
 //CHECK-NEXT:   %constraint = alloca i1, align 1
 //CHECK-NEXT:   call void @__constraint_values(i256 %[[T01]], i256 %[[T03]], i1* %constraint)
+//CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subc_[[X2]], i32 0
 //CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = load i256, i256* %subc_[[X2]], align 4
 //CHECK-NEXT:   %[[C02:[0-9a-zA-Z_.]+]] = call i256 @fr_sub(i256 %[[T04]], i256 1)
-//CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subc_[[X2]], i32 0
 //CHECK-NEXT:   store i256 %[[C02]], i256* %[[T05]], align 4
 //CHECK-NEXT:   call void @Sigma_0_run([0 x i256]* %sub_[[X2]])
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY: 
 //CHECK-NEXT: store2:
+//CHECK-NEXT:   %[[T08:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 0
 //CHECK-NEXT:   %[[T06:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 0
 //CHECK-NEXT:   %[[T07:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T06]], align 4
 //CHECK-NEXT:   %[[C03:[0-9a-zA-Z_.]+]] = call i256 @fr_add(i256 %[[T07]], i256 1)
-//CHECK-NEXT:   %[[T08:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 0
 //CHECK-NEXT:   store i256 %[[C03]], i256* %[[T08]], align 4
 //CHECK-NEXT:   br label %return3
 //CHECK-EMPTY: 
@@ -67,10 +67,10 @@ component main = Poseidon();
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY: 
 //CHECK-NEXT: store2:
+//CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 0
 //CHECK-NEXT:   %[[T00:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 0
 //CHECK-NEXT:   %[[T01:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T00]], align 4
 //CHECK-NEXT:   %[[C01:[0-9a-zA-Z_.]+]] = call i256 @fr_add(i256 %[[T01]], i256 1)
-//CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 0
 //CHECK-NEXT:   store i256 %[[C01]], i256* %[[T02]], align 4
 //CHECK-NEXT:   br label %return3
 //CHECK-EMPTY: 
@@ -84,25 +84,25 @@ component main = Poseidon();
 //CHECK-NEXT:   br label %fold_false1
 //CHECK-EMPTY: 
 //CHECK-NEXT: fold_false1:
+//CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subsig_[[X2]], i32 0
 //CHECK-NEXT:   %[[T00:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %signals, i32 0, i32 0
 //CHECK-NEXT:   %[[T01:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T00]], align 4
-//CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subsig_[[X2]], i32 0
 //CHECK-NEXT:   store i256 %[[T01]], i256* %[[T02]], align 4
 //CHECK-NEXT:   %[[T03:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T02]], align 4
 //CHECK-NEXT:   %constraint = alloca i1, align 1
 //CHECK-NEXT:   call void @__constraint_values(i256 %[[T01]], i256 %[[T03]], i1* %constraint)
+//CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subc_[[X2]], i32 0
 //CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = load i256, i256* %subc_[[X2]], align 4
 //CHECK-NEXT:   %[[C04:[0-9a-zA-Z_.]+]] = call i256 @fr_sub(i256 %[[T04]], i256 1)
-//CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subc_[[X2]], i32 0
 //CHECK-NEXT:   store i256 %[[C04]], i256* %[[T05]], align 4
 //CHECK-NEXT:   call void @Sigma_0_run([0 x i256]* %sub_[[X2]])
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY: 
 //CHECK-NEXT: store2:
+//CHECK-NEXT:   %[[T08:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 0
 //CHECK-NEXT:   %[[T06:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 0
 //CHECK-NEXT:   %[[T07:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T06]], align 4
 //CHECK-NEXT:   %[[C05:[0-9a-zA-Z_.]+]] = call i256 @fr_add(i256 %[[T07]], i256 1)
-//CHECK-NEXT:   %[[T08:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 0
 //CHECK-NEXT:   store i256 %[[C05]], i256* %[[T08]], align 4
 //CHECK-NEXT:   br label %return3
 //CHECK-EMPTY: 

--- a/circom/tests/loops/inner_conditional_2.circom
+++ b/circom/tests/loops/inner_conditional_2.circom
@@ -35,20 +35,20 @@ component main = runner();
 //CHECK-NEXT:   br label %store1
 //CHECK-EMPTY: 
 //CHECK-NEXT: store1:
+//CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
 //CHECK-NEXT:   %[[T00:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
 //CHECK-NEXT:   %[[T01:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T00]], align 4
 //CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 3
 //CHECK-NEXT:   %[[T03:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T02]], align 4
 //CHECK-NEXT:   %[[C01:[0-9a-zA-Z_.]+]] = call i256 @fr_add(i256 %[[T01]], i256 %[[T03]])
-//CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
 //CHECK-NEXT:   store i256 %[[C01]], i256* %[[T04]], align 4
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY: 
 //CHECK-NEXT: store2:
+//CHECK-NEXT:   %[[T07:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 3
 //CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 3
 //CHECK-NEXT:   %[[T06:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T05]], align 4
 //CHECK-NEXT:   %[[C02:[0-9a-zA-Z_.]+]] = call i256 @fr_add(i256 %[[T06]], i256 1)
-//CHECK-NEXT:   %[[T07:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 3
 //CHECK-NEXT:   store i256 %[[C02]], i256* %[[T07]], align 4
 //CHECK-NEXT:   br label %return3
 //CHECK-EMPTY: 
@@ -62,20 +62,20 @@ component main = runner();
 //CHECK-NEXT:   br label %store1
 //CHECK-EMPTY: 
 //CHECK-NEXT: store1:
+//CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
 //CHECK-NEXT:   %[[T00:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
 //CHECK-NEXT:   %[[T01:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T00]], align 4
 //CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 3
 //CHECK-NEXT:   %[[T03:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T02]], align 4
 //CHECK-NEXT:   %[[C01:[0-9a-zA-Z_.]+]] = call i256 @fr_mul(i256 %[[T01]], i256 %[[T03]])
-//CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
 //CHECK-NEXT:   store i256 %[[C01]], i256* %[[T04]], align 4
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY: 
 //CHECK-NEXT: store2:
+//CHECK-NEXT:   %[[T07:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 3
 //CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 3
 //CHECK-NEXT:   %[[T06:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T05]], align 4
 //CHECK-NEXT:   %[[C02:[0-9a-zA-Z_.]+]] = call i256 @fr_add(i256 %[[T06]], i256 1)
-//CHECK-NEXT:   %[[T07:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 3
 //CHECK-NEXT:   store i256 %[[C02]], i256* %[[T07]], align 4
 //CHECK-NEXT:   br label %return3
 //CHECK-EMPTY: 
@@ -200,6 +200,7 @@ component main = runner();
 //CHECK-NEXT:   br label %store3
 //CHECK-EMPTY: 
 //CHECK-NEXT: store3:
+//CHECK-NEXT:   %[[T15:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
 //CHECK-NEXT:   %[[T07:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
 //CHECK-NEXT:   %[[T08:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T07]], align 8
 //CHECK-NEXT:   %[[T09:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T08]], i32 0, i32 0
@@ -209,7 +210,6 @@ component main = runner();
 //CHECK-NEXT:   %[[T13:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T12]], i32 0, i32 0
 //CHECK-NEXT:   %[[T14:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T13]], align 4
 //CHECK-NEXT:   %[[C01:[0-9a-zA-Z_.]+]] = call i256 @fr_add(i256 %[[T10]], i256 %[[T14]])
-//CHECK-NEXT:   %[[T15:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
 //CHECK-NEXT:   store i256 %[[C01]], i256* %[[T15]], align 4
 //CHECK-NEXT:   br label %prologue
 //CHECK-EMPTY: 

--- a/circom/tests/loops/inner_conditional_3.circom
+++ b/circom/tests/loops/inner_conditional_3.circom
@@ -33,22 +33,22 @@ component main = InnerConditional3(3);
 //CHECK-NEXT:   br i1 %[[C01]], label %if.then, label %if.else
 //CHECK-EMPTY: 
 //CHECK-NEXT: if.then:
+//CHECK-NEXT:   %[[T06:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
 //CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
 //CHECK-NEXT:   %[[T03:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T02]], align 4
 //CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
 //CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T04]], align 4
 //CHECK-NEXT:   %[[C02:[0-9a-zA-Z_.]+]] = call i256 @fr_add(i256 %[[T03]], i256 %[[T05]])
-//CHECK-NEXT:   %[[T06:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
 //CHECK-NEXT:   store i256 %[[C02]], i256* %[[T06]], align 4
 //CHECK-NEXT:   br label %if.merge
 //CHECK-EMPTY: 
 //CHECK-NEXT: if.else:
+//CHECK-NEXT:   %[[T11:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
 //CHECK-NEXT:   %[[T07:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
 //CHECK-NEXT:   %[[T08:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T07]], align 4
 //CHECK-NEXT:   %[[T09:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
 //CHECK-NEXT:   %[[T10:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T09]], align 4
 //CHECK-NEXT:   %[[C03:[0-9a-zA-Z_.]+]] = call i256 @fr_sub(i256 %[[T08]], i256 %[[T10]])
-//CHECK-NEXT:   %[[T11:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
 //CHECK-NEXT:   store i256 %[[C03]], i256* %[[T11]], align 4
 //CHECK-NEXT:   br label %if.merge
 //CHECK-EMPTY: 
@@ -56,10 +56,10 @@ component main = InnerConditional3(3);
 //CHECK-NEXT:   br label %store5
 //CHECK-EMPTY: 
 //CHECK-NEXT: store5:
+//CHECK-NEXT:   %[[T14:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
 //CHECK-NEXT:   %[[T12:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
 //CHECK-NEXT:   %[[T13:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T12]], align 4
 //CHECK-NEXT:   %[[C04:[0-9a-zA-Z_.]+]] = call i256 @fr_add(i256 %[[T13]], i256 1)
-//CHECK-NEXT:   %[[T14:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
 //CHECK-NEXT:   store i256 %[[C04]], i256* %[[T14]], align 4
 //CHECK-NEXT:   br label %return6
 //CHECK-EMPTY: 
@@ -98,9 +98,9 @@ component main = InnerConditional3(3);
 //CHECK-NEXT:   br label %store5
 //CHECK-EMPTY: 
 //CHECK-NEXT: store5:
+//CHECK-NEXT:   %[[T09:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
 //CHECK-NEXT:   %[[T07:[0-9a-zA-Z_.]+]] = getelementptr [3 x i256], [3 x i256]* %lvars, i32 0, i32 1
 //CHECK-NEXT:   %[[T08:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T07]], align 4
-//CHECK-NEXT:   %[[T09:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
 //CHECK-NEXT:   store i256 %[[T08]], i256* %[[T09]], align 4
 //CHECK-NEXT:   br label %prologue
 //CHECK-EMPTY: 

--- a/circom/tests/loops/inner_conditional_4.circom
+++ b/circom/tests/loops/inner_conditional_4.circom
@@ -24,18 +24,18 @@ component main = InnerConditional4(6);
 //CHECK-NEXT:   br label %fold_true1
 //CHECK-EMPTY: 
 //CHECK-NEXT: fold_true1:
+//CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_[[X1]], i32 0
 //CHECK-NEXT:   %[[T00:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %signals, i32 0, i32 6
 //CHECK-NEXT:   %[[T01:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T00]], align 4
 //CHECK-NEXT:   %[[C01:[0-9a-zA-Z_.]+]] = call i256 @fr_neg(i256 %[[T01]])
-//CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_[[X1]], i32 0
 //CHECK-NEXT:   store i256 %[[C01]], i256* %[[T02]], align 4
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY: 
 //CHECK-NEXT: store2:
+//CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
 //CHECK-NEXT:   %[[T03:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
 //CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T03]], align 4
 //CHECK-NEXT:   %[[C02:[0-9a-zA-Z_.]+]] = call i256 @fr_add(i256 %[[T04]], i256 1)
-//CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
 //CHECK-NEXT:   store i256 %[[C02]], i256* %[[T05]], align 4
 //CHECK-NEXT:   br label %return3
 //CHECK-EMPTY: 
@@ -49,17 +49,17 @@ component main = InnerConditional4(6);
 //CHECK-NEXT:   br label %fold_false1
 //CHECK-EMPTY: 
 //CHECK-NEXT: fold_false1:
+//CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_[[X2]], i32 0
 //CHECK-NEXT:   %[[T00:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %signals, i32 0, i32 6
 //CHECK-NEXT:   %[[T01:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T00]], align 4
-//CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_[[X2]], i32 0
 //CHECK-NEXT:   store i256 %[[T01]], i256* %[[T02]], align 4
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY: 
 //CHECK-NEXT: store2:
+//CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
 //CHECK-NEXT:   %[[T03:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
 //CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T03]], align 4
 //CHECK-NEXT:   %[[C01:[0-9a-zA-Z_.]+]] = call i256 @fr_add(i256 %[[T04]], i256 1)
-//CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
 //CHECK-NEXT:   store i256 %[[C01]], i256* %[[T05]], align 4
 //CHECK-NEXT:   br label %return3
 //CHECK-EMPTY: 

--- a/circom/tests/loops/inner_conditional_5.circom
+++ b/circom/tests/loops/inner_conditional_5.circom
@@ -37,10 +37,10 @@ component main = runner();
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY: 
 //CHECK-NEXT: store2:
+//CHECK-NEXT:   %[[T03:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
 //CHECK-NEXT:   %[[T01:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
 //CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T01]], align 4
 //CHECK-NEXT:   %[[C01:[0-9a-zA-Z_.]+]] = call i256 @fr_add(i256 %[[T02]], i256 1)
-//CHECK-NEXT:   %[[T03:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
 //CHECK-NEXT:   store i256 %[[C01]], i256* %[[T03]], align 4
 //CHECK-NEXT:   br label %return3
 //CHECK-EMPTY: 
@@ -59,10 +59,10 @@ component main = runner();
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY: 
 //CHECK-NEXT: store2:
+//CHECK-NEXT:   %[[T03:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
 //CHECK-NEXT:   %[[T01:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
 //CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T01]], align 4
 //CHECK-NEXT:   %[[C01:[0-9a-zA-Z_.]+]] = call i256 @fr_add(i256 %[[T02]], i256 1)
-//CHECK-NEXT:   %[[T03:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
 //CHECK-NEXT:   store i256 %[[C01]], i256* %[[T03]], align 4
 //CHECK-NEXT:   br label %return3
 //CHECK-EMPTY: 
@@ -176,6 +176,7 @@ component main = runner();
 //CHECK-NEXT:   br label %store3
 //CHECK-EMPTY: 
 //CHECK-NEXT: store3:
+//CHECK-NEXT:   %[[T15:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
 //CHECK-NEXT:   %[[T07:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
 //CHECK-NEXT:   %[[T08:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T07]], align 8
 //CHECK-NEXT:   %[[T09:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T08]], i32 0, i32 1
@@ -185,7 +186,6 @@ component main = runner();
 //CHECK-NEXT:   %[[T13:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T12]], i32 0, i32 0
 //CHECK-NEXT:   %[[T14:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T13]], align 4
 //CHECK-NEXT:   %[[C01:[0-9a-zA-Z_.]+]] = call i256 @fr_add(i256 %[[T10]], i256 %[[T14]])
-//CHECK-NEXT:   %[[T15:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
 //CHECK-NEXT:   store i256 %[[C01]], i256* %[[T15]], align 4
 //CHECK-NEXT:   br label %prologue
 //CHECK-EMPTY: 

--- a/circom/tests/loops/inner_conditional_6.circom
+++ b/circom/tests/loops/inner_conditional_6.circom
@@ -56,17 +56,17 @@ component main = InnerConditional6(4);
 //CHECK-NEXT:   br label %store6
 //CHECK-EMPTY: 
 //CHECK-NEXT: store6:
+//CHECK-NEXT:   %[[T07:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_[[X2]], i32 0
 //CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
 //CHECK-NEXT:   %[[T06:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T05]], align 4
-//CHECK-NEXT:   %[[T07:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_[[X2]], i32 0
 //CHECK-NEXT:   store i256 %[[T06]], i256* %[[T07]], align 4
 //CHECK-NEXT:   br label %store7
 //CHECK-EMPTY: 
 //CHECK-NEXT: store7:
+//CHECK-NEXT:   %[[T10:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
 //CHECK-NEXT:   %[[T08:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
 //CHECK-NEXT:   %[[T09:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T08]], align 4
 //CHECK-NEXT:   %[[C02:[0-9a-zA-Z_.]+]] = call i256 @fr_add(i256 %[[T09]], i256 1)
-//CHECK-NEXT:   %[[T10:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
 //CHECK-NEXT:   store i256 %[[C02]], i256* %[[T10]], align 4
 //CHECK-NEXT:   br label %return8
 //CHECK-EMPTY: 

--- a/circom/tests/loops/inner_conditional_7.circom
+++ b/circom/tests/loops/inner_conditional_7.circom
@@ -34,18 +34,18 @@ component main = InnerConditional7(3);
 //CHECK-NEXT:   br label %fold_false1
 //CHECK-EMPTY: 
 //CHECK-NEXT: fold_false1:
+//CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %var_[[X1]], i32 0
 //CHECK-NEXT:   %[[T00:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %var_[[X2]], i32 0
 //CHECK-NEXT:   %[[T01:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T00]], align 4
 //CHECK-NEXT:   %[[C01:[0-9a-zA-Z_.]+]] = call i256 @fr_sub(i256 %[[T01]], i256 111)
-//CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %var_[[X1]], i32 0
 //CHECK-NEXT:   store i256 %[[C01]], i256* %[[T02]], align 4
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY: 
 //CHECK-NEXT: store2:
+//CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 5
 //CHECK-NEXT:   %[[T03:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 5
 //CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T03]], align 4
 //CHECK-NEXT:   %[[C02:[0-9a-zA-Z_.]+]] = call i256 @fr_add(i256 %[[T04]], i256 1)
-//CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 5
 //CHECK-NEXT:   store i256 %[[C02]], i256* %[[T05]], align 4
 //CHECK-NEXT:   br label %return3
 //CHECK-EMPTY: 
@@ -64,10 +64,10 @@ component main = InnerConditional7(3);
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY: 
 //CHECK-NEXT: store2:
+//CHECK-NEXT:   %[[T03:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 5
 //CHECK-NEXT:   %[[T01:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 5
 //CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T01]], align 4
 //CHECK-NEXT:   %[[C01:[0-9a-zA-Z_.]+]] = call i256 @fr_add(i256 %[[T02]], i256 1)
-//CHECK-NEXT:   %[[T03:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 5
 //CHECK-NEXT:   store i256 %[[C01]], i256* %[[T03]], align 4
 //CHECK-NEXT:   br label %return3
 //CHECK-EMPTY: 

--- a/circom/tests/loops/inner_conditional_8.circom
+++ b/circom/tests/loops/inner_conditional_8.circom
@@ -51,34 +51,34 @@ component main = InnerConditional8(4);
 //CHECK-NEXT:   br label %store9
 //CHECK-EMPTY: 
 //CHECK-NEXT: if.then:
+//CHECK-NEXT:   %[[T07:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %var_[[X3]], i32 0
 //CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %var_[[X4]], i32 0
 //CHECK-NEXT:   %[[T06:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T05]], align 4
 //CHECK-NEXT:   %[[C06:[0-9a-zA-Z_.]+]] = call i256 @fr_add(i256 %[[T06]], i256 999)
-//CHECK-NEXT:   %[[T07:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %var_[[X3]], i32 0
 //CHECK-NEXT:   store i256 %[[C06]], i256* %[[T07]], align 4
 //CHECK-NEXT:   br label %if.merge
 //CHECK-EMPTY: 
 //CHECK-NEXT: if.else:
+//CHECK-NEXT:   %[[T10:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %var_[[X1]], i32 0
 //CHECK-NEXT:   %[[T08:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %var_[[X2]], i32 0
 //CHECK-NEXT:   %[[T09:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T08]], align 4
 //CHECK-NEXT:   %[[C03:[0-9a-zA-Z_.]+]] = call i256 @fr_sub(i256 %[[T09]], i256 111)
-//CHECK-NEXT:   %[[T10:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %var_[[X1]], i32 0
 //CHECK-NEXT:   store i256 %[[C03]], i256* %[[T10]], align 4
 //CHECK-NEXT:   br label %if.merge
 //CHECK-EMPTY: 
 //CHECK-NEXT: if.merge:
+//CHECK-NEXT:   %[[T13:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 6
 //CHECK-NEXT:   %[[T11:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 6
 //CHECK-NEXT:   %[[T12:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T11]], align 4
 //CHECK-NEXT:   %[[C04:[0-9a-zA-Z_.]+]] = call i256 @fr_add(i256 %[[T12]], i256 1)
-//CHECK-NEXT:   %[[T13:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 6
 //CHECK-NEXT:   store i256 %[[C04]], i256* %[[T13]], align 4
 //CHECK-NEXT:   br label %loop.cond
 //CHECK-EMPTY: 
 //CHECK-NEXT: store9:
+//CHECK-NEXT:   %[[T16:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 5
 //CHECK-NEXT:   %[[T14:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 5
 //CHECK-NEXT:   %[[T15:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T14]], align 4
 //CHECK-NEXT:   %[[C05:[0-9a-zA-Z_.]+]] = call i256 @fr_add(i256 %[[T15]], i256 1)
-//CHECK-NEXT:   %[[T16:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 5
 //CHECK-NEXT:   store i256 %[[C05]], i256* %[[T16]], align 4
 //CHECK-NEXT:   br label %return10
 //CHECK-EMPTY: 

--- a/circom/tests/loops/inner_conditional_9.circom
+++ b/circom/tests/loops/inner_conditional_9.circom
@@ -42,15 +42,15 @@ component main = InnerConditional9(4);
 //CHECK-NEXT:   br i1 %[[C01]], label %loop.body, label %loop.end
 //CHECK-EMPTY: 
 //CHECK-NEXT: loop.body:
+//CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %var_[[X1]], i32 0
 //CHECK-NEXT:   %[[T03:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %var_[[X2]], i32 0
 //CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T03]], align 4
 //CHECK-NEXT:   %[[C02:[0-9a-zA-Z_.]+]] = call i256 @fr_sub(i256 %[[T04]], i256 999)
-//CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %var_[[X1]], i32 0
 //CHECK-NEXT:   store i256 %[[C02]], i256* %[[T05]], align 4
+//CHECK-NEXT:   %[[T08:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 6
 //CHECK-NEXT:   %[[T06:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 6
 //CHECK-NEXT:   %[[T07:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T06]], align 4
 //CHECK-NEXT:   %[[C03:[0-9a-zA-Z_.]+]] = call i256 @fr_add(i256 %[[T07]], i256 1)
-//CHECK-NEXT:   %[[T08:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 6
 //CHECK-NEXT:   store i256 %[[C03]], i256* %[[T08]], align 4
 //CHECK-NEXT:   br label %loop.cond
 //CHECK-EMPTY: 
@@ -58,10 +58,10 @@ component main = InnerConditional9(4);
 //CHECK-NEXT:   br label %store5
 //CHECK-EMPTY: 
 //CHECK-NEXT: store5:
+//CHECK-NEXT:   %[[T11:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 5
 //CHECK-NEXT:   %[[T09:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 5
 //CHECK-NEXT:   %[[T10:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T09]], align 4
 //CHECK-NEXT:   %[[C04:[0-9a-zA-Z_.]+]] = call i256 @fr_add(i256 %[[T10]], i256 1)
-//CHECK-NEXT:   %[[T11:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 5
 //CHECK-NEXT:   store i256 %[[C04]], i256* %[[T11]], align 4
 //CHECK-NEXT:   br label %return6
 //CHECK-EMPTY: 
@@ -86,15 +86,15 @@ component main = InnerConditional9(4);
 //CHECK-NEXT:   br i1 %[[C01]], label %loop.body, label %loop.end
 //CHECK-EMPTY: 
 //CHECK-NEXT: loop.body:
+//CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %var_[[X3]], i32 0
 //CHECK-NEXT:   %[[T03:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %var_[[X4]], i32 0
 //CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T03]], align 4
 //CHECK-NEXT:   %[[C02:[0-9a-zA-Z_.]+]] = call i256 @fr_add(i256 %[[T04]], i256 999)
-//CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %var_[[X3]], i32 0
 //CHECK-NEXT:   store i256 %[[C02]], i256* %[[T05]], align 4
+//CHECK-NEXT:   %[[T08:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 6
 //CHECK-NEXT:   %[[T06:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 6
 //CHECK-NEXT:   %[[T07:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T06]], align 4
 //CHECK-NEXT:   %[[C03:[0-9a-zA-Z_.]+]] = call i256 @fr_add(i256 %[[T07]], i256 1)
-//CHECK-NEXT:   %[[T08:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 6
 //CHECK-NEXT:   store i256 %[[C03]], i256* %[[T08]], align 4
 //CHECK-NEXT:   br label %loop.cond
 //CHECK-EMPTY: 
@@ -102,10 +102,10 @@ component main = InnerConditional9(4);
 //CHECK-NEXT:   br label %store5
 //CHECK-EMPTY: 
 //CHECK-NEXT: store5:
+//CHECK-NEXT:   %[[T11:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 5
 //CHECK-NEXT:   %[[T09:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 5
 //CHECK-NEXT:   %[[T10:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T09]], align 4
 //CHECK-NEXT:   %[[C04:[0-9a-zA-Z_.]+]] = call i256 @fr_add(i256 %[[T10]], i256 1)
-//CHECK-NEXT:   %[[T11:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 5
 //CHECK-NEXT:   store i256 %[[C04]], i256* %[[T11]], align 4
 //CHECK-NEXT:   br label %return6
 //CHECK-EMPTY: 

--- a/circom/tests/loops/inner_loop_simple.circom
+++ b/circom/tests/loops/inner_loop_simple.circom
@@ -31,17 +31,17 @@ component main = InnerLoops(2, 3);
 //CHECK-NEXT:   %[[C01:[0-9a-zA-Z_.]+]] = call i32 @fr_cast_to_addr(i256 %[[T01]])
 //CHECK-NEXT:   %[[A01:[0-9a-zA-Z_.]+]] = mul i32 1, %[[C01]]
 //CHECK-NEXT:   %[[A02:[0-9a-zA-Z_.]+]] = add i32 %[[A01]], 2
+//CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 %[[A02]]
 //CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_0, i32 0
 //CHECK-NEXT:   %[[T03:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T02]], align 4
-//CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 %[[A02]]
 //CHECK-NEXT:   store i256 %[[T03]], i256* %[[T04]], align 4
 //CHECK-NEXT:   br label %store{{[0-9]+}}
 //CHECK-EMPTY: 
 //CHECK-NEXT: store{{[0-9]+}}:
+//CHECK-NEXT:   %[[T07:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 5
 //CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 5
 //CHECK-NEXT:   %[[T06:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T05]], align 4
 //CHECK-NEXT:   %[[C02:[0-9a-zA-Z_.]+]] = call i256 @fr_add(i256 %[[T06]], i256 1)
-//CHECK-NEXT:   %[[T07:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 5
 //CHECK-NEXT:   store i256 %[[C02]], i256* %[[T07]], align 4
 //CHECK-NEXT:   br label %return{{[0-9]+}}
 //CHECK-EMPTY: 
@@ -80,9 +80,9 @@ component main = InnerLoops(2, 3);
 //CHECK-NEXT:   br label %store{{[0-9]+}}
 //CHECK-EMPTY: 
 //CHECK-NEXT: store{{[0-9]+}}:
+//CHECK-NEXT:   %[[T24:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
 //CHECK-NEXT:   %[[T22:[0-9a-zA-Z_.]+]] = getelementptr [6 x i256], [6 x i256]* %lvars, i32 0, i32 2
 //CHECK-NEXT:   %[[T23:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T22]], align 4
-//CHECK-NEXT:   %[[T24:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
 //CHECK-NEXT:   store i256 %[[T23]], i256* %[[T24]], align 4
 //CHECK-NEXT:   br label %prologue
 //CHECK-EMPTY: 

--- a/circom/tests/loops/inner_loops.circom
+++ b/circom/tests/loops/inner_loops.circom
@@ -41,6 +41,7 @@ component main = InnerLoops(2);
 //CHECK-NEXT:   %[[C01:[0-9a-zA-Z_.]+]] = call i32 @fr_cast_to_addr(i256 %[[T01]])
 //CHECK-NEXT:   %[[A01:[0-9a-zA-Z_.]+]] = mul i32 1, %[[C01]]
 //CHECK-NEXT:   %[[A02:[0-9a-zA-Z_.]+]] = add i32 %[[A01]], 1
+//CHECK-NEXT:   %[[T12:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 %[[A02]]
 //CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 3
 //CHECK-NEXT:   %[[T03:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T02]], align 4
 //CHECK-NEXT:   %[[C02:[0-9a-zA-Z_.]+]] = call i32 @fr_cast_to_addr(i256 %[[T03]])
@@ -59,15 +60,14 @@ component main = InnerLoops(2);
 //CHECK-NEXT:   %[[T10:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %signals, i32 0, i32 %add_addr6
 //CHECK-NEXT:   %[[T11:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T10]], align 4
 //CHECK-NEXT:   %[[C05:[0-9a-zA-Z_.]+]] = call i256 @fr_add(i256 %[[T05]], i256 %[[T11]])
-//CHECK-NEXT:   %[[T12:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 %[[A02]]
 //CHECK-NEXT:   store i256 %[[C05]], i256* %[[T12]], align 4
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY: 
 //CHECK-NEXT: store2:
+//CHECK-NEXT:   %[[T15:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 4
 //CHECK-NEXT:   %[[T13:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 4
 //CHECK-NEXT:   %[[T14:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T13]], align 4
 //CHECK-NEXT:   %[[C06:[0-9a-zA-Z_.]+]] = call i256 @fr_add(i256 %[[T14]], i256 1)
-//CHECK-NEXT:   %[[T15:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 4
 //CHECK-NEXT:   store i256 %[[C06]], i256* %[[T15]], align 4
 //CHECK-NEXT:   br label %return3
 //CHECK-EMPTY: 
@@ -86,6 +86,7 @@ component main = InnerLoops(2);
 //CHECK-NEXT:   %[[C01:[0-9a-zA-Z_.]+]] = call i32 @fr_cast_to_addr(i256 %[[T01]])
 //CHECK-NEXT:   %[[A01:[0-9a-zA-Z_.]+]] = mul i32 1, %[[C01]]
 //CHECK-NEXT:   %[[A02:[0-9a-zA-Z_.]+]] = add i32 %[[A01]], 1
+//CHECK-NEXT:   %[[T08:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 %[[A02]]
 //CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 3
 //CHECK-NEXT:   %[[T03:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T02]], align 4
 //CHECK-NEXT:   %[[C01:[0-9a-zA-Z_.]+]] = call i32 @fr_cast_to_addr(i256 %[[T03]])
@@ -96,15 +97,14 @@ component main = InnerLoops(2);
 //CHECK-NEXT:   %[[T06:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_0, i32 0
 //CHECK-NEXT:   %[[T07:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T06]], align 4
 //CHECK-NEXT:   %[[C02:[0-9a-zA-Z_.]+]] = call i256 @fr_add(i256 %[[T05]], i256 %[[T07]])
-//CHECK-NEXT:   %[[T08:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 %[[A02]]
 //CHECK-NEXT:   store i256 %[[C02]], i256* %[[T08]], align 4
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY: 
 //CHECK-NEXT: store2:
+//CHECK-NEXT:   %[[T11:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 4
 //CHECK-NEXT:   %[[T09:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 4
 //CHECK-NEXT:   %[[T10:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T09]], align 4
 //CHECK-NEXT:   %[[C03:[0-9a-zA-Z_.]+]] = call i256 @fr_add(i256 %[[T10]], i256 1)
-//CHECK-NEXT:   %[[T11:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 4
 //CHECK-NEXT:   store i256 %[[C03]], i256* %[[T11]], align 4
 //CHECK-NEXT:   br label %return3
 //CHECK-EMPTY: 

--- a/circom/tests/loops/inner_loops2.circom
+++ b/circom/tests/loops/inner_loops2.circom
@@ -40,9 +40,9 @@ component main = InnerLoops(5);
 //CHECK-NEXT:   br label %store{{[0-9]+}}
 //CHECK-EMPTY: 
 //CHECK-NEXT: store{{[0-9]+}}:
+//CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
 //CHECK-NEXT:   %[[T00:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %signals, i32 0, i32 0
 //CHECK-NEXT:   %[[T01:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T00]], align 4
-//CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
 //CHECK-NEXT:   store i256 %[[T01]], i256* %[[T02]], align 4
 //CHECK-NEXT:   br label %store{{[0-9]+}}
 //CHECK-EMPTY: 
@@ -61,17 +61,17 @@ component main = InnerLoops(5);
 //CHECK-NEXT:   br label %store{{[0-9]+}}
 //CHECK-EMPTY: 
 //CHECK-NEXT: store{{[0-9]+}}:
+//CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
 //CHECK-NEXT:   %[[T00:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_0, i32 0
 //CHECK-NEXT:   %[[T01:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T00]], align 4
-//CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
 //CHECK-NEXT:   store i256 %[[T01]], i256* %[[T02]], align 4
 //CHECK-NEXT:   br label %store{{[0-9]+}}
 //CHECK-EMPTY: 
 //CHECK-NEXT: store{{[0-9]+}}:
+//CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 7
 //CHECK-NEXT:   %[[T03:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 7
 //CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T03]], align 4
 //CHECK-NEXT:   %[[C01:[0-9a-zA-Z_.]+]] = call i256 @fr_add(i256 %[[T04]], i256 1)
-//CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 7
 //CHECK-NEXT:   store i256 %[[C01]], i256* %[[T05]], align 4
 //CHECK-NEXT:   br label %return{{[0-9]+}}
 //CHECK-EMPTY: 
@@ -85,17 +85,17 @@ component main = InnerLoops(5);
 //CHECK-NEXT:   br label %store{{[0-9]+}}
 //CHECK-EMPTY: 
 //CHECK-NEXT: store{{[0-9]+}}:
+//CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 3
 //CHECK-NEXT:   %[[T00:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_0, i32 0
 //CHECK-NEXT:   %[[T01:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T00]], align 4
-//CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 3
 //CHECK-NEXT:   store i256 %[[T01]], i256* %[[T02]], align 4
 //CHECK-NEXT:   br label %store{{[0-9]+}}
 //CHECK-EMPTY: 
 //CHECK-NEXT: store{{[0-9]+}}:
+//CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 7
 //CHECK-NEXT:   %[[T03:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 7
 //CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T03]], align 4
 //CHECK-NEXT:   %[[C01:[0-9a-zA-Z_.]+]] = call i256 @fr_add(i256 %[[T04]], i256 1)
-//CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 7
 //CHECK-NEXT:   store i256 %[[C01]], i256* %[[T05]], align 4
 //CHECK-NEXT:   br label %return{{[0-9]+}}
 //CHECK-EMPTY: 
@@ -109,17 +109,17 @@ component main = InnerLoops(5);
 //CHECK-NEXT:   br label %store{{[0-9]+}}
 //CHECK-EMPTY: 
 //CHECK-NEXT: store{{[0-9]+}}:
+//CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 4
 //CHECK-NEXT:   %[[T00:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_0, i32 0
 //CHECK-NEXT:   %[[T01:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T00]], align 4
-//CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 4
 //CHECK-NEXT:   store i256 %[[T01]], i256* %[[T02]], align 4
 //CHECK-NEXT:   br label %store{{[0-9]+}}
 //CHECK-EMPTY: 
 //CHECK-NEXT: store{{[0-9]+}}:
+//CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 7
 //CHECK-NEXT:   %[[T03:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 7
 //CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T03]], align 4
 //CHECK-NEXT:   %[[C01:[0-9a-zA-Z_.]+]] = call i256 @fr_add(i256 %[[T04]], i256 1)
-//CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 7
 //CHECK-NEXT:   store i256 %[[C01]], i256* %[[T05]], align 4
 //CHECK-NEXT:   br label %return{{[0-9]+}}
 //CHECK-EMPTY: 
@@ -133,17 +133,17 @@ component main = InnerLoops(5);
 //CHECK-NEXT:   br label %store{{[0-9]+}}
 //CHECK-EMPTY: 
 //CHECK-NEXT: store{{[0-9]+}}:
+//CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 5
 //CHECK-NEXT:   %[[T00:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_0, i32 0
 //CHECK-NEXT:   %[[T01:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T00]], align 4
-//CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 5
 //CHECK-NEXT:   store i256 %[[T01]], i256* %[[T02]], align 4
 //CHECK-NEXT:   br label %store{{[0-9]+}}
 //CHECK-EMPTY: 
 //CHECK-NEXT: store{{[0-9]+}}:
+//CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 7
 //CHECK-NEXT:   %[[T03:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 7
 //CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T03]], align 4
 //CHECK-NEXT:   %[[C01:[0-9a-zA-Z_.]+]] = call i256 @fr_add(i256 %[[T04]], i256 1)
-//CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 7
 //CHECK-NEXT:   store i256 %[[C01]], i256* %[[T05]], align 4
 //CHECK-NEXT:   br label %return{{[0-9]+}}
 //CHECK-EMPTY: 

--- a/circom/tests/loops/inner_loops3.circom
+++ b/circom/tests/loops/inner_loops3.circom
@@ -31,9 +31,9 @@ component main = InnerLoops(5);
 //CHECK-NEXT:   br label %store{{[0-9]+}}
 //CHECK-EMPTY: 
 //CHECK-NEXT: store{{[0-9]+}}:
+//CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
 //CHECK-NEXT:   %[[T00:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %signals, i32 0, i32 0
 //CHECK-NEXT:   %[[T01:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T00]], align 4
-//CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
 //CHECK-NEXT:   store i256 %[[T01]], i256* %[[T02]], align 4
 //CHECK-NEXT:   br label %store{{[0-9]+}}
 //CHECK-EMPTY: 
@@ -52,17 +52,17 @@ component main = InnerLoops(5);
 //CHECK-NEXT:   br label %store{{[0-9]+}}
 //CHECK-EMPTY: 
 //CHECK-NEXT: store{{[0-9]+}}:
+//CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
 //CHECK-NEXT:   %[[T00:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_0, i32 0
 //CHECK-NEXT:   %[[T01:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T00]], align 4
-//CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
 //CHECK-NEXT:   store i256 %[[T01]], i256* %[[T02]], align 4
 //CHECK-NEXT:   br label %store{{[0-9]+}}
 //CHECK-EMPTY: 
 //CHECK-NEXT: store{{[0-9]+}}:
+//CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 6
 //CHECK-NEXT:   %[[T03:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 6
 //CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T03]], align 4
 //CHECK-NEXT:   %[[C01:[0-9a-zA-Z_.]+]] = call i256 @fr_add(i256 %[[T04]], i256 1)
-//CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 6
 //CHECK-NEXT:   store i256 %[[C01]], i256* %[[T05]], align 4
 //CHECK-NEXT:   br label %return{{[0-9]+}}
 //CHECK-EMPTY: 
@@ -76,17 +76,17 @@ component main = InnerLoops(5);
 //CHECK-NEXT:   br label %store{{[0-9]+}}
 //CHECK-EMPTY: 
 //CHECK-NEXT: store{{[0-9]+}}:
+//CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 3
 //CHECK-NEXT:   %[[T00:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_0, i32 0
 //CHECK-NEXT:   %[[T01:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T00]], align 4
-//CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 3
 //CHECK-NEXT:   store i256 %[[T01]], i256* %[[T02]], align 4
 //CHECK-NEXT:   br label %store{{[0-9]+}}
 //CHECK-EMPTY: 
 //CHECK-NEXT: store{{[0-9]+}}:
+//CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 6
 //CHECK-NEXT:   %[[T03:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 6
 //CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T03]], align 4
 //CHECK-NEXT:   %[[C01:[0-9a-zA-Z_.]+]] = call i256 @fr_add(i256 %[[T04]], i256 1)
-//CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 6
 //CHECK-NEXT:   store i256 %[[C01]], i256* %[[T05]], align 4
 //CHECK-NEXT:   br label %return{{[0-9]+}}
 //CHECK-EMPTY: 
@@ -100,17 +100,17 @@ component main = InnerLoops(5);
 //CHECK-NEXT:   br label %store{{[0-9]+}}
 //CHECK-EMPTY: 
 //CHECK-NEXT: store{{[0-9]+}}:
+//CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 4
 //CHECK-NEXT:   %[[T00:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_0, i32 0
 //CHECK-NEXT:   %[[T01:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T00]], align 4
-//CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 4
 //CHECK-NEXT:   store i256 %[[T01]], i256* %[[T02]], align 4
 //CHECK-NEXT:   br label %store{{[0-9]+}}
 //CHECK-EMPTY: 
 //CHECK-NEXT: store{{[0-9]+}}:
+//CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 6
 //CHECK-NEXT:   %[[T03:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 6
 //CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T03]], align 4
 //CHECK-NEXT:   %[[C01:[0-9a-zA-Z_.]+]] = call i256 @fr_add(i256 %[[T04]], i256 1)
-//CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 6
 //CHECK-NEXT:   store i256 %[[C01]], i256* %[[T05]], align 4
 //CHECK-NEXT:   br label %return{{[0-9]+}}
 //CHECK-EMPTY: 
@@ -124,17 +124,17 @@ component main = InnerLoops(5);
 //CHECK-NEXT:   br label %store{{[0-9]+}}
 //CHECK-EMPTY: 
 //CHECK-NEXT: store{{[0-9]+}}:
+//CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 5
 //CHECK-NEXT:   %[[T00:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_0, i32 0
 //CHECK-NEXT:   %[[T01:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T00]], align 4
-//CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 5
 //CHECK-NEXT:   store i256 %[[T01]], i256* %[[T02]], align 4
 //CHECK-NEXT:   br label %store{{[0-9]+}}
 //CHECK-EMPTY: 
 //CHECK-NEXT: store{{[0-9]+}}:
+//CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 6
 //CHECK-NEXT:   %[[T03:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 6
 //CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T03]], align 4
 //CHECK-NEXT:   %[[C01:[0-9a-zA-Z_.]+]] = call i256 @fr_add(i256 %[[T04]], i256 1)
-//CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 6
 //CHECK-NEXT:   store i256 %[[C01]], i256* %[[T05]], align 4
 //CHECK-NEXT:   br label %return{{[0-9]+}}
 //CHECK-EMPTY: 
@@ -219,7 +219,6 @@ component main = InnerLoops(5);
 //CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_5]]([0 x i256]* %[[T37]], [0 x i256]* %0, i256* %[[T38]])
 //CHECK-NEXT:   %[[T39:[0-9a-zA-Z_.]+]] = bitcast [7 x i256]* %lvars to [0 x i256]*
 //CHECK-NEXT:   %[[T40:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 0
-//DELETE:   %[[T40:[0-9a-zA-Z_.]+]] = bitcast i256* %[[T40]] to [0 x i256]*
 //CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_5]]([0 x i256]* %[[T39]], [0 x i256]* %0, i256* %[[T40]])
 //CHECK-NEXT:   br label %prologue
 //CHECK-EMPTY: 

--- a/circom/tests/loops/inner_loops4.circom
+++ b/circom/tests/loops/inner_loops4.circom
@@ -42,6 +42,7 @@ component main = InnerLoops(2);
 //CHECK-NEXT:   %[[C01:[0-9a-zA-Z_.]+]] = call i32 @fr_cast_to_addr(i256 %[[T01]])
 //CHECK-NEXT:   %[[A01:[0-9a-zA-Z_.]+]] = mul i32 1, %[[C01]]
 //CHECK-NEXT:   %[[A02:[0-9a-zA-Z_.]+]] = add i32 %[[A01]], 1
+//CHECK-NEXT:   %[[T08:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 %[[A02]]
 //CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 4
 //CHECK-NEXT:   %[[T03:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T02]], align 4
 //CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 3
@@ -52,15 +53,14 @@ component main = InnerLoops(2);
 //CHECK-NEXT:   %[[A04:[0-9a-zA-Z_.]+]] = add i32 %[[A03]], 0
 //CHECK-NEXT:   %[[T06:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %signals, i32 0, i32 %[[A04]]
 //CHECK-NEXT:   %[[T07:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T06]], align 4
-//CHECK-NEXT:   %[[T08:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 %[[A02]]
 //CHECK-NEXT:   store i256 %[[T07]], i256* %[[T08]], align 4
 //CHECK-NEXT:   br label %store{{[0-9]+}}
 //CHECK-EMPTY: 
 //CHECK-NEXT: store{{[0-9]+}}:
+//CHECK-NEXT:   %[[T11:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 3
 //CHECK-NEXT:   %[[T09:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 3
 //CHECK-NEXT:   %[[T10:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T09]], align 4
 //CHECK-NEXT:   %[[C04:[0-9a-zA-Z_.]+]] = call i256 @fr_add(i256 %[[T10]], i256 1)
-//CHECK-NEXT:   %[[T11:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 3
 //CHECK-NEXT:   store i256 %[[C04]], i256* %[[T11]], align 4
 //CHECK-NEXT:   br label %return{{[0-9]+}}
 //CHECK-EMPTY: 
@@ -79,17 +79,17 @@ component main = InnerLoops(2);
 //CHECK-NEXT:   %[[C01:[0-9a-zA-Z_.]+]] = call i32 @fr_cast_to_addr(i256 %[[T01]])
 //CHECK-NEXT:   %[[A05:[0-9a-zA-Z_.]+]] = mul i32 1, %[[C01]]
 //CHECK-NEXT:   %[[A06:[0-9a-zA-Z_.]+]] = add i32 %[[A05]], 1
+//CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 %[[A06]]
 //CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_0, i32 0
 //CHECK-NEXT:   %[[T03:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T02]], align 4
-//CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 %[[A06]]
 //CHECK-NEXT:   store i256 %[[T03]], i256* %[[T04]], align 4
 //CHECK-NEXT:   br label %store{{[0-9]+}}
 //CHECK-EMPTY: 
 //CHECK-NEXT: store{{[0-9]+}}:
+//CHECK-NEXT:   %[[T07:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 3
 //CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 3
 //CHECK-NEXT:   %[[T06:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T05]], align 4
 //CHECK-NEXT:   %[[C02:[0-9a-zA-Z_.]+]] = call i256 @fr_add(i256 %[[T06]], i256 1)
-//CHECK-NEXT:   %[[T07:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 3
 //CHECK-NEXT:   store i256 %[[C02]], i256* %[[T07]], align 4
 //CHECK-NEXT:   br label %return{{[0-9]+}}
 //CHECK-EMPTY: 

--- a/circom/tests/loops/inner_loops5.circom
+++ b/circom/tests/loops/inner_loops5.circom
@@ -2,70 +2,57 @@ pragma circom 2.0.0;
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llvm -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 
-// %0 (i.e. signal arena)  = [ out, in ]
-// %lvars =  [ n, temp, i, j ]
+// %0 (i.e. signal arena)  = [ out[0], out[1], out[2], out[3], in ]
+// %lvars =  [ n, i, j ]
 // %subcmps = []
 template Num2Bits(n) {
     signal input in;
-    signal output out;
+    signal output out[n*n];
 
-	var temp = 0;
     for (var i = 0; i < n; i++) {
     	for (var j = 0; j < n; j++) {
-        	temp += (in >> j) & 1;
+            // NOTE: When processing the outer loop, the following statement is determined NOT
+            //  safe to move into a new function since it uses 'j' which is unknown. That results
+            //  in the outer loop unrolling without extrating the body to a new function. Then
+            //  the two copies of the inner loop are processed and their bodies are extracted to
+            //  new functions and replaced with calls to those functions before unrolling. So it
+            //  ends up creating two different functions for this innermost body, one for each
+            //  iteration of the outer loop (i.e. when b=0 and when b=1). In this case, those 2
+            //  function are identical. This is logically correct but not optimal in code size.
+        	out[i*n + j] <-- in;
         }
     }
 }
 
-component main = Num2Bits(4);
-
+component main = Num2Bits(2);
+//
+// %0 (i.e. signal arena) = { out[0], out[1], out[2], out[3], in }
+// %lvars = { n, i, j }
+//
+//unrolled code:
+//	out[0] = in;
+//	out[1] = in;
+//	out[2] = in;
+//	out[3] = in;
+//
 //CHECK-LABEL: define{{.*}} void @..generated..loop.body.
-//CHECK-SAME: [[$F_ID_1:[0-9]+]]([0 x i256]* %lvars, [0 x i256]* %signals){{.*}} {
+//CHECK-SAME: [[$F_ID_1:[0-9]+]]([0 x i256]* %lvars, [0 x i256]* %signals, i256* %sig_0){{.*}} {
 //CHECK-NEXT: ..generated..loop.body.[[$F_ID_1]]:
 //CHECK-NEXT:   br label %store{{[0-9]+}}
 //CHECK-EMPTY: 
 //CHECK-NEXT: store{{[0-9]+}}:
-//CHECK-NEXT:   %[[T00:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 3
-//CHECK-NEXT:   store i256 0, i256* %[[T00]], align 4
-//CHECK-NEXT:   br label %loop{{[0-9]+}}
-//CHECK-EMPTY: 
-//CHECK-NEXT: loop{{[0-9]+}}:
-//CHECK-NEXT:   br label %loop.cond
-//CHECK-EMPTY: 
-//CHECK-NEXT: loop.cond:
-//CHECK-NEXT:   %[[T01:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 3
-//CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T01]], align 4
-//CHECK-NEXT:   %[[C01:[0-9a-zA-Z_.]+]] = call i1 @fr_lt(i256 %[[T02]], i256 4)
-//CHECK-NEXT:   br i1 %[[C01]], label %loop.body, label %loop.end
-//CHECK-EMPTY: 
-//CHECK-NEXT: loop.body:
-//CHECK-NEXT:   %[[T03:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
-//CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T03]], align 4
-//CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %signals, i32 0, i32 1
-//CHECK-NEXT:   %[[T06:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T05]], align 4
-//CHECK-NEXT:   %[[T07:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 3
-//CHECK-NEXT:   %[[T08:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T07]], align 4
-//CHECK-NEXT:   %[[C02:[0-9a-zA-Z_.]+]] = call i256 @fr_shr(i256 %[[T06]], i256 %[[T08]])
-//CHECK-NEXT:   %[[C03:[0-9a-zA-Z_.]+]] = call i256 @fr_bit_and(i256 %[[C02]], i256 1)
-//CHECK-NEXT:   %[[C04:[0-9a-zA-Z_.]+]] = call i256 @fr_add(i256 %[[T04]], i256 %[[C03]])
-//CHECK-NEXT:   %[[T09:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
-//CHECK-NEXT:   store i256 %[[C04]], i256* %[[T09]], align 4
-//CHECK-NEXT:   %[[T10:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 3
-//CHECK-NEXT:   %[[T11:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T10]], align 4
-//CHECK-NEXT:   %[[C05:[0-9a-zA-Z_.]+]] = call i256 @fr_add(i256 %[[T11]], i256 1)
-//CHECK-NEXT:   %[[T12:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 3
-//CHECK-NEXT:   store i256 %[[C05:[0-9a-zA-Z_.]+]], i256* %[[T12]], align 4
-//CHECK-NEXT:   br label %loop.cond
-//CHECK-EMPTY: 
-//CHECK-NEXT: loop.end:
+//CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_0, i32 0
+//CHECK-NEXT:   %[[T00:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %signals, i32 0, i32 4
+//CHECK-NEXT:   %[[T01:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T00]], align 4
+//CHECK-NEXT:   store i256 %[[T01]], i256* %[[T02]], align 4
 //CHECK-NEXT:   br label %store{{[0-9]+}}
 //CHECK-EMPTY: 
 //CHECK-NEXT: store{{[0-9]+}}:
-//CHECK-NEXT:   %[[T13:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
-//CHECK-NEXT:   %[[T14:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T13]], align 4
-//CHECK-NEXT:   %[[C06:[0-9a-zA-Z_.]+]] = call i256 @fr_add(i256 %[[T14]], i256 1)
-//CHECK-NEXT:   %[[T15:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
-//CHECK-NEXT:   store i256 %[[C06:[0-9a-zA-Z_.]+]], i256* %[[T15]], align 4
+//CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
+//CHECK-NEXT:   %[[T03:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
+//CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T03]], align 4
+//CHECK-NEXT:   %[[C01:[0-9a-zA-Z_.]+]] = call i256 @fr_add(i256 %[[T04]], i256 1)
+//CHECK-NEXT:   store i256 %[[C01]], i256* %[[T05]], align 4
 //CHECK-NEXT:   br label %return{{[0-9]+}}
 //CHECK-EMPTY: 
 //CHECK-NEXT: return{{[0-9]+}}:
@@ -74,14 +61,26 @@ component main = Num2Bits(4);
 //
 //CHECK-LABEL: define{{.*}} void @Num2Bits_{{[0-9]+}}_run([0 x i256]* %0){{.*}} {
 //CHECK:      unrolled_loop{{[0-9]+}}:
-//CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = bitcast [4 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %[[T04]], [0 x i256]* %0)
-//CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = bitcast [4 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %[[T05]], [0 x i256]* %0)
-//CHECK-NEXT:   %[[T06:[0-9a-zA-Z_.]+]] = bitcast [4 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %[[T06]], [0 x i256]* %0)
-//CHECK-NEXT:   %[[T07:[0-9a-zA-Z_.]+]] = bitcast [4 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %[[T07]], [0 x i256]* %0)
+//CHECK-NEXT:   %[[T03:[0-9a-zA-Z_.]+]] = getelementptr [3 x i256], [3 x i256]* %lvars, i32 0, i32 2
+//CHECK-NEXT:   store i256 0, i256* %[[T03]], align 4
+//CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = bitcast [3 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 0
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %[[T04]], [0 x i256]* %0, i256* %[[T05]])
+//CHECK-NEXT:   %[[T06:[0-9a-zA-Z_.]+]] = bitcast [3 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T07:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 1
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %[[T06]], [0 x i256]* %0, i256* %[[T07]])
+//CHECK-NEXT:   %[[T08:[0-9a-zA-Z_.]+]] = getelementptr [3 x i256], [3 x i256]* %lvars, i32 0, i32 1
+//CHECK-NEXT:   store i256 1, i256* %[[T08]], align 4
+//CHECK-NEXT:   %[[T09:[0-9a-zA-Z_.]+]] = getelementptr [3 x i256], [3 x i256]* %lvars, i32 0, i32 2
+//CHECK-NEXT:   store i256 0, i256* %[[T09]], align 4
+//CHECK-NEXT:   %[[T10:[0-9a-zA-Z_.]+]] = bitcast [3 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T11:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 2
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %[[T10]], [0 x i256]* %0, i256* %[[T11]])
+//CHECK-NEXT:   %[[T12:[0-9a-zA-Z_.]+]] = bitcast [3 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T13:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 3
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %[[T12]], [0 x i256]* %0, i256* %[[T13]])
+//CHECK-NEXT:   %[[T14:[0-9a-zA-Z_.]+]] = getelementptr [3 x i256], [3 x i256]* %lvars, i32 0, i32 1
+//CHECK-NEXT:   store i256 2, i256* %[[T14]], align 4
 //CHECK-NEXT:   br label %prologue
 //CHECK-EMPTY: 
 //CHECK-NEXT: prologue:

--- a/circom/tests/loops/inner_loops6.circom
+++ b/circom/tests/loops/inner_loops6.circom
@@ -3,7 +3,7 @@ pragma circom 2.0.0;
 // RUN: rm -rf %t && mkdir %t && %circom --llvm -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 
 // %0 (i.e. signal arena)  = [ out[0], out[1], out[2], out[3], in ]
-// %lvars =  [ n, i, j ]
+// %lvars = [ n, i, j ]
 // %subcmps = []
 template Num2Bits(n) {
     signal input in;
@@ -41,17 +41,17 @@ component main = Num2Bits(2);
 //CHECK-NEXT:   br label %store{{[0-9]+}}
 //CHECK-EMPTY: 
 //CHECK-NEXT: store{{[0-9]+}}:
+//CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_0, i32 0
 //CHECK-NEXT:   %[[T00:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %signals, i32 0, i32 4
 //CHECK-NEXT:   %[[T01:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T00]], align 4
-//CHECK-NEXT:   %[[T02:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_0, i32 0
 //CHECK-NEXT:   store i256 %[[T01]], i256* %[[T02]], align 4
 //CHECK-NEXT:   br label %store{{[0-9]+}}
 //CHECK-EMPTY: 
 //CHECK-NEXT: store{{[0-9]+}}:
+//CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
 //CHECK-NEXT:   %[[T03:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
 //CHECK-NEXT:   %[[T04:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T03]], align 4
 //CHECK-NEXT:   %[[C01:[0-9a-zA-Z_.]+]] = call i256 @fr_add(i256 %[[T04]], i256 1)
-//CHECK-NEXT:   %[[T05:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
 //CHECK-NEXT:   store i256 %[[C01]], i256* %[[T05]], align 4
 //CHECK-NEXT:   br label %return{{[0-9]+}}
 //CHECK-EMPTY: 

--- a/circom/tests/loops/simple_variant_idx.circom
+++ b/circom/tests/loops/simple_variant_idx.circom
@@ -20,31 +20,31 @@ component main = SimpleVariantIdx(3);
 //	reference outside of the body function call. All else can be done inside.
 //
 // %0 (i.e. signal arena) = [ out[0], out[1], out[2], in ]
-// %lvars =  [ n, lc, i ]
+// %lvars = [ n, lc, i ]
 // %subcmps = []
 //
 //CHECK-LABEL: define{{.*}} void @..generated..loop.body.
 //CHECK-SAME: [[$F_ID:[0-9]+]]([0 x i256]* %lvars, [0 x i256]* %signals, i256* %sig_[[X1:[0-9]+]], i256* %sig_[[X2:[0-9]+]]){{.*}} {
 //CHECK:      store{{[0-9]+}}:
-//CHECK-NEXT:   %0 = getelementptr [0 x i256], [0 x i256]* %signals, i32 0, i32 3
-//CHECK-NEXT:   %1 = load i256, i256* %0, align 4
-//CHECK-NEXT:   %2 = getelementptr i256, i256* %sig_[[X1]], i32 0
-//CHECK-NEXT:   store i256 %1, i256* %2, align 4
+//CHECK-NEXT:   %[[T002:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_[[X1]], i32 0
+//CHECK-NEXT:   %[[T000:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %signals, i32 0, i32 3
+//CHECK-NEXT:   %[[T001:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T000]], align 4
+//CHECK-NEXT:   store i256 %[[T001]], i256* %[[T002]], align 4
 //CHECK-NEXT:   br label %store{{[0-9]+}}
 //CHECK-EMPTY:
 //CHECK-NEXT: store{{[0-9]+}}:
-//CHECK-NEXT:   %3 = getelementptr i256, i256* %sig_[[X2]], i32 0
-//CHECK-NEXT:   %4 = load i256, i256* %3, align 4
-//CHECK-NEXT:   %5 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
-//CHECK-NEXT:   store i256 %4, i256* %5, align 4
+//CHECK-NEXT:   %[[T005:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
+//CHECK-NEXT:   %[[T003:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_[[X2]], i32 0
+//CHECK-NEXT:   %[[T004:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T003]], align 4
+//CHECK-NEXT:   store i256 %[[T004]], i256* %[[T005]], align 4
 //CHECK-NEXT:   br label %store{{[0-9]+}}
 //CHECK-EMPTY:
 //CHECK-NEXT: store{{[0-9]+}}:
-//CHECK-NEXT:   %6 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
-//CHECK-NEXT:   %7 = load i256, i256* %6, align 4
-//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %7, i256 1)
-//CHECK-NEXT:   %8 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
-//CHECK-NEXT:   store i256 %call.fr_add, i256* %8, align 4
+//CHECK-NEXT:   %[[T008:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
+//CHECK-NEXT:   %[[T006:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
+//CHECK-NEXT:   %[[T007:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T006]], align 4
+//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %[[T007]], i256 1)
+//CHECK-NEXT:   store i256 %call.fr_add, i256* %[[T008]], align 4
 //CHECK-NEXT:   br label %return{{[0-9]+}}
 //CHECK-EMPTY:
 //CHECK-NEXT: return{{[0-9]+}}:
@@ -52,18 +52,18 @@ component main = SimpleVariantIdx(3);
 //CHECK-NEXT: }
 //
 //CHECK-LABEL: define{{.*}} void @SimpleVariantIdx_{{[0-9]+}}_run
-//CHECK-SAME: ([0 x i256]* %[[ARG:[0-9]+]])
+//CHECK-SAME: ([0 x i256]* %0)
 //CHECK:      unrolled_loop{{[0-9]+}}:
-//CHECK-NEXT:   %4 = bitcast [3 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %5 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 0
-//CHECK-NEXT:   %6 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 0
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID]]([0 x i256]* %4, [0 x i256]* %0, i256* %5, i256* %6)
-//CHECK-NEXT:   %7 = bitcast [3 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %8 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 1
-//CHECK-NEXT:   %9 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 1
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID]]([0 x i256]* %7, [0 x i256]* %0, i256* %8, i256* %9)
-//CHECK-NEXT:   %10 = bitcast [3 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %11 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 2
-//CHECK-NEXT:   %12 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 2
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID]]([0 x i256]* %10, [0 x i256]* %0, i256* %11, i256* %12)
+//CHECK-NEXT:   %[[T004:[0-9a-zA-Z_.]+]] = bitcast [3 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T005:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 0
+//CHECK-NEXT:   %[[T006:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 0
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID]]([0 x i256]* %[[T004]], [0 x i256]* %0, i256* %[[T005]], i256* %[[T006]])
+//CHECK-NEXT:   %[[T007:[0-9a-zA-Z_.]+]] = bitcast [3 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T008:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 1
+//CHECK-NEXT:   %[[T009:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 1
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID]]([0 x i256]* %[[T007]], [0 x i256]* %0, i256* %[[T008]], i256* %[[T009]])
+//CHECK-NEXT:   %[[T010:[0-9a-zA-Z_.]+]] = bitcast [3 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T011:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 2
+//CHECK-NEXT:   %[[T012:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 2
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID]]([0 x i256]* %[[T010]], [0 x i256]* %0, i256* %[[T011]], i256* %[[T012]])
 //CHECK-NEXT:   br label %prologue

--- a/circom/tests/loops/vanguard-uc-comp.circom
+++ b/circom/tests/loops/vanguard-uc-comp.circom
@@ -21,7 +21,7 @@ template Num2Bits(n) {
 component main = Num2Bits(2);
 
 // %0 (i.e. signal arena) = [ out[0], out[1], in ]
-// %lvars =  [ n, lc1, e2, i ]
+// %lvars = [ n, lc1, e2, i ]
 // %subcmps = []
 //
 //CHECK-LABEL: define{{.*}} void @..generated..loop.body.
@@ -30,23 +30,23 @@ component main = Num2Bits(2);
 //CHECK-NEXT:   br label %store1
 //CHECK-EMPTY: 
 //CHECK-NEXT: store1:
-//CHECK-NEXT:   %0 = getelementptr [0 x i256], [0 x i256]* %signals, i32 0, i32 2
-//CHECK-NEXT:   %1 = load i256, i256* %0, align 4
-//CHECK-NEXT:   %2 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 3
-//CHECK-NEXT:   %3 = load i256, i256* %2, align 4
-//CHECK-NEXT:   %call.fr_shr = call i256 @fr_shr(i256 %1, i256 %3)
+//CHECK-NEXT:   %[[T004:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_[[X1]], i32 0
+//CHECK-NEXT:   %[[T000:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %signals, i32 0, i32 2
+//CHECK-NEXT:   %[[T001:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T000]], align 4
+//CHECK-NEXT:   %[[T002:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 3
+//CHECK-NEXT:   %[[T003:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T002]], align 4
+//CHECK-NEXT:   %call.fr_shr = call i256 @fr_shr(i256 %[[T001]], i256 %[[T003]])
 //CHECK-NEXT:   %call.fr_bit_and = call i256 @fr_bit_and(i256 %call.fr_shr, i256 1)
-//CHECK-NEXT:   %4 = getelementptr i256, i256* %sig_[[X1]], i32 0
-//CHECK-NEXT:   store i256 %call.fr_bit_and, i256* %4, align 4
+//CHECK-NEXT:   store i256 %call.fr_bit_and, i256* %[[T004]], align 4
 //CHECK-NEXT:   br label %assert2
 //CHECK-EMPTY: 
 //CHECK-NEXT: assert2:
-//CHECK-NEXT:   %5 = getelementptr i256, i256* %sig_[[X2]], i32 0
-//CHECK-NEXT:   %6 = load i256, i256* %5, align 4
-//CHECK-NEXT:   %7 = getelementptr i256, i256* %sig_[[X3]], i32 0
-//CHECK-NEXT:   %8 = load i256, i256* %7, align 4
-//CHECK-NEXT:   %call.fr_sub = call i256 @fr_sub(i256 %8, i256 1)
-//CHECK-NEXT:   %call.fr_mul = call i256 @fr_mul(i256 %6, i256 %call.fr_sub)
+//CHECK-NEXT:   %[[T005:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_[[X2]], i32 0
+//CHECK-NEXT:   %[[T006:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T005]], align 4
+//CHECK-NEXT:   %[[T007:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_[[X3]], i32 0
+//CHECK-NEXT:   %[[T008:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T007]], align 4
+//CHECK-NEXT:   %call.fr_sub = call i256 @fr_sub(i256 %[[T008]], i256 1)
+//CHECK-NEXT:   %call.fr_mul = call i256 @fr_mul(i256 %[[T006]], i256 %call.fr_sub)
 //CHECK-NEXT:   %call.fr_eq = call i1 @fr_eq(i256 %call.fr_mul, i256 0)
 //CHECK-NEXT:   call void @__assert(i1 %call.fr_eq)
 //CHECK-NEXT:   %constraint = alloca i1, align 1
@@ -54,34 +54,34 @@ component main = Num2Bits(2);
 //CHECK-NEXT:   br label %store3
 //CHECK-EMPTY: 
 //CHECK-NEXT: store3:
-//CHECK-NEXT:   %9 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
-//CHECK-NEXT:   %10 = load i256, i256* %9, align 4
-//CHECK-NEXT:   %11 = getelementptr i256, i256* %sig_[[X4]], i32 0
-//CHECK-NEXT:   %12 = load i256, i256* %11, align 4
-//CHECK-NEXT:   %13 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
-//CHECK-NEXT:   %14 = load i256, i256* %13, align 4
-//CHECK-NEXT:   %call.fr_mul1 = call i256 @fr_mul(i256 %12, i256 %14)
-//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %10, i256 %call.fr_mul1)
-//CHECK-NEXT:   %15 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
-//CHECK-NEXT:   store i256 %call.fr_add, i256* %15, align 4
+//CHECK-NEXT:   %[[T015:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
+//CHECK-NEXT:   %[[T009:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
+//CHECK-NEXT:   %[[T010:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T009]], align 4
+//CHECK-NEXT:   %[[T011:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_[[X4]], i32 0
+//CHECK-NEXT:   %[[T012:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T011]], align 4
+//CHECK-NEXT:   %[[T013:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
+//CHECK-NEXT:   %[[T014:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T013]], align 4
+//CHECK-NEXT:   %call.fr_mul1 = call i256 @fr_mul(i256 %[[T012]], i256 %[[T014]])
+//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %[[T010]], i256 %call.fr_mul1)
+//CHECK-NEXT:   store i256 %call.fr_add, i256* %[[T015]], align 4
 //CHECK-NEXT:   br label %store4
 //CHECK-EMPTY: 
 //CHECK-NEXT: store4:
-//CHECK-NEXT:   %16 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
-//CHECK-NEXT:   %17 = load i256, i256* %16, align 4
-//CHECK-NEXT:   %18 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
-//CHECK-NEXT:   %19 = load i256, i256* %18, align 4
-//CHECK-NEXT:   %call.fr_add2 = call i256 @fr_add(i256 %17, i256 %19)
-//CHECK-NEXT:   %20 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
-//CHECK-NEXT:   store i256 %call.fr_add2, i256* %20, align 4
+//CHECK-NEXT:   %[[T020:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
+//CHECK-NEXT:   %[[T016:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
+//CHECK-NEXT:   %[[T017:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T016]], align 4
+//CHECK-NEXT:   %[[T018:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
+//CHECK-NEXT:   %[[T019:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T018]], align 4
+//CHECK-NEXT:   %call.fr_add2 = call i256 @fr_add(i256 %[[T017]], i256 %[[T019]])
+//CHECK-NEXT:   store i256 %call.fr_add2, i256* %[[T020]], align 4
 //CHECK-NEXT:   br label %store5
 //CHECK-EMPTY: 
 //CHECK-NEXT: store5:
-//CHECK-NEXT:   %21 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 3
-//CHECK-NEXT:   %22 = load i256, i256* %21, align 4
-//CHECK-NEXT:   %call.fr_add3 = call i256 @fr_add(i256 %22, i256 1)
-//CHECK-NEXT:   %23 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 3
-//CHECK-NEXT:   store i256 %call.fr_add3, i256* %23, align 4
+//CHECK-NEXT:   %[[T023:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 3
+//CHECK-NEXT:   %[[T021:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 3
+//CHECK-NEXT:   %[[T022:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T021]], align 4
+//CHECK-NEXT:   %call.fr_add3 = call i256 @fr_add(i256 %[[T022]], i256 1)
+//CHECK-NEXT:   store i256 %call.fr_add3, i256* %[[T023]], align 4
 //CHECK-NEXT:   br label %return6
 //CHECK-EMPTY: 
 //CHECK-NEXT: return6:
@@ -91,26 +91,26 @@ component main = Num2Bits(2);
 //CHECK-LABEL: define{{.*}} void @Num2Bits_{{[0-9]+}}_run
 //CHECK-SAME: ([0 x i256]* %[[ARG:[0-9]+]])
 //CHECK:      unrolled_loop{{[0-9]+}}:
-//CHECK-NEXT:   %5 = bitcast [4 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %6 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 0
-//CHECK-NEXT:   %7 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 0
-//CHECK-NEXT:   %8 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 0
-//CHECK-NEXT:   %9 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 0
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID]]([0 x i256]* %5, [0 x i256]* %0, i256* %6, i256* %7, i256* %8, i256* %9)
-//CHECK-NEXT:   %10 = bitcast [4 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %11 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 1
-//CHECK-NEXT:   %12 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 1
-//CHECK-NEXT:   %13 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 1
-//CHECK-NEXT:   %14 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 1
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID]]([0 x i256]* %10, [0 x i256]* %0, i256* %11, i256* %12, i256* %13, i256* %14)
+//CHECK-NEXT:   %[[T005:[0-9a-zA-Z_.]+]] = bitcast [4 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T006:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 0
+//CHECK-NEXT:   %[[T007:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 0
+//CHECK-NEXT:   %[[T008:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 0
+//CHECK-NEXT:   %[[T009:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 0
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID]]([0 x i256]* %[[T005]], [0 x i256]* %[[ARG]], i256* %[[T006]], i256* %[[T007]], i256* %[[T008]], i256* %[[T009]])
+//CHECK-NEXT:   %[[T010:[0-9a-zA-Z_.]+]] = bitcast [4 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T011:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 1
+//CHECK-NEXT:   %[[T012:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 1
+//CHECK-NEXT:   %[[T013:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 1
+//CHECK-NEXT:   %[[T014:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i256 1
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID]]([0 x i256]* %[[T010]], [0 x i256]* %[[ARG]], i256* %[[T011]], i256* %[[T012]], i256* %[[T013]], i256* %[[T014]])
 //CHECK-NEXT:   br label %assert{{[0-9]+}}
 //CHECK-EMPTY: 
 //CHECK-NEXT: assert{{[0-9]+}}:
-//CHECK-NEXT:   %15 = getelementptr [4 x i256], [4 x i256]* %lvars, i32 0, i32 1
-//CHECK-NEXT:   %16 = load i256, i256* %15, align 4
-//CHECK-NEXT:   %17 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 2
-//CHECK-NEXT:   %18 = load i256, i256* %17, align 4
-//CHECK-NEXT:   %call.fr_eq = call i1 @fr_eq(i256 %16, i256 %18)
+//CHECK-NEXT:   %[[T015:[0-9a-zA-Z_.]+]] = getelementptr [4 x i256], [4 x i256]* %lvars, i32 0, i32 1
+//CHECK-NEXT:   %[[T016:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T015]], align 4
+//CHECK-NEXT:   %[[T017:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[ARG]], i32 0, i32 2
+//CHECK-NEXT:   %[[T018:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T017]], align 4
+//CHECK-NEXT:   %call.fr_eq = call i1 @fr_eq(i256 %[[T016]], i256 %[[T018]])
 //CHECK-NEXT:   call void @__assert(i1 %call.fr_eq)
 //CHECK-NEXT:   %constraint = alloca i1, align 1
 //CHECK-NEXT:   call void @__constraint_value(i1 %call.fr_eq, i1* %constraint)

--- a/circom/tests/loops/variant_idx_in_loop_A.circom
+++ b/circom/tests/loops/variant_idx_in_loop_A.circom
@@ -14,27 +14,27 @@ template VariantIndex(n) {
 component main = VariantIndex(2);
 
 // %0 (i.e. signal arena) = [ out[0], out[1], in ]
-// %lvars =  [ n, i ]
+// %lvars = [ n, i ]
 // %subcmps = []
 //
 //CHECK-LABEL: define{{.*}} void @..generated..loop.body.
 //CHECK-SAME: [[$F_ID:[0-9]+]]([0 x i256]* %lvars, [0 x i256]* %signals, i256* %sig_0){{.*}} {
 //CHECK:      store{{[0-9]+}}:
-//CHECK-NEXT:   %0 = getelementptr [0 x i256], [0 x i256]* %signals, i32 0, i32 2
-//CHECK-NEXT:   %1 = load i256, i256* %0, align 4
-//CHECK-NEXT:   %2 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
-//CHECK-NEXT:   %3 = load i256, i256* %2, align 4
-//CHECK-NEXT:   %call.fr_shr = call i256 @fr_shr(i256 %1, i256 %3)
-//CHECK-NEXT:   %4 = getelementptr i256, i256* %sig_0, i32 0
-//CHECK-NEXT:   store i256 %call.fr_shr, i256* %4, align 4
+//CHECK-NEXT:   %[[T004:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_0, i32 0
+//CHECK-NEXT:   %[[T000:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %signals, i32 0, i32 2
+//CHECK-NEXT:   %[[T001:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T000]], align 4
+//CHECK-NEXT:   %[[T002:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
+//CHECK-NEXT:   %[[T003:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T002]], align 4
+//CHECK-NEXT:   %call.fr_shr = call i256 @fr_shr(i256 %[[T001]], i256 %[[T003]])
+//CHECK-NEXT:   store i256 %call.fr_shr, i256* %[[T004]], align 4
 //CHECK-NEXT:   br label %store{{[0-9]+}}
 //CHECK-EMPTY: 
 //CHECK-NEXT: store{{[0-9]+}}:
-//CHECK-NEXT:   %5 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
-//CHECK-NEXT:   %6 = load i256, i256* %5, align 4
-//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %6, i256 1)
-//CHECK-NEXT:   %7 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
-//CHECK-NEXT:   store i256 %call.fr_add, i256* %7, align 4
+//CHECK-NEXT:   %[[T007:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
+//CHECK-NEXT:   %[[T005:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
+//CHECK-NEXT:   %[[T006:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T005]], align 4
+//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %[[T006]], i256 1)
+//CHECK-NEXT:   store i256 %call.fr_add, i256* %[[T007]], align 4
 //CHECK-NEXT:   br label %return{{[0-9]+}}
 //CHECK-EMPTY: 
 //CHECK-NEXT: return{{[0-9]+}}:
@@ -44,10 +44,10 @@ component main = VariantIndex(2);
 //CHECK-LABEL: define{{.*}} void @VariantIndex_{{[0-9]+}}_run
 //CHECK-SAME: ([0 x i256]* %[[ARG:[0-9]+]])
 //CHECK:      unrolled_loop{{[0-9]+}}:
-//CHECK-NEXT:   %3 = bitcast [2 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %4 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 0
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID]]([0 x i256]* %3, [0 x i256]* %0, i256* %4)
-//CHECK-NEXT:   %5 = bitcast [2 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %6 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 1
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID]]([0 x i256]* %5, [0 x i256]* %0, i256* %6)
+//CHECK-NEXT:   %[[T003:[0-9a-zA-Z_.]+]] = bitcast [2 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T004:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 0
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID]]([0 x i256]* %[[T003]], [0 x i256]* %0, i256* %[[T004]])
+//CHECK-NEXT:   %[[T005:[0-9a-zA-Z_.]+]] = bitcast [2 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T006:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 1
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID]]([0 x i256]* %[[T005]], [0 x i256]* %0, i256* %[[T006]])
 //CHECK-NEXT:   br label %prologue

--- a/circom/tests/loops/variant_idx_in_loop_B.circom
+++ b/circom/tests/loops/variant_idx_in_loop_B.circom
@@ -16,27 +16,27 @@ template VariantIndex(n) {
 component main = VariantIndex(2);
 
 // %0 (i.e. signal arena) = [ out, in ]
-// %lvars =  [ n, temp[0], temp[1], i ]
+// %lvars = [ n, temp[0], temp[1], i ]
 // %subcmps = []
 //
 //CHECK-LABEL: define{{.*}} void @..generated..loop.body.
 //CHECK-SAME: [[$F_ID:[0-9]+]]([0 x i256]* %lvars, [0 x i256]* %signals, i256* %var_0){{.*}} {
 //CHECK:      store{{[0-9]+}}:
-//CHECK-NEXT:   %0 = getelementptr [0 x i256], [0 x i256]* %signals, i32 0, i32 1
-//CHECK-NEXT:   %1 = load i256, i256* %0, align 4
-//CHECK-NEXT:   %2 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 3
-//CHECK-NEXT:   %3 = load i256, i256* %2, align 4
-//CHECK-NEXT:   %call.fr_shr = call i256 @fr_shr(i256 %1, i256 %3)
-//CHECK-NEXT:   %4 = getelementptr i256, i256* %var_0, i32 0
-//CHECK-NEXT:   store i256 %call.fr_shr, i256* %4, align 4
+//CHECK-NEXT:   %[[T004:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %var_0, i32 0
+//CHECK-NEXT:   %[[T000:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %signals, i32 0, i32 1
+//CHECK-NEXT:   %[[T001:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T000]], align 4
+//CHECK-NEXT:   %[[T002:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 3
+//CHECK-NEXT:   %[[T003:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T002]], align 4
+//CHECK-NEXT:   %call.fr_shr = call i256 @fr_shr(i256 %[[T001]], i256 %[[T003]])
+//CHECK-NEXT:   store i256 %call.fr_shr, i256* %[[T004]], align 4
 //CHECK-NEXT:   br label %store{{[0-9]+}}
 //CHECK-EMPTY: 
 //CHECK-NEXT: store{{[0-9]+}}:
-//CHECK-NEXT:   %5 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 3
-//CHECK-NEXT:   %6 = load i256, i256* %5, align 4
-//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %6, i256 1)
-//CHECK-NEXT:   %7 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 3
-//CHECK-NEXT:   store i256 %call.fr_add, i256* %7, align 4
+//CHECK-NEXT:   %[[T007:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 3
+//CHECK-NEXT:   %[[T005:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 3
+//CHECK-NEXT:   %[[T006:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T005]], align 4
+//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %[[T006]], i256 1)
+//CHECK-NEXT:   store i256 %call.fr_add, i256* %[[T007]], align 4
 //CHECK-NEXT:   br label %return{{[0-9]+}}
 //CHECK-EMPTY: 
 //CHECK-NEXT: return{{[0-9]+}}:
@@ -46,24 +46,24 @@ component main = VariantIndex(2);
 //CHECK-LABEL: define{{.*}} void @VariantIndex_{{[0-9]+}}_run
 //CHECK-SAME: ([0 x i256]* %[[ARG:[0-9]+]])
 //CHECK:      unrolled_loop{{[0-9]+}}:
-//CHECK-NEXT:   %5 = bitcast [4 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %6 = bitcast [4 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %7 = getelementptr [0 x i256], [0 x i256]* %6, i32 0, i256 1
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID]]([0 x i256]* %5, [0 x i256]* %0, i256* %7)
-//CHECK-NEXT:   %8 = bitcast [4 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %9 = bitcast [4 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %10 = getelementptr [0 x i256], [0 x i256]* %9, i32 0, i256 2
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID]]([0 x i256]* %8, [0 x i256]* %0, i256* %10)
+//CHECK-NEXT:   %[[T005:[0-9a-zA-Z_.]+]] = bitcast [4 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T006:[0-9a-zA-Z_.]+]] = bitcast [4 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T007:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T006]], i32 0, i256 1
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID]]([0 x i256]* %[[T005]], [0 x i256]* %0, i256* %[[T007]])
+//CHECK-NEXT:   %[[T008:[0-9a-zA-Z_.]+]] = bitcast [4 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T009:[0-9a-zA-Z_.]+]] = bitcast [4 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T010:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T009]], i32 0, i256 2
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID]]([0 x i256]* %[[T008]], [0 x i256]* %0, i256* %[[T010]])
 //CHECK-NEXT:   br label %store{{[0-9]+}}
 //CHECK-EMPTY: 
 //CHECK-NEXT: store{{[0-9]+}}:
-//CHECK-NEXT:   %11 = getelementptr [4 x i256], [4 x i256]* %lvars, i32 0, i32 1
-//CHECK-NEXT:   %12 = load i256, i256* %11, align 4
-//CHECK-NEXT:   %13 = getelementptr [4 x i256], [4 x i256]* %lvars, i32 0, i32 2
-//CHECK-NEXT:   %14 = load i256, i256* %13, align 4
-//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %12, i256 %14)
-//CHECK-NEXT:   %15 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
-//CHECK-NEXT:   store i256 %call.fr_add, i256* %15, align 4
+//CHECK-NEXT:   %[[T015:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
+//CHECK-NEXT:   %[[T011:[0-9a-zA-Z_.]+]] = getelementptr [4 x i256], [4 x i256]* %lvars, i32 0, i32 1
+//CHECK-NEXT:   %[[T012:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T011]], align 4
+//CHECK-NEXT:   %[[T013:[0-9a-zA-Z_.]+]] = getelementptr [4 x i256], [4 x i256]* %lvars, i32 0, i32 2
+//CHECK-NEXT:   %[[T014:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T013]], align 4
+//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %[[T012]], i256 %[[T014]])
+//CHECK-NEXT:   store i256 %call.fr_add, i256* %[[T015]], align 4
 //CHECK-NEXT:   br label %prologue
 //CHECK-EMPTY: 
 //CHECK-NEXT: prologue:

--- a/circom/tests/subcmps/conv_map2idx_B.circom
+++ b/circom/tests/subcmps/conv_map2idx_B.circom
@@ -24,12 +24,12 @@ component main = ComputeValue();
 
 //CHECK-LABEL: define{{.*}} void @GetWeight_0_build({ [0 x i256]*, i32 }* %0){{.*}} {
 //CHECK-NEXT: main:
-//CHECK-NEXT:   %1 = alloca [3 x i256], align 8
-//CHECK-NEXT:   %2 = getelementptr { [0 x i256]*, i32 }, { [0 x i256]*, i32 }* %0, i32 0, i32 1
-//CHECK-NEXT:   store i32 0, i32* %2, align 4
-//CHECK-NEXT:   %3 = getelementptr { [0 x i256]*, i32 }, { [0 x i256]*, i32 }* %0, i32 0, i32 0
-//CHECK-NEXT:   %4 = bitcast [3 x i256]* %1 to [0 x i256]*
-//CHECK-NEXT:   store [0 x i256]* %4, [0 x i256]** %3, align 8
+//CHECK-NEXT:   %[[T001:[0-9a-zA-Z_.]+]] = alloca [3 x i256], align 8
+//CHECK-NEXT:   %[[T002:[0-9a-zA-Z_.]+]] = getelementptr { [0 x i256]*, i32 }, { [0 x i256]*, i32 }* %0, i32 0, i32 1
+//CHECK-NEXT:   store i32 0, i32* %[[T002]], align 4
+//CHECK-NEXT:   %[[T003:[0-9a-zA-Z_.]+]] = getelementptr { [0 x i256]*, i32 }, { [0 x i256]*, i32 }* %0, i32 0, i32 0
+//CHECK-NEXT:   %[[T004:[0-9a-zA-Z_.]+]] = bitcast [3 x i256]* %[[T001]] to [0 x i256]*
+//CHECK-NEXT:   store [0 x i256]* %[[T004]], [0 x i256]** %[[T003]], align 8
 //CHECK-NEXT:   ret void
 //CHECK-NEXT: }
 //
@@ -40,18 +40,18 @@ component main = ComputeValue();
 //CHECK-NEXT:   br label %store1
 //CHECK-EMPTY: 
 //CHECK-NEXT: store1:
-//CHECK-NEXT:   %1 = getelementptr [2 x i256], [2 x i256]* %lvars, i32 0, i32 0
-//CHECK-NEXT:   store i256 999, i256* %1, align 4
+//CHECK-NEXT:   %[[T001:[0-9a-zA-Z_.]+]] = getelementptr [2 x i256], [2 x i256]* %lvars, i32 0, i32 0
+//CHECK-NEXT:   store i256 999, i256* %[[T001]], align 4
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY: 
 //CHECK-NEXT: store2:
-//CHECK-NEXT:   %2 = getelementptr [2 x i256], [2 x i256]* %lvars, i32 0, i32 1
-//CHECK-NEXT:   store i256 0, i256* %2, align 4
+//CHECK-NEXT:   %[[T002:[0-9a-zA-Z_.]+]] = getelementptr [2 x i256], [2 x i256]* %lvars, i32 0, i32 1
+//CHECK-NEXT:   store i256 0, i256* %[[T002]], align 4
 //CHECK-NEXT:   br label %store3
 //CHECK-EMPTY: 
 //CHECK-NEXT: store3:
-//CHECK-NEXT:   %3 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 2
-//CHECK-NEXT:   store i256 999, i256* %3, align 4
+//CHECK-NEXT:   %[[T003:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 2
+//CHECK-NEXT:   store i256 999, i256* %[[T003]], align 4
 //CHECK-NEXT:   br label %prologue
 //CHECK-EMPTY: 
 //CHECK-NEXT: prologue:
@@ -65,18 +65,18 @@ component main = ComputeValue();
 //CHECK-NEXT:   br label %store1
 //CHECK-EMPTY: 
 //CHECK-NEXT: store1:
-//CHECK-NEXT:   %1 = getelementptr [2 x i256], [2 x i256]* %lvars, i32 0, i32 0
-//CHECK-NEXT:   store i256 888, i256* %1, align 4
+//CHECK-NEXT:   %[[T001:[0-9a-zA-Z_.]+]] = getelementptr [2 x i256], [2 x i256]* %lvars, i32 0, i32 0
+//CHECK-NEXT:   store i256 888, i256* %[[T001]], align 4
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY: 
 //CHECK-NEXT: store2:
-//CHECK-NEXT:   %2 = getelementptr [2 x i256], [2 x i256]* %lvars, i32 0, i32 1
-//CHECK-NEXT:   store i256 1, i256* %2, align 4
+//CHECK-NEXT:   %[[T002:[0-9a-zA-Z_.]+]] = getelementptr [2 x i256], [2 x i256]* %lvars, i32 0, i32 1
+//CHECK-NEXT:   store i256 1, i256* %[[T002]], align 4
 //CHECK-NEXT:   br label %store3
 //CHECK-EMPTY: 
 //CHECK-NEXT: store3:
-//CHECK-NEXT:   %3 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 2
-//CHECK-NEXT:   store i256 888, i256* %3, align 4
+//CHECK-NEXT:   %[[T003:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 2
+//CHECK-NEXT:   store i256 888, i256* %[[T003]], align 4
 //CHECK-NEXT:   br label %prologue
 //CHECK-EMPTY: 
 //CHECK-NEXT: prologue:
@@ -85,12 +85,12 @@ component main = ComputeValue();
 //
 //CHECK-LABEL: define{{.*}} void @ComputeValue_2_build({ [0 x i256]*, i32 }* %0){{.*}} {
 //CHECK-NEXT: main:
-//CHECK-NEXT:   %1 = alloca [2 x i256], align 8
-//CHECK-NEXT:   %2 = getelementptr { [0 x i256]*, i32 }, { [0 x i256]*, i32 }* %0, i32 0, i32 1
-//CHECK-NEXT:   store i32 0, i32* %2, align 4
-//CHECK-NEXT:   %3 = getelementptr { [0 x i256]*, i32 }, { [0 x i256]*, i32 }* %0, i32 0, i32 0
-//CHECK-NEXT:   %4 = bitcast [2 x i256]* %1 to [0 x i256]*
-//CHECK-NEXT:   store [0 x i256]* %4, [0 x i256]** %3, align 8
+//CHECK-NEXT:   %[[T001:[0-9a-zA-Z_.]+]] = alloca [2 x i256], align 8
+//CHECK-NEXT:   %[[T002:[0-9a-zA-Z_.]+]] = getelementptr { [0 x i256]*, i32 }, { [0 x i256]*, i32 }* %0, i32 0, i32 1
+//CHECK-NEXT:   store i32 0, i32* %[[T002]], align 4
+//CHECK-NEXT:   %[[T003:[0-9a-zA-Z_.]+]] = getelementptr { [0 x i256]*, i32 }, { [0 x i256]*, i32 }* %0, i32 0, i32 0
+//CHECK-NEXT:   %[[T004:[0-9a-zA-Z_.]+]] = bitcast [2 x i256]* %[[T001]] to [0 x i256]*
+//CHECK-NEXT:   store [0 x i256]* %[[T004]], [0 x i256]** %[[T003]], align 8
 //CHECK-NEXT:   ret void
 //CHECK-NEXT: }
 //
@@ -101,43 +101,43 @@ component main = ComputeValue();
 //CHECK-NEXT:   br label %create_cmp1
 //CHECK-EMPTY: 
 //CHECK-NEXT: create_cmp1:
-//CHECK-NEXT:   %1 = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0
-//CHECK-NEXT:   call void @GetWeight_0_build({ [0 x i256]*, i32 }* %1)
-//CHECK-NEXT:   %2 = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
-//CHECK-NEXT:   %3 = load [0 x i256]*, [0 x i256]** %2, align 8
-//CHECK-NEXT:   call void @GetWeight_0_run([0 x i256]* %3)
+//CHECK-NEXT:   %[[T001:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0
+//CHECK-NEXT:   call void @GetWeight_0_build({ [0 x i256]*, i32 }* %[[T001]])
+//CHECK-NEXT:   %[[T002:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
+//CHECK-NEXT:   %[[T003:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T002]], align 8
+//CHECK-NEXT:   call void @GetWeight_0_run([0 x i256]* %[[T003]])
 //CHECK-NEXT:   br label %create_cmp2
 //CHECK-EMPTY: 
 //CHECK-NEXT: create_cmp2:
-//CHECK-NEXT:   %4 = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1
-//CHECK-NEXT:   call void @GetWeight_0_build({ [0 x i256]*, i32 }* %4)
-//CHECK-NEXT:   %5 = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 0
-//CHECK-NEXT:   %6 = load [0 x i256]*, [0 x i256]** %5, align 8
-//CHECK-NEXT:   call void @GetWeight_1_run([0 x i256]* %6)
+//CHECK-NEXT:   %[[T004:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1
+//CHECK-NEXT:   call void @GetWeight_0_build({ [0 x i256]*, i32 }* %[[T004]])
+//CHECK-NEXT:   %[[T005:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 0
+//CHECK-NEXT:   %[[T006:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T005]], align 8
+//CHECK-NEXT:   call void @GetWeight_1_run([0 x i256]* %[[T006]])
 //CHECK-NEXT:   br label %store3
 //CHECK-EMPTY: 
 //CHECK-NEXT: store3:
-//CHECK-NEXT:   %7 = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
-//CHECK-NEXT:   %8 = load [0 x i256]*, [0 x i256]** %7, align 8
-//CHECK-NEXT:   %9 = getelementptr [0 x i256], [0 x i256]* %8, i32 0, i32 2
-//CHECK-NEXT:   %10 = load i256, i256* %9, align 4
-//CHECK-NEXT:   %11 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
-//CHECK-NEXT:   store i256 %10, i256* %11, align 4
-//CHECK-NEXT:   %12 = load i256, i256* %11, align 4
+//CHECK-NEXT:   %[[T011:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
+//CHECK-NEXT:   %[[T007:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
+//CHECK-NEXT:   %[[T008:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T007]], align 8
+//CHECK-NEXT:   %[[T009:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T008]], i32 0, i32 2
+//CHECK-NEXT:   %[[T010:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T009]], align 4
+//CHECK-NEXT:   store i256 %[[T010]], i256* %[[T011]], align 4
+//CHECK-NEXT:   %[[T012:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T011]], align 4
 //CHECK-NEXT:   %constraint = alloca i1, align 1
-//CHECK-NEXT:   call void @__constraint_values(i256 %10, i256 %12, i1* %constraint)
+//CHECK-NEXT:   call void @__constraint_values(i256 %[[T010]], i256 %[[T012]], i1* %constraint)
 //CHECK-NEXT:   br label %store4
 //CHECK-EMPTY: 
 //CHECK-NEXT: store4:
-//CHECK-NEXT:   %13 = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 0
-//CHECK-NEXT:   %14 = load [0 x i256]*, [0 x i256]** %13, align 8
-//CHECK-NEXT:   %15 = getelementptr [0 x i256], [0 x i256]* %14, i32 0, i32 2
-//CHECK-NEXT:   %16 = load i256, i256* %15, align 4
-//CHECK-NEXT:   %17 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 1
-//CHECK-NEXT:   store i256 %16, i256* %17, align 4
-//CHECK-NEXT:   %18 = load i256, i256* %17, align 4
+//CHECK-NEXT:   %[[T017:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 1
+//CHECK-NEXT:   %[[T013:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 0
+//CHECK-NEXT:   %[[T014:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T013]], align 8
+//CHECK-NEXT:   %[[T015:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T014]], i32 0, i32 2
+//CHECK-NEXT:   %[[T016:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T015]], align 4
+//CHECK-NEXT:   store i256 %[[T016]], i256* %[[T017]], align 4
+//CHECK-NEXT:   %[[T018:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T017]], align 4
 //CHECK-NEXT:   %constraint1 = alloca i1, align 1
-//CHECK-NEXT:   call void @__constraint_values(i256 %16, i256 %18, i1* %constraint1)
+//CHECK-NEXT:   call void @__constraint_values(i256 %[[T016]], i256 %[[T018]], i1* %constraint1)
 //CHECK-NEXT:   br label %prologue
 //CHECK-EMPTY: 
 //CHECK-NEXT: prologue:

--- a/circom/tests/subcmps/mapped.circom
+++ b/circom/tests/subcmps/mapped.circom
@@ -50,12 +50,12 @@ component main = B(2);
 //CHECK-NEXT:   br label %store1
 //CHECK-EMPTY: 
 //CHECK-NEXT: store1:
+//CHECK-NEXT:   %[[T004:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_[[X1]], i32 0
 //CHECK-NEXT:   %[[T000:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_[[X2]], i32 0
 //CHECK-NEXT:   %[[T001:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T000]], align 4
 //CHECK-NEXT:   %[[T002:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_[[X3]], i32 0
 //CHECK-NEXT:   %[[T003:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T002]], align 4
 //CHECK-NEXT:   %[[C001:[0-9a-zA-Z_.]+]] = call i256 @fr_mul(i256 %[[T001]], i256 %[[T003]])
-//CHECK-NEXT:   %[[T004:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_[[X1]], i32 0
 //CHECK-NEXT:   store i256 %[[C001]], i256* %[[T004]], align 4
 //CHECK-NEXT:   %[[T005:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T004]], align 4
 //CHECK-NEXT:   %constraint = alloca i1, align 1
@@ -63,10 +63,10 @@ component main = B(2);
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY: 
 //CHECK-NEXT: store2:
+//CHECK-NEXT:   %[[T008:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
 //CHECK-NEXT:   %[[T006:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
 //CHECK-NEXT:   %[[T007:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T006]], align 4
 //CHECK-NEXT:   %[[C002:[0-9a-zA-Z_.]+]] = call i256 @fr_add(i256 %[[T007]], i256 1)
-//CHECK-NEXT:   %[[T008:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
 //CHECK-NEXT:   store i256 %[[C002]], i256* %[[T008]], align 4
 //CHECK-NEXT:   br label %return3
 //CHECK-EMPTY: 
@@ -192,11 +192,11 @@ component main = B(2);
 //CHECK-NEXT:   br label %unrolled_loop6
 //CHECK-EMPTY: 
 //CHECK-NEXT: unrolled_loop6:
-//CHECK-NEXT:   %[[T006:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 2
-//CHECK-NEXT:   %[[T007:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T006]], align 4
 //CHECK-NEXT:   %[[T008:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
 //CHECK-NEXT:   %[[T009:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T008]], align 8
 //CHECK-NEXT:   %[[T010:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T009]], i32 0, i32 4
+//CHECK-NEXT:   %[[T006:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 2
+//CHECK-NEXT:   %[[T007:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T006]], align 4
 //CHECK-NEXT:   store i256 %[[T007]], i256* %[[T010]], align 4
 //CHECK-NEXT:   %[[T011:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 1
 //CHECK-NEXT:   %load.subcmp.counter = load i32, i32* %[[T011]], align 4
@@ -205,11 +205,11 @@ component main = B(2);
 //CHECK-NEXT:   %[[T012:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T010]], align 4
 //CHECK-NEXT:   %constraint = alloca i1, align 1
 //CHECK-NEXT:   call void @__constraint_values(i256 %[[T007]], i256 %[[T012]], i1* %constraint)
-//CHECK-NEXT:   %[[T013:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 6
-//CHECK-NEXT:   %[[T014:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T013]], align 4
 //CHECK-NEXT:   %[[T015:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
 //CHECK-NEXT:   %[[T016:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T015]], align 8
 //CHECK-NEXT:   %[[T017:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T016]], i32 0, i32 8
+//CHECK-NEXT:   %[[T013:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 6
+//CHECK-NEXT:   %[[T014:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T013]], align 4
 //CHECK-NEXT:   store i256 %[[T014]], i256* %[[T017]], align 4
 //CHECK-NEXT:   %[[T018:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 1
 //CHECK-NEXT:   %load.subcmp.counter1 = load i32, i32* %[[T018]], align 4
@@ -220,11 +220,11 @@ component main = B(2);
 //CHECK-NEXT:   call void @__constraint_values(i256 %[[T014]], i256 %[[T019]], i1* %constraint3)
 //CHECK-NEXT:   %[[T020:[0-9a-zA-Z_.]+]] = getelementptr [2 x i256], [2 x i256]* %lvars, i32 0, i32 1
 //CHECK-NEXT:   store i256 1, i256* %[[T020]], align 4
-//CHECK-NEXT:   %[[T021:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 3
-//CHECK-NEXT:   %[[T022:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T021]], align 4
 //CHECK-NEXT:   %[[T023:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
 //CHECK-NEXT:   %[[T024:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T023]], align 8
 //CHECK-NEXT:   %[[T025:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T024]], i32 0, i32 5
+//CHECK-NEXT:   %[[T021:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 3
+//CHECK-NEXT:   %[[T022:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T021]], align 4
 //CHECK-NEXT:   store i256 %[[T022]], i256* %[[T025]], align 4
 //CHECK-NEXT:   %[[T026:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 1
 //CHECK-NEXT:   %load.subcmp.counter4 = load i32, i32* %[[T026]], align 4
@@ -233,11 +233,11 @@ component main = B(2);
 //CHECK-NEXT:   %[[T027:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T025]], align 4
 //CHECK-NEXT:   %constraint6 = alloca i1, align 1
 //CHECK-NEXT:   call void @__constraint_values(i256 %[[T022]], i256 %[[T027]], i1* %constraint6)
-//CHECK-NEXT:   %[[T028:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 7
-//CHECK-NEXT:   %[[T029:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T028]], align 4
 //CHECK-NEXT:   %[[T030:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
 //CHECK-NEXT:   %[[T031:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T030]], align 8
 //CHECK-NEXT:   %[[T032:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T031]], i32 0, i32 9
+//CHECK-NEXT:   %[[T028:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 7
+//CHECK-NEXT:   %[[T029:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T028]], align 4
 //CHECK-NEXT:   store i256 %[[T029]], i256* %[[T032]], align 4
 //CHECK-NEXT:   %[[T033:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 1
 //CHECK-NEXT:   %load.subcmp.counter7 = load i32, i32* %[[T033]], align 4
@@ -248,11 +248,11 @@ component main = B(2);
 //CHECK-NEXT:   call void @__constraint_values(i256 %[[T029]], i256 %[[T034]], i1* %constraint9)
 //CHECK-NEXT:   %[[T035:[0-9a-zA-Z_.]+]] = getelementptr [2 x i256], [2 x i256]* %lvars, i32 0, i32 1
 //CHECK-NEXT:   store i256 2, i256* %[[T035]], align 4
-//CHECK-NEXT:   %[[T036:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 4
-//CHECK-NEXT:   %[[T037:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T036]], align 4
 //CHECK-NEXT:   %[[T038:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
 //CHECK-NEXT:   %[[T039:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T038]], align 8
 //CHECK-NEXT:   %[[T040:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T039]], i32 0, i32 6
+//CHECK-NEXT:   %[[T036:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 4
+//CHECK-NEXT:   %[[T037:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T036]], align 4
 //CHECK-NEXT:   store i256 %[[T037]], i256* %[[T040]], align 4
 //CHECK-NEXT:   %[[T041:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 1
 //CHECK-NEXT:   %load.subcmp.counter10 = load i32, i32* %[[T041]], align 4
@@ -261,11 +261,11 @@ component main = B(2);
 //CHECK-NEXT:   %[[T042:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T040]], align 4
 //CHECK-NEXT:   %constraint12 = alloca i1, align 1
 //CHECK-NEXT:   call void @__constraint_values(i256 %[[T037]], i256 %[[T042]], i1* %constraint12)
-//CHECK-NEXT:   %[[T043:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 8
-//CHECK-NEXT:   %[[T044:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T043]], align 4
 //CHECK-NEXT:   %[[T045:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
 //CHECK-NEXT:   %[[T046:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T045]], align 8
 //CHECK-NEXT:   %[[T047:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T046]], i32 0, i32 10
+//CHECK-NEXT:   %[[T043:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 8
+//CHECK-NEXT:   %[[T044:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T043]], align 4
 //CHECK-NEXT:   store i256 %[[T044]], i256* %[[T047]], align 4
 //CHECK-NEXT:   %[[T048:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 1
 //CHECK-NEXT:   %load.subcmp.counter13 = load i32, i32* %[[T048]], align 4
@@ -276,11 +276,11 @@ component main = B(2);
 //CHECK-NEXT:   call void @__constraint_values(i256 %[[T044]], i256 %[[T049]], i1* %constraint15)
 //CHECK-NEXT:   %[[T050:[0-9a-zA-Z_.]+]] = getelementptr [2 x i256], [2 x i256]* %lvars, i32 0, i32 1
 //CHECK-NEXT:   store i256 3, i256* %[[T050]], align 4
-//CHECK-NEXT:   %[[T051:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 5
-//CHECK-NEXT:   %[[T052:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T051]], align 4
 //CHECK-NEXT:   %[[T053:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
 //CHECK-NEXT:   %[[T054:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T053]], align 8
 //CHECK-NEXT:   %[[T055:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T054]], i32 0, i32 7
+//CHECK-NEXT:   %[[T051:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 5
+//CHECK-NEXT:   %[[T052:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T051]], align 4
 //CHECK-NEXT:   store i256 %[[T052]], i256* %[[T055]], align 4
 //CHECK-NEXT:   %[[T056:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 1
 //CHECK-NEXT:   %load.subcmp.counter16 = load i32, i32* %[[T056]], align 4
@@ -289,11 +289,11 @@ component main = B(2);
 //CHECK-NEXT:   %[[T057:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T055]], align 4
 //CHECK-NEXT:   %constraint18 = alloca i1, align 1
 //CHECK-NEXT:   call void @__constraint_values(i256 %[[T052]], i256 %[[T057]], i1* %constraint18)
-//CHECK-NEXT:   %[[T058:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 9
-//CHECK-NEXT:   %[[T059:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T058]], align 4
 //CHECK-NEXT:   %[[T060:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
 //CHECK-NEXT:   %[[T061:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T060]], align 8
 //CHECK-NEXT:   %[[T062:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T061]], i32 0, i32 11
+//CHECK-NEXT:   %[[T058:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 9
+//CHECK-NEXT:   %[[T059:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T058]], align 4
 //CHECK-NEXT:   store i256 %[[T059]], i256* %[[T062]], align 4
 //CHECK-NEXT:   %[[T063:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 1
 //CHECK-NEXT:   %load.subcmp.counter19 = load i32, i32* %[[T063]], align 4
@@ -315,13 +315,13 @@ component main = B(2);
 //CHECK-NEXT:   br label %unrolled_loop8
 //CHECK-EMPTY: 
 //CHECK-NEXT: unrolled_loop8:
+//CHECK-NEXT:   %[[T073:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 0
+//CHECK-NEXT:   %[[T074:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T073]], align 8
+//CHECK-NEXT:   %[[T075:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T074]], i32 0, i32 2
 //CHECK-NEXT:   %[[T069:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
 //CHECK-NEXT:   %[[T070:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T069]], align 8
 //CHECK-NEXT:   %[[T071:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T070]], i32 0, i32 0
 //CHECK-NEXT:   %[[T072:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T071]], align 4
-//CHECK-NEXT:   %[[T073:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 0
-//CHECK-NEXT:   %[[T074:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T073]], align 8
-//CHECK-NEXT:   %[[T075:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T074]], i32 0, i32 2
 //CHECK-NEXT:   store i256 %[[T072]], i256* %[[T075]], align 4
 //CHECK-NEXT:   %[[T076:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 1
 //CHECK-NEXT:   %load.subcmp.counter22 = load i32, i32* %[[T076]], align 4
@@ -330,13 +330,13 @@ component main = B(2);
 //CHECK-NEXT:   %[[T077:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T075]], align 4
 //CHECK-NEXT:   %constraint24 = alloca i1, align 1
 //CHECK-NEXT:   call void @__constraint_values(i256 %[[T072]], i256 %[[T077]], i1* %constraint24)
+//CHECK-NEXT:   %[[T082:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 0
+//CHECK-NEXT:   %[[T083:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T082]], align 8
+//CHECK-NEXT:   %[[T084:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T083]], i32 0, i32 4
 //CHECK-NEXT:   %[[T078:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
 //CHECK-NEXT:   %[[T079:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T078]], align 8
 //CHECK-NEXT:   %[[T080:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T079]], i32 0, i32 2
 //CHECK-NEXT:   %[[T081:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T080]], align 4
-//CHECK-NEXT:   %[[T082:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 0
-//CHECK-NEXT:   %[[T083:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T082]], align 8
-//CHECK-NEXT:   %[[T084:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T083]], i32 0, i32 4
 //CHECK-NEXT:   store i256 %[[T081]], i256* %[[T084]], align 4
 //CHECK-NEXT:   %[[T085:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 1
 //CHECK-NEXT:   %load.subcmp.counter25 = load i32, i32* %[[T085]], align 4
@@ -347,13 +347,13 @@ component main = B(2);
 //CHECK-NEXT:   call void @__constraint_values(i256 %[[T081]], i256 %[[T086]], i1* %constraint27)
 //CHECK-NEXT:   %[[T087:[0-9a-zA-Z_.]+]] = getelementptr [2 x i256], [2 x i256]* %lvars, i32 0, i32 1
 //CHECK-NEXT:   store i256 1, i256* %[[T087]], align 4
+//CHECK-NEXT:   %[[T092:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 0
+//CHECK-NEXT:   %[[T093:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T092]], align 8
+//CHECK-NEXT:   %[[T094:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T093]], i32 0, i32 3
 //CHECK-NEXT:   %[[T088:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
 //CHECK-NEXT:   %[[T089:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T088]], align 8
 //CHECK-NEXT:   %[[T090:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T089]], i32 0, i32 1
 //CHECK-NEXT:   %[[T091:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T090]], align 4
-//CHECK-NEXT:   %[[T092:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 0
-//CHECK-NEXT:   %[[T093:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T092]], align 8
-//CHECK-NEXT:   %[[T094:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T093]], i32 0, i32 3
 //CHECK-NEXT:   store i256 %[[T091]], i256* %[[T094]], align 4
 //CHECK-NEXT:   %[[T095:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 1
 //CHECK-NEXT:   %load.subcmp.counter28 = load i32, i32* %[[T095]], align 4
@@ -362,13 +362,13 @@ component main = B(2);
 //CHECK-NEXT:   %[[T096:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T094]], align 4
 //CHECK-NEXT:   %constraint30 = alloca i1, align 1
 //CHECK-NEXT:   call void @__constraint_values(i256 %[[T091]], i256 %[[T096]], i1* %constraint30)
+//CHECK-NEXT:   %[[T101:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 0
+//CHECK-NEXT:   %[[T102:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T101]], align 8
+//CHECK-NEXT:   %[[T103:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T102]], i32 0, i32 5
 //CHECK-NEXT:   %[[T097:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
 //CHECK-NEXT:   %[[T098:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T097]], align 8
 //CHECK-NEXT:   %[[T099:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T098]], i32 0, i32 3
 //CHECK-NEXT:   %[[T100:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T099]], align 4
-//CHECK-NEXT:   %[[T101:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 0
-//CHECK-NEXT:   %[[T102:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T101]], align 8
-//CHECK-NEXT:   %[[T103:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T102]], i32 0, i32 5
 //CHECK-NEXT:   store i256 %[[T100]], i256* %[[T103]], align 4
 //CHECK-NEXT:   %[[T104:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 1
 //CHECK-NEXT:   %load.subcmp.counter31 = load i32, i32* %[[T104]], align 4
@@ -390,22 +390,22 @@ component main = B(2);
 //CHECK-NEXT:   br label %unrolled_loop10
 //CHECK-EMPTY: 
 //CHECK-NEXT: unrolled_loop10:
+//CHECK-NEXT:   %[[T114:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
 //CHECK-NEXT:   %[[T110:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 0
 //CHECK-NEXT:   %[[T111:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T110]], align 8
 //CHECK-NEXT:   %[[T112:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T111]], i32 0, i32 0
 //CHECK-NEXT:   %[[T113:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T112]], align 4
-//CHECK-NEXT:   %[[T114:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
 //CHECK-NEXT:   store i256 %[[T113]], i256* %[[T114]], align 4
 //CHECK-NEXT:   %[[T115:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T114]], align 4
 //CHECK-NEXT:   %constraint34 = alloca i1, align 1
 //CHECK-NEXT:   call void @__constraint_values(i256 %[[T113]], i256 %[[T115]], i1* %constraint34)
 //CHECK-NEXT:   %[[T116:[0-9a-zA-Z_.]+]] = getelementptr [2 x i256], [2 x i256]* %lvars, i32 0, i32 1
 //CHECK-NEXT:   store i256 1, i256* %[[T116]], align 4
+//CHECK-NEXT:   %[[T121:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 1
 //CHECK-NEXT:   %[[T117:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 0
 //CHECK-NEXT:   %[[T118:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T117]], align 8
 //CHECK-NEXT:   %[[T119:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T118]], i32 0, i32 1
 //CHECK-NEXT:   %[[T120:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T119]], align 4
-//CHECK-NEXT:   %[[T121:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 1
 //CHECK-NEXT:   store i256 %[[T120]], i256* %[[T121]], align 4
 //CHECK-NEXT:   %[[T122:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T121]], align 4
 //CHECK-NEXT:   %constraint35 = alloca i1, align 1

--- a/circom/tests/subcmps/mapped2.circom
+++ b/circom/tests/subcmps/mapped2.circom
@@ -66,10 +66,10 @@ component main = B(2, 3, 2);
 //CHECK-NEXT:   br label %store1
 //CHECK-EMPTY: 
 //CHECK-NEXT: store1:
+//CHECK-NEXT:   %[[T002:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_0, i32 0
 //CHECK-NEXT:   %[[T000:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_1, i32 0
 //CHECK-NEXT:   %[[T001:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T000]], align 4
 //CHECK-NEXT:   %[[C001:[0-9a-zA-Z_.]+]] = call i256 @fr_mul(i256 %[[T001]], i256 2)
-//CHECK-NEXT:   %[[T002:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_0, i32 0
 //CHECK-NEXT:   store i256 %[[C001]], i256* %[[T002]], align 4
 //CHECK-NEXT:   %[[T003:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T002]], align 4
 //CHECK-NEXT:   %constraint = alloca i1, align 1
@@ -77,10 +77,10 @@ component main = B(2, 3, 2);
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY: 
 //CHECK-NEXT: store2:
+//CHECK-NEXT:   %[[T006:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
 //CHECK-NEXT:   %[[T004:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
 //CHECK-NEXT:   %[[T005:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T004]], align 4
 //CHECK-NEXT:   %[[C002:[0-9a-zA-Z_.]+]] = call i256 @fr_add(i256 %[[T005]], i256 1)
-//CHECK-NEXT:   %[[T006:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
 //CHECK-NEXT:   store i256 %[[C002]], i256* %[[T006]], align 4
 //CHECK-NEXT:   br label %return3
 //CHECK-EMPTY: 
@@ -235,11 +235,11 @@ component main = B(2, 3, 2);
 //CHECK-NEXT: unrolled_loop13:
 //CHECK-NEXT:   %[[T014:[0-9a-zA-Z_.]+]] = getelementptr [5 x i256], [5 x i256]* %lvars, i32 0, i32 4
 //CHECK-NEXT:   store i256 0, i256* %[[T014]], align 4
-//CHECK-NEXT:   %[[T015:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 10
-//CHECK-NEXT:   %[[T016:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T015]], align 4
 //CHECK-NEXT:   %[[T017:[0-9a-zA-Z_.]+]] = getelementptr [4 x { [0 x i256]*, i32 }], [4 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
 //CHECK-NEXT:   %[[T018:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T017]], align 8
 //CHECK-NEXT:   %[[T019:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T018]], i32 0, i32 2
+//CHECK-NEXT:   %[[T015:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 10
+//CHECK-NEXT:   %[[T016:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T015]], align 4
 //CHECK-NEXT:   store i256 %[[T016]], i256* %[[T019]], align 4
 //CHECK-NEXT:   %[[T020:[0-9a-zA-Z_.]+]] = getelementptr [4 x { [0 x i256]*, i32 }], [4 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 1
 //CHECK-NEXT:   %load.subcmp.counter = load i32, i32* %[[T020]], align 4
@@ -250,11 +250,11 @@ component main = B(2, 3, 2);
 //CHECK-NEXT:   call void @__constraint_values(i256 %[[T016]], i256 %[[T021]], i1* %constraint)
 //CHECK-NEXT:   %[[T022:[0-9a-zA-Z_.]+]] = getelementptr [5 x i256], [5 x i256]* %lvars, i32 0, i32 4
 //CHECK-NEXT:   store i256 1, i256* %[[T022]], align 4
-//CHECK-NEXT:   %[[T023:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 11
-//CHECK-NEXT:   %[[T024:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T023]], align 4
 //CHECK-NEXT:   %[[T025:[0-9a-zA-Z_.]+]] = getelementptr [4 x { [0 x i256]*, i32 }], [4 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 0
 //CHECK-NEXT:   %[[T026:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T025]], align 8
 //CHECK-NEXT:   %[[T027:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T026]], i32 0, i32 2
+//CHECK-NEXT:   %[[T023:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 11
+//CHECK-NEXT:   %[[T024:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T023]], align 4
 //CHECK-NEXT:   store i256 %[[T024]], i256* %[[T027]], align 4
 //CHECK-NEXT:   %[[T028:[0-9a-zA-Z_.]+]] = getelementptr [4 x { [0 x i256]*, i32 }], [4 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 1
 //CHECK-NEXT:   %load.subcmp.counter1 = load i32, i32* %[[T028]], align 4
@@ -269,11 +269,11 @@ component main = B(2, 3, 2);
 //CHECK-NEXT:   store i256 1, i256* %[[T031]], align 4
 //CHECK-NEXT:   %[[T032:[0-9a-zA-Z_.]+]] = getelementptr [5 x i256], [5 x i256]* %lvars, i32 0, i32 4
 //CHECK-NEXT:   store i256 0, i256* %[[T032]], align 4
-//CHECK-NEXT:   %[[T033:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 12
-//CHECK-NEXT:   %[[T034:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T033]], align 4
 //CHECK-NEXT:   %[[T035:[0-9a-zA-Z_.]+]] = getelementptr [4 x { [0 x i256]*, i32 }], [4 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
 //CHECK-NEXT:   %[[T036:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T035]], align 8
 //CHECK-NEXT:   %[[T037:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T036]], i32 0, i32 3
+//CHECK-NEXT:   %[[T033:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 12
+//CHECK-NEXT:   %[[T034:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T033]], align 4
 //CHECK-NEXT:   store i256 %[[T034]], i256* %[[T037]], align 4
 //CHECK-NEXT:   %[[T038:[0-9a-zA-Z_.]+]] = getelementptr [4 x { [0 x i256]*, i32 }], [4 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 1
 //CHECK-NEXT:   %load.subcmp.counter4 = load i32, i32* %[[T038]], align 4
@@ -287,11 +287,11 @@ component main = B(2, 3, 2);
 //CHECK-NEXT:   call void @__constraint_values(i256 %[[T034]], i256 %[[T041]], i1* %constraint6)
 //CHECK-NEXT:   %[[T042:[0-9a-zA-Z_.]+]] = getelementptr [5 x i256], [5 x i256]* %lvars, i32 0, i32 4
 //CHECK-NEXT:   store i256 1, i256* %[[T042]], align 4
-//CHECK-NEXT:   %[[T043:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 13
-//CHECK-NEXT:   %[[T044:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T043]], align 4
 //CHECK-NEXT:   %[[T045:[0-9a-zA-Z_.]+]] = getelementptr [4 x { [0 x i256]*, i32 }], [4 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 0
 //CHECK-NEXT:   %[[T046:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T045]], align 8
 //CHECK-NEXT:   %[[T047:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T046]], i32 0, i32 3
+//CHECK-NEXT:   %[[T043:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 13
+//CHECK-NEXT:   %[[T044:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T043]], align 4
 //CHECK-NEXT:   store i256 %[[T044]], i256* %[[T047]], align 4
 //CHECK-NEXT:   %[[T048:[0-9a-zA-Z_.]+]] = getelementptr [4 x { [0 x i256]*, i32 }], [4 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 1
 //CHECK-NEXT:   %load.subcmp.counter7 = load i32, i32* %[[T048]], align 4
@@ -329,11 +329,11 @@ component main = B(2, 3, 2);
 //CHECK-NEXT: unrolled_loop17:
 //CHECK-NEXT:   %[[T058:[0-9a-zA-Z_.]+]] = getelementptr [5 x i256], [5 x i256]* %lvars, i32 0, i32 4
 //CHECK-NEXT:   store i256 0, i256* %[[T058]], align 4
-//CHECK-NEXT:   %[[T059:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 14
-//CHECK-NEXT:   %[[T060:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T059]], align 4
 //CHECK-NEXT:   %[[T061:[0-9a-zA-Z_.]+]] = getelementptr [4 x { [0 x i256]*, i32 }], [4 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 2, i32 0
 //CHECK-NEXT:   %[[T062:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T061]], align 8
 //CHECK-NEXT:   %[[T063:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T062]], i32 0, i32 3
+//CHECK-NEXT:   %[[T059:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 14
+//CHECK-NEXT:   %[[T060:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T059]], align 4
 //CHECK-NEXT:   store i256 %[[T060]], i256* %[[T063]], align 4
 //CHECK-NEXT:   %[[T064:[0-9a-zA-Z_.]+]] = getelementptr [4 x { [0 x i256]*, i32 }], [4 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 2, i32 1
 //CHECK-NEXT:   %load.subcmp.counter10 = load i32, i32* %[[T064]], align 4
@@ -344,11 +344,11 @@ component main = B(2, 3, 2);
 //CHECK-NEXT:   call void @__constraint_values(i256 %[[T060]], i256 %[[T065]], i1* %constraint12)
 //CHECK-NEXT:   %[[T066:[0-9a-zA-Z_.]+]] = getelementptr [5 x i256], [5 x i256]* %lvars, i32 0, i32 4
 //CHECK-NEXT:   store i256 1, i256* %[[T066]], align 4
-//CHECK-NEXT:   %[[T067:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 15
-//CHECK-NEXT:   %[[T068:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T067]], align 4
 //CHECK-NEXT:   %[[T069:[0-9a-zA-Z_.]+]] = getelementptr [4 x { [0 x i256]*, i32 }], [4 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 3, i32 0
 //CHECK-NEXT:   %[[T070:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T069]], align 8
 //CHECK-NEXT:   %[[T071:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T070]], i32 0, i32 3
+//CHECK-NEXT:   %[[T067:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 15
+//CHECK-NEXT:   %[[T068:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T067]], align 4
 //CHECK-NEXT:   store i256 %[[T068]], i256* %[[T071]], align 4
 //CHECK-NEXT:   %[[T072:[0-9a-zA-Z_.]+]] = getelementptr [4 x { [0 x i256]*, i32 }], [4 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 3, i32 1
 //CHECK-NEXT:   %load.subcmp.counter13 = load i32, i32* %[[T072]], align 4
@@ -363,11 +363,11 @@ component main = B(2, 3, 2);
 //CHECK-NEXT:   store i256 1, i256* %[[T075]], align 4
 //CHECK-NEXT:   %[[T076:[0-9a-zA-Z_.]+]] = getelementptr [5 x i256], [5 x i256]* %lvars, i32 0, i32 4
 //CHECK-NEXT:   store i256 0, i256* %[[T076]], align 4
-//CHECK-NEXT:   %[[T077:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 16
-//CHECK-NEXT:   %[[T078:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T077]], align 4
 //CHECK-NEXT:   %[[T079:[0-9a-zA-Z_.]+]] = getelementptr [4 x { [0 x i256]*, i32 }], [4 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 2, i32 0
 //CHECK-NEXT:   %[[T080:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T079]], align 8
 //CHECK-NEXT:   %[[T081:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T080]], i32 0, i32 4
+//CHECK-NEXT:   %[[T077:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 16
+//CHECK-NEXT:   %[[T078:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T077]], align 4
 //CHECK-NEXT:   store i256 %[[T078]], i256* %[[T081]], align 4
 //CHECK-NEXT:   %[[T082:[0-9a-zA-Z_.]+]] = getelementptr [4 x { [0 x i256]*, i32 }], [4 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 2, i32 1
 //CHECK-NEXT:   %load.subcmp.counter16 = load i32, i32* %[[T082]], align 4
@@ -378,11 +378,11 @@ component main = B(2, 3, 2);
 //CHECK-NEXT:   call void @__constraint_values(i256 %[[T078]], i256 %[[T083]], i1* %constraint18)
 //CHECK-NEXT:   %[[T084:[0-9a-zA-Z_.]+]] = getelementptr [5 x i256], [5 x i256]* %lvars, i32 0, i32 4
 //CHECK-NEXT:   store i256 1, i256* %[[T084]], align 4
-//CHECK-NEXT:   %[[T085:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 17
-//CHECK-NEXT:   %[[T086:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T085]], align 4
 //CHECK-NEXT:   %[[T087:[0-9a-zA-Z_.]+]] = getelementptr [4 x { [0 x i256]*, i32 }], [4 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 3, i32 0
 //CHECK-NEXT:   %[[T088:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T087]], align 8
 //CHECK-NEXT:   %[[T089:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T088]], i32 0, i32 4
+//CHECK-NEXT:   %[[T085:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 17
+//CHECK-NEXT:   %[[T086:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T085]], align 4
 //CHECK-NEXT:   store i256 %[[T086]], i256* %[[T089]], align 4
 //CHECK-NEXT:   %[[T090:[0-9a-zA-Z_.]+]] = getelementptr [4 x { [0 x i256]*, i32 }], [4 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 3, i32 1
 //CHECK-NEXT:   %load.subcmp.counter19 = load i32, i32* %[[T090]], align 4
@@ -397,11 +397,11 @@ component main = B(2, 3, 2);
 //CHECK-NEXT:   store i256 2, i256* %[[T093]], align 4
 //CHECK-NEXT:   %[[T094:[0-9a-zA-Z_.]+]] = getelementptr [5 x i256], [5 x i256]* %lvars, i32 0, i32 4
 //CHECK-NEXT:   store i256 0, i256* %[[T094]], align 4
-//CHECK-NEXT:   %[[T095:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 18
-//CHECK-NEXT:   %[[T096:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T095]], align 4
 //CHECK-NEXT:   %[[T097:[0-9a-zA-Z_.]+]] = getelementptr [4 x { [0 x i256]*, i32 }], [4 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 2, i32 0
 //CHECK-NEXT:   %[[T098:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T097]], align 8
 //CHECK-NEXT:   %[[T099:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T098]], i32 0, i32 5
+//CHECK-NEXT:   %[[T095:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 18
+//CHECK-NEXT:   %[[T096:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T095]], align 4
 //CHECK-NEXT:   store i256 %[[T096]], i256* %[[T099]], align 4
 //CHECK-NEXT:   %[[T100:[0-9a-zA-Z_.]+]] = getelementptr [4 x { [0 x i256]*, i32 }], [4 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 2, i32 1
 //CHECK-NEXT:   %load.subcmp.counter22 = load i32, i32* %[[T100]], align 4
@@ -415,11 +415,11 @@ component main = B(2, 3, 2);
 //CHECK-NEXT:   call void @__constraint_values(i256 %[[T096]], i256 %[[T103]], i1* %constraint24)
 //CHECK-NEXT:   %[[T104:[0-9a-zA-Z_.]+]] = getelementptr [5 x i256], [5 x i256]* %lvars, i32 0, i32 4
 //CHECK-NEXT:   store i256 1, i256* %[[T104]], align 4
-//CHECK-NEXT:   %[[T105:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 19
-//CHECK-NEXT:   %[[T106:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T105]], align 4
 //CHECK-NEXT:   %[[T107:[0-9a-zA-Z_.]+]] = getelementptr [4 x { [0 x i256]*, i32 }], [4 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 3, i32 0
 //CHECK-NEXT:   %[[T108:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T107]], align 8
 //CHECK-NEXT:   %[[T109:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T108]], i32 0, i32 5
+//CHECK-NEXT:   %[[T105:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 19
+//CHECK-NEXT:   %[[T106:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T105]], align 4
 //CHECK-NEXT:   store i256 %[[T106]], i256* %[[T109]], align 4
 //CHECK-NEXT:   %[[T110:[0-9a-zA-Z_.]+]] = getelementptr [4 x { [0 x i256]*, i32 }], [4 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 3, i32 1
 //CHECK-NEXT:   %load.subcmp.counter25 = load i32, i32* %[[T110]], align 4
@@ -445,22 +445,22 @@ component main = B(2, 3, 2);
 //CHECK-NEXT: unrolled_loop19:
 //CHECK-NEXT:   %[[T117:[0-9a-zA-Z_.]+]] = getelementptr [5 x i256], [5 x i256]* %lvars, i32 0, i32 4
 //CHECK-NEXT:   store i256 0, i256* %[[T117]], align 4
+//CHECK-NEXT:   %[[T122:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
 //CHECK-NEXT:   %[[T118:[0-9a-zA-Z_.]+]] = getelementptr [4 x { [0 x i256]*, i32 }], [4 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
 //CHECK-NEXT:   %[[T119:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T118]], align 8
 //CHECK-NEXT:   %[[T120:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T119]], i32 0, i32 0
 //CHECK-NEXT:   %[[T121:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T120]], align 4
-//CHECK-NEXT:   %[[T122:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
 //CHECK-NEXT:   store i256 %[[T121]], i256* %[[T122]], align 4
 //CHECK-NEXT:   %[[T123:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T122]], align 4
 //CHECK-NEXT:   %constraint28 = alloca i1, align 1
 //CHECK-NEXT:   call void @__constraint_values(i256 %[[T121]], i256 %[[T123]], i1* %constraint28)
 //CHECK-NEXT:   %[[T124:[0-9a-zA-Z_.]+]] = getelementptr [5 x i256], [5 x i256]* %lvars, i32 0, i32 4
 //CHECK-NEXT:   store i256 1, i256* %[[T124]], align 4
+//CHECK-NEXT:   %[[T129:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 1
 //CHECK-NEXT:   %[[T125:[0-9a-zA-Z_.]+]] = getelementptr [4 x { [0 x i256]*, i32 }], [4 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 0
 //CHECK-NEXT:   %[[T126:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T125]], align 8
 //CHECK-NEXT:   %[[T127:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T126]], i32 0, i32 0
 //CHECK-NEXT:   %[[T128:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T127]], align 4
-//CHECK-NEXT:   %[[T129:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 1
 //CHECK-NEXT:   store i256 %[[T128]], i256* %[[T129]], align 4
 //CHECK-NEXT:   %[[T130:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T129]], align 4
 //CHECK-NEXT:   %constraint29 = alloca i1, align 1
@@ -471,22 +471,22 @@ component main = B(2, 3, 2);
 //CHECK-NEXT:   store i256 1, i256* %[[T132]], align 4
 //CHECK-NEXT:   %[[T133:[0-9a-zA-Z_.]+]] = getelementptr [5 x i256], [5 x i256]* %lvars, i32 0, i32 4
 //CHECK-NEXT:   store i256 0, i256* %[[T133]], align 4
+//CHECK-NEXT:   %[[T138:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 2
 //CHECK-NEXT:   %[[T134:[0-9a-zA-Z_.]+]] = getelementptr [4 x { [0 x i256]*, i32 }], [4 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
 //CHECK-NEXT:   %[[T135:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T134]], align 8
 //CHECK-NEXT:   %[[T136:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T135]], i32 0, i32 1
 //CHECK-NEXT:   %[[T137:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T136]], align 4
-//CHECK-NEXT:   %[[T138:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 2
 //CHECK-NEXT:   store i256 %[[T137]], i256* %[[T138]], align 4
 //CHECK-NEXT:   %[[T139:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T138]], align 4
 //CHECK-NEXT:   %constraint30 = alloca i1, align 1
 //CHECK-NEXT:   call void @__constraint_values(i256 %[[T137]], i256 %[[T139]], i1* %constraint30)
 //CHECK-NEXT:   %[[T140:[0-9a-zA-Z_.]+]] = getelementptr [5 x i256], [5 x i256]* %lvars, i32 0, i32 4
 //CHECK-NEXT:   store i256 1, i256* %[[T140]], align 4
+//CHECK-NEXT:   %[[T145:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 3
 //CHECK-NEXT:   %[[T141:[0-9a-zA-Z_.]+]] = getelementptr [4 x { [0 x i256]*, i32 }], [4 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 0
 //CHECK-NEXT:   %[[T142:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T141]], align 8
 //CHECK-NEXT:   %[[T143:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T142]], i32 0, i32 1
 //CHECK-NEXT:   %[[T144:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T143]], align 4
-//CHECK-NEXT:   %[[T145:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 3
 //CHECK-NEXT:   store i256 %[[T144]], i256* %[[T145]], align 4
 //CHECK-NEXT:   %[[T146:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T145]], align 4
 //CHECK-NEXT:   %constraint31 = alloca i1, align 1
@@ -505,22 +505,22 @@ component main = B(2, 3, 2);
 //CHECK-NEXT: unrolled_loop21:
 //CHECK-NEXT:   %[[T150:[0-9a-zA-Z_.]+]] = getelementptr [5 x i256], [5 x i256]* %lvars, i32 0, i32 4
 //CHECK-NEXT:   store i256 0, i256* %[[T150]], align 4
+//CHECK-NEXT:   %[[T155:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 4
 //CHECK-NEXT:   %[[T151:[0-9a-zA-Z_.]+]] = getelementptr [4 x { [0 x i256]*, i32 }], [4 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 2, i32 0
 //CHECK-NEXT:   %[[T152:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T151]], align 8
 //CHECK-NEXT:   %[[T153:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T152]], i32 0, i32 0
 //CHECK-NEXT:   %[[T154:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T153]], align 4
-//CHECK-NEXT:   %[[T155:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 4
 //CHECK-NEXT:   store i256 %[[T154]], i256* %[[T155]], align 4
 //CHECK-NEXT:   %[[T156:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T155]], align 4
 //CHECK-NEXT:   %constraint32 = alloca i1, align 1
 //CHECK-NEXT:   call void @__constraint_values(i256 %[[T154]], i256 %[[T156]], i1* %constraint32)
 //CHECK-NEXT:   %[[T157:[0-9a-zA-Z_.]+]] = getelementptr [5 x i256], [5 x i256]* %lvars, i32 0, i32 4
 //CHECK-NEXT:   store i256 1, i256* %[[T157]], align 4
+//CHECK-NEXT:   %[[T162:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 5
 //CHECK-NEXT:   %[[T158:[0-9a-zA-Z_.]+]] = getelementptr [4 x { [0 x i256]*, i32 }], [4 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 3, i32 0
 //CHECK-NEXT:   %[[T159:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T158]], align 8
 //CHECK-NEXT:   %[[T160:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T159]], i32 0, i32 0
 //CHECK-NEXT:   %[[T161:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T160]], align 4
-//CHECK-NEXT:   %[[T162:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 5
 //CHECK-NEXT:   store i256 %[[T161]], i256* %[[T162]], align 4
 //CHECK-NEXT:   %[[T163:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T162]], align 4
 //CHECK-NEXT:   %constraint33 = alloca i1, align 1
@@ -531,22 +531,22 @@ component main = B(2, 3, 2);
 //CHECK-NEXT:   store i256 1, i256* %[[T165]], align 4
 //CHECK-NEXT:   %[[T166:[0-9a-zA-Z_.]+]] = getelementptr [5 x i256], [5 x i256]* %lvars, i32 0, i32 4
 //CHECK-NEXT:   store i256 0, i256* %[[T166]], align 4
+//CHECK-NEXT:   %[[T171:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 6
 //CHECK-NEXT:   %[[T167:[0-9a-zA-Z_.]+]] = getelementptr [4 x { [0 x i256]*, i32 }], [4 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 2, i32 0
 //CHECK-NEXT:   %[[T168:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T167]], align 8
 //CHECK-NEXT:   %[[T169:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T168]], i32 0, i32 1
 //CHECK-NEXT:   %[[T170:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T169]], align 4
-//CHECK-NEXT:   %[[T171:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 6
 //CHECK-NEXT:   store i256 %[[T170]], i256* %[[T171]], align 4
 //CHECK-NEXT:   %[[T172:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T171]], align 4
 //CHECK-NEXT:   %constraint34 = alloca i1, align 1
 //CHECK-NEXT:   call void @__constraint_values(i256 %[[T170]], i256 %[[T172]], i1* %constraint34)
 //CHECK-NEXT:   %[[T173:[0-9a-zA-Z_.]+]] = getelementptr [5 x i256], [5 x i256]* %lvars, i32 0, i32 4
 //CHECK-NEXT:   store i256 1, i256* %[[T173]], align 4
+//CHECK-NEXT:   %[[T178:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 7
 //CHECK-NEXT:   %[[T174:[0-9a-zA-Z_.]+]] = getelementptr [4 x { [0 x i256]*, i32 }], [4 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 3, i32 0
 //CHECK-NEXT:   %[[T175:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T174]], align 8
 //CHECK-NEXT:   %[[T176:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T175]], i32 0, i32 1
 //CHECK-NEXT:   %[[T177:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T176]], align 4
-//CHECK-NEXT:   %[[T178:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 7
 //CHECK-NEXT:   store i256 %[[T177]], i256* %[[T178]], align 4
 //CHECK-NEXT:   %[[T179:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T178]], align 4
 //CHECK-NEXT:   %constraint35 = alloca i1, align 1
@@ -557,22 +557,22 @@ component main = B(2, 3, 2);
 //CHECK-NEXT:   store i256 2, i256* %[[T181]], align 4
 //CHECK-NEXT:   %[[T182:[0-9a-zA-Z_.]+]] = getelementptr [5 x i256], [5 x i256]* %lvars, i32 0, i32 4
 //CHECK-NEXT:   store i256 0, i256* %[[T182]], align 4
+//CHECK-NEXT:   %[[T187:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 8
 //CHECK-NEXT:   %[[T183:[0-9a-zA-Z_.]+]] = getelementptr [4 x { [0 x i256]*, i32 }], [4 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 2, i32 0
 //CHECK-NEXT:   %[[T184:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T183]], align 8
 //CHECK-NEXT:   %[[T185:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T184]], i32 0, i32 2
 //CHECK-NEXT:   %[[T186:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T185]], align 4
-//CHECK-NEXT:   %[[T187:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 8
 //CHECK-NEXT:   store i256 %[[T186]], i256* %[[T187]], align 4
 //CHECK-NEXT:   %[[T188:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T187]], align 4
 //CHECK-NEXT:   %constraint36 = alloca i1, align 1
 //CHECK-NEXT:   call void @__constraint_values(i256 %[[T186]], i256 %[[T188]], i1* %constraint36)
 //CHECK-NEXT:   %[[T189:[0-9a-zA-Z_.]+]] = getelementptr [5 x i256], [5 x i256]* %lvars, i32 0, i32 4
 //CHECK-NEXT:   store i256 1, i256* %[[T189]], align 4
+//CHECK-NEXT:   %[[T194:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 9
 //CHECK-NEXT:   %[[T190:[0-9a-zA-Z_.]+]] = getelementptr [4 x { [0 x i256]*, i32 }], [4 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 3, i32 0
 //CHECK-NEXT:   %[[T191:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T190]], align 8
 //CHECK-NEXT:   %[[T192:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T191]], i32 0, i32 2
 //CHECK-NEXT:   %[[T193:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T192]], align 4
-//CHECK-NEXT:   %[[T194:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 9
 //CHECK-NEXT:   store i256 %[[T193]], i256* %[[T194]], align 4
 //CHECK-NEXT:   %[[T195:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T194]], align 4
 //CHECK-NEXT:   %constraint37 = alloca i1, align 1

--- a/circom/tests/subcmps/mapped3.circom
+++ b/circom/tests/subcmps/mapped3.circom
@@ -140,9 +140,9 @@ component main = Wrapper();
 //CHECK: call void @ArrayOp_[[$RUN_4]]_run([0 x i256]* %
 //COM: offset = (1 * (3 * 7)) + (2 * (7)) + (3) + 1 (since 0 is output) = 21 + 14 + 3 + 1 = 39
 //CHECK: store{{[0-9]+}}:{{ +}}; preds = %unrolled_loop{{[0-9]+}}
+//CHECK-NEXT: %[[OUTP_PTR:.*]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
 //CHECK-NEXT: %[[SUB_PTR:.*]] = getelementptr [4 x { [0 x i256]*, i32 }], [4 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 2, i32 0
 //CHECK-NEXT: %[[SUBCMP:.*]] = load [0 x i256]*, [0 x i256]** %[[SUB_PTR]]
 //CHECK-NEXT: %[[VAL_PTR:.*]] = getelementptr [0 x i256], [0 x i256]* %[[SUBCMP]], i32 0, i32 3
 //CHECK-NEXT: %[[VAL:.*]] = load i256, i256* %[[VAL_PTR]]
-//CHECK-NEXT: %[[OUTP_PTR:.*]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
 //CHECK-NEXT: store i256 %[[VAL]], i256* %[[OUTP_PTR]]

--- a/circom/tests/subcmps/mapped4.circom
+++ b/circom/tests/subcmps/mapped4.circom
@@ -155,9 +155,9 @@ component main = Wrapper();
 //CHECK: call void @MatrixOp_[[$RUN_3]]_run([0 x i256]* %
 //CHECK: call void @MatrixOp_[[$RUN_4]]_run([0 x i256]* %
 //CHECK: store{{[0-9]+}}:{{ +}}; preds = %unrolled_loop{{[0-9]+}}
+//CHECK-NEXT: %[[OUTP_PTR:.*]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
 //CHECK-NEXT: %[[SUB_PTR:.*]] = getelementptr [4 x { [0 x i256]*, i32 }], [4 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 2, i32 0
 //CHECK-NEXT: %[[SUBCMP:.*]] = load [0 x i256]*, [0 x i256]** %[[SUB_PTR]]
 //CHECK-NEXT: %[[VAL_PTR:.*]] = getelementptr [0 x i256], [0 x i256]* %[[SUBCMP]], i32 0, i32 5
 //CHECK-NEXT: %[[VAL:.*]] = load i256, i256* %[[VAL_PTR]]
-//CHECK-NEXT: %[[OUTP_PTR:.*]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
 //CHECK-NEXT: store i256 %[[VAL]], i256* %[[OUTP_PTR]]

--- a/circom/tests/subcmps/subcmps0A.circom
+++ b/circom/tests/subcmps/subcmps0A.circom
@@ -31,17 +31,17 @@ component main = SubCmps0A(2);
 //CHECK-NEXT:   br label %store1
 //CHECK-EMPTY: 
 //CHECK-NEXT: store1:
-//CHECK-NEXT:   %0 = getelementptr i256, i256* %sig_[[X2]], i32 0
-//CHECK-NEXT:   %1 = load i256, i256* %0, align 4
-//CHECK-NEXT:   %2 = getelementptr i256, i256* %subsig_[[X1]], i32 0
-//CHECK-NEXT:   store i256 %1, i256* %2, align 4
+//CHECK-NEXT:   %[[T002:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subsig_[[X1]], i32 0
+//CHECK-NEXT:   %[[T000:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_[[X2]], i32 0
+//CHECK-NEXT:   %[[T001:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T000]], align 4
+//CHECK-NEXT:   store i256 %[[T001]], i256* %[[T002]], align 4
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY: 
 //CHECK-NEXT: store2:
-//CHECK-NEXT:   %3 = load i256, i256* %subc_[[X4]], align 4
-//CHECK-NEXT:   %call.fr_sub = call i256 @fr_sub(i256 %3, i256 1)
-//CHECK-NEXT:   %4 = getelementptr i256, i256* %subc_[[X4]], i32 0
-//CHECK-NEXT:   store i256 %call.fr_sub, i256* %4, align 4
+//CHECK-NEXT:   %[[T004:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subc_[[X4]], i32 0
+//CHECK-NEXT:   %[[T003:[0-9a-zA-Z_.]+]] = load i256, i256* %subc_[[X4]], align 4
+//CHECK-NEXT:   %call.fr_sub = call i256 @fr_sub(i256 %[[T003]], i256 1)
+//CHECK-NEXT:   store i256 %call.fr_sub, i256* %[[T004]], align 4
 //CHECK-NEXT:   br label %fold_true3
 //CHECK-EMPTY: 
 //CHECK-NEXT: fold_true3:
@@ -49,18 +49,18 @@ component main = SubCmps0A(2);
 //CHECK-NEXT:   br label %store4
 //CHECK-EMPTY: 
 //CHECK-NEXT: store4:
-//CHECK-NEXT:   %5 = getelementptr i256, i256* %subsig_[[X4]], i32 0
-//CHECK-NEXT:   %6 = load i256, i256* %5, align 4
-//CHECK-NEXT:   %7 = getelementptr i256, i256* %sig_[[X3]], i32 0
-//CHECK-NEXT:   store i256 %6, i256* %7, align 4
+//CHECK-NEXT:   %[[T007:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_[[X3]], i32 0
+//CHECK-NEXT:   %[[T005:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subsig_[[X4]], i32 0
+//CHECK-NEXT:   %[[T006:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T005]], align 4
+//CHECK-NEXT:   store i256 %[[T006]], i256* %[[T007]], align 4
 //CHECK-NEXT:   br label %store5
 //CHECK-EMPTY: 
 //CHECK-NEXT: store5:
-//CHECK-NEXT:   %8 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
-//CHECK-NEXT:   %9 = load i256, i256* %8, align 4
-//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %9, i256 1)
-//CHECK-NEXT:   %10 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
-//CHECK-NEXT:   store i256 %call.fr_add, i256* %10, align 4
+//CHECK-NEXT:   %[[T010:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
+//CHECK-NEXT:   %[[T008:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
+//CHECK-NEXT:   %[[T009:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T008]], align 4
+//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %[[T009]], i256 1)
+//CHECK-NEXT:   store i256 %call.fr_add, i256* %[[T010]], align 4
 //CHECK-NEXT:   br label %return6
 //CHECK-EMPTY: 
 //CHECK-NEXT: return6:
@@ -74,11 +74,11 @@ component main = SubCmps0A(2);
 //CHECK-NEXT:   br label %store1
 //CHECK-EMPTY: 
 //CHECK-NEXT: store1:
-//CHECK-NEXT:   %1 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 1
-//CHECK-NEXT:   %2 = load i256, i256* %1, align 4
-//CHECK-NEXT:   %call.fr_neg = call i256 @fr_neg(i256 %2)
-//CHECK-NEXT:   %3 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
-//CHECK-NEXT:   store i256 %call.fr_neg, i256* %3, align 4
+//CHECK-NEXT:   %[[T003:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
+//CHECK-NEXT:   %[[T001:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 1
+//CHECK-NEXT:   %[[T002:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T001]], align 4
+//CHECK-NEXT:   %call.fr_neg = call i256 @fr_neg(i256 %[[T002]])
+//CHECK-NEXT:   store i256 %call.fr_neg, i256* %[[T003]], align 4
 //CHECK-NEXT:   br label %prologue
 //CHECK-EMPTY: 
 //CHECK-NEXT: prologue:

--- a/circom/tests/subcmps/subcmps0B.circom
+++ b/circom/tests/subcmps/subcmps0B.circom
@@ -32,17 +32,17 @@ component main = SubCmps0B(2);
 //CHECK-NEXT:   br label %store1
 //CHECK-EMPTY: 
 //CHECK-NEXT: store1:
-//CHECK-NEXT:   %0 = getelementptr i256, i256* %sig_[[X2]], i32 0
-//CHECK-NEXT:   %1 = load i256, i256* %0, align 4
-//CHECK-NEXT:   %2 = getelementptr i256, i256* %subsig_[[X1]], i32 0
-//CHECK-NEXT:   store i256 %1, i256* %2, align 4
+//CHECK-NEXT:   %[[T002:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subsig_[[X1]], i32 0
+//CHECK-NEXT:   %[[T000:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_[[X2]], i32 0
+//CHECK-NEXT:   %[[T001:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T000]], align 4
+//CHECK-NEXT:   store i256 %[[T001]], i256* %[[T002]], align 4
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY: 
 //CHECK-NEXT: store2:
-//CHECK-NEXT:   %3 = load i256, i256* %subc_[[X5]], align 4
-//CHECK-NEXT:   %call.fr_sub = call i256 @fr_sub(i256 %3, i256 1)
-//CHECK-NEXT:   %4 = getelementptr i256, i256* %subc_[[X5]], i32 0
-//CHECK-NEXT:   store i256 %call.fr_sub, i256* %4, align 4
+//CHECK-NEXT:   %[[T004:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subc_[[X5]], i32 0
+//CHECK-NEXT:   %[[T003:[0-9a-zA-Z_.]+]] = load i256, i256* %subc_[[X5]], align 4
+//CHECK-NEXT:   %call.fr_sub = call i256 @fr_sub(i256 %[[T003]], i256 1)
+//CHECK-NEXT:   store i256 %call.fr_sub, i256* %[[T004]], align 4
 //CHECK-NEXT:   br label %fold_true3
 //CHECK-EMPTY: 
 //CHECK-NEXT: fold_true3:
@@ -50,25 +50,25 @@ component main = SubCmps0B(2);
 //CHECK-NEXT:   br label %store4
 //CHECK-EMPTY: 
 //CHECK-NEXT: store4:
-//CHECK-NEXT:   %5 = getelementptr i256, i256* %subsig_[[X4]], i32 0
-//CHECK-NEXT:   %6 = load i256, i256* %5, align 4
-//CHECK-NEXT:   %7 = getelementptr i256, i256* %sig_[[X3]], i32 0
-//CHECK-NEXT:   store i256 %6, i256* %7, align 4
+//CHECK-NEXT:   %[[T007:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_[[X3]], i32 0
+//CHECK-NEXT:   %[[T005:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subsig_[[X4]], i32 0
+//CHECK-NEXT:   %[[T006:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T005]], align 4
+//CHECK-NEXT:   store i256 %[[T006]], i256* %[[T007]], align 4
 //CHECK-NEXT:   br label %store5
 //CHECK-EMPTY: 
 //CHECK-NEXT: store5:
-//CHECK-NEXT:   %8 = getelementptr i256, i256* %subsig_[[X5]], i32 0
-//CHECK-NEXT:   %9 = load i256, i256* %8, align 4
-//CHECK-NEXT:   %10 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
-//CHECK-NEXT:   store i256 %9, i256* %10, align 4
+//CHECK-NEXT:   %[[T010:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
+//CHECK-NEXT:   %[[T008:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subsig_[[X5]], i32 0
+//CHECK-NEXT:   %[[T009:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T008]], align 4
+//CHECK-NEXT:   store i256 %[[T009]], i256* %[[T010]], align 4
 //CHECK-NEXT:   br label %store6
 //CHECK-EMPTY: 
 //CHECK-NEXT: store6:
-//CHECK-NEXT:   %11 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
-//CHECK-NEXT:   %12 = load i256, i256* %11, align 4
-//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %12, i256 1)
-//CHECK-NEXT:   %13 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
-//CHECK-NEXT:   store i256 %call.fr_add, i256* %13, align 4
+//CHECK-NEXT:   %[[T013:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
+//CHECK-NEXT:   %[[T011:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
+//CHECK-NEXT:   %[[T012:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T011]], align 4
+//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %[[T012]], i256 1)
+//CHECK-NEXT:   store i256 %call.fr_add, i256* %[[T013]], align 4
 //CHECK-NEXT:   br label %return7
 //CHECK-EMPTY: 
 //CHECK-NEXT: return7:
@@ -82,11 +82,11 @@ component main = SubCmps0B(2);
 //CHECK-NEXT:   br label %store1
 //CHECK-EMPTY: 
 //CHECK-NEXT: store1:
-//CHECK-NEXT:   %1 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 1
-//CHECK-NEXT:   %2 = load i256, i256* %1, align 4
-//CHECK-NEXT:   %call.fr_neg = call i256 @fr_neg(i256 %2)
-//CHECK-NEXT:   %3 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
-//CHECK-NEXT:   store i256 %call.fr_neg, i256* %3, align 4
+//CHECK-NEXT:   %[[T003:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
+//CHECK-NEXT:   %[[T001:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 1
+//CHECK-NEXT:   %[[T002:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T001]], align 4
+//CHECK-NEXT:   %call.fr_neg = call i256 @fr_neg(i256 %[[T002]])
+//CHECK-NEXT:   store i256 %call.fr_neg, i256* %[[T003]], align 4
 //CHECK-NEXT:   br label %prologue
 //CHECK-EMPTY: 
 //CHECK-NEXT: prologue:

--- a/circom/tests/subcmps/subcmps0C.circom
+++ b/circom/tests/subcmps/subcmps0C.circom
@@ -30,17 +30,17 @@ component main = SubCmps0C(2);
 //CHECK-NEXT:   br label %store1
 //CHECK-EMPTY: 
 //CHECK-NEXT: store1:
-//CHECK-NEXT:   %0 = getelementptr i256, i256* %sig_[[X2]], i32 0
-//CHECK-NEXT:   %1 = load i256, i256* %0, align 4
-//CHECK-NEXT:   %2 = getelementptr i256, i256* %subsig_[[X1]], i32 0
-//CHECK-NEXT:   store i256 %1, i256* %2, align 4
+//CHECK-NEXT:   %[[T002:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subsig_[[X1]], i32 0
+//CHECK-NEXT:   %[[T000:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_[[X2]], i32 0
+//CHECK-NEXT:   %[[T001:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T000]], align 4
+//CHECK-NEXT:   store i256 %[[T001]], i256* %[[T002]], align 4
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY: 
 //CHECK-NEXT: store2:
-//CHECK-NEXT:   %3 = load i256, i256* %subc_[[X4]], align 4
-//CHECK-NEXT:   %call.fr_sub = call i256 @fr_sub(i256 %3, i256 1)
-//CHECK-NEXT:   %4 = getelementptr i256, i256* %subc_[[X4]], i32 0
-//CHECK-NEXT:   store i256 %call.fr_sub, i256* %4, align 4
+//CHECK-NEXT:   %[[T004:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subc_[[X4]], i32 0
+//CHECK-NEXT:   %[[T003:[0-9a-zA-Z_.]+]] = load i256, i256* %subc_[[X4]], align 4
+//CHECK-NEXT:   %call.fr_sub = call i256 @fr_sub(i256 %[[T003]], i256 1)
+//CHECK-NEXT:   store i256 %call.fr_sub, i256* %[[T004]], align 4
 //CHECK-NEXT:   br label %fold_true3
 //CHECK-EMPTY: 
 //CHECK-NEXT: fold_true3:
@@ -48,18 +48,18 @@ component main = SubCmps0C(2);
 //CHECK-NEXT:   br label %store4
 //CHECK-EMPTY: 
 //CHECK-NEXT: store4:
-//CHECK-NEXT:   %5 = getelementptr i256, i256* %subsig_[[X4]], i32 0
-//CHECK-NEXT:   %6 = load i256, i256* %5, align 4
-//CHECK-NEXT:   %7 = getelementptr i256, i256* %sig_[[X3]], i32 0
-//CHECK-NEXT:   store i256 %6, i256* %7, align 4
+//CHECK-NEXT:   %[[T007:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_[[X3]], i32 0
+//CHECK-NEXT:   %[[T005:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subsig_[[X4]], i32 0
+//CHECK-NEXT:   %[[T006:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T005]], align 4
+//CHECK-NEXT:   store i256 %[[T006]], i256* %[[T007]], align 4
 //CHECK-NEXT:   br label %store5
 //CHECK-EMPTY: 
 //CHECK-NEXT: store5:
-//CHECK-NEXT:   %8 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
-//CHECK-NEXT:   %9 = load i256, i256* %8, align 4
-//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %9, i256 1)
-//CHECK-NEXT:   %10 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
-//CHECK-NEXT:   store i256 %call.fr_add, i256* %10, align 4
+//CHECK-NEXT:   %[[T010:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
+//CHECK-NEXT:   %[[T008:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
+//CHECK-NEXT:   %[[T009:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T008]], align 4
+//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %[[T009]], i256 1)
+//CHECK-NEXT:   store i256 %call.fr_add, i256* %[[T010]], align 4
 //CHECK-NEXT:   br label %return6
 //CHECK-EMPTY: 
 //CHECK-NEXT: return6:
@@ -73,21 +73,21 @@ component main = SubCmps0C(2);
 //CHECK-NEXT:   br label %store1
 //CHECK-EMPTY: 
 //CHECK-NEXT: store1:
-//CHECK-NEXT:   %1 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 1
-//CHECK-NEXT:   %2 = load i256, i256* %1, align 4
-//CHECK-NEXT:   %call.fr_neg = call i256 @fr_neg(i256 %2)
-//CHECK-NEXT:   %3 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 2
-//CHECK-NEXT:   store i256 %call.fr_neg, i256* %3, align 4
+//CHECK-NEXT:   %[[T003:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 2
+//CHECK-NEXT:   %[[T001:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 1
+//CHECK-NEXT:   %[[T002:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T001]], align 4
+//CHECK-NEXT:   %call.fr_neg = call i256 @fr_neg(i256 %[[T002]])
+//CHECK-NEXT:   store i256 %call.fr_neg, i256* %[[T003]], align 4
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY: 
 //CHECK-NEXT: store2:
-//CHECK-NEXT:   %4 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 2
-//CHECK-NEXT:   %5 = load i256, i256* %4, align 4
-//CHECK-NEXT:   %6 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 2
-//CHECK-NEXT:   %7 = load i256, i256* %6, align 4
-//CHECK-NEXT:   %call.fr_mul = call i256 @fr_mul(i256 %5, i256 %7)
-//CHECK-NEXT:   %8 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
-//CHECK-NEXT:   store i256 %call.fr_mul, i256* %8, align 4
+//CHECK-NEXT:   %[[T008:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
+//CHECK-NEXT:   %[[T004:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 2
+//CHECK-NEXT:   %[[T005:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T004]], align 4
+//CHECK-NEXT:   %[[T006:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 2
+//CHECK-NEXT:   %[[T007:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T006]], align 4
+//CHECK-NEXT:   %call.fr_mul = call i256 @fr_mul(i256 %[[T005]], i256 %[[T007]])
+//CHECK-NEXT:   store i256 %call.fr_mul, i256* %[[T008]], align 4
 //CHECK-NEXT:   br label %prologue
 //CHECK-EMPTY: 
 //CHECK-NEXT: prologue:

--- a/circom/tests/subcmps/subcmps0D.circom
+++ b/circom/tests/subcmps/subcmps0D.circom
@@ -31,34 +31,34 @@ component main = SubCmps0D(3);
 //CHECK-NEXT:   br label %store1
 //CHECK-EMPTY: 
 //CHECK-NEXT: store1:
-//CHECK-NEXT:   %0 = getelementptr i256, i256* %sig_[[X2]], i32 0
-//CHECK-NEXT:   %1 = load i256, i256* %0, align 4
-//CHECK-NEXT:   %2 = getelementptr i256, i256* %subsig_[[X1]], i32 0
-//CHECK-NEXT:   store i256 %1, i256* %2, align 4
+//CHECK-NEXT:   %[[T002:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subsig_[[X1]], i32 0
+//CHECK-NEXT:   %[[T000:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_[[X2]], i32 0
+//CHECK-NEXT:   %[[T001:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T000]], align 4
+//CHECK-NEXT:   store i256 %[[T001]], i256* %[[T002]], align 4
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY: 
 //CHECK-NEXT: store2:
-//CHECK-NEXT:   %3 = load i256, i256* %subc_[[X6]], align 4
-//CHECK-NEXT:   %call.fr_sub = call i256 @fr_sub(i256 %3, i256 1)
-//CHECK-NEXT:   %4 = getelementptr i256, i256* %subc_[[X6]], i32 0
-//CHECK-NEXT:   store i256 %call.fr_sub, i256* %4, align 4
+//CHECK-NEXT:   %[[T004:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subc_[[X6]], i32 0
+//CHECK-NEXT:   %[[T003:[0-9a-zA-Z_.]+]] = load i256, i256* %subc_[[X6]], align 4
+//CHECK-NEXT:   %call.fr_sub = call i256 @fr_sub(i256 %[[T003]], i256 1)
+//CHECK-NEXT:   store i256 %call.fr_sub, i256* %[[T004]], align 4
 //CHECK-NEXT:   br label %fold_false3
 //CHECK-EMPTY: 
 //CHECK-NEXT: fold_false3:
 //CHECK-NEXT:   br label %store4
 //CHECK-EMPTY: 
 //CHECK-NEXT: store4:
-//CHECK-NEXT:   %5 = getelementptr i256, i256* %sig_[[X4]], i32 0
-//CHECK-NEXT:   %6 = load i256, i256* %5, align 4
-//CHECK-NEXT:   %7 = getelementptr i256, i256* %subsig_[[X3]], i32 0
-//CHECK-NEXT:   store i256 %6, i256* %7, align 4
+//CHECK-NEXT:   %[[T007:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subsig_[[X3]], i32 0
+//CHECK-NEXT:   %[[T005:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_[[X4]], i32 0
+//CHECK-NEXT:   %[[T006:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T005]], align 4
+//CHECK-NEXT:   store i256 %[[T006]], i256* %[[T007]], align 4
 //CHECK-NEXT:   br label %store5
 //CHECK-EMPTY: 
 //CHECK-NEXT: store5:
-//CHECK-NEXT:   %8 = load i256, i256* %subc_[[X6]], align 4
-//CHECK-NEXT:   %call.fr_sub1 = call i256 @fr_sub(i256 %8, i256 1)
-//CHECK-NEXT:   %9 = getelementptr i256, i256* %subc_[[X6]], i32 0
-//CHECK-NEXT:   store i256 %call.fr_sub1, i256* %9, align 4
+//CHECK-NEXT:   %[[T009:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subc_[[X6]], i32 0
+//CHECK-NEXT:   %[[T008:[0-9a-zA-Z_.]+]] = load i256, i256* %subc_[[X6]], align 4
+//CHECK-NEXT:   %call.fr_sub1 = call i256 @fr_sub(i256 %[[T008]], i256 1)
+//CHECK-NEXT:   store i256 %call.fr_sub1, i256* %[[T009]], align 4
 //CHECK-NEXT:   br label %fold_true6
 //CHECK-EMPTY: 
 //CHECK-NEXT: fold_true6:
@@ -66,18 +66,18 @@ component main = SubCmps0D(3);
 //CHECK-NEXT:   br label %store7
 //CHECK-EMPTY: 
 //CHECK-NEXT: store7:
-//CHECK-NEXT:   %10 = getelementptr i256, i256* %subsig_[[X6]], i32 0
-//CHECK-NEXT:   %11 = load i256, i256* %10, align 4
-//CHECK-NEXT:   %12 = getelementptr i256, i256* %sig_[[X5]], i32 0
-//CHECK-NEXT:   store i256 %11, i256* %12, align 4
+//CHECK-NEXT:   %[[T012:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_[[X5]], i32 0
+//CHECK-NEXT:   %[[T010:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subsig_[[X6]], i32 0
+//CHECK-NEXT:   %[[T011:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T010]], align 4
+//CHECK-NEXT:   store i256 %[[T011]], i256* %[[T012]], align 4
 //CHECK-NEXT:   br label %store8
 //CHECK-EMPTY: 
 //CHECK-NEXT: store8:
-//CHECK-NEXT:   %13 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
-//CHECK-NEXT:   %14 = load i256, i256* %13, align 4
-//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %14, i256 1)
-//CHECK-NEXT:   %15 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
-//CHECK-NEXT:   store i256 %call.fr_add, i256* %15, align 4
+//CHECK-NEXT:   %[[T015:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
+//CHECK-NEXT:   %[[T013:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
+//CHECK-NEXT:   %[[T014:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T013]], align 4
+//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %[[T014]], i256 1)
+//CHECK-NEXT:   store i256 %call.fr_add, i256* %[[T015]], align 4
 //CHECK-NEXT:   br label %return9
 //CHECK-EMPTY: 
 //CHECK-NEXT: return9:
@@ -91,13 +91,13 @@ component main = SubCmps0D(3);
 //CHECK-NEXT:   br label %store1
 //CHECK-EMPTY: 
 //CHECK-NEXT: store1:
-//CHECK-NEXT:   %1 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 1
-//CHECK-NEXT:   %2 = load i256, i256* %1, align 4
-//CHECK-NEXT:   %3 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 2
-//CHECK-NEXT:   %4 = load i256, i256* %3, align 4
-//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %2, i256 %4)
-//CHECK-NEXT:   %5 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
-//CHECK-NEXT:   store i256 %call.fr_add, i256* %5, align 4
+//CHECK-NEXT:   %[[T005:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
+//CHECK-NEXT:   %[[T001:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 1
+//CHECK-NEXT:   %[[T002:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T001]], align 4
+//CHECK-NEXT:   %[[T003:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 2
+//CHECK-NEXT:   %[[T004:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T003]], align 4
+//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %[[T002]], i256 %[[T004]])
+//CHECK-NEXT:   store i256 %call.fr_add, i256* %[[T005]], align 4
 //CHECK-NEXT:   br label %prologue
 //CHECK-EMPTY: 
 //CHECK-NEXT: prologue:

--- a/circom/tests/subcmps/subcmps1.circom
+++ b/circom/tests/subcmps/subcmps1.circom
@@ -41,20 +41,20 @@ component main = SubCmps1(3);
 //CHECK-NEXT:   br label %store1
 //CHECK-EMPTY: 
 //CHECK-NEXT: store1:
-//CHECK-NEXT:   %0 = getelementptr i256, i256* %sig_[[X2]], i32 0
-//CHECK-NEXT:   %1 = load i256, i256* %0, align 4
-//CHECK-NEXT:   %2 = getelementptr i256, i256* %subsig_[[X1]], i32 0
-//CHECK-NEXT:   store i256 %1, i256* %2, align 4
-//CHECK-NEXT:   %3 = load i256, i256* %2, align 4
+//CHECK-NEXT:   %[[T002:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subsig_[[X1]], i32 0
+//CHECK-NEXT:   %[[T000:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_[[X2]], i32 0
+//CHECK-NEXT:   %[[T001:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T000]], align 4
+//CHECK-NEXT:   store i256 %[[T001]], i256* %[[T002]], align 4
+//CHECK-NEXT:   %[[T003:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T002]], align 4
 //CHECK-NEXT:   %constraint = alloca i1, align 1
-//CHECK-NEXT:   call void @__constraint_values(i256 %1, i256 %3, i1* %constraint)
+//CHECK-NEXT:   call void @__constraint_values(i256 %[[T001]], i256 %[[T003]], i1* %constraint)
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY: 
 //CHECK-NEXT: store2:
-//CHECK-NEXT:   %4 = load i256, i256* %subc_[[X4]], align 4
-//CHECK-NEXT:   %call.fr_sub = call i256 @fr_sub(i256 %4, i256 1)
-//CHECK-NEXT:   %5 = getelementptr i256, i256* %subc_[[X4]], i32 0
-//CHECK-NEXT:   store i256 %call.fr_sub, i256* %5, align 4
+//CHECK-NEXT:   %[[T005:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subc_[[X4]], i32 0
+//CHECK-NEXT:   %[[T004:[0-9a-zA-Z_.]+]] = load i256, i256* %subc_[[X4]], align 4
+//CHECK-NEXT:   %call.fr_sub = call i256 @fr_sub(i256 %[[T004]], i256 1)
+//CHECK-NEXT:   store i256 %call.fr_sub, i256* %[[T005]], align 4
 //CHECK-NEXT:   br label %fold_true3
 //CHECK-EMPTY: 
 //CHECK-NEXT: fold_true3:
@@ -62,21 +62,21 @@ component main = SubCmps1(3);
 //CHECK-NEXT:   br label %store4
 //CHECK-EMPTY: 
 //CHECK-NEXT: store4:
-//CHECK-NEXT:   %6 = getelementptr i256, i256* %subsig_[[X4]], i32 0
-//CHECK-NEXT:   %7 = load i256, i256* %6, align 4
-//CHECK-NEXT:   %8 = getelementptr i256, i256* %sig_[[X3]], i32 0
-//CHECK-NEXT:   store i256 %7, i256* %8, align 4
-//CHECK-NEXT:   %9 = load i256, i256* %8, align 4
+//CHECK-NEXT:   %[[T008:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_[[X3]], i32 0
+//CHECK-NEXT:   %[[T006:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subsig_[[X4]], i32 0
+//CHECK-NEXT:   %[[T007:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T006]], align 4
+//CHECK-NEXT:   store i256 %[[T007]], i256* %[[T008]], align 4
+//CHECK-NEXT:   %[[T009:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T008]], align 4
 //CHECK-NEXT:   %constraint1 = alloca i1, align 1
-//CHECK-NEXT:   call void @__constraint_values(i256 %7, i256 %9, i1* %constraint1)
+//CHECK-NEXT:   call void @__constraint_values(i256 %[[T007]], i256 %[[T009]], i1* %constraint1)
 //CHECK-NEXT:   br label %store5
 //CHECK-EMPTY: 
 //CHECK-NEXT: store5:
-//CHECK-NEXT:   %10 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
-//CHECK-NEXT:   %11 = load i256, i256* %10, align 4
-//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %11, i256 1)
-//CHECK-NEXT:   %12 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
-//CHECK-NEXT:   store i256 %call.fr_add, i256* %12, align 4
+//CHECK-NEXT:   %[[T012:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
+//CHECK-NEXT:   %[[T010:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
+//CHECK-NEXT:   %[[T011:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T010]], align 4
+//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %[[T011]], i256 1)
+//CHECK-NEXT:   store i256 %call.fr_add, i256* %[[T012]], align 4
 //CHECK-NEXT:   br label %return6
 //CHECK-EMPTY: 
 //CHECK-NEXT: return6:

--- a/circom/tests/subcmps/subcmps2.circom
+++ b/circom/tests/subcmps/subcmps2.circom
@@ -40,21 +40,21 @@ component main = Caller();
 //CHECK-NEXT:   br label %store1
 //CHECK-EMPTY: 
 //CHECK-NEXT: store1:
-//CHECK-NEXT:   %0 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
-//CHECK-NEXT:   %1 = load i256, i256* %0, align 4
-//CHECK-NEXT:   %2 = getelementptr i256, i256* %sig_[[X1]], i32 0
-//CHECK-NEXT:   %3 = load i256, i256* %2, align 4
-//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %1, i256 %3)
-//CHECK-NEXT:   %4 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
-//CHECK-NEXT:   store i256 %call.fr_add, i256* %4, align 4
+//CHECK-NEXT:   %[[T004:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
+//CHECK-NEXT:   %[[T000:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
+//CHECK-NEXT:   %[[T001:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T000]], align 4
+//CHECK-NEXT:   %[[T002:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_[[X1]], i32 0
+//CHECK-NEXT:   %[[T003:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T002]], align 4
+//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %[[T001]], i256 %[[T003]])
+//CHECK-NEXT:   store i256 %call.fr_add, i256* %[[T004]], align 4
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY: 
 //CHECK-NEXT: store2:
-//CHECK-NEXT:   %5 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
-//CHECK-NEXT:   %6 = load i256, i256* %5, align 4
-//CHECK-NEXT:   %call.fr_add1 = call i256 @fr_add(i256 %6, i256 1)
-//CHECK-NEXT:   %7 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
-//CHECK-NEXT:   store i256 %call.fr_add1, i256* %7, align 4
+//CHECK-NEXT:   %[[T007:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
+//CHECK-NEXT:   %[[T005:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
+//CHECK-NEXT:   %[[T006:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T005]], align 4
+//CHECK-NEXT:   %call.fr_add1 = call i256 @fr_add(i256 %[[T006]], i256 1)
+//CHECK-NEXT:   store i256 %call.fr_add1, i256* %[[T007]], align 4
 //CHECK-NEXT:   br label %return3
 //CHECK-EMPTY: 
 //CHECK-NEXT: return3:
@@ -68,35 +68,35 @@ component main = Caller();
 //CHECK-EMPTY: 
 //CHECK-NEXT: call1:
 //CHECK-NEXT:   %nop_0_arena = alloca [1 x i256], align 8
-//CHECK-NEXT:   %0 = getelementptr [1 x i256], [1 x i256]* %nop_0_arena, i32 0, i32 0
-//CHECK-NEXT:   %1 = getelementptr i256, i256* %sig_[[X2]], i32 0
-//CHECK-NEXT:   %2 = load i256, i256* %1, align 4
-//CHECK-NEXT:   store i256 %2, i256* %0, align 4
-//CHECK-NEXT:   %3 = bitcast [1 x i256]* %nop_0_arena to i256*
-//CHECK-NEXT:   %call.nop_0 = call i256 @nop_0(i256* %3)
-//CHECK-NEXT:   %4 = getelementptr i256, i256* %subsig_[[X1]], i32 0
-//CHECK-NEXT:   store i256 %call.nop_0, i256* %4, align 4
-//CHECK-NEXT:   %5 = load i256, i256* %4, align 4
+//CHECK-NEXT:   %[[T000:[0-9a-zA-Z_.]+]] = getelementptr [1 x i256], [1 x i256]* %nop_0_arena, i32 0, i32 0
+//CHECK-NEXT:   %[[T001:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_[[X2]], i32 0
+//CHECK-NEXT:   %[[T002:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T001]], align 4
+//CHECK-NEXT:   store i256 %[[T002]], i256* %[[T000]], align 4
+//CHECK-NEXT:   %[[T003:[0-9a-zA-Z_.]+]] = bitcast [1 x i256]* %nop_0_arena to i256*
+//CHECK-NEXT:   %call.nop_0 = call i256 @nop_0(i256* %[[T003]])
+//CHECK-NEXT:   %[[T004:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subsig_[[X1]], i32 0
+//CHECK-NEXT:   store i256 %call.nop_0, i256* %[[T004]], align 4
+//CHECK-NEXT:   %[[T005:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T004]], align 4
 //CHECK-NEXT:   %constraint = alloca i1, align 1
-//CHECK-NEXT:   call void @__constraint_values(i256 %call.nop_0, i256 %5, i1* %constraint)
+//CHECK-NEXT:   call void @__constraint_values(i256 %call.nop_0, i256 %[[T005]], i1* %constraint)
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY: 
 //CHECK-NEXT: store2:
-//CHECK-NEXT:   %6 = load i256, i256* %subc_[[X4]], align 4
-//CHECK-NEXT:   %call.fr_sub = call i256 @fr_sub(i256 %6, i256 1)
-//CHECK-NEXT:   %7 = getelementptr i256, i256* %subc_[[X4]], i32 0
-//CHECK-NEXT:   store i256 %call.fr_sub, i256* %7, align 4
+//CHECK-NEXT:   %[[T007:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subc_[[X4]], i32 0
+//CHECK-NEXT:   %[[T006:[0-9a-zA-Z_.]+]] = load i256, i256* %subc_[[X4]], align 4
+//CHECK-NEXT:   %call.fr_sub = call i256 @fr_sub(i256 %[[T006]], i256 1)
+//CHECK-NEXT:   store i256 %call.fr_sub, i256* %[[T007]], align 4
 //CHECK-NEXT:   br label %fold_false3
 //CHECK-EMPTY: 
 //CHECK-NEXT: fold_false3:
 //CHECK-NEXT:   br label %store4
 //CHECK-EMPTY: 
 //CHECK-NEXT: store4:
-//CHECK-NEXT:   %8 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 0
-//CHECK-NEXT:   %9 = load i256, i256* %8, align 4
-//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %9, i256 1)
-//CHECK-NEXT:   %10 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 0
-//CHECK-NEXT:   store i256 %call.fr_add, i256* %10, align 4
+//CHECK-NEXT:   %[[T010:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 0
+//CHECK-NEXT:   %[[T008:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 0
+//CHECK-NEXT:   %[[T009:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T008]], align 4
+//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %[[T009]], i256 1)
+//CHECK-NEXT:   store i256 %call.fr_add, i256* %[[T010]], align 4
 //CHECK-NEXT:   br label %return5
 //CHECK-EMPTY: 
 //CHECK-NEXT: return5:
@@ -110,24 +110,24 @@ component main = Caller();
 //CHECK-EMPTY: 
 //CHECK-NEXT: call1:
 //CHECK-NEXT:   %nop_0_arena = alloca [1 x i256], align 8
-//CHECK-NEXT:   %0 = getelementptr [1 x i256], [1 x i256]* %nop_0_arena, i32 0, i32 0
-//CHECK-NEXT:   %1 = getelementptr i256, i256* %sig_[[X2]], i32 0
-//CHECK-NEXT:   %2 = load i256, i256* %1, align 4
-//CHECK-NEXT:   store i256 %2, i256* %0, align 4
-//CHECK-NEXT:   %3 = bitcast [1 x i256]* %nop_0_arena to i256*
-//CHECK-NEXT:   %call.nop_0 = call i256 @nop_0(i256* %3)
-//CHECK-NEXT:   %4 = getelementptr i256, i256* %subsig_[[X1]], i32 0
-//CHECK-NEXT:   store i256 %call.nop_0, i256* %4, align 4
-//CHECK-NEXT:   %5 = load i256, i256* %4, align 4
+//CHECK-NEXT:   %[[T000:[0-9a-zA-Z_.]+]] = getelementptr [1 x i256], [1 x i256]* %nop_0_arena, i32 0, i32 0
+//CHECK-NEXT:   %[[T001:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_[[X2]], i32 0
+//CHECK-NEXT:   %[[T002:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T001]], align 4
+//CHECK-NEXT:   store i256 %[[T002]], i256* %[[T000]], align 4
+//CHECK-NEXT:   %[[T003:[0-9a-zA-Z_.]+]] = bitcast [1 x i256]* %nop_0_arena to i256*
+//CHECK-NEXT:   %call.nop_0 = call i256 @nop_0(i256* %[[T003]])
+//CHECK-NEXT:   %[[T004:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subsig_[[X1]], i32 0
+//CHECK-NEXT:   store i256 %call.nop_0, i256* %[[T004]], align 4
+//CHECK-NEXT:   %[[T005:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T004]], align 4
 //CHECK-NEXT:   %constraint = alloca i1, align 1
-//CHECK-NEXT:   call void @__constraint_values(i256 %call.nop_0, i256 %5, i1* %constraint)
+//CHECK-NEXT:   call void @__constraint_values(i256 %call.nop_0, i256 %[[T005]], i1* %constraint)
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY: 
 //CHECK-NEXT: store2:
-//CHECK-NEXT:   %6 = load i256, i256* %subc_[[X4]], align 4
-//CHECK-NEXT:   %call.fr_sub = call i256 @fr_sub(i256 %6, i256 1)
-//CHECK-NEXT:   %7 = getelementptr i256, i256* %subc_[[X4]], i32 0
-//CHECK-NEXT:   store i256 %call.fr_sub, i256* %7, align 4
+//CHECK-NEXT:   %[[T007:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subc_[[X4]], i32 0
+//CHECK-NEXT:   %[[T006:[0-9a-zA-Z_.]+]] = load i256, i256* %subc_[[X4]], align 4
+//CHECK-NEXT:   %call.fr_sub = call i256 @fr_sub(i256 %[[T006]], i256 1)
+//CHECK-NEXT:   store i256 %call.fr_sub, i256* %[[T007]], align 4
 //CHECK-NEXT:   br label %fold_true3
 //CHECK-EMPTY: 
 //CHECK-NEXT: fold_true3:
@@ -135,11 +135,11 @@ component main = Caller();
 //CHECK-NEXT:   br label %store4
 //CHECK-EMPTY: 
 //CHECK-NEXT: store4:
-//CHECK-NEXT:   %8 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 0
-//CHECK-NEXT:   %9 = load i256, i256* %8, align 4
-//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %9, i256 1)
-//CHECK-NEXT:   %10 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 0
-//CHECK-NEXT:   store i256 %call.fr_add, i256* %10, align 4
+//CHECK-NEXT:   %[[T010:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 0
+//CHECK-NEXT:   %[[T008:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 0
+//CHECK-NEXT:   %[[T009:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T008]], align 4
+//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %[[T009]], i256 1)
+//CHECK-NEXT:   store i256 %call.fr_add, i256* %[[T010]], align 4
 //CHECK-NEXT:   br label %return5
 //CHECK-EMPTY: 
 //CHECK-NEXT: return5:
@@ -153,43 +153,43 @@ component main = Caller();
 //CHECK-NEXT:   br label %store1
 //CHECK-EMPTY: 
 //CHECK-NEXT: store1:
-//CHECK-NEXT:   %1 = getelementptr [3 x i256], [3 x i256]* %lvars, i32 0, i32 0
-//CHECK-NEXT:   store i256 4, i256* %1, align 4
+//CHECK-NEXT:   %[[T001:[0-9a-zA-Z_.]+]] = getelementptr [3 x i256], [3 x i256]* %lvars, i32 0, i32 0
+//CHECK-NEXT:   store i256 4, i256* %[[T001]], align 4
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY: 
 //CHECK-NEXT: store2:
-//CHECK-NEXT:   %2 = getelementptr [3 x i256], [3 x i256]* %lvars, i32 0, i32 1
-//CHECK-NEXT:   store i256 0, i256* %2, align 4
+//CHECK-NEXT:   %[[T002:[0-9a-zA-Z_.]+]] = getelementptr [3 x i256], [3 x i256]* %lvars, i32 0, i32 1
+//CHECK-NEXT:   store i256 0, i256* %[[T002]], align 4
 //CHECK-NEXT:   br label %store3
 //CHECK-EMPTY: 
 //CHECK-NEXT: store3:
-//CHECK-NEXT:   %3 = getelementptr [3 x i256], [3 x i256]* %lvars, i32 0, i32 2
-//CHECK-NEXT:   store i256 0, i256* %3, align 4
+//CHECK-NEXT:   %[[T003:[0-9a-zA-Z_.]+]] = getelementptr [3 x i256], [3 x i256]* %lvars, i32 0, i32 2
+//CHECK-NEXT:   store i256 0, i256* %[[T003]], align 4
 //CHECK-NEXT:   br label %unrolled_loop4
 //CHECK-EMPTY: 
 //CHECK-NEXT: unrolled_loop4:
-//CHECK-NEXT:   %4 = bitcast [3 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %5 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 1
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %4, [0 x i256]* %0, i256* %5)
-//CHECK-NEXT:   %6 = bitcast [3 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %7 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 2
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %6, [0 x i256]* %0, i256* %7)
-//CHECK-NEXT:   %8 = bitcast [3 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %9 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 3
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %8, [0 x i256]* %0, i256* %9)
-//CHECK-NEXT:   %10 = bitcast [3 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %11 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 4
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %10, [0 x i256]* %0, i256* %11)
+//CHECK-NEXT:   %[[T004:[0-9a-zA-Z_.]+]] = bitcast [3 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T005:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 1
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %[[T004]], [0 x i256]* %0, i256* %[[T005]])
+//CHECK-NEXT:   %[[T006:[0-9a-zA-Z_.]+]] = bitcast [3 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T007:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 2
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %[[T006]], [0 x i256]* %0, i256* %[[T007]])
+//CHECK-NEXT:   %[[T008:[0-9a-zA-Z_.]+]] = bitcast [3 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T009:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 3
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %[[T008]], [0 x i256]* %0, i256* %[[T009]])
+//CHECK-NEXT:   %[[T010:[0-9a-zA-Z_.]+]] = bitcast [3 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T011:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 4
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %[[T010]], [0 x i256]* %0, i256* %[[T011]])
 //CHECK-NEXT:   br label %store5
 //CHECK-EMPTY: 
 //CHECK-NEXT: store5:
-//CHECK-NEXT:   %12 = getelementptr [3 x i256], [3 x i256]* %lvars, i32 0, i32 1
-//CHECK-NEXT:   %13 = load i256, i256* %12, align 4
-//CHECK-NEXT:   %14 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
-//CHECK-NEXT:   store i256 %13, i256* %14, align 4
-//CHECK-NEXT:   %15 = load i256, i256* %14, align 4
+//CHECK-NEXT:   %[[T014:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
+//CHECK-NEXT:   %[[T012:[0-9a-zA-Z_.]+]] = getelementptr [3 x i256], [3 x i256]* %lvars, i32 0, i32 1
+//CHECK-NEXT:   %[[T013:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T012]], align 4
+//CHECK-NEXT:   store i256 %[[T013]], i256* %[[T014]], align 4
+//CHECK-NEXT:   %[[T015:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T014]], align 4
 //CHECK-NEXT:   %constraint = alloca i1, align 1
-//CHECK-NEXT:   call void @__constraint_values(i256 %13, i256 %15, i1* %constraint)
+//CHECK-NEXT:   call void @__constraint_values(i256 %[[T013]], i256 %[[T015]], i1* %constraint)
 //CHECK-NEXT:   br label %prologue
 //CHECK-EMPTY: 
 //CHECK-NEXT: prologue:
@@ -203,76 +203,76 @@ component main = Caller();
 //CHECK-NEXT:   br label %create_cmp1
 //CHECK-EMPTY: 
 //CHECK-NEXT: create_cmp1:
-//CHECK-NEXT:   %1 = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0
-//CHECK-NEXT:   call void @Sum_0_build({ [0 x i256]*, i32 }* %1)
+//CHECK-NEXT:   %[[T001:[0-9a-zA-Z_.]+]] = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0
+//CHECK-NEXT:   call void @Sum_0_build({ [0 x i256]*, i32 }* %[[T001]])
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY: 
 //CHECK-NEXT: store2:
-//CHECK-NEXT:   %2 = getelementptr [1 x i256], [1 x i256]* %lvars, i32 0, i32 0
-//CHECK-NEXT:   store i256 0, i256* %2, align 4
+//CHECK-NEXT:   %[[T002:[0-9a-zA-Z_.]+]] = getelementptr [1 x i256], [1 x i256]* %lvars, i32 0, i32 0
+//CHECK-NEXT:   store i256 0, i256* %[[T002]], align 4
 //CHECK-NEXT:   br label %unrolled_loop3
 //CHECK-EMPTY: 
 //CHECK-NEXT: unrolled_loop3:
-//CHECK-NEXT:   %3 = bitcast [1 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %4 = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
-//CHECK-NEXT:   %5 = load [0 x i256]*, [0 x i256]** %4, align 8
-//CHECK-NEXT:   %6 = getelementptr [0 x i256], [0 x i256]* %5, i32 0
-//CHECK-NEXT:   %7 = getelementptr [0 x i256], [0 x i256]* %6, i32 0, i256 1
-//CHECK-NEXT:   %8 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 1
-//CHECK-NEXT:   %9 = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
-//CHECK-NEXT:   %10 = load [0 x i256]*, [0 x i256]** %9, align 8
-//CHECK-NEXT:   %11 = getelementptr [0 x i256], [0 x i256]* %10, i32 0
-//CHECK-NEXT:   %12 = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 1
-//CHECK-NEXT:   %13 = bitcast i32* %12 to i256*
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_2]]([0 x i256]* %3, [0 x i256]* %0, i256* %7, i256* %8, [0 x i256]* %11, i256* %13)
-//CHECK-NEXT:   %14 = bitcast [1 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %15 = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
-//CHECK-NEXT:   %16 = load [0 x i256]*, [0 x i256]** %15, align 8
-//CHECK-NEXT:   %17 = getelementptr [0 x i256], [0 x i256]* %16, i32 0
-//CHECK-NEXT:   %18 = getelementptr [0 x i256], [0 x i256]* %17, i32 0, i256 2
-//CHECK-NEXT:   %19 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 2
-//CHECK-NEXT:   %20 = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
-//CHECK-NEXT:   %21 = load [0 x i256]*, [0 x i256]** %20, align 8
-//CHECK-NEXT:   %22 = getelementptr [0 x i256], [0 x i256]* %21, i32 0
-//CHECK-NEXT:   %23 = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 1
-//CHECK-NEXT:   %24 = bitcast i32* %23 to i256*
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_2]]([0 x i256]* %14, [0 x i256]* %0, i256* %18, i256* %19, [0 x i256]* %22, i256* %24)
-//CHECK-NEXT:   %25 = bitcast [1 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %26 = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
-//CHECK-NEXT:   %27 = load [0 x i256]*, [0 x i256]** %26, align 8
-//CHECK-NEXT:   %28 = getelementptr [0 x i256], [0 x i256]* %27, i32 0
-//CHECK-NEXT:   %29 = getelementptr [0 x i256], [0 x i256]* %28, i32 0, i256 3
-//CHECK-NEXT:   %30 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 3
-//CHECK-NEXT:   %31 = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
-//CHECK-NEXT:   %32 = load [0 x i256]*, [0 x i256]** %31, align 8
-//CHECK-NEXT:   %33 = getelementptr [0 x i256], [0 x i256]* %32, i32 0
-//CHECK-NEXT:   %34 = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 1
-//CHECK-NEXT:   %35 = bitcast i32* %34 to i256*
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_2]]([0 x i256]* %25, [0 x i256]* %0, i256* %29, i256* %30, [0 x i256]* %33, i256* %35)
-//CHECK-NEXT:   %36 = bitcast [1 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %37 = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
-//CHECK-NEXT:   %38 = load [0 x i256]*, [0 x i256]** %37, align 8
-//CHECK-NEXT:   %39 = getelementptr [0 x i256], [0 x i256]* %38, i32 0
-//CHECK-NEXT:   %40 = getelementptr [0 x i256], [0 x i256]* %39, i32 0, i256 4
-//CHECK-NEXT:   %41 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 4
-//CHECK-NEXT:   %42 = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
-//CHECK-NEXT:   %43 = load [0 x i256]*, [0 x i256]** %42, align 8
-//CHECK-NEXT:   %44 = getelementptr [0 x i256], [0 x i256]* %43, i32 0
-//CHECK-NEXT:   %45 = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 1
-//CHECK-NEXT:   %46 = bitcast i32* %45 to i256*
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_3]]([0 x i256]* %36, [0 x i256]* %0, i256* %40, i256* %41, [0 x i256]* %44, i256* %46)
+//CHECK-NEXT:   %[[T003:[0-9a-zA-Z_.]+]] = bitcast [1 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T004:[0-9a-zA-Z_.]+]] = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
+//CHECK-NEXT:   %[[T005:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T004]], align 8
+//CHECK-NEXT:   %[[T006:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T005]], i32 0
+//CHECK-NEXT:   %[[T007:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T006]], i32 0, i256 1
+//CHECK-NEXT:   %[[T008:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 1
+//CHECK-NEXT:   %[[T009:[0-9a-zA-Z_.]+]] = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
+//CHECK-NEXT:   %[[T010:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T009]], align 8
+//CHECK-NEXT:   %[[T011:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T010]], i32 0
+//CHECK-NEXT:   %[[T012:[0-9a-zA-Z_.]+]] = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 1
+//CHECK-NEXT:   %[[T013:[0-9a-zA-Z_.]+]] = bitcast i32* %[[T012]] to i256*
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_2]]([0 x i256]* %[[T003]], [0 x i256]* %0, i256* %[[T007]], i256* %[[T008]], [0 x i256]* %[[T011]], i256* %[[T013]])
+//CHECK-NEXT:   %[[T014:[0-9a-zA-Z_.]+]] = bitcast [1 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T015:[0-9a-zA-Z_.]+]] = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
+//CHECK-NEXT:   %[[T016:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T015]], align 8
+//CHECK-NEXT:   %[[T017:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T016]], i32 0
+//CHECK-NEXT:   %[[T018:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T017]], i32 0, i256 2
+//CHECK-NEXT:   %[[T019:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 2
+//CHECK-NEXT:   %[[T020:[0-9a-zA-Z_.]+]] = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
+//CHECK-NEXT:   %[[T021:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T020]], align 8
+//CHECK-NEXT:   %[[T022:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T021]], i32 0
+//CHECK-NEXT:   %[[T023:[0-9a-zA-Z_.]+]] = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 1
+//CHECK-NEXT:   %[[T024:[0-9a-zA-Z_.]+]] = bitcast i32* %[[T023]] to i256*
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_2]]([0 x i256]* %[[T014]], [0 x i256]* %0, i256* %[[T018]], i256* %[[T019]], [0 x i256]* %[[T022]], i256* %[[T024]])
+//CHECK-NEXT:   %[[T025:[0-9a-zA-Z_.]+]] = bitcast [1 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T026:[0-9a-zA-Z_.]+]] = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
+//CHECK-NEXT:   %[[T027:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T026]], align 8
+//CHECK-NEXT:   %[[T028:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T027]], i32 0
+//CHECK-NEXT:   %[[T029:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T028]], i32 0, i256 3
+//CHECK-NEXT:   %[[T030:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 3
+//CHECK-NEXT:   %[[T031:[0-9a-zA-Z_.]+]] = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
+//CHECK-NEXT:   %[[T032:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T031]], align 8
+//CHECK-NEXT:   %[[T033:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T032]], i32 0
+//CHECK-NEXT:   %[[T034:[0-9a-zA-Z_.]+]] = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 1
+//CHECK-NEXT:   %[[T035:[0-9a-zA-Z_.]+]] = bitcast i32* %[[T034]] to i256*
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_2]]([0 x i256]* %[[T025]], [0 x i256]* %0, i256* %[[T029]], i256* %[[T030]], [0 x i256]* %[[T033]], i256* %[[T035]])
+//CHECK-NEXT:   %[[T036:[0-9a-zA-Z_.]+]] = bitcast [1 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T037:[0-9a-zA-Z_.]+]] = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
+//CHECK-NEXT:   %[[T038:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T037]], align 8
+//CHECK-NEXT:   %[[T039:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T038]], i32 0
+//CHECK-NEXT:   %[[T040:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T039]], i32 0, i256 4
+//CHECK-NEXT:   %[[T041:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 4
+//CHECK-NEXT:   %[[T042:[0-9a-zA-Z_.]+]] = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
+//CHECK-NEXT:   %[[T043:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T042]], align 8
+//CHECK-NEXT:   %[[T044:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T043]], i32 0
+//CHECK-NEXT:   %[[T045:[0-9a-zA-Z_.]+]] = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 1
+//CHECK-NEXT:   %[[T046:[0-9a-zA-Z_.]+]] = bitcast i32* %[[T045]] to i256*
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_3]]([0 x i256]* %[[T036]], [0 x i256]* %0, i256* %[[T040]], i256* %[[T041]], [0 x i256]* %[[T044]], i256* %[[T046]])
 //CHECK-NEXT:   br label %store4
 //CHECK-EMPTY: 
 //CHECK-NEXT: store4:
-//CHECK-NEXT:   %47 = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
-//CHECK-NEXT:   %48 = load [0 x i256]*, [0 x i256]** %47, align 8
-//CHECK-NEXT:   %49 = getelementptr [0 x i256], [0 x i256]* %48, i32 0, i32 0
-//CHECK-NEXT:   %50 = load i256, i256* %49, align 4
-//CHECK-NEXT:   %51 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
-//CHECK-NEXT:   store i256 %50, i256* %51, align 4
-//CHECK-NEXT:   %52 = load i256, i256* %51, align 4
+//CHECK-NEXT:   %[[T051:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
+//CHECK-NEXT:   %[[T047:[0-9a-zA-Z_.]+]] = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
+//CHECK-NEXT:   %[[T048:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T047]], align 8
+//CHECK-NEXT:   %[[T049:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T048]], i32 0, i32 0
+//CHECK-NEXT:   %[[T050:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T049]], align 4
+//CHECK-NEXT:   store i256 %[[T050]], i256* %[[T051]], align 4
+//CHECK-NEXT:   %[[T052:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T051]], align 4
 //CHECK-NEXT:   %constraint = alloca i1, align 1
-//CHECK-NEXT:   call void @__constraint_values(i256 %50, i256 %52, i1* %constraint)
+//CHECK-NEXT:   call void @__constraint_values(i256 %[[T050]], i256 %[[T052]], i1* %constraint)
 //CHECK-NEXT:   br label %prologue
 //CHECK-EMPTY: 
 //CHECK-NEXT: prologue:

--- a/circom/tests/subcmps/subcmps3.circom
+++ b/circom/tests/subcmps/subcmps3.circom
@@ -37,21 +37,21 @@ component main = SubCmps3();
 //CHECK-NEXT:   br label %store1
 //CHECK-EMPTY: 
 //CHECK-NEXT: store1:
-//CHECK-NEXT:   %0 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
-//CHECK-NEXT:   %1 = load i256, i256* %0, align 4
-//CHECK-NEXT:   %2 = getelementptr i256, i256* %sig_[[X1]], i32 0
-//CHECK-NEXT:   %3 = load i256, i256* %2, align 4
-//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %1, i256 %3)
-//CHECK-NEXT:   %4 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
-//CHECK-NEXT:   store i256 %call.fr_add, i256* %4, align 4
+//CHECK-NEXT:   %[[T004:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
+//CHECK-NEXT:   %[[T000:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
+//CHECK-NEXT:   %[[T001:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T000]], align 4
+//CHECK-NEXT:   %[[T002:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_[[X1]], i32 0
+//CHECK-NEXT:   %[[T003:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T002]], align 4
+//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %[[T001]], i256 %[[T003]])
+//CHECK-NEXT:   store i256 %call.fr_add, i256* %[[T004]], align 4
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY: 
 //CHECK-NEXT: store2:
-//CHECK-NEXT:   %5 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
-//CHECK-NEXT:   %6 = load i256, i256* %5, align 4
-//CHECK-NEXT:   %call.fr_add1 = call i256 @fr_add(i256 %6, i256 1)
-//CHECK-NEXT:   %7 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
-//CHECK-NEXT:   store i256 %call.fr_add1, i256* %7, align 4
+//CHECK-NEXT:   %[[T007:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
+//CHECK-NEXT:   %[[T005:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
+//CHECK-NEXT:   %[[T006:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T005]], align 4
+//CHECK-NEXT:   %call.fr_add1 = call i256 @fr_add(i256 %[[T006]], i256 1)
+//CHECK-NEXT:   store i256 %call.fr_add1, i256* %[[T007]], align 4
 //CHECK-NEXT:   br label %return3
 //CHECK-EMPTY: 
 //CHECK-NEXT: return3:
@@ -64,20 +64,20 @@ component main = SubCmps3();
 //CHECK-NEXT:   br label %store1
 //CHECK-EMPTY: 
 //CHECK-NEXT: store1:
-//CHECK-NEXT:   %0 = getelementptr i256, i256* %sig_[[X2]], i32 0
-//CHECK-NEXT:   %1 = load i256, i256* %0, align 4
-//CHECK-NEXT:   %2 = getelementptr i256, i256* %subsig_[[X1]], i32 0
-//CHECK-NEXT:   store i256 %1, i256* %2, align 4
-//CHECK-NEXT:   %3 = load i256, i256* %2, align 4
+//CHECK-NEXT:   %[[T002:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subsig_[[X1]], i32 0
+//CHECK-NEXT:   %[[T000:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_[[X2]], i32 0
+//CHECK-NEXT:   %[[T001:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T000]], align 4
+//CHECK-NEXT:   store i256 %[[T001]], i256* %[[T002]], align 4
+//CHECK-NEXT:   %[[T003:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T002]], align 4
 //CHECK-NEXT:   %constraint = alloca i1, align 1
-//CHECK-NEXT:   call void @__constraint_values(i256 %1, i256 %3, i1* %constraint)
+//CHECK-NEXT:   call void @__constraint_values(i256 %[[T001]], i256 %[[T003]], i1* %constraint)
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY: 
 //CHECK-NEXT: store2:
-//CHECK-NEXT:   %4 = load i256, i256* %subc_[[X3]], align 4
-//CHECK-NEXT:   %call.fr_sub = call i256 @fr_sub(i256 %4, i256 1)
-//CHECK-NEXT:   %5 = getelementptr i256, i256* %subc_[[X3]], i32 0
-//CHECK-NEXT:   store i256 %call.fr_sub, i256* %5, align 4
+//CHECK-NEXT:   %[[T005:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subc_[[X3]], i32 0
+//CHECK-NEXT:   %[[T004:[0-9a-zA-Z_.]+]] = load i256, i256* %subc_[[X3]], align 4
+//CHECK-NEXT:   %call.fr_sub = call i256 @fr_sub(i256 %[[T004]], i256 1)
+//CHECK-NEXT:   store i256 %call.fr_sub, i256* %[[T005]], align 4
 //CHECK-NEXT:   br label %fold_false3
 //CHECK-EMPTY: 
 //CHECK-NEXT: fold_false3:
@@ -87,11 +87,11 @@ component main = SubCmps3();
 //CHECK-NEXT:   br label %store5
 //CHECK-EMPTY: 
 //CHECK-NEXT: store5:
-//CHECK-NEXT:   %6 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 0
-//CHECK-NEXT:   %7 = load i256, i256* %6, align 4
-//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %7, i256 1)
-//CHECK-NEXT:   %8 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 0
-//CHECK-NEXT:   store i256 %call.fr_add, i256* %8, align 4
+//CHECK-NEXT:   %[[T008:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 0
+//CHECK-NEXT:   %[[T006:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 0
+//CHECK-NEXT:   %[[T007:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T006]], align 4
+//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %[[T007]], i256 1)
+//CHECK-NEXT:   store i256 %call.fr_add, i256* %[[T008]], align 4
 //CHECK-NEXT:   br label %return6
 //CHECK-EMPTY: 
 //CHECK-NEXT: return6:
@@ -104,20 +104,20 @@ component main = SubCmps3();
 //CHECK-NEXT:   br label %store1
 //CHECK-EMPTY: 
 //CHECK-NEXT: store1:
-//CHECK-NEXT:   %0 = getelementptr i256, i256* %sig_[[X2]], i32 0
-//CHECK-NEXT:   %1 = load i256, i256* %0, align 4
-//CHECK-NEXT:   %2 = getelementptr i256, i256* %subsig_[[X1]], i32 0
-//CHECK-NEXT:   store i256 %1, i256* %2, align 4
-//CHECK-NEXT:   %3 = load i256, i256* %2, align 4
+//CHECK-NEXT:   %[[T002:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subsig_[[X1]], i32 0
+//CHECK-NEXT:   %[[T000:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_[[X2]], i32 0
+//CHECK-NEXT:   %[[T001:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T000]], align 4
+//CHECK-NEXT:   store i256 %[[T001]], i256* %[[T002]], align 4
+//CHECK-NEXT:   %[[T003:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T002]], align 4
 //CHECK-NEXT:   %constraint = alloca i1, align 1
-//CHECK-NEXT:   call void @__constraint_values(i256 %1, i256 %3, i1* %constraint)
+//CHECK-NEXT:   call void @__constraint_values(i256 %[[T001]], i256 %[[T003]], i1* %constraint)
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY: 
 //CHECK-NEXT: store2:
-//CHECK-NEXT:   %4 = load i256, i256* %subc_[[X3]], align 4
-//CHECK-NEXT:   %call.fr_sub = call i256 @fr_sub(i256 %4, i256 1)
-//CHECK-NEXT:   %5 = getelementptr i256, i256* %subc_[[X3]], i32 0
-//CHECK-NEXT:   store i256 %call.fr_sub, i256* %5, align 4
+//CHECK-NEXT:   %[[T005:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subc_[[X3]], i32 0
+//CHECK-NEXT:   %[[T004:[0-9a-zA-Z_.]+]] = load i256, i256* %subc_[[X3]], align 4
+//CHECK-NEXT:   %call.fr_sub = call i256 @fr_sub(i256 %[[T004]], i256 1)
+//CHECK-NEXT:   store i256 %call.fr_sub, i256* %[[T005]], align 4
 //CHECK-NEXT:   br label %fold_true3
 //CHECK-EMPTY: 
 //CHECK-NEXT: fold_true3:
@@ -125,21 +125,21 @@ component main = SubCmps3();
 //CHECK-NEXT:   br label %fold_true4
 //CHECK-EMPTY: 
 //CHECK-NEXT: fold_true4:
-//CHECK-NEXT:   %6 = getelementptr i256, i256* %subsig_[[X3]], i32 0
-//CHECK-NEXT:   %7 = load i256, i256* %6, align 4
-//CHECK-NEXT:   %8 = getelementptr [0 x i256], [0 x i256]* %signals, i32 0, i32 0
-//CHECK-NEXT:   store i256 %7, i256* %8, align 4
-//CHECK-NEXT:   %9 = load i256, i256* %8, align 4
+//CHECK-NEXT:   %[[T008:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %signals, i32 0, i32 0
+//CHECK-NEXT:   %[[T006:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subsig_[[X3]], i32 0
+//CHECK-NEXT:   %[[T007:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T006]], align 4
+//CHECK-NEXT:   store i256 %[[T007]], i256* %[[T008]], align 4
+//CHECK-NEXT:   %[[T009:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T008]], align 4
 //CHECK-NEXT:   %constraint1 = alloca i1, align 1
-//CHECK-NEXT:   call void @__constraint_values(i256 %7, i256 %9, i1* %constraint1)
+//CHECK-NEXT:   call void @__constraint_values(i256 %[[T007]], i256 %[[T009]], i1* %constraint1)
 //CHECK-NEXT:   br label %store5
 //CHECK-EMPTY: 
 //CHECK-NEXT: store5:
-//CHECK-NEXT:   %10 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 0
-//CHECK-NEXT:   %11 = load i256, i256* %10, align 4
-//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %11, i256 1)
-//CHECK-NEXT:   %12 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 0
-//CHECK-NEXT:   store i256 %call.fr_add, i256* %12, align 4
+//CHECK-NEXT:   %[[T012:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 0
+//CHECK-NEXT:   %[[T010:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 0
+//CHECK-NEXT:   %[[T011:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T010]], align 4
+//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %[[T011]], i256 1)
+//CHECK-NEXT:   store i256 %call.fr_add, i256* %[[T012]], align 4
 //CHECK-NEXT:   br label %return6
 //CHECK-EMPTY: 
 //CHECK-NEXT: return6:
@@ -153,43 +153,43 @@ component main = SubCmps3();
 //CHECK-NEXT:   br label %store1
 //CHECK-EMPTY: 
 //CHECK-NEXT: store1:
-//CHECK-NEXT:   %1 = getelementptr [3 x i256], [3 x i256]* %lvars, i32 0, i32 0
-//CHECK-NEXT:   store i256 4, i256* %1, align 4
+//CHECK-NEXT:   %[[T001:[0-9a-zA-Z_.]+]] = getelementptr [3 x i256], [3 x i256]* %lvars, i32 0, i32 0
+//CHECK-NEXT:   store i256 4, i256* %[[T001]], align 4
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY: 
 //CHECK-NEXT: store2:
-//CHECK-NEXT:   %2 = getelementptr [3 x i256], [3 x i256]* %lvars, i32 0, i32 1
-//CHECK-NEXT:   store i256 0, i256* %2, align 4
+//CHECK-NEXT:   %[[T002:[0-9a-zA-Z_.]+]] = getelementptr [3 x i256], [3 x i256]* %lvars, i32 0, i32 1
+//CHECK-NEXT:   store i256 0, i256* %[[T002]], align 4
 //CHECK-NEXT:   br label %store3
 //CHECK-EMPTY: 
 //CHECK-NEXT: store3:
-//CHECK-NEXT:   %3 = getelementptr [3 x i256], [3 x i256]* %lvars, i32 0, i32 2
-//CHECK-NEXT:   store i256 0, i256* %3, align 4
+//CHECK-NEXT:   %[[T003:[0-9a-zA-Z_.]+]] = getelementptr [3 x i256], [3 x i256]* %lvars, i32 0, i32 2
+//CHECK-NEXT:   store i256 0, i256* %[[T003]], align 4
 //CHECK-NEXT:   br label %unrolled_loop4
 //CHECK-EMPTY: 
 //CHECK-NEXT: unrolled_loop4:
-//CHECK-NEXT:   %4 = bitcast [3 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %5 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 1
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %4, [0 x i256]* %0, i256* %5)
-//CHECK-NEXT:   %6 = bitcast [3 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %7 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 2
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %6, [0 x i256]* %0, i256* %7)
-//CHECK-NEXT:   %8 = bitcast [3 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %9 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 3
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %8, [0 x i256]* %0, i256* %9)
-//CHECK-NEXT:   %10 = bitcast [3 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %11 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 4
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %10, [0 x i256]* %0, i256* %11)
+//CHECK-NEXT:   %[[T004:[0-9a-zA-Z_.]+]] = bitcast [3 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T005:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 1
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %[[T004]], [0 x i256]* %0, i256* %[[T005]])
+//CHECK-NEXT:   %[[T006:[0-9a-zA-Z_.]+]] = bitcast [3 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T007:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 2
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %[[T006]], [0 x i256]* %0, i256* %[[T007]])
+//CHECK-NEXT:   %[[T008:[0-9a-zA-Z_.]+]] = bitcast [3 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T009:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 3
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %[[T008]], [0 x i256]* %0, i256* %[[T009]])
+//CHECK-NEXT:   %[[T010:[0-9a-zA-Z_.]+]] = bitcast [3 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T011:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 4
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %[[T010]], [0 x i256]* %0, i256* %[[T011]])
 //CHECK-NEXT:   br label %store5
 //CHECK-EMPTY: 
 //CHECK-NEXT: store5:
-//CHECK-NEXT:   %12 = getelementptr [3 x i256], [3 x i256]* %lvars, i32 0, i32 1
-//CHECK-NEXT:   %13 = load i256, i256* %12, align 4
-//CHECK-NEXT:   %14 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
-//CHECK-NEXT:   store i256 %13, i256* %14, align 4
-//CHECK-NEXT:   %15 = load i256, i256* %14, align 4
+//CHECK-NEXT:   %[[T014:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
+//CHECK-NEXT:   %[[T012:[0-9a-zA-Z_.]+]] = getelementptr [3 x i256], [3 x i256]* %lvars, i32 0, i32 1
+//CHECK-NEXT:   %[[T013:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T012]], align 4
+//CHECK-NEXT:   store i256 %[[T013]], i256* %[[T014]], align 4
+//CHECK-NEXT:   %[[T015:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T014]], align 4
 //CHECK-NEXT:   %constraint = alloca i1, align 1
-//CHECK-NEXT:   call void @__constraint_values(i256 %13, i256 %15, i1* %constraint)
+//CHECK-NEXT:   call void @__constraint_values(i256 %[[T013]], i256 %[[T015]], i1* %constraint)
 //CHECK-NEXT:   br label %prologue
 //CHECK-EMPTY: 
 //CHECK-NEXT: prologue:
@@ -203,68 +203,68 @@ component main = SubCmps3();
 //CHECK-NEXT:   br label %create_cmp1
 //CHECK-EMPTY: 
 //CHECK-NEXT: create_cmp1:
-//CHECK-NEXT:   %1 = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0
-//CHECK-NEXT:   call void @Sum_0_build({ [0 x i256]*, i32 }* %1)
+//CHECK-NEXT:   %[[T001:[0-9a-zA-Z_.]+]] = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0
+//CHECK-NEXT:   call void @Sum_0_build({ [0 x i256]*, i32 }* %[[T001]])
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY: 
 //CHECK-NEXT: store2:
-//CHECK-NEXT:   %2 = getelementptr [1 x i256], [1 x i256]* %lvars, i32 0, i32 0
-//CHECK-NEXT:   store i256 0, i256* %2, align 4
+//CHECK-NEXT:   %[[T002:[0-9a-zA-Z_.]+]] = getelementptr [1 x i256], [1 x i256]* %lvars, i32 0, i32 0
+//CHECK-NEXT:   store i256 0, i256* %[[T002]], align 4
 //CHECK-NEXT:   br label %unrolled_loop3
 //CHECK-EMPTY: 
 //CHECK-NEXT: unrolled_loop3:
-//CHECK-NEXT:  %3 = bitcast [1 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:  %4 = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
-//CHECK-NEXT:  %5 = load [0 x i256]*, [0 x i256]** %4, align 8
-//CHECK-NEXT:  %6 = getelementptr [0 x i256], [0 x i256]* %5, i32 0
-//CHECK-NEXT:  %7 = getelementptr [0 x i256], [0 x i256]* %6, i32 0, i256 1
-//CHECK-NEXT:  %8 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 1
-//CHECK-NEXT:  %9 = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
-//CHECK-NEXT:  %10 = load [0 x i256]*, [0 x i256]** %9, align 8
-//CHECK-NEXT:  %11 = getelementptr [0 x i256], [0 x i256]* %10, i32 0
-//CHECK-NEXT:  %12 = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 1
-//CHECK-NEXT:  %13 = bitcast i32* %12 to i256*
-//CHECK-NEXT:  call void @..generated..loop.body.[[$F_ID_2]]([0 x i256]* %3, [0 x i256]* %0, i256* %7, i256* %8, i256* null, [0 x i256]* %11, i256* %13)
-//CHECK-NEXT:  %14 = bitcast [1 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:  %15 = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
-//CHECK-NEXT:  %16 = load [0 x i256]*, [0 x i256]** %15, align 8
-//CHECK-NEXT:  %17 = getelementptr [0 x i256], [0 x i256]* %16, i32 0
-//CHECK-NEXT:  %18 = getelementptr [0 x i256], [0 x i256]* %17, i32 0, i256 2
-//CHECK-NEXT:  %19 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 2
-//CHECK-NEXT:  %20 = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
-//CHECK-NEXT:  %21 = load [0 x i256]*, [0 x i256]** %20, align 8
-//CHECK-NEXT:  %22 = getelementptr [0 x i256], [0 x i256]* %21, i32 0
-//CHECK-NEXT:  %23 = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 1
-//CHECK-NEXT:  %24 = bitcast i32* %23 to i256*
-//CHECK-NEXT:  call void @..generated..loop.body.[[$F_ID_2]]([0 x i256]* %14, [0 x i256]* %0, i256* %18, i256* %19, i256* null, [0 x i256]* %22, i256* %24)
-//CHECK-NEXT:  %25 = bitcast [1 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:  %26 = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
-//CHECK-NEXT:  %27 = load [0 x i256]*, [0 x i256]** %26, align 8
-//CHECK-NEXT:  %28 = getelementptr [0 x i256], [0 x i256]* %27, i32 0
-//CHECK-NEXT:  %29 = getelementptr [0 x i256], [0 x i256]* %28, i32 0, i256 3
-//CHECK-NEXT:  %30 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 3
-//CHECK-NEXT:  %31 = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
-//CHECK-NEXT:  %32 = load [0 x i256]*, [0 x i256]** %31, align 8
-//CHECK-NEXT:  %33 = getelementptr [0 x i256], [0 x i256]* %32, i32 0
-//CHECK-NEXT:  %34 = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 1
-//CHECK-NEXT:  %35 = bitcast i32* %34 to i256*
-//CHECK-NEXT:  call void @..generated..loop.body.[[$F_ID_2]]([0 x i256]* %25, [0 x i256]* %0, i256* %29, i256* %30, i256* null, [0 x i256]* %33, i256* %35)
-//CHECK-NEXT:  %36 = bitcast [1 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:  %37 = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
-//CHECK-NEXT:  %38 = load [0 x i256]*, [0 x i256]** %37, align 8
-//CHECK-NEXT:  %39 = getelementptr [0 x i256], [0 x i256]* %38, i32 0
-//CHECK-NEXT:  %40 = getelementptr [0 x i256], [0 x i256]* %39, i32 0, i256 4
-//CHECK-NEXT:  %41 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 4
-//CHECK-NEXT:  %42 = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
-//CHECK-NEXT:  %43 = load [0 x i256]*, [0 x i256]** %42, align 8
-//CHECK-NEXT:  %44 = getelementptr [0 x i256], [0 x i256]* %43, i32 0
-//CHECK-NEXT:  %45 = getelementptr [0 x i256], [0 x i256]* %44, i32 0, i256 0
-//CHECK-NEXT:  %46 = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
-//CHECK-NEXT:  %47 = load [0 x i256]*, [0 x i256]** %46, align 8
-//CHECK-NEXT:  %48 = getelementptr [0 x i256], [0 x i256]* %47, i32 0
-//CHECK-NEXT:  %49 = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 1
-//CHECK-NEXT:  %50 = bitcast i32* %49 to i256*
-//CHECK-NEXT:  call void @..generated..loop.body.[[$F_ID_3]]([0 x i256]* %36, [0 x i256]* %0, i256* %40, i256* %41, i256* %45, [0 x i256]* %48, i256* %50)
+//CHECK-NEXT:  %[[T003:[0-9a-zA-Z_.]+]] = bitcast [1 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:  %[[T004:[0-9a-zA-Z_.]+]] = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
+//CHECK-NEXT:  %[[T005:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T004]], align 8
+//CHECK-NEXT:  %[[T006:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T005]], i32 0
+//CHECK-NEXT:  %[[T007:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T006]], i32 0, i256 1
+//CHECK-NEXT:  %[[T008:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 1
+//CHECK-NEXT:  %[[T009:[0-9a-zA-Z_.]+]] = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
+//CHECK-NEXT:  %[[T010:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T009]], align 8
+//CHECK-NEXT:  %[[T011:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T010]], i32 0
+//CHECK-NEXT:  %[[T012:[0-9a-zA-Z_.]+]] = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 1
+//CHECK-NEXT:  %[[T013:[0-9a-zA-Z_.]+]] = bitcast i32* %[[T012]] to i256*
+//CHECK-NEXT:  call void @..generated..loop.body.[[$F_ID_2]]([0 x i256]* %[[T003]], [0 x i256]* %0, i256* %[[T007]], i256* %[[T008]], i256* null, [0 x i256]* %[[T011]], i256* %[[T013]])
+//CHECK-NEXT:  %[[T014:[0-9a-zA-Z_.]+]] = bitcast [1 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:  %[[T015:[0-9a-zA-Z_.]+]] = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
+//CHECK-NEXT:  %[[T016:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T015]], align 8
+//CHECK-NEXT:  %[[T017:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T016]], i32 0
+//CHECK-NEXT:  %[[T018:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T017]], i32 0, i256 2
+//CHECK-NEXT:  %[[T019:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 2
+//CHECK-NEXT:  %[[T020:[0-9a-zA-Z_.]+]] = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
+//CHECK-NEXT:  %[[T021:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T020]], align 8
+//CHECK-NEXT:  %[[T022:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T021]], i32 0
+//CHECK-NEXT:  %[[T023:[0-9a-zA-Z_.]+]] = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 1
+//CHECK-NEXT:  %[[T024:[0-9a-zA-Z_.]+]] = bitcast i32* %[[T023]] to i256*
+//CHECK-NEXT:  call void @..generated..loop.body.[[$F_ID_2]]([0 x i256]* %[[T014]], [0 x i256]* %0, i256* %[[T018]], i256* %[[T019]], i256* null, [0 x i256]* %[[T022]], i256* %[[T024]])
+//CHECK-NEXT:  %[[T025:[0-9a-zA-Z_.]+]] = bitcast [1 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:  %[[T026:[0-9a-zA-Z_.]+]] = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
+//CHECK-NEXT:  %[[T027:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T026]], align 8
+//CHECK-NEXT:  %[[T028:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T027]], i32 0
+//CHECK-NEXT:  %[[T029:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T028]], i32 0, i256 3
+//CHECK-NEXT:  %[[T030:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 3
+//CHECK-NEXT:  %[[T031:[0-9a-zA-Z_.]+]] = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
+//CHECK-NEXT:  %[[T032:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T031]], align 8
+//CHECK-NEXT:  %[[T033:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T032]], i32 0
+//CHECK-NEXT:  %[[T034:[0-9a-zA-Z_.]+]] = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 1
+//CHECK-NEXT:  %[[T035:[0-9a-zA-Z_.]+]] = bitcast i32* %[[T034]] to i256*
+//CHECK-NEXT:  call void @..generated..loop.body.[[$F_ID_2]]([0 x i256]* %[[T025]], [0 x i256]* %0, i256* %[[T029]], i256* %[[T030]], i256* null, [0 x i256]* %[[T033]], i256* %[[T035]])
+//CHECK-NEXT:  %[[T036:[0-9a-zA-Z_.]+]] = bitcast [1 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:  %[[T037:[0-9a-zA-Z_.]+]] = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
+//CHECK-NEXT:  %[[T038:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T037]], align 8
+//CHECK-NEXT:  %[[T039:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T038]], i32 0
+//CHECK-NEXT:  %[[T040:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T039]], i32 0, i256 4
+//CHECK-NEXT:  %[[T041:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 4
+//CHECK-NEXT:  %[[T042:[0-9a-zA-Z_.]+]] = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
+//CHECK-NEXT:  %[[T043:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T042]], align 8
+//CHECK-NEXT:  %[[T044:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T043]], i32 0
+//CHECK-NEXT:  %[[T045:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T044]], i32 0, i256 0
+//CHECK-NEXT:  %[[T046:[0-9a-zA-Z_.]+]] = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
+//CHECK-NEXT:  %[[T047:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T046]], align 8
+//CHECK-NEXT:  %[[T048:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T047]], i32 0
+//CHECK-NEXT:  %[[T049:[0-9a-zA-Z_.]+]] = getelementptr [1 x { [0 x i256]*, i32 }], [1 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 1
+//CHECK-NEXT:  %[[T050:[0-9a-zA-Z_.]+]] = bitcast i32* %[[T049]] to i256*
+//CHECK-NEXT:  call void @..generated..loop.body.[[$F_ID_3]]([0 x i256]* %[[T036]], [0 x i256]* %0, i256* %[[T040]], i256* %[[T041]], i256* %[[T045]], [0 x i256]* %[[T048]], i256* %[[T050]])
 //CHECK-NEXT:  br label %prologue
 //CHECK-EMPTY: 
 //CHECK-NEXT: prologue:

--- a/circom/tests/subcmps/subcmps4.circom
+++ b/circom/tests/subcmps/subcmps4.circom
@@ -41,21 +41,21 @@ component main = SubCmps4(3);
 //CHECK-NEXT:   br label %store1
 //CHECK-EMPTY: 
 //CHECK-NEXT: store1:
-//CHECK-NEXT:   %0 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
-//CHECK-NEXT:   %1 = load i256, i256* %0, align 4
-//CHECK-NEXT:   %2 = getelementptr i256, i256* %sig_0, i32 0
-//CHECK-NEXT:   %3 = load i256, i256* %2, align 4
-//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %1, i256 %3)
-//CHECK-NEXT:   %4 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
-//CHECK-NEXT:   store i256 %call.fr_add, i256* %4, align 4
+//CHECK-NEXT:   %[[T004:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
+//CHECK-NEXT:   %[[T000:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
+//CHECK-NEXT:   %[[T001:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T000]], align 4
+//CHECK-NEXT:   %[[T002:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_0, i32 0
+//CHECK-NEXT:   %[[T003:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T002]], align 4
+//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %[[T001]], i256 %[[T003]])
+//CHECK-NEXT:   store i256 %call.fr_add, i256* %[[T004]], align 4
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY: 
 //CHECK-NEXT: store2:
-//CHECK-NEXT:   %5 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
-//CHECK-NEXT:   %6 = load i256, i256* %5, align 4
-//CHECK-NEXT:   %call.fr_add1 = call i256 @fr_add(i256 %6, i256 1)
-//CHECK-NEXT:   %7 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
-//CHECK-NEXT:   store i256 %call.fr_add1, i256* %7, align 4
+//CHECK-NEXT:   %[[T007:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
+//CHECK-NEXT:   %[[T005:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 2
+//CHECK-NEXT:   %[[T006:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T005]], align 4
+//CHECK-NEXT:   %call.fr_add1 = call i256 @fr_add(i256 %[[T006]], i256 1)
+//CHECK-NEXT:   store i256 %call.fr_add1, i256* %[[T007]], align 4
 //CHECK-NEXT:   br label %return3
 //CHECK-EMPTY: 
 //CHECK-NEXT: return3:
@@ -69,25 +69,25 @@ component main = SubCmps4(3);
 //CHECK-NEXT:   br label %fold_true1
 //CHECK-EMPTY: 
 //CHECK-NEXT: fold_true1:
-//CHECK-NEXT:   %0 = getelementptr i256, i256* %sig_[[X2]], i32 0
-//CHECK-NEXT:   %1 = load i256, i256* %0, align 4
-//CHECK-NEXT:   %2 = getelementptr i256, i256* %subsig_[[X1]], i32 0
-//CHECK-NEXT:   store i256 %1, i256* %2, align 4
-//CHECK-NEXT:   %3 = load i256, i256* %2, align 4
+//CHECK-NEXT:   %[[T002:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subsig_[[X1]], i32 0
+//CHECK-NEXT:   %[[T000:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_[[X2]], i32 0
+//CHECK-NEXT:   %[[T001:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T000]], align 4
+//CHECK-NEXT:   store i256 %[[T001]], i256* %[[T002]], align 4
+//CHECK-NEXT:   %[[T003:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T002]], align 4
 //CHECK-NEXT:   %constraint = alloca i1, align 1
-//CHECK-NEXT:   call void @__constraint_values(i256 %1, i256 %3, i1* %constraint)
-//CHECK-NEXT:   %4 = load i256, i256* %subc_[[X3]], align 4
-//CHECK-NEXT:   %call.fr_sub = call i256 @fr_sub(i256 %4, i256 1)
-//CHECK-NEXT:   %5 = getelementptr i256, i256* %subc_[[X3]], i32 0
-//CHECK-NEXT:   store i256 %call.fr_sub, i256* %5, align 4
+//CHECK-NEXT:   call void @__constraint_values(i256 %[[T001]], i256 %[[T003]], i1* %constraint)
+//CHECK-NEXT:   %[[T005:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subc_[[X3]], i32 0
+//CHECK-NEXT:   %[[T004:[0-9a-zA-Z_.]+]] = load i256, i256* %subc_[[X3]], align 4
+//CHECK-NEXT:   %call.fr_sub = call i256 @fr_sub(i256 %[[T004]], i256 1)
+//CHECK-NEXT:   store i256 %call.fr_sub, i256* %[[T005]], align 4
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY: 
 //CHECK-NEXT: store2:
-//CHECK-NEXT:   %6 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
-//CHECK-NEXT:   %7 = load i256, i256* %6, align 4
-//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %7, i256 1)
-//CHECK-NEXT:   %8 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
-//CHECK-NEXT:   store i256 %call.fr_add, i256* %8, align 4
+//CHECK-NEXT:   %[[T008:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
+//CHECK-NEXT:   %[[T006:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
+//CHECK-NEXT:   %[[T007:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T006]], align 4
+//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %[[T007]], i256 1)
+//CHECK-NEXT:   store i256 %call.fr_add, i256* %[[T008]], align 4
 //CHECK-NEXT:   br label %return3
 //CHECK-EMPTY: 
 //CHECK-NEXT: return3:
@@ -101,25 +101,25 @@ component main = SubCmps4(3);
 //CHECK-NEXT:   br label %fold_false1
 //CHECK-EMPTY: 
 //CHECK-NEXT: fold_false1:
-//CHECK-NEXT:   %0 = getelementptr i256, i256* %sig_[[X4]], i32 0
-//CHECK-NEXT:   %1 = load i256, i256* %0, align 4
-//CHECK-NEXT:   %2 = getelementptr i256, i256* %subsig_[[X3]], i32 0
-//CHECK-NEXT:   store i256 %1, i256* %2, align 4
-//CHECK-NEXT:   %3 = load i256, i256* %2, align 4
+//CHECK-NEXT:   %[[T002:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subsig_[[X3]], i32 0
+//CHECK-NEXT:   %[[T000:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_[[X4]], i32 0
+//CHECK-NEXT:   %[[T001:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T000]], align 4
+//CHECK-NEXT:   store i256 %[[T001]], i256* %[[T002]], align 4
+//CHECK-NEXT:   %[[T003:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T002]], align 4
 //CHECK-NEXT:   %constraint = alloca i1, align 1
-//CHECK-NEXT:   call void @__constraint_values(i256 %1, i256 %3, i1* %constraint)
-//CHECK-NEXT:   %4 = load i256, i256* %subc_[[X3]], align 4
-//CHECK-NEXT:   %call.fr_sub = call i256 @fr_sub(i256 %4, i256 1)
-//CHECK-NEXT:   %5 = getelementptr i256, i256* %subc_[[X3]], i32 0
-//CHECK-NEXT:   store i256 %call.fr_sub, i256* %5, align 4
+//CHECK-NEXT:   call void @__constraint_values(i256 %[[T001]], i256 %[[T003]], i1* %constraint)
+//CHECK-NEXT:   %[[T005:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subc_[[X3]], i32 0
+//CHECK-NEXT:   %[[T004:[0-9a-zA-Z_.]+]] = load i256, i256* %subc_[[X3]], align 4
+//CHECK-NEXT:   %call.fr_sub = call i256 @fr_sub(i256 %[[T004]], i256 1)
+//CHECK-NEXT:   store i256 %call.fr_sub, i256* %[[T005]], align 4
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY: 
 //CHECK-NEXT: store2:
-//CHECK-NEXT:   %6 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
-//CHECK-NEXT:   %7 = load i256, i256* %6, align 4
-//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %7, i256 1)
-//CHECK-NEXT:   %8 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
-//CHECK-NEXT:   store i256 %call.fr_add, i256* %8, align 4
+//CHECK-NEXT:   %[[T008:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
+//CHECK-NEXT:   %[[T006:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
+//CHECK-NEXT:   %[[T007:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T006]], align 4
+//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %[[T007]], i256 1)
+//CHECK-NEXT:   store i256 %call.fr_add, i256* %[[T008]], align 4
 //CHECK-NEXT:   br label %return3
 //CHECK-EMPTY: 
 //CHECK-NEXT: return3:
@@ -133,26 +133,26 @@ component main = SubCmps4(3);
 //CHECK-NEXT:   br label %fold_true1
 //CHECK-EMPTY: 
 //CHECK-NEXT: fold_true1:
-//CHECK-NEXT:   %0 = getelementptr i256, i256* %sig_[[X2]], i32 0
-//CHECK-NEXT:   %1 = load i256, i256* %0, align 4
-//CHECK-NEXT:   %2 = getelementptr i256, i256* %subsig_[[X1]], i32 0
-//CHECK-NEXT:   store i256 %1, i256* %2, align 4
-//CHECK-NEXT:   %3 = load i256, i256* %2, align 4
+//CHECK-NEXT:   %[[T002:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subsig_[[X1]], i32 0
+//CHECK-NEXT:   %[[T000:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_[[X2]], i32 0
+//CHECK-NEXT:   %[[T001:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T000]], align 4
+//CHECK-NEXT:   store i256 %[[T001]], i256* %[[T002]], align 4
+//CHECK-NEXT:   %[[T003:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T002]], align 4
 //CHECK-NEXT:   %constraint = alloca i1, align 1
-//CHECK-NEXT:   call void @__constraint_values(i256 %1, i256 %3, i1* %constraint)
-//CHECK-NEXT:   %4 = load i256, i256* %subc_[[X3]], align 4
-//CHECK-NEXT:   %call.fr_sub = call i256 @fr_sub(i256 %4, i256 1)
-//CHECK-NEXT:   %5 = getelementptr i256, i256* %subc_[[X3]], i32 0
-//CHECK-NEXT:   store i256 %call.fr_sub, i256* %5, align 4
+//CHECK-NEXT:   call void @__constraint_values(i256 %[[T001]], i256 %[[T003]], i1* %constraint)
+//CHECK-NEXT:   %[[T005:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subc_[[X3]], i32 0
+//CHECK-NEXT:   %[[T004:[0-9a-zA-Z_.]+]] = load i256, i256* %subc_[[X3]], align 4
+//CHECK-NEXT:   %call.fr_sub = call i256 @fr_sub(i256 %[[T004]], i256 1)
+//CHECK-NEXT:   store i256 %call.fr_sub, i256* %[[T005]], align 4
 //CHECK-NEXT:   call void @Sum_0_run([0 x i256]* %sub_[[X3]])
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY: 
 //CHECK-NEXT: store2:
-//CHECK-NEXT:   %6 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
-//CHECK-NEXT:   %7 = load i256, i256* %6, align 4
-//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %7, i256 1)
-//CHECK-NEXT:   %8 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
-//CHECK-NEXT:   store i256 %call.fr_add, i256* %8, align 4
+//CHECK-NEXT:   %[[T008:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
+//CHECK-NEXT:   %[[T006:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
+//CHECK-NEXT:   %[[T007:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T006]], align 4
+//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %[[T007]], i256 1)
+//CHECK-NEXT:   store i256 %call.fr_add, i256* %[[T008]], align 4
 //CHECK-NEXT:   br label %return3
 //CHECK-EMPTY: 
 //CHECK-NEXT: return3:
@@ -166,26 +166,26 @@ component main = SubCmps4(3);
 //CHECK-NEXT:   br label %fold_false1
 //CHECK-EMPTY: 
 //CHECK-NEXT: fold_false1:
-//CHECK-NEXT:   %0 = getelementptr i256, i256* %sig_[[X4]], i32 0
-//CHECK-NEXT:   %1 = load i256, i256* %0, align 4
-//CHECK-NEXT:   %2 = getelementptr i256, i256* %subsig_[[X3]], i32 0
-//CHECK-NEXT:   store i256 %1, i256* %2, align 4
-//CHECK-NEXT:   %3 = load i256, i256* %2, align 4
+//CHECK-NEXT:   %[[T002:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subsig_[[X3]], i32 0
+//CHECK-NEXT:   %[[T000:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %sig_[[X4]], i32 0
+//CHECK-NEXT:   %[[T001:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T000]], align 4
+//CHECK-NEXT:   store i256 %[[T001]], i256* %[[T002]], align 4
+//CHECK-NEXT:   %[[T003:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T002]], align 4
 //CHECK-NEXT:   %constraint = alloca i1, align 1
-//CHECK-NEXT:   call void @__constraint_values(i256 %1, i256 %3, i1* %constraint)
-//CHECK-NEXT:   %4 = load i256, i256* %subc_[[X3]], align 4
-//CHECK-NEXT:   %call.fr_sub = call i256 @fr_sub(i256 %4, i256 1)
-//CHECK-NEXT:   %5 = getelementptr i256, i256* %subc_[[X3]], i32 0
-//CHECK-NEXT:   store i256 %call.fr_sub, i256* %5, align 4
+//CHECK-NEXT:   call void @__constraint_values(i256 %[[T001]], i256 %[[T003]], i1* %constraint)
+//CHECK-NEXT:   %[[T005:[0-9a-zA-Z_.]+]] = getelementptr i256, i256* %subc_[[X3]], i32 0
+//CHECK-NEXT:   %[[T004:[0-9a-zA-Z_.]+]] = load i256, i256* %subc_[[X3]], align 4
+//CHECK-NEXT:   %call.fr_sub = call i256 @fr_sub(i256 %[[T004]], i256 1)
+//CHECK-NEXT:   store i256 %call.fr_sub, i256* %[[T005]], align 4
 //CHECK-NEXT:   call void @Sum_0_run([0 x i256]* %sub_[[X3]])
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY: 
 //CHECK-NEXT: store2:
-//CHECK-NEXT:   %6 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
-//CHECK-NEXT:   %7 = load i256, i256* %6, align 4
-//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %7, i256 1)
-//CHECK-NEXT:   %8 = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
-//CHECK-NEXT:   store i256 %call.fr_add, i256* %8, align 4
+//CHECK-NEXT:   %[[T008:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
+//CHECK-NEXT:   %[[T006:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %lvars, i32 0, i32 1
+//CHECK-NEXT:   %[[T007:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T006]], align 4
+//CHECK-NEXT:   %call.fr_add = call i256 @fr_add(i256 %[[T007]], i256 1)
+//CHECK-NEXT:   store i256 %call.fr_add, i256* %[[T008]], align 4
 //CHECK-NEXT:   br label %return3
 //CHECK-EMPTY: 
 //CHECK-NEXT: return3:
@@ -199,163 +199,163 @@ component main = SubCmps4(3);
 //CHECK-NEXT:   br label %store1
 //CHECK-EMPTY: 
 //CHECK-NEXT: store1:
-//CHECK-NEXT:   %1 = getelementptr [3 x i256], [3 x i256]* %lvars, i32 0, i32 0
-//CHECK-NEXT:   store i256 3, i256* %1, align 4
+//CHECK-NEXT:   %[[T001:[0-9a-zA-Z_.]+]] = getelementptr [3 x i256], [3 x i256]* %lvars, i32 0, i32 0
+//CHECK-NEXT:   store i256 3, i256* %[[T001]], align 4
 //CHECK-NEXT:   br label %store2
 //CHECK-EMPTY: 
 //CHECK-NEXT: store2:
-//CHECK-NEXT:   %2 = getelementptr [3 x i256], [3 x i256]* %lvars, i32 0, i32 1
-//CHECK-NEXT:   store i256 0, i256* %2, align 4
+//CHECK-NEXT:   %[[T002:[0-9a-zA-Z_.]+]] = getelementptr [3 x i256], [3 x i256]* %lvars, i32 0, i32 1
+//CHECK-NEXT:   store i256 0, i256* %[[T002]], align 4
 //CHECK-NEXT:   br label %store3
 //CHECK-EMPTY: 
 //CHECK-NEXT: store3:
-//CHECK-NEXT:   %3 = getelementptr [3 x i256], [3 x i256]* %lvars, i32 0, i32 2
-//CHECK-NEXT:   store i256 0, i256* %3, align 4
+//CHECK-NEXT:   %[[T003:[0-9a-zA-Z_.]+]] = getelementptr [3 x i256], [3 x i256]* %lvars, i32 0, i32 2
+//CHECK-NEXT:   store i256 0, i256* %[[T003]], align 4
 //CHECK-NEXT:   br label %unrolled_loop4
 //CHECK-EMPTY: 
 //CHECK-NEXT: unrolled_loop4:
-//CHECK-NEXT:   %4 = bitcast [3 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %5 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 1
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %4, [0 x i256]* %0, i256* %5)
-//CHECK-NEXT:   %6 = bitcast [3 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %7 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 2
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %6, [0 x i256]* %0, i256* %7)
-//CHECK-NEXT:   %8 = bitcast [3 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %9 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 3
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %8, [0 x i256]* %0, i256* %9)
+//CHECK-NEXT:   %[[T004:[0-9a-zA-Z_.]+]] = bitcast [3 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T005:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 1
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %[[T004]], [0 x i256]* %0, i256* %[[T005]])
+//CHECK-NEXT:   %[[T006:[0-9a-zA-Z_.]+]] = bitcast [3 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T007:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 2
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %[[T006]], [0 x i256]* %0, i256* %[[T007]])
+//CHECK-NEXT:   %[[T008:[0-9a-zA-Z_.]+]] = bitcast [3 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T009:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 3
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_1]]([0 x i256]* %[[T008]], [0 x i256]* %0, i256* %[[T009]])
 //CHECK-NEXT:   br label %store5
 //CHECK-EMPTY: 
 //CHECK-NEXT: store5:
-//CHECK-NEXT:   %10 = getelementptr [3 x i256], [3 x i256]* %lvars, i32 0, i32 1
-//CHECK-NEXT:   %11 = load i256, i256* %10, align 4
-//CHECK-NEXT:   %12 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
-//CHECK-NEXT:   store i256 %11, i256* %12, align 4
-//CHECK-NEXT:   %13 = load i256, i256* %12, align 4
+//CHECK-NEXT:   %[[T012:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
+//CHECK-NEXT:   %[[T010:[0-9a-zA-Z_.]+]] = getelementptr [3 x i256], [3 x i256]* %lvars, i32 0, i32 1
+//CHECK-NEXT:   %[[T011:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T010]], align 4
+//CHECK-NEXT:   store i256 %[[T011]], i256* %[[T012]], align 4
+//CHECK-NEXT:   %[[T013:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T012]], align 4
 //CHECK-NEXT:   %constraint = alloca i1, align 1
-//CHECK-NEXT:   call void @__constraint_values(i256 %11, i256 %13, i1* %constraint)
+//CHECK-NEXT:   call void @__constraint_values(i256 %[[T011]], i256 %[[T013]], i1* %constraint)
 //CHECK-NEXT:   br label %prologue
 //CHECK-EMPTY: 
 //CHECK-NEXT: prologue:
 //CHECK-NEXT:   ret void
 //CHECK-NEXT: }
 //
-//CHECK-LABEL: define{{.*}} void @SubCmps4_1_run([0 x i256]* %0){{.*}} {
+//CHECK-LABEL: define dso_local void @SubCmps4_1_run([0 x i256]* %0){{.*}} {
 //CHECK-NEXT: prelude:
 //CHECK-NEXT:   %lvars = alloca [2 x i256], align 8
 //CHECK-NEXT:   %subcmps = alloca [2 x { [0 x i256]*, i32 }], align 8
 //CHECK-NEXT:   br label %store1
 //CHECK-EMPTY: 
 //CHECK-NEXT: store1:
-//CHECK-NEXT:   %1 = getelementptr [2 x i256], [2 x i256]* %lvars, i32 0, i32 0
-//CHECK-NEXT:   store i256 3, i256* %1, align 4
+//CHECK-NEXT:   %[[T001:[0-9a-zA-Z_.]+]] = getelementptr [2 x i256], [2 x i256]* %lvars, i32 0, i32 0
+//CHECK-NEXT:   store i256 3, i256* %[[T001]], align 4
 //CHECK-NEXT:   br label %create_cmp2
 //CHECK-EMPTY: 
 //CHECK-NEXT: create_cmp2:
-//CHECK-NEXT:   %2 = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0
-//CHECK-NEXT:   call void @Sum_0_build({ [0 x i256]*, i32 }* %2)
+//CHECK-NEXT:   %[[T002:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0
+//CHECK-NEXT:   call void @Sum_0_build({ [0 x i256]*, i32 }* %[[T002]])
 //CHECK-NEXT:   br label %create_cmp3
 //CHECK-EMPTY: 
 //CHECK-NEXT: create_cmp3:
-//CHECK-NEXT:   %3 = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1
-//CHECK-NEXT:   call void @Sum_0_build({ [0 x i256]*, i32 }* %3)
+//CHECK-NEXT:   %[[T003:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1
+//CHECK-NEXT:   call void @Sum_0_build({ [0 x i256]*, i32 }* %[[T003]])
 //CHECK-NEXT:   br label %store4
 //CHECK-EMPTY: 
 //CHECK-NEXT: store4:
-//CHECK-NEXT:   %4 = getelementptr [2 x i256], [2 x i256]* %lvars, i32 0, i32 1
-//CHECK-NEXT:   store i256 0, i256* %4, align 4
+//CHECK-NEXT:   %[[T004:[0-9a-zA-Z_.]+]] = getelementptr [2 x i256], [2 x i256]* %lvars, i32 0, i32 1
+//CHECK-NEXT:   store i256 0, i256* %[[T004]], align 4
 //CHECK-NEXT:   br label %unrolled_loop5
 //CHECK-EMPTY: 
 //CHECK-NEXT: unrolled_loop5:
-//CHECK-NEXT:   %5 = bitcast [2 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %6 = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
-//CHECK-NEXT:   %7 = load [0 x i256]*, [0 x i256]** %6, align 8
-//CHECK-NEXT:   %8 = getelementptr [0 x i256], [0 x i256]* %7, i32 0
-//CHECK-NEXT:   %9 = getelementptr [0 x i256], [0 x i256]* %8, i32 0, i256 1
-//CHECK-NEXT:   %10 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 2
-//CHECK-NEXT:   %11 = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
-//CHECK-NEXT:   %12 = load [0 x i256]*, [0 x i256]** %11, align 8
-//CHECK-NEXT:   %13 = getelementptr [0 x i256], [0 x i256]* %12, i32 0
-//CHECK-NEXT:   %14 = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 1
-//CHECK-NEXT:   %15 = bitcast i32* %14 to i256*
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_2]]([0 x i256]* %5, [0 x i256]* %0, i256* %9, i256* %10, i256* null, i256* null, [0 x i256]* %13, i256* %15)
-//CHECK-NEXT:   %16 = bitcast [2 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %17 = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 0
-//CHECK-NEXT:   %18 = load [0 x i256]*, [0 x i256]** %17, align 8
-//CHECK-NEXT:   %19 = getelementptr [0 x i256], [0 x i256]* %18, i32 0
-//CHECK-NEXT:   %20 = getelementptr [0 x i256], [0 x i256]* %19, i32 0, i256 1
-//CHECK-NEXT:   %21 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 3
-//CHECK-NEXT:   %22 = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 0
-//CHECK-NEXT:   %23 = load [0 x i256]*, [0 x i256]** %22, align 8
-//CHECK-NEXT:   %24 = getelementptr [0 x i256], [0 x i256]* %23, i32 0
-//CHECK-NEXT:   %25 = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 1
-//CHECK-NEXT:   %26 = bitcast i32* %25 to i256*
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_3]]([0 x i256]* %16, [0 x i256]* %0, i256* null, i256* null, i256* %20, i256* %21, [0 x i256]* %24, i256* %26)
-//CHECK-NEXT:   %27 = bitcast [2 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %28 = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
-//CHECK-NEXT:   %29 = load [0 x i256]*, [0 x i256]** %28, align 8
-//CHECK-NEXT:   %30 = getelementptr [0 x i256], [0 x i256]* %29, i32 0
-//CHECK-NEXT:   %31 = getelementptr [0 x i256], [0 x i256]* %30, i32 0, i256 2
-//CHECK-NEXT:   %32 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 4
-//CHECK-NEXT:   %33 = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
-//CHECK-NEXT:   %34 = load [0 x i256]*, [0 x i256]** %33, align 8
-//CHECK-NEXT:   %35 = getelementptr [0 x i256], [0 x i256]* %34, i32 0
-//CHECK-NEXT:   %36 = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 1
-//CHECK-NEXT:   %37 = bitcast i32* %36 to i256*
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_2]]([0 x i256]* %27, [0 x i256]* %0, i256* %31, i256* %32, i256* null, i256* null, [0 x i256]* %35, i256* %37)
-//CHECK-NEXT:   %38 = bitcast [2 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %39 = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 0
-//CHECK-NEXT:   %40 = load [0 x i256]*, [0 x i256]** %39, align 8
-//CHECK-NEXT:   %41 = getelementptr [0 x i256], [0 x i256]* %40, i32 0
-//CHECK-NEXT:   %42 = getelementptr [0 x i256], [0 x i256]* %41, i32 0, i256 2
-//CHECK-NEXT:   %43 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 5
-//CHECK-NEXT:   %44 = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 0
-//CHECK-NEXT:   %45 = load [0 x i256]*, [0 x i256]** %44, align 8
-//CHECK-NEXT:   %46 = getelementptr [0 x i256], [0 x i256]* %45, i32 0
-//CHECK-NEXT:   %47 = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 1
-//CHECK-NEXT:   %48 = bitcast i32* %47 to i256*
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_3]]([0 x i256]* %38, [0 x i256]* %0, i256* null, i256* null, i256* %42, i256* %43, [0 x i256]* %46, i256* %48)
-//CHECK-NEXT:   %49 = bitcast [2 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %50 = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
-//CHECK-NEXT:   %51 = load [0 x i256]*, [0 x i256]** %50, align 8
-//CHECK-NEXT:   %52 = getelementptr [0 x i256], [0 x i256]* %51, i32 0
-//CHECK-NEXT:   %53 = getelementptr [0 x i256], [0 x i256]* %52, i32 0, i256 3
-//CHECK-NEXT:   %54 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 6
-//CHECK-NEXT:   %55 = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
-//CHECK-NEXT:   %56 = load [0 x i256]*, [0 x i256]** %55, align 8
-//CHECK-NEXT:   %57 = getelementptr [0 x i256], [0 x i256]* %56, i32 0
-//CHECK-NEXT:   %58 = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 1
-//CHECK-NEXT:   %59 = bitcast i32* %58 to i256*
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_4]]([0 x i256]* %49, [0 x i256]* %0, i256* %53, i256* %54, i256* null, i256* null, [0 x i256]* %57, i256* %59)
-//CHECK-NEXT:   %60 = bitcast [2 x i256]* %lvars to [0 x i256]*
-//CHECK-NEXT:   %61 = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 0
-//CHECK-NEXT:   %62 = load [0 x i256]*, [0 x i256]** %61, align 8
-//CHECK-NEXT:   %63 = getelementptr [0 x i256], [0 x i256]* %62, i32 0
-//CHECK-NEXT:   %64 = getelementptr [0 x i256], [0 x i256]* %63, i32 0, i256 3
-//CHECK-NEXT:   %65 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 7
-//CHECK-NEXT:   %66 = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 0
-//CHECK-NEXT:   %67 = load [0 x i256]*, [0 x i256]** %66, align 8
-//CHECK-NEXT:   %68 = getelementptr [0 x i256], [0 x i256]* %67, i32 0
-//CHECK-NEXT:   %69 = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 1
-//CHECK-NEXT:   %70 = bitcast i32* %69 to i256*
-//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_5]]([0 x i256]* %60, [0 x i256]* %0, i256* null, i256* null, i256* %64, i256* %65, [0 x i256]* %68, i256* %70)
+//CHECK-NEXT:   %[[T005:[0-9a-zA-Z_.]+]] = bitcast [2 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T006:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
+//CHECK-NEXT:   %[[T007:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T006]], align 8
+//CHECK-NEXT:   %[[T008:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T007]], i32 0
+//CHECK-NEXT:   %[[T009:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T008]], i32 0, i256 1
+//CHECK-NEXT:   %[[T010:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 2
+//CHECK-NEXT:   %[[T011:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
+//CHECK-NEXT:   %[[T012:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T011]], align 8
+//CHECK-NEXT:   %[[T013:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T012]], i32 0
+//CHECK-NEXT:   %[[T014:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 1
+//CHECK-NEXT:   %[[T015:[0-9a-zA-Z_.]+]] = bitcast i32* %[[T014]] to i256*
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_2]]([0 x i256]* %[[T005]], [0 x i256]* %0, i256* %[[T009]], i256* %[[T010]], i256* null, i256* null, [0 x i256]* %[[T013]], i256* %[[T015]])
+//CHECK-NEXT:   %[[T016:[0-9a-zA-Z_.]+]] = bitcast [2 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T017:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 0
+//CHECK-NEXT:   %[[T018:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T017]], align 8
+//CHECK-NEXT:   %[[T019:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T018]], i32 0
+//CHECK-NEXT:   %[[T020:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T019]], i32 0, i256 1
+//CHECK-NEXT:   %[[T021:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 3
+//CHECK-NEXT:   %[[T022:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 0
+//CHECK-NEXT:   %[[T023:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T022]], align 8
+//CHECK-NEXT:   %[[T024:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T023]], i32 0
+//CHECK-NEXT:   %[[T025:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 1
+//CHECK-NEXT:   %[[T026:[0-9a-zA-Z_.]+]] = bitcast i32* %[[T025]] to i256*
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_3]]([0 x i256]* %[[T016]], [0 x i256]* %0, i256* null, i256* null, i256* %[[T020]], i256* %[[T021]], [0 x i256]* %[[T024]], i256* %[[T026]])
+//CHECK-NEXT:   %[[T027:[0-9a-zA-Z_.]+]] = bitcast [2 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T028:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
+//CHECK-NEXT:   %[[T029:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T028]], align 8
+//CHECK-NEXT:   %[[T030:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T029]], i32 0
+//CHECK-NEXT:   %[[T031:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T030]], i32 0, i256 2
+//CHECK-NEXT:   %[[T032:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 4
+//CHECK-NEXT:   %[[T033:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
+//CHECK-NEXT:   %[[T034:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T033]], align 8
+//CHECK-NEXT:   %[[T035:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T034]], i32 0
+//CHECK-NEXT:   %[[T036:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 1
+//CHECK-NEXT:   %[[T037:[0-9a-zA-Z_.]+]] = bitcast i32* %[[T036]] to i256*
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_2]]([0 x i256]* %[[T027]], [0 x i256]* %0, i256* %[[T031]], i256* %[[T032]], i256* null, i256* null, [0 x i256]* %[[T035]], i256* %[[T037]])
+//CHECK-NEXT:   %[[T038:[0-9a-zA-Z_.]+]] = bitcast [2 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T039:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 0
+//CHECK-NEXT:   %[[T040:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T039]], align 8
+//CHECK-NEXT:   %[[T041:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T040]], i32 0
+//CHECK-NEXT:   %[[T042:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T041]], i32 0, i256 2
+//CHECK-NEXT:   %[[T043:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 5
+//CHECK-NEXT:   %[[T044:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 0
+//CHECK-NEXT:   %[[T045:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T044]], align 8
+//CHECK-NEXT:   %[[T046:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T045]], i32 0
+//CHECK-NEXT:   %[[T047:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 1
+//CHECK-NEXT:   %[[T048:[0-9a-zA-Z_.]+]] = bitcast i32* %[[T047]] to i256*
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_3]]([0 x i256]* %[[T038]], [0 x i256]* %0, i256* null, i256* null, i256* %[[T042]], i256* %[[T043]], [0 x i256]* %[[T046]], i256* %[[T048]])
+//CHECK-NEXT:   %[[T049:[0-9a-zA-Z_.]+]] = bitcast [2 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T050:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
+//CHECK-NEXT:   %[[T051:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T050]], align 8
+//CHECK-NEXT:   %[[T052:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T051]], i32 0
+//CHECK-NEXT:   %[[T053:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T052]], i32 0, i256 3
+//CHECK-NEXT:   %[[T054:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 6
+//CHECK-NEXT:   %[[T055:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
+//CHECK-NEXT:   %[[T056:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T055]], align 8
+//CHECK-NEXT:   %[[T057:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T056]], i32 0
+//CHECK-NEXT:   %[[T058:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 1
+//CHECK-NEXT:   %[[T059:[0-9a-zA-Z_.]+]] = bitcast i32* %[[T058]] to i256*
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_4]]([0 x i256]* %[[T049]], [0 x i256]* %0, i256* %[[T053]], i256* %[[T054]], i256* null, i256* null, [0 x i256]* %[[T057]], i256* %[[T059]])
+//CHECK-NEXT:   %[[T060:[0-9a-zA-Z_.]+]] = bitcast [2 x i256]* %lvars to [0 x i256]*
+//CHECK-NEXT:   %[[T061:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 0
+//CHECK-NEXT:   %[[T062:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T061]], align 8
+//CHECK-NEXT:   %[[T063:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T062]], i32 0
+//CHECK-NEXT:   %[[T064:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T063]], i32 0, i256 3
+//CHECK-NEXT:   %[[T065:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i256 7
+//CHECK-NEXT:   %[[T066:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 0
+//CHECK-NEXT:   %[[T067:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T066]], align 8
+//CHECK-NEXT:   %[[T068:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T067]], i32 0
+//CHECK-NEXT:   %[[T069:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 1
+//CHECK-NEXT:   %[[T070:[0-9a-zA-Z_.]+]] = bitcast i32* %[[T069]] to i256*
+//CHECK-NEXT:   call void @..generated..loop.body.[[$F_ID_5]]([0 x i256]* %[[T060]], [0 x i256]* %0, i256* null, i256* null, i256* %[[T064]], i256* %[[T065]], [0 x i256]* %[[T068]], i256* %[[T070]])
 //CHECK-NEXT:   br label %store6
 //CHECK-EMPTY: 
 //CHECK-NEXT: store6:
-//CHECK-NEXT:   %71 = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
-//CHECK-NEXT:   %72 = load [0 x i256]*, [0 x i256]** %71, align 8
-//CHECK-NEXT:   %73 = getelementptr [0 x i256], [0 x i256]* %72, i32 0, i32 0
-//CHECK-NEXT:   %74 = load i256, i256* %73, align 4
-//CHECK-NEXT:   %75 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
-//CHECK-NEXT:   store i256 %74, i256* %75, align 4
+//CHECK-NEXT:   %[[T075:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 0
+//CHECK-NEXT:   %[[T071:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 0, i32 0
+//CHECK-NEXT:   %[[T072:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T071]], align 8
+//CHECK-NEXT:   %[[T073:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T072]], i32 0, i32 0
+//CHECK-NEXT:   %[[T074:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T073]], align 4
+//CHECK-NEXT:   store i256 %[[T074]], i256* %[[T075]], align 4
 //CHECK-NEXT:   br label %store7
 //CHECK-EMPTY: 
 //CHECK-NEXT: store7:
-//CHECK-NEXT:   %76 = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 0
-//CHECK-NEXT:   %77 = load [0 x i256]*, [0 x i256]** %76, align 8
-//CHECK-NEXT:   %78 = getelementptr [0 x i256], [0 x i256]* %77, i32 0, i32 0
-//CHECK-NEXT:   %79 = load i256, i256* %78, align 4
-//CHECK-NEXT:   %80 = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 1
-//CHECK-NEXT:   store i256 %79, i256* %80, align 4
+//CHECK-NEXT:   %[[T080:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %0, i32 0, i32 1
+//CHECK-NEXT:   %[[T076:[0-9a-zA-Z_.]+]] = getelementptr [2 x { [0 x i256]*, i32 }], [2 x { [0 x i256]*, i32 }]* %subcmps, i32 0, i32 1, i32 0
+//CHECK-NEXT:   %[[T077:[0-9a-zA-Z_.]+]] = load [0 x i256]*, [0 x i256]** %[[T076]], align 8
+//CHECK-NEXT:   %[[T078:[0-9a-zA-Z_.]+]] = getelementptr [0 x i256], [0 x i256]* %[[T077]], i32 0, i32 0
+//CHECK-NEXT:   %[[T079:[0-9a-zA-Z_.]+]] = load i256, i256* %[[T078]], align 4
+//CHECK-NEXT:   store i256 %[[T079]], i256* %[[T080]], align 4
 //CHECK-NEXT:   br label %prologue
 //CHECK-EMPTY: 
 //CHECK-NEXT: prologue:


### PR DESCRIPTION
There are two cases for what could be generated for the source of a StoreBucket and in some scenarios, both cases would execute resulting in dead code being generated by the first case that executes. Used a closure that is updated based on the proper case and then generates code only when it is finally needed.