### PR TITLE
Refactor so lint checks can be added on just the LLZK generation code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,9 +179,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.38"
+version = "1.2.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80f41ae168f955c12fb8960b057d70d0ca153fb83182b57d86380443527be7e9"
+checksum = "e1d05d92f4b1fd76aad469d46cdd858ca761576082cd37df81416691e50199fb"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -207,7 +207,6 @@ name = "circom"
 version = "2.2.2"
 dependencies = [
  "ansi_term",
- "anyhow",
  "assert_cmd",
  "assert_fs",
  "clap",
@@ -217,10 +216,7 @@ dependencies = [
  "dag",
  "glob",
  "lazy_static",
- "llzk",
- "melior",
- "melior-macro",
- "mlir-sys",
+ "llzk_backend",
  "parser",
  "program_structure",
  "rand 0.9.2",
@@ -531,9 +527,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
+checksum = "0399f9d26e5191ce32c498bebd31e7a3ceabc2745f0ac54af3f335126c3f24b3"
 
 [[package]]
 name = "fixedbitset"
@@ -823,6 +819,19 @@ dependencies = [
  "cmake",
  "glob",
  "tempfile",
+]
+
+[[package]]
+name = "llzk_backend"
+version = "0.1.0"
+dependencies = [
+ "ansi_term",
+ "anyhow",
+ "llzk",
+ "melior",
+ "melior-macro",
+ "mlir-sys",
+ "program_structure",
 ]
 
 [[package]]
@@ -1469,7 +1478,7 @@ dependencies = [
  "bindgen",
  "cc",
  "paste",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -1531,11 +1540,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.16"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
- "thiserror-impl 2.0.16",
+ "thiserror-impl 2.0.17",
 ]
 
 [[package]]
@@ -1551,9 +1560,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.16"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,6 @@ members = [
     "constraint_writers",
     "constant_tracking",
     "code_producers",
+    "llzk_backend",
     "dag"
 ]

--- a/circom/Cargo.toml
+++ b/circom/Cargo.toml
@@ -20,14 +20,10 @@ constraint_generation = { path = "../constraint_generation" }
 constraint_writers = { path = "../constraint_writers" }
 compiler = { path = "../compiler" }
 dag = { path = "../dag" }
+llzk_backend = { path = "../llzk_backend" }
 clap = "2.33.0"
 ansi_term = "0.12.1"
-anyhow = "1"
 wast = "39.0.0"
-mlir-sys = "0.5.0"
-melior = "0.25.0"
-melior-macro = "0.18.0"
-llzk = { git = "https://github.com/Veridise/llzk-rs", package = "llzk" }
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/circom/src/main.rs
+++ b/circom/src/main.rs
@@ -3,7 +3,6 @@ mod execution_user;
 mod input_user;
 mod parser_user;
 mod type_analysis_user;
-mod llzk_backend;
 
 const VERSION: &'static str = env!("CARGO_PKG_VERSION");
 

--- a/llzk_backend/Cargo.toml
+++ b/llzk_backend/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "llzk_backend"
+version = "0.1.0"
+authors = ["Veridise"]
+edition = "2018"
+
+[dependencies]
+program_structure = { path = "../program_structure" }
+ansi_term = "0.12.1"
+anyhow = "1"
+mlir-sys = "0.5.0"
+melior = "0.25.0"
+melior-macro = "0.18.0"
+llzk = { git = "https://github.com/Veridise/llzk-rs", package = "llzk" }

--- a/llzk_backend/src/codegen.rs
+++ b/llzk_backend/src/codegen.rs
@@ -10,16 +10,13 @@ use program_structure::{
     file_definition::{FileID, FileLibrary, FileLocation},
     program_archive::ProgramArchive,
 };
-use melior::{
-    self,
-    ir::{operation::OperationLike as _, Location, Module, ValueLike},
-};
+use melior::ir::{operation::OperationLike as _, Location, Module, ValueLike};
 use llzk::prelude::LlzkContext;
 
 /// Stores necessary context for generating LLZK IR along with the generated `Module`.
 /// 'ast: lifetime of the circom AST element
 /// 'llzk: lifetime of the `LlzkContext` and generated `Module`
-pub struct LlzkCodegen<'ast, 'llzk> {
+struct LlzkCodegen<'ast, 'llzk> {
     files: &'ast FileLibrary,
     context: &'llzk LlzkContext,
     module: Module<'llzk>,
@@ -79,7 +76,7 @@ impl<'ast, 'llzk> LlzkCodegen<'ast, 'llzk> {
 }
 
 /// A trait to produce LLZK IR from the `ProgramArchive` nodes.
-pub trait ProduceLLZK {
+trait ProduceLLZK {
     /// Produces LLZK IR from the circom `ProgramArchive` AST element.
     /// 'ret: lifetime of the returned `ValueLike` object
     /// 'ast: lifetime of the circom AST element

--- a/llzk_backend/src/lib.rs
+++ b/llzk_backend/src/lib.rs
@@ -6,6 +6,7 @@
 #![deny(rustdoc::broken_intra_doc_links)]
 #![warn(redundant_imports)]
 
+/// The LLZK code generation module.
 mod codegen;
 
 pub use codegen::generate_llzk;

--- a/llzk_backend/src/lib.rs
+++ b/llzk_backend/src/lib.rs
@@ -1,0 +1,11 @@
+//! Provides functionality to generate LLZK code from the Circom AST.
+
+#![deny(missing_debug_implementations)]
+#![deny(missing_docs)]
+#![deny(clippy::missing_docs_in_private_items)]
+#![deny(rustdoc::broken_intra_doc_links)]
+#![warn(redundant_imports)]
+
+mod codegen;
+
+pub use codegen::generate_llzk;


### PR DESCRIPTION
This also fixes issues reported by `cargo clippy -p llzk_backend -- --no-deps`