### PR TITLE
Minimal end-to-end implementation to generate an empty LLZK module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,6 +207,7 @@ name = "circom"
 version = "2.2.2"
 dependencies = [
  "ansi_term",
+ "anyhow",
  "assert_cmd",
  "assert_fs",
  "clap",
@@ -214,7 +215,6 @@ dependencies = [
  "constraint_generation",
  "constraint_writers",
  "dag",
- "exitcode",
  "glob",
  "lazy_static",
  "llzk",
@@ -523,12 +523,6 @@ dependencies = [
  "libc",
  "windows-sys 0.61.0",
 ]
-
-[[package]]
-name = "exitcode"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de853764b47027c2e862a995c34978ffa63c1501f2e15f987ba11bd4f9bba193"
 
 [[package]]
 name = "fastrand"

--- a/circom/Cargo.toml
+++ b/circom/Cargo.toml
@@ -22,8 +22,8 @@ compiler = { path = "../compiler" }
 dag = { path = "../dag" }
 clap = "2.33.0"
 ansi_term = "0.12.1"
+anyhow = "1"
 wast = "39.0.0"
-exitcode = "1.1.2"
 mlir-sys = "0.5.0"
 melior = "0.25.0"
 melior-macro = "0.18.0"

--- a/circom/src/llzk_backend.rs
+++ b/circom/src/llzk_backend.rs
@@ -5,57 +5,97 @@ use std::{
     path::Path,
 };
 use ansi_term::Color;
+use anyhow::Result;
+use program_structure::{
+    file_definition::{FileID, FileLibrary, FileLocation},
+    program_archive::ProgramArchive,
+};
 use melior::{
     self,
-    dialect::DialectRegistry,
-    ir::{operation::OperationLike, Location, Module},
-    Context,
+    ir::{operation::OperationLike as _, Location, Module, ValueLike},
 };
-use program_structure::program_archive::ProgramArchive;
+use llzk::prelude::LlzkContext;
 
-pub fn generate_llzk(program_archive: &ProgramArchive, filename: &str) -> Result<(), ()> {
-    let registry = DialectRegistry::new();
-    llzk::register_all_llzk_dialects(&registry);
-    let context = Context::new();
-
-    let main_file_name = program_archive
-        .get_file_library()
-        .get_filename_or_default(program_archive.get_file_id_main());
-    let main_file_location = Location::new(&context, &main_file_name, 0, 0);
-    let root_module: Module = llzk::dialect::module::llzk_module(main_file_location);
-
-    //TODO: build the LLZK module from the ProgramArchive
-
-    // Verify the module and write it to file
-    assert!(root_module.as_operation().verify());
-    write_module_to_file(root_module, filename).expect("Failed to write LLZK code");
-
-    return Result::Ok(());
+pub struct LlzkCodegen<'c, 'a> {
+    files: &'a FileLibrary,
+    context: &'c LlzkContext,
+    module: Module<'c>,
 }
 
-fn write_module_to_file(module: Module, filename: &str) -> Result<(), ()> {
-    let out_path = Path::new(filename);
-    // Ensure parent directories exist
-    if let Some(parent) = out_path.parent() {
-        fs::create_dir_all(parent).map_err(|_err| {})?;
-    }
-    let mut file = File::create(out_path).map_err(|_err| {})?;
-
-    unsafe extern "C" fn callback(string_ref: mlir_sys::MlirStringRef, user_data: *mut c_void) {
-        let file = &mut *(user_data as *mut File);
-        let slice = std::slice::from_raw_parts(string_ref.data as *const u8, string_ref.length);
-        let _ = file.write_all(slice).unwrap();
+impl<'c, 'a> LlzkCodegen<'c, 'a> {
+    pub fn new(context: &'c LlzkContext, program_archive: &'a ProgramArchive) -> Self {
+        let files = &program_archive.file_library;
+        let filename = files.get_filename_or_default(program_archive.get_file_id_main());
+        let main_file_location = Location::new(&context, &filename, 0, 0);
+        let module = llzk::dialect::module::llzk_module(main_file_location);
+        Self { files, context, module }
     }
 
-    unsafe {
-        // TODO: may need to switch to bytecode at some point. Or add an option for it.
-        // mlir_sys::mlirOperationWriteBytecode(
-        mlir_sys::mlirOperationPrint(
-            module.as_operation().to_raw(),
-            Some(callback),
-            &mut file as *mut File as *mut c_void,
-        );
+    pub fn get_location(&self, file_id: FileID, file_location: FileLocation) -> Location<'c> {
+        let filename = self.files.get_filename_or_default(&file_id);
+        let line = self.files.get_line(file_location.start, file_id).unwrap_or(0);
+        let column = self.files.get_column(file_location.start, file_id).unwrap_or(0);
+        Location::new(&self.context, &filename, line, column)
     }
-    println!("{} {}", Color::Green.paint("Written successfully:"), filename);
-    Result::Ok(())
+
+    pub fn verify(&self) -> bool {
+        self.module.as_operation().verify()
+    }
+
+    pub fn write_to_file(&self, filename: &str) -> Result<(), ()> {
+        let out_path = Path::new(filename);
+        // Ensure parent directories exist
+        if let Some(parent) = out_path.parent() {
+            fs::create_dir_all(parent).map_err(|_err| {})?;
+        }
+        let mut file = File::create(out_path).map_err(|_err| {})?;
+
+        unsafe extern "C" fn callback(string_ref: mlir_sys::MlirStringRef, user_data: *mut c_void) {
+            let file = &mut *(user_data as *mut File);
+            let slice = std::slice::from_raw_parts(string_ref.data as *const u8, string_ref.length);
+            let _ = file.write_all(slice).unwrap();
+        }
+
+        unsafe {
+            // TODO: may need to switch to bytecode at some point. Or add an option for it.
+            // mlir_sys::mlirOperationWriteBytecode(
+            mlir_sys::mlirOperationPrint(
+                self.module.as_operation().to_raw(),
+                Some(callback),
+                &mut file as *mut File as *mut c_void,
+            );
+        }
+        println!("{} {}", Color::Green.paint("Written successfully:"), filename);
+        Result::Ok(())
+    }
+}
+
+pub trait ProduceLLZK {
+    fn produce_llzk_ir<'b, 'a: 'b>(
+        &'a self,
+        codegen: &LlzkCodegen<'a, 'a>,
+    ) -> Result<Box<dyn ValueLike<'a> + 'b>>;
+}
+
+impl ProduceLLZK for ProgramArchive {
+    fn produce_llzk_ir<'b, 'a: 'b>(
+        &'a self,
+        codegen: &LlzkCodegen<'a, 'a>,
+    ) -> Result<Box<dyn ValueLike<'a> + 'b>> {
+        todo!("Not yet implemented")
+    }
+}
+
+pub fn generate_llzk(program_archive: &ProgramArchive, filename: &str) -> Result<(), ()> {
+    let ctx = LlzkContext::new();
+    let codegen = LlzkCodegen::new(&ctx, program_archive);
+
+    // TODO: uncomment when implemented
+    // program_archive.produce_llzk_ir(&codegen).expect("Failed to generate LLZK IR");
+
+    // Verify the module and write it to file
+    assert!(codegen.verify());
+    codegen.write_to_file(filename).expect("Failed to write LLZK code");
+
+    return Result::Ok(());
 }

--- a/circom/src/llzk_backend.rs
+++ b/circom/src/llzk_backend.rs
@@ -16,18 +16,18 @@ use melior::{
 };
 use llzk::prelude::LlzkContext;
 
-/// Stores necessary context for generating LLZK IR along with the generated Module.
+/// Stores necessary context for generating LLZK IR along with the generated `Module`.
 /// 'ast: lifetime of the circom AST element
-/// 'llzk: lifetime of the LlzkContext and generated Module
+/// 'llzk: lifetime of the `LlzkContext` and generated `Module`
 pub struct LlzkCodegen<'ast, 'llzk> {
     files: &'ast FileLibrary,
     context: &'llzk LlzkContext,
     module: Module<'llzk>,
 }
 
-/// Helper for generating LLZK IR from a circom ProgramArchive.
+/// Helper for generating LLZK IR from a circom `ProgramArchive`.
 impl<'ast, 'llzk> LlzkCodegen<'ast, 'llzk> {
-    /// Creates a new LLZK code generator to generate code for the given ProgramArchive.
+    /// Creates a new LLZK code generator to generate code for the given `ProgramArchive`.
     pub fn new(context: &'llzk LlzkContext, program_archive: &'ast ProgramArchive) -> Self {
         let files = &program_archive.file_library;
         let filename = files.get_filename_or_default(program_archive.get_file_id_main());
@@ -44,12 +44,12 @@ impl<'ast, 'llzk> LlzkCodegen<'ast, 'llzk> {
         Location::new(&self.context, &filename, line, column)
     }
 
-    /// Verify the generated module.
+    /// Verify the generated `Module`.
     pub fn verify(&self) -> bool {
         self.module.as_operation().verify()
     }
 
-    /// Write the generated module to a file.
+    /// Write the generated `Module` to a file.
     pub fn write_to_file(&self, filename: &str) -> Result<(), ()> {
         let out_path = Path::new(filename);
         // Ensure parent directories exist
@@ -78,12 +78,12 @@ impl<'ast, 'llzk> LlzkCodegen<'ast, 'llzk> {
     }
 }
 
-/// A trait to produce LLZK IR from the ProgramArchive nodes.
+/// A trait to produce LLZK IR from the `ProgramArchive` nodes.
 pub trait ProduceLLZK {
-    /// Produces LLZK IR from the circom ProgramArchive AST element.
-    /// 'ret: lifetime of the returned ValueLike object
+    /// Produces LLZK IR from the circom `ProgramArchive` AST element.
+    /// 'ret: lifetime of the returned `ValueLike` object
     /// 'ast: lifetime of the circom AST element
-    /// 'llzk: lifetime of the LlzkContext and generated Module
+    /// 'llzk: lifetime of the `LlzkContext` and generated `Module`
     fn produce_llzk_ir<'ret, 'ast: 'ret, 'llzk: 'ret>(
         &'ast self,
         codegen: &LlzkCodegen<'ast, 'llzk>,
@@ -99,7 +99,7 @@ impl ProduceLLZK for ProgramArchive {
     }
 }
 
-/// Generate LLZK IR from the given ProgramArchive and write it to a file with the given filename.
+/// Generate LLZK IR from the given `ProgramArchive` and write it to a file with the given filename.
 pub fn generate_llzk(program_archive: &ProgramArchive, filename: &str) -> Result<(), ()> {
     let ctx = LlzkContext::new();
     let codegen = LlzkCodegen::new(&ctx, program_archive);

--- a/circom/src/llzk_backend.rs
+++ b/circom/src/llzk_backend.rs
@@ -16,6 +16,7 @@ use melior::{
 };
 use llzk::prelude::LlzkContext;
 
+/// Stores necessary context for generating LLZK IR along with the generated Module.
 pub struct LlzkCodegen<'c, 'a> {
     files: &'a FileLibrary,
     context: &'c LlzkContext,
@@ -23,6 +24,7 @@ pub struct LlzkCodegen<'c, 'a> {
 }
 
 impl<'c, 'a> LlzkCodegen<'c, 'a> {
+    /// Creates a new LLZK code generator to generate code for the given ProgramArchive.
     pub fn new(context: &'c LlzkContext, program_archive: &'a ProgramArchive) -> Self {
         let files = &program_archive.file_library;
         let filename = files.get_filename_or_default(program_archive.get_file_id_main());
@@ -31,6 +33,7 @@ impl<'c, 'a> LlzkCodegen<'c, 'a> {
         Self { files, context, module }
     }
 
+    /// Convert circom location information to MLIR location.
     pub fn get_location(&self, file_id: FileID, file_location: FileLocation) -> Location<'c> {
         let filename = self.files.get_filename_or_default(&file_id);
         let line = self.files.get_line(file_location.start, file_id).unwrap_or(0);
@@ -38,10 +41,12 @@ impl<'c, 'a> LlzkCodegen<'c, 'a> {
         Location::new(&self.context, &filename, line, column)
     }
 
+    /// Verify the generated module.
     pub fn verify(&self) -> bool {
         self.module.as_operation().verify()
     }
 
+    /// Write the generated module to a file.
     pub fn write_to_file(&self, filename: &str) -> Result<(), ()> {
         let out_path = Path::new(filename);
         // Ensure parent directories exist
@@ -70,6 +75,7 @@ impl<'c, 'a> LlzkCodegen<'c, 'a> {
     }
 }
 
+/// A trait to produce LLZK IR from the ProgramArchive nodes.
 pub trait ProduceLLZK {
     fn produce_llzk_ir<'b, 'a: 'b>(
         &'a self,
@@ -86,6 +92,7 @@ impl ProduceLLZK for ProgramArchive {
     }
 }
 
+/// Generate LLZK IR from the given ProgramArchive and write it to a file with the given filename.
 pub fn generate_llzk(program_archive: &ProgramArchive, filename: &str) -> Result<(), ()> {
     let ctx = LlzkContext::new();
     let codegen = LlzkCodegen::new(&ctx, program_archive);

--- a/circom/src/llzk_backend.rs
+++ b/circom/src/llzk_backend.rs
@@ -1,5 +1,61 @@
+use std::{
+    fs::{self, File},
+    io::Write,
+    os::raw::c_void,
+    path::Path,
+};
+use ansi_term::Color;
+use melior::{
+    self,
+    dialect::DialectRegistry,
+    ir::{operation::OperationLike, Location, Module},
+    Context,
+};
 use program_structure::program_archive::ProgramArchive;
 
 pub fn generate_llzk(program_archive: &ProgramArchive, filename: &str) -> Result<(), ()> {
-    todo!("Generate LLZK code to {}", filename);
+    let registry = DialectRegistry::new();
+    llzk::register_all_llzk_dialects(&registry);
+    let context = Context::new();
+
+    let main_file_name = program_archive
+        .get_file_library()
+        .get_filename_or_default(program_archive.get_file_id_main());
+    let main_file_location = Location::new(&context, &main_file_name, 0, 0);
+    let root_module: Module = llzk::dialect::module::llzk_module(main_file_location);
+
+    //TODO: build the LLZK module from the ProgramArchive
+
+    // Verify the module and write it to file
+    assert!(root_module.as_operation().verify());
+    write_module_to_file(root_module, filename).expect("Failed to write LLZK code");
+
+    return Result::Ok(());
+}
+
+fn write_module_to_file(module: Module, filename: &str) -> Result<(), ()> {
+    let out_path = Path::new(filename);
+    // Ensure parent directories exist
+    if let Some(parent) = out_path.parent() {
+        fs::create_dir_all(parent).map_err(|_err| {})?;
+    }
+    let mut file = File::create(out_path).map_err(|_err| {})?;
+
+    unsafe extern "C" fn callback(string_ref: mlir_sys::MlirStringRef, user_data: *mut c_void) {
+        let file = &mut *(user_data as *mut File);
+        let slice = std::slice::from_raw_parts(string_ref.data as *const u8, string_ref.length);
+        let _ = file.write_all(slice).unwrap();
+    }
+
+    unsafe {
+        // TODO: may need to switch to bytecode at some point. Or add an option for it.
+        // mlir_sys::mlirOperationWriteBytecode(
+        mlir_sys::mlirOperationPrint(
+            module.as_operation().to_raw(),
+            Some(callback),
+            &mut file as *mut File as *mut c_void,
+        );
+    }
+    println!("{} {}", Color::Green.paint("Written successfully:"), filename);
+    Result::Ok(())
 }

--- a/circom/tests/simple/trivially_empty.circom
+++ b/circom/tests/simple/trivially_empty.circom
@@ -1,0 +1,10 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+
+pragma circom 2.0.0;
+
+template EmptyTemplate() {
+}
+component main = EmptyTemplate();
+//CHECK-LABEL:  module attributes {veridise.lang = "llzk"} {
+//CHECK-NEXT:   }


### PR DESCRIPTION
This is the beginning of the circom-to-llzk implementation. The `ProduceLLZK` trait will need to be implemented for each kind of element within the `ProgramArchive` to generate the LLZK module.