### PR TITLE
create tests from circom documentation

### DIFF
--- a/circom/tests/circom_doc_examples/01.circom
+++ b/circom/tests/circom_doc_examples/01.circom
@@ -1,0 +1,16 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// XFAIL:.*
+
+pragma circom 2.0.0;
+
+template Multiplier2() {
+   //Declaration of signals
+   signal input in1;
+   signal input in2;
+   signal output out;
+   out <== in1 * in2;
+}
+
+component main {public [in1,in2]} = Multiplier2();
+// CHECK: TODO

--- a/circom/tests/circom_doc_examples/01.circom
+++ b/circom/tests/circom_doc_examples/01.circom
@@ -13,4 +13,4 @@ template Multiplier2() {
 }
 
 component main {public [in1,in2]} = Multiplier2();
-// CHECK: TODO
+//CHECK-LABEL:  module attributes {veridise.lang = "llzk"} {

--- a/circom/tests/circom_doc_examples/02.circom
+++ b/circom/tests/circom_doc_examples/02.circom
@@ -1,0 +1,15 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// XFAIL:.*
+
+pragma circom 2.0.0;
+
+template Multiplier2(){
+   //Declaration of signals
+   signal input in1;
+   signal input in2;
+   signal output out <== in1 * in2;
+}
+
+component main {public [in1,in2]} = Multiplier2();
+// CHECK: TODO

--- a/circom/tests/circom_doc_examples/02.circom
+++ b/circom/tests/circom_doc_examples/02.circom
@@ -12,4 +12,4 @@ template Multiplier2(){
 }
 
 component main {public [in1,in2]} = Multiplier2();
-// CHECK: TODO
+//CHECK-LABEL:  module attributes {veridise.lang = "llzk"} {

--- a/circom/tests/circom_doc_examples/03.circom
+++ b/circom/tests/circom_doc_examples/03.circom
@@ -27,4 +27,4 @@ template B(N){
 }
 
 component main = B(1);
-// CHECK: TODO
+//CHECK-LABEL:  module attributes {veridise.lang = "llzk"} {

--- a/circom/tests/circom_doc_examples/03.circom
+++ b/circom/tests/circom_doc_examples/03.circom
@@ -1,0 +1,30 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// XFAIL:.*
+
+pragma circom 2.0.0;
+
+template A(N){
+   signal input in;
+   signal output out;
+   out <== in;
+}
+template C(N){
+   signal output out;
+   out <== N;
+}
+template B(N){
+  signal output out;
+  component a;
+  if(N > 0){
+     a = A(N);
+  }
+  else{
+     a = A(0);
+  }
+  a.in <== 1;
+  a.out ==> out;
+}
+
+component main = B(1);
+// CHECK: TODO

--- a/circom/tests/circom_doc_examples/04.circom
+++ b/circom/tests/circom_doc_examples/04.circom
@@ -1,0 +1,43 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// XFAIL:.*
+
+pragma circom 2.0.0;
+
+template AND() {
+    signal input a;
+    signal input b;
+    signal output out;
+
+    out <== a*b;
+}
+
+template MultiAND(n) {
+    signal input in[n];
+    signal output out;
+    component and;
+    component ands[2];
+    var i;
+    if (n==1) {
+        out <== in[0];
+    } else if (n==2) {
+          and = AND();
+        and.a <== in[0];
+        and.b <== in[1];
+        out <== and.out;
+    } else {
+        and = AND();
+        var n1 = n\2;
+        var n2 = n-n\2;
+        ands[0] = MultiAND(n1);
+        ands[1] = MultiAND(n2);
+        for (i=0; i<n1; i++) ands[0].in[i] <== in[i];
+        for (i=0; i<n2; i++) ands[1].in[i] <== in[n1+i];
+        and.a <== ands[0].out;
+        and.b <== ands[1].out;
+        out <== and.out;
+    }
+}
+
+component main = MultiAND(5);
+// CHECK: TODO

--- a/circom/tests/circom_doc_examples/04.circom
+++ b/circom/tests/circom_doc_examples/04.circom
@@ -40,4 +40,4 @@ template MultiAND(n) {
 }
 
 component main = MultiAND(5);
-// CHECK: TODO
+//CHECK-LABEL:  module attributes {veridise.lang = "llzk"} {

--- a/circom/tests/circom_doc_examples/05.circom
+++ b/circom/tests/circom_doc_examples/05.circom
@@ -1,0 +1,17 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// XFAIL:.*
+
+pragma circom 2.0.6; // note that custom templates are only allowed since version 2.0.6
+pragma custom_templates;
+
+template custom Example() {
+   // custom template's code
+}
+
+template UsingExample() {
+   component example = Example(); // instantiation of the custom template
+}
+
+component main = UsingExample();
+// CHECK: TODO

--- a/circom/tests/circom_doc_examples/05.circom
+++ b/circom/tests/circom_doc_examples/05.circom
@@ -14,4 +14,4 @@ template UsingExample() {
 }
 
 component main = UsingExample();
-// CHECK: TODO
+//CHECK-LABEL:  module attributes {veridise.lang = "llzk"} {

--- a/circom/tests/circom_doc_examples/06.circom
+++ b/circom/tests/circom_doc_examples/06.circom
@@ -30,4 +30,4 @@ template Caller() {
 
 component main = Caller();
 
-// CHECK: TODO
+//CHECK-LABEL:  module attributes {veridise.lang = "llzk"} {

--- a/circom/tests/circom_doc_examples/06.circom
+++ b/circom/tests/circom_doc_examples/06.circom
@@ -1,0 +1,33 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// XFAIL:.*
+
+pragma circom 2.0.0;
+
+// This function calculates the number of extra bits 
+// in the output to do the full sum.
+function nbits(a) {
+    var n = 1;
+    var r = 0;
+    while (n-1<a) {
+        r++;
+        n *= 2;
+    }
+    return r;
+}
+
+function example(N){
+    if (N >= 0) { return 1; }
+    else { return 0; }
+}
+
+template Caller() {
+    signal input in;
+    signal output out;
+
+    out <== example(nbits(in));
+}
+
+component main = Caller();
+
+// CHECK: TODO

--- a/circom/tests/circom_doc_examples/07.circom
+++ b/circom/tests/circom_doc_examples/07.circom
@@ -12,4 +12,4 @@ template A(){
 }
 
 component main {public [in1]}= A();
-// CHECK: TODO
+//CHECK-LABEL:  module attributes {veridise.lang = "llzk"} {

--- a/circom/tests/circom_doc_examples/07.circom
+++ b/circom/tests/circom_doc_examples/07.circom
@@ -1,0 +1,15 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// XFAIL:.*
+
+pragma circom 2.0.0;
+
+template A(){
+    signal input in1;
+    signal input in2;
+    signal output out;
+    out <== in1 * in2;
+}
+
+component main {public [in1]}= A();
+// CHECK: TODO

--- a/circom/tests/circom_doc_examples/08.circom
+++ b/circom/tests/circom_doc_examples/08.circom
@@ -14,4 +14,4 @@ template IsZero() {
 }
 
 component main {public [in]}= IsZero();
-// CHECK: TODO
+//CHECK-LABEL:  module attributes {veridise.lang = "llzk"} {

--- a/circom/tests/circom_doc_examples/08.circom
+++ b/circom/tests/circom_doc_examples/08.circom
@@ -1,0 +1,17 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// XFAIL:.*
+
+pragma circom 2.0.0;
+
+template IsZero() {
+    signal input in;
+    signal output out;
+    signal inv;
+    inv <-- in!=0 ? 1/in : 0;
+    out <== -in*inv +1;
+    in*out === 0;
+}
+
+component main {public [in]}= IsZero();
+// CHECK: TODO

--- a/circom/tests/circom_doc_examples/09.circom
+++ b/circom/tests/circom_doc_examples/09.circom
@@ -19,4 +19,4 @@ template Num2Bits(n) {
 }
 
 component main {public [in]}= Num2Bits(3);
-// CHECK: TODO
+//CHECK-LABEL:  module attributes {veridise.lang = "llzk"} {

--- a/circom/tests/circom_doc_examples/09.circom
+++ b/circom/tests/circom_doc_examples/09.circom
@@ -1,0 +1,22 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// XFAIL:.*
+
+pragma circom 2.0.0;
+
+template Num2Bits(n) {
+    signal input in;
+    signal output out[n];
+    var lc1=0;
+    var e2=1;
+    for (var i = 0; i<n; i++) {
+        out[i] <-- (in >> i) & 1;
+        out[i] * (out[i] -1 ) === 0;
+        lc1 += out[i] * e2;
+        e2 = e2+e2;
+    }
+    lc1 === in;
+}
+
+component main {public [in]}= Num2Bits(3);
+// CHECK: TODO

--- a/circom/tests/circom_doc_examples/10.circom
+++ b/circom/tests/circom_doc_examples/10.circom
@@ -1,0 +1,21 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// XFAIL:.*
+
+pragma circom 2.0.0;
+
+template T14() {
+    signal output out;
+    var x = 0;
+    var y = 1;
+    if (x >= 0) {
+        x = y + 1;
+        y += 1;
+    } else {
+        y = x;
+    }
+    out <== x + y;
+}
+
+component main = T14();
+// CHECK: TODO

--- a/circom/tests/circom_doc_examples/10.circom
+++ b/circom/tests/circom_doc_examples/10.circom
@@ -18,4 +18,4 @@ template T14() {
 }
 
 component main = T14();
-// CHECK: TODO
+//CHECK-LABEL:  module attributes {veridise.lang = "llzk"} {

--- a/circom/tests/circom_doc_examples/11.circom
+++ b/circom/tests/circom_doc_examples/11.circom
@@ -14,4 +14,4 @@ template T15() {
 }
 
 component main = T15();
-// CHECK: TODO
+//CHECK-LABEL:  module attributes {veridise.lang = "llzk"} {

--- a/circom/tests/circom_doc_examples/11.circom
+++ b/circom/tests/circom_doc_examples/11.circom
@@ -1,0 +1,17 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// XFAIL:.*
+
+pragma circom 2.0.0;
+
+template T15() {
+    signal output out;
+    var y = 0;
+    for(var i = 0; i < 100; i++){
+        y++;
+    }
+    out <== y;
+}
+
+component main = T15();
+// CHECK: TODO

--- a/circom/tests/circom_doc_examples/12.circom
+++ b/circom/tests/circom_doc_examples/12.circom
@@ -16,4 +16,4 @@ template T16() {
 }
 
 component main = T16();
-// CHECK: TODO
+//CHECK-LABEL:  module attributes {veridise.lang = "llzk"} {

--- a/circom/tests/circom_doc_examples/12.circom
+++ b/circom/tests/circom_doc_examples/12.circom
@@ -1,0 +1,19 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// XFAIL:.*
+
+pragma circom 2.0.0;
+
+template T16() {
+    signal output out;
+    var y = 0;
+    var i = 0;
+    while(i < 100){
+        i++;
+        y += y;
+    }
+    out <== y;
+}
+
+component main = T16();
+// CHECK: TODO

--- a/circom/tests/circom_doc_examples/13.circom
+++ b/circom/tests/circom_doc_examples/13.circom
@@ -14,4 +14,4 @@ template right(N){
 }
 
 component main = right(10);
-// CHECK: TODO
+//CHECK-LABEL:  module attributes {veridise.lang = "llzk"} {

--- a/circom/tests/circom_doc_examples/13.circom
+++ b/circom/tests/circom_doc_examples/13.circom
@@ -1,0 +1,17 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// XFAIL:.*
+
+pragma circom 2.0.0;
+
+template right(N){
+    signal input in;
+    var x = 2;
+    var t = 5;
+    if(in > N){
+      t = 2;
+    }
+}
+
+component main = right(10);
+// CHECK: TODO

--- a/circom/tests/circom_doc_examples/14.circom
+++ b/circom/tests/circom_doc_examples/14.circom
@@ -15,4 +15,4 @@ template right(N1,N2){
 }
 
 component main = right(10, 5);
-// CHECK: TODO
+//CHECK-LABEL:  module attributes {veridise.lang = "llzk"} {

--- a/circom/tests/circom_doc_examples/14.circom
+++ b/circom/tests/circom_doc_examples/14.circom
@@ -1,0 +1,18 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// XFAIL:.*
+
+pragma circom 2.0.0;
+
+template right(N1,N2){
+    signal input in;
+    var x = 2;
+    var t = 5;
+    if(N1 > N2){
+      t = 2;
+    }
+    x === t;
+}
+
+component main = right(10, 5);
+// CHECK: TODO

--- a/circom/tests/circom_doc_examples/15.circom
+++ b/circom/tests/circom_doc_examples/15.circom
@@ -21,4 +21,4 @@ template mult4(){
 }
 
 component main = mult4();
-// CHECK: TODO
+//CHECK-LABEL:  module attributes {veridise.lang = "llzk"} {

--- a/circom/tests/circom_doc_examples/15.circom
+++ b/circom/tests/circom_doc_examples/15.circom
@@ -1,0 +1,24 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// XFAIL:.*
+
+pragma circom 2.0.0;
+
+template mult(){
+  signal input in[2];
+  signal output out;
+  out <== in[0] * in[1];
+}
+
+template mult4(){
+  signal input in[4];
+  component comp1 = mult();
+  component comp2 = mult();
+  comp1.in[0] <== in[0];
+  comp2.in[0] <== in[1];
+  comp2.in[1] <== in[2];
+  comp1.in[1] <== in[3];
+}
+
+component main = mult4();
+// CHECK: TODO

--- a/circom/tests/circom_doc_examples/16.circom
+++ b/circom/tests/circom_doc_examples/16.circom
@@ -1,0 +1,20 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// XFAIL:.*
+
+pragma circom 2.0.0;
+
+template fun(N){
+  signal output out;
+  out <== N;
+}
+
+template all(N){
+  component c[N];
+  for(var i = 0; i < N; i++){
+     c[i] = fun(i);
+  }
+}
+
+component main = all(5);
+// CHECK: TODO

--- a/circom/tests/circom_doc_examples/16.circom
+++ b/circom/tests/circom_doc_examples/16.circom
@@ -17,4 +17,4 @@ template all(N){
 }
 
 component main = all(5);
-// CHECK: TODO
+//CHECK-LABEL:  module attributes {veridise.lang = "llzk"} {

--- a/circom/tests/circom_doc_examples/17.circom
+++ b/circom/tests/circom_doc_examples/17.circom
@@ -16,4 +16,4 @@ template A(n){
 }
 
 component main = A(5);
-// CHECK: TODO
+//CHECK-LABEL:  module attributes {veridise.lang = "llzk"} {

--- a/circom/tests/circom_doc_examples/17.circom
+++ b/circom/tests/circom_doc_examples/17.circom
@@ -1,0 +1,19 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// XFAIL:.*
+
+pragma circom 2.1.5;
+
+template A(n){
+   signal input in;
+   signal output outA;
+   var i = 0;
+   if(i < n){
+    signal out <== 2;
+    i = out;
+   } 
+   outA <== i;
+}
+
+component main = A(5);
+// CHECK: TODO

--- a/circom/tests/circom_doc_examples/18.circom
+++ b/circom/tests/circom_doc_examples/18.circom
@@ -1,0 +1,21 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// XFAIL:.*
+
+pragma circom 2.0.0;
+
+template A(n){
+   signal input a, b;
+   signal output c;
+   c <== a*b;
+}
+template B(n){
+   signal input in[n];
+   signal out;
+   component temp_a = A(n);
+   temp_a.a <== in[0]; 
+   temp_a.b <== in[1];
+   out <== temp_a.c;
+}
+component main = B(2);
+// CHECK: TODO

--- a/circom/tests/circom_doc_examples/18.circom
+++ b/circom/tests/circom_doc_examples/18.circom
@@ -18,4 +18,4 @@ template B(n){
    out <== temp_a.c;
 }
 component main = B(2);
-// CHECK: TODO
+//CHECK-LABEL:  module attributes {veridise.lang = "llzk"} {

--- a/circom/tests/circom_doc_examples/19.circom
+++ b/circom/tests/circom_doc_examples/19.circom
@@ -1,0 +1,17 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// XFAIL:.*
+
+pragma circom 2.1.0;
+
+template A(n){
+   signal input a, b;
+   signal output c;
+   c <== a*b;
+}
+template B(n){
+   signal input in[n];
+   signal out <== A(n)(in[0],in[1]);
+}
+component main = B(2);
+// CHECK: TODO

--- a/circom/tests/circom_doc_examples/19.circom
+++ b/circom/tests/circom_doc_examples/19.circom
@@ -14,4 +14,4 @@ template B(n){
    signal out <== A(n)(in[0],in[1]);
 }
 component main = B(2);
-// CHECK: TODO
+//CHECK-LABEL:  module attributes {veridise.lang = "llzk"} {

--- a/circom/tests/circom_doc_examples/20.circom
+++ b/circom/tests/circom_doc_examples/20.circom
@@ -14,4 +14,4 @@ template B(n){
    signal out <== A(n)(b <== in[1], a <== in[0]);
 }
 component main = B(2);
-// CHECK: TODO
+//CHECK-LABEL:  module attributes {veridise.lang = "llzk"} {

--- a/circom/tests/circom_doc_examples/20.circom
+++ b/circom/tests/circom_doc_examples/20.circom
@@ -1,0 +1,17 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// XFAIL:.*
+
+pragma circom 2.1.0;
+
+template A(n){
+   signal input a, b;
+   signal output c;
+   c <== a*b;
+}
+template B(n){
+   signal input in[n];
+   signal out <== A(n)(b <== in[1], a <== in[0]);
+}
+component main = B(2);
+// CHECK: TODO

--- a/circom/tests/circom_doc_examples/21.circom
+++ b/circom/tests/circom_doc_examples/21.circom
@@ -11,4 +11,4 @@ template Ex(n,m){
 }
 
 component main = Ex(3,3);
-// CHECK: TODO
+//CHECK-LABEL:  module attributes {veridise.lang = "llzk"} {

--- a/circom/tests/circom_doc_examples/21.circom
+++ b/circom/tests/circom_doc_examples/21.circom
@@ -1,0 +1,14 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// XFAIL:.*
+
+pragma circom 2.1.0;
+
+template Ex(n,m){ 
+   signal input in[n];
+   signal output out[m];
+   out <== in;
+}
+
+component main = Ex(3,3);
+// CHECK: TODO

--- a/circom/tests/circom_doc_examples/22.circom
+++ b/circom/tests/circom_doc_examples/22.circom
@@ -1,0 +1,18 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// XFAIL:.*
+
+pragma circom 2.1.0;
+
+template Ex(n, m){ 
+   signal input in[n];
+   signal output out[m];
+   var i = 0;
+   while(i < n) { 
+      out[i] <== in[i];
+      i += 1;
+   }
+}
+
+component main = Ex(3, 3);
+// CHECK: TODO

--- a/circom/tests/circom_doc_examples/22.circom
+++ b/circom/tests/circom_doc_examples/22.circom
@@ -15,4 +15,4 @@ template Ex(n, m){
 }
 
 component main = Ex(3, 3);
-// CHECK: TODO
+//CHECK-LABEL:  module attributes {veridise.lang = "llzk"} {

--- a/circom/tests/circom_doc_examples/23.circom
+++ b/circom/tests/circom_doc_examples/23.circom
@@ -21,4 +21,4 @@ template A {
 }
 
 component main = A();
-// CHECK: TODO
+//CHECK-LABEL:  module attributes {veridise.lang = "llzk"} {

--- a/circom/tests/circom_doc_examples/23.circom
+++ b/circom/tests/circom_doc_examples/23.circom
@@ -1,0 +1,24 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// XFAIL:.*
+
+pragma circom 2.1.0;
+
+template Ex(n, m){ 
+   signal input in[n];
+   signal output out[m];
+   var i = 0;
+   while(i < n) { 
+      out[i] <== in[i];
+      i += 1;
+   }
+}
+
+template A {
+   signal input i[4];
+   signal output o[4];
+   o <== Ex(4,4)(i);
+}
+
+component main = A();
+// CHECK: TODO

--- a/circom/tests/circom_doc_examples/24.circom
+++ b/circom/tests/circom_doc_examples/24.circom
@@ -1,0 +1,33 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// XFAIL:.*
+
+pragma circom 2.1.0;
+
+template Ex(n, m){ 
+   signal input in[n];
+   signal output out[m];
+   var i = 0;
+   while(i < n) { 
+      out[i] <== in[i];
+      i += 1;
+   }
+}
+
+template A{
+   signal input inp[4];
+   signal output out[4];
+   component anon = Ex(4,4);
+   var i = 0;
+   while(i < 4){ 
+      anon.in[i] <== inp[i];
+      i += 1;
+   }
+   i = 0;
+   while(i < 4){
+      out[i] <== anon.out[i];
+      i += 1;
+   }
+}
+component main = A();
+// CHECK: TODO

--- a/circom/tests/circom_doc_examples/24.circom
+++ b/circom/tests/circom_doc_examples/24.circom
@@ -30,4 +30,4 @@ template A{
    }
 }
 component main = A();
-// CHECK: TODO
+//CHECK-LABEL:  module attributes {veridise.lang = "llzk"} {

--- a/circom/tests/circom_doc_examples/25.circom
+++ b/circom/tests/circom_doc_examples/25.circom
@@ -1,0 +1,18 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// XFAIL:.*
+
+pragma circom 2.1.0;
+
+template A(n){
+   signal input a, b, c;
+   signal output d;
+   d <== a*b+c;
+   a * b === c;
+}
+template B(n){
+   signal input in[n];
+   _ <== A(n)(in[0],in[1],in[2]);
+}
+component main = B(3);
+// CHECK: TODO

--- a/circom/tests/circom_doc_examples/25.circom
+++ b/circom/tests/circom_doc_examples/25.circom
@@ -15,4 +15,4 @@ template B(n){
    _ <== A(n)(in[0],in[1],in[2]);
 }
 component main = B(3);
-// CHECK: TODO
+//CHECK-LABEL:  module attributes {veridise.lang = "llzk"} {

--- a/circom/tests/circom_doc_examples/26.circom
+++ b/circom/tests/circom_doc_examples/26.circom
@@ -1,0 +1,20 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// XFAIL:.*
+
+pragma circom 2.1.0;
+
+template A(n){
+   signal input a;
+   signal output b, c, d;
+   b <== a * a;
+   c <== a + 2;
+   d <== a * a + 2;
+}
+template B(n){
+   signal input in;
+   signal output out1;
+   (_,out1,_) <== A(n)(in);
+}
+component main = B(3);
+// CHECK: TODO

--- a/circom/tests/circom_doc_examples/26.circom
+++ b/circom/tests/circom_doc_examples/26.circom
@@ -17,4 +17,4 @@ template B(n){
    (_,out1,_) <== A(n)(in);
 }
 component main = B(3);
-// CHECK: TODO
+//CHECK-LABEL:  module attributes {veridise.lang = "llzk"} {

--- a/circom/tests/circom_doc_examples/27.circom
+++ b/circom/tests/circom_doc_examples/27.circom
@@ -27,4 +27,4 @@ template A(){
 }
 
 component main = A();
-// CHECK: TODO
+//CHECK-LABEL:  module attributes {veridise.lang = "llzk"} {

--- a/circom/tests/circom_doc_examples/27.circom
+++ b/circom/tests/circom_doc_examples/27.circom
@@ -1,0 +1,30 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// XFAIL:.*
+
+pragma circom 2.1.0;
+
+template Bits2Num(n) {
+    signal input {binary} in[n];
+    signal output out;
+    var lc1=0;
+
+    var e2 = 1;
+    for (var i = 0; i<n; i++) {
+        lc1 += in[i] * e2;
+        e2 = e2 + e2;
+    }
+
+    lc1 ==> out;
+}
+
+template A(){
+    signal input a[10];
+    signal output out;
+    component b = Bits2Num(10);
+    b.in <== a;
+    out <== b.out;
+}
+
+component main = A();
+// CHECK: TODO

--- a/circom/tests/circom_doc_examples/28.circom
+++ b/circom/tests/circom_doc_examples/28.circom
@@ -21,4 +21,4 @@ template Caller(){
 }
 
 component main = Caller();
-// CHECK: TODO
+//CHECK-LABEL:  module attributes {veridise.lang = "llzk"} {

--- a/circom/tests/circom_doc_examples/28.circom
+++ b/circom/tests/circom_doc_examples/28.circom
@@ -1,0 +1,24 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// XFAIL:.*
+
+pragma circom 2.1.0;
+
+template A() {
+    signal input {binary} in;
+    signal intermediate;
+    signal output {binary} out;
+    intermediate <== in;
+    out <== intermediate;
+}
+
+template Caller(){
+    signal input inp;
+    signal output out;
+    component a = A();
+    a.in <== inp;
+    out <== a.out;
+}
+
+component main = Caller();
+// CHECK: TODO

--- a/circom/tests/circom_doc_examples/29.circom
+++ b/circom/tests/circom_doc_examples/29.circom
@@ -1,0 +1,17 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// XFAIL:.*
+
+pragma circom 2.1.0;
+
+template IsZero() {
+    signal input in;
+    signal output {binary} out;
+    signal inv;
+    inv <-- in!=0 ? 1/in : 0;
+    out <== -in*inv +1;
+    in*out === 0;
+}
+
+component main = IsZero();
+// CHECK: TODO

--- a/circom/tests/circom_doc_examples/29.circom
+++ b/circom/tests/circom_doc_examples/29.circom
@@ -14,4 +14,4 @@ template IsZero() {
 }
 
 component main = IsZero();
-// CHECK: TODO
+//CHECK-LABEL:  module attributes {veridise.lang = "llzk"} {

--- a/circom/tests/circom_doc_examples/30.circom
+++ b/circom/tests/circom_doc_examples/30.circom
@@ -1,0 +1,27 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// XFAIL:.*
+
+pragma circom 2.1.0;
+
+template Bits2Num(n) {
+    signal input {binary} in[n];
+    signal output {maxbit} out;
+    var lc1=0;
+
+    var e2 = 1;
+    for (var i = 0; i<n; i++) {
+        lc1 += in[i] * e2;
+        e2 = e2 + e2;
+    }
+    out.maxbit = n;
+    lc1 ==> out;
+}
+
+template Caller(n) {
+    signal input in[n];
+    signal output out <== Bits2Num(n)(in);
+}
+
+component main = Caller(64);
+// CHECK: TODO

--- a/circom/tests/circom_doc_examples/30.circom
+++ b/circom/tests/circom_doc_examples/30.circom
@@ -24,4 +24,4 @@ template Caller(n) {
 }
 
 component main = Caller(64);
-// CHECK: TODO
+//CHECK-LABEL:  module attributes {veridise.lang = "llzk"} {

--- a/circom/tests/circom_doc_examples/31.circom
+++ b/circom/tests/circom_doc_examples/31.circom
@@ -11,4 +11,4 @@ template A(){
 }
 
 component main = A();
-// CHECK: TODO
+//CHECK-LABEL:  module attributes {veridise.lang = "llzk"} {

--- a/circom/tests/circom_doc_examples/31.circom
+++ b/circom/tests/circom_doc_examples/31.circom
@@ -1,0 +1,14 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// XFAIL:.*
+
+pragma circom 2.1.0;
+
+template A(){
+    signal output {max} out[100];
+    out[0] <== 1;
+    out.max = 10;
+}
+
+component main = A();
+// CHECK: TODO

--- a/circom/tests/circom_doc_examples/32.circom
+++ b/circom/tests/circom_doc_examples/32.circom
@@ -32,4 +32,4 @@ template Caller() {
 }
 
 component main = Caller();
-// CHECK: TODO
+//CHECK-LABEL:  module attributes {veridise.lang = "llzk"} {

--- a/circom/tests/circom_doc_examples/32.circom
+++ b/circom/tests/circom_doc_examples/32.circom
@@ -1,0 +1,35 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// XFAIL:.*
+
+pragma circom 2.2.0;
+
+bus Point(){
+    signal x;
+    signal y;
+}
+
+template Edwards2Montgomery() {
+    input Point() { edwards_point } in ;
+    output Point() { montgomery_point } out ;
+
+    out.x <-- (1 + in.y ) / (1 - in.y ) ;
+    out.y <-- out.x / in.x ;
+
+    out.x * (1 - in.y ) === (1 + in.y ) ;
+    out.y * in.x === out.x ;
+}
+
+template Caller() {
+    input signal a, b;
+    output Point() conv;
+
+    Point() p;
+    p.x <== a;
+    p.y <== b;
+
+    conv <== Edwards2Montgomery()(p);
+}
+
+component main = Caller();
+// CHECK: TODO

--- a/circom/tests/circom_doc_examples/33.circom
+++ b/circom/tests/circom_doc_examples/33.circom
@@ -1,0 +1,92 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// XFAIL:.*
+
+pragma circom 2.2.0;
+
+template IsZero() {
+    signal input in;
+    signal output out;
+
+    signal inv;
+
+    inv <-- in!=0 ? 1/in : 0;
+
+    out <== -in*inv +1;
+    in*out === 0;
+}
+
+template IsEqual() {
+    signal input in[2];
+    signal output out;
+
+    component isz = IsZero();
+
+    in[1] - in[0] ==> isz.in;
+
+    isz.out ==> out;
+}
+
+template Num2Bits(n) {
+    signal input in;
+    signal output out[n];
+    var lc1=0;
+
+    var e2=1;
+    for (var i = 0; i<n; i++) {
+        out[i] <-- (in >> i) & 1;
+        out[i] * (out[i] -1 ) === 0;
+        lc1 += out[i] * e2;
+        e2 = e2+e2;
+    }
+
+    lc1 === in;
+}
+
+template LessThan(n) {
+    assert(n <= 252);
+    signal input in[2];
+    signal output out;
+
+    component n2b = Num2Bits(n+1);
+
+    n2b.in <== in[0]+ (1<<n) - in[1];
+
+    out <== 1-n2b.out[n];
+}
+
+bus Book() {
+    signal {maxvalue} title[50];
+    signal {maxvalue} author[50];
+    signal {maxvalue} sold_copies;
+    signal {maxvalue} year;
+}
+
+template BestSeller2024() {
+    input Book() book;
+    output Book() {best_seller2024} best_book;
+    signal check_copies <== LessThan(book.sold_copies.maxvalue)([1000000,book.sold_copies]);
+    check_copies === 1;
+    signal check_2024 <== IsEqual()([book.year,2024]);
+    check_2024 === 1;
+    best_book <== book;
+}
+
+template Caller() {
+    input signal title[50];
+    input signal author[50];
+    input signal sold_copies;
+    input signal year;
+
+    Book() b;
+    b.title <== title;
+    b.author <== author;
+    b.sold_copies <== sold_copies;
+    b.year <== year;
+
+    Book seller <== BestSeller2024()(b);
+    output signal sold <== seller.sold_copies;
+}
+
+component main = Caller();
+// CHECK: TODO

--- a/circom/tests/circom_doc_examples/33.circom
+++ b/circom/tests/circom_doc_examples/33.circom
@@ -89,4 +89,4 @@ template Caller() {
 }
 
 component main = Caller();
-// CHECK: TODO
+//CHECK-LABEL:  module attributes {veridise.lang = "llzk"} {

--- a/circom/tests/circom_doc_examples/34.circom
+++ b/circom/tests/circom_doc_examples/34.circom
@@ -64,4 +64,4 @@ template well_defined_figure(num_sides, dimension){
 }
 
 component main = well_defined_figure(3,2);
-// CHECK: TODO
+//CHECK-LABEL:  module attributes {veridise.lang = "llzk"} {

--- a/circom/tests/circom_doc_examples/34.circom
+++ b/circom/tests/circom_doc_examples/34.circom
@@ -1,0 +1,67 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// XFAIL:.*
+
+pragma circom 2.2.0;
+
+template IsZero() {
+    signal input in;
+    signal output out;
+
+    signal inv;
+
+    inv <-- in!=0 ? 1/in : 0;
+
+    out <== -in*inv +1;
+    in*out === 0;
+}
+
+template IsEqual() {
+    signal input in[2];
+    signal output out;
+
+    component isz = IsZero();
+
+    in[1] - in[0] ==> isz.in;
+
+    isz.out ==> out;
+}
+
+bus PointN(dim){
+    signal x[dim];
+}
+
+bus Line(dim){
+    PointN(dim) start;
+    PointN(dim) end;
+}
+
+bus Figure(num_sides, dim){
+    Line(dim) side[num_sides];
+}
+
+bus Triangle2D(){
+    Figure(3,2) {well_defined} triangle;
+}
+
+bus Square3D(){
+    Figure(4,3) {well_defined} square;
+}
+
+template well_defined_figure(num_sides, dimension){
+    input Figure(num_sides,dimension) t;
+    output Figure(num_sides,dimension) {well_defined} correct_t;
+    var all_equals = 0;
+    var isequal = 0;
+    for(var i = 0; i < num_sides; i=i+1){
+        for(var j = 0; j < dimension; j=j+1){
+            isequal = IsEqual()([t.side[i].end.x[j],t.side[(i+1)%num_sides].start.x[j]]);
+            all_equals += isequal;
+        }
+    }
+    all_equals === num_sides;
+    correct_t <== t;
+}
+
+component main = well_defined_figure(3,2);
+// CHECK: TODO

--- a/circom/tests/circom_doc_examples/35A.circom
+++ b/circom/tests/circom_doc_examples/35A.circom
@@ -11,4 +11,4 @@ template A(n) {
 }
 
 component main = A(0);
-// CHECK: TODO
+//CHECK-LABEL:  module attributes {veridise.lang = "llzk"} {

--- a/circom/tests/circom_doc_examples/35A.circom
+++ b/circom/tests/circom_doc_examples/35A.circom
@@ -1,0 +1,14 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// XFAIL:.*
+
+pragma circom 2.0.0;
+
+template A(n) {
+  signal input in;
+  assert(n>0);
+  in * in === n;
+}
+
+component main = A(0);
+// CHECK: TODO

--- a/circom/tests/circom_doc_examples/35B.circom
+++ b/circom/tests/circom_doc_examples/35B.circom
@@ -11,4 +11,4 @@ template A(n) {
 }
 
 component main = A(1);
-// CHECK: TODO
+//CHECK-LABEL:  module attributes {veridise.lang = "llzk"} {

--- a/circom/tests/circom_doc_examples/35B.circom
+++ b/circom/tests/circom_doc_examples/35B.circom
@@ -1,0 +1,14 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// XFAIL:.*
+
+pragma circom 2.0.0;
+
+template A(n) {
+  signal input in;
+  assert(n>0);
+  in * in === n;
+}
+
+component main = A(1);
+// CHECK: TODO

--- a/circom/tests/circom_doc_examples/36.circom
+++ b/circom/tests/circom_doc_examples/36.circom
@@ -1,0 +1,13 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// XFAIL:.*
+
+pragma circom 2.0.0;
+
+template Translate(n) {
+  signal input in;  
+  assert(in<=254);
+}
+
+component main = Translate(1);
+// CHECK: TODO

--- a/circom/tests/circom_doc_examples/36.circom
+++ b/circom/tests/circom_doc_examples/36.circom
@@ -10,4 +10,4 @@ template Translate(n) {
 }
 
 component main = Translate(1);
-// CHECK: TODO
+//CHECK-LABEL:  module attributes {veridise.lang = "llzk"} {

--- a/circom/tests/circom_doc_examples/37.circom
+++ b/circom/tests/circom_doc_examples/37.circom
@@ -29,4 +29,4 @@ template Multiplier3() {
 }
 
 component main = Multiplier3();
-// CHECK: TODO
+//CHECK-LABEL:  module attributes {veridise.lang = "llzk"} {

--- a/circom/tests/circom_doc_examples/37.circom
+++ b/circom/tests/circom_doc_examples/37.circom
@@ -1,0 +1,32 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// XFAIL:.*
+
+pragma circom 2.0.0;
+
+template Multiplier2() {
+   signal input in1;
+   signal input in2;
+   signal output out <== in1 * in2;
+}
+
+//This circuit multiplies in1, in2, and in3.
+template Multiplier3() {
+   //Declaration of signals and components.
+   signal input in1;
+   signal input in2;
+   signal input in3;
+   signal output out;
+   component mult1 = Multiplier2();
+   component mult2 = Multiplier2();
+
+   //Statements.
+   mult1.in1 <== in1;
+   mult1.in2 <== in2;
+   mult2.in1 <== mult1.out;
+   mult2.in2 <== in3;
+   out <== mult2.out;
+}
+
+component main = Multiplier3();
+// CHECK: TODO

--- a/circom/tests/circom_doc_examples/38.circom
+++ b/circom/tests/circom_doc_examples/38.circom
@@ -52,4 +52,4 @@ template MultiplierN(N){
 }
 
 component main {public [in]} = MultiplierN(3);
-// CHECK: TODO
+//CHECK-LABEL:  module attributes {veridise.lang = "llzk"} {

--- a/circom/tests/circom_doc_examples/38.circom
+++ b/circom/tests/circom_doc_examples/38.circom
@@ -1,0 +1,55 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// XFAIL:.*
+
+pragma circom 2.0.0;
+
+template Multiplier2(){
+   //Declaration of signals.
+   signal input in1;
+   signal input in2;
+   signal output out;
+
+   //Statements.
+   out <== in1 * in2;
+}
+
+template Multiplier3() {
+   //Declaration of signals.
+   signal input in1;
+   signal input in2;
+   signal input in3;
+   signal output out;
+   component mult1 = Multiplier2();
+   component mult2 = Multiplier2();
+
+   //Statements.
+   mult1.in1 <== in1;
+   mult1.in2 <== in2;
+   mult2.in1 <== mult1.out;
+   mult2.in2 <== in3;
+   out <== mult2.out;
+}
+
+template MultiplierN(N){
+   //Declaration of signals.
+   signal input in[N];
+   signal output out;
+   component comp[N-1];
+
+   //Statements.
+   for(var i = 0; i < N-1; i++){
+       comp[i] = Multiplier2();
+   }
+   comp[0].in1 <== in[0];
+   comp[0].in2 <== in[1];
+   for(var i = 0; i < N-2; i++){
+       comp[i+1].in1 <== comp[i].out;
+       comp[i+1].in2 <== in[i+2];
+
+   }
+   out <== comp[N-2].out; 
+}
+
+component main {public [in]} = MultiplierN(3);
+// CHECK: TODO

--- a/circom/tests/simple/trivially_empty.circom
+++ b/circom/tests/simple/trivially_empty.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// XFAIL:.*
 
 pragma circom 2.0.0;
 
@@ -7,4 +8,3 @@ template EmptyTemplate() {
 }
 component main = EmptyTemplate();
 //CHECK-LABEL:  module attributes {veridise.lang = "llzk"} {
-//CHECK-NEXT:   }

--- a/llzk_backend/src/codegen.rs
+++ b/llzk_backend/src/codegen.rs
@@ -104,8 +104,7 @@ pub fn generate_llzk(program_archive: &ProgramArchive, filename: &str) -> Result
     let ctx = LlzkContext::new();
     let codegen = LlzkCodegen::new(&ctx, program_archive);
 
-    // TODO: uncomment when implemented
-    // program_archive.produce_llzk_ir(&codegen).expect("Failed to generate LLZK IR");
+    program_archive.produce_llzk_ir(&codegen).expect("Failed to generate LLZK IR");
 
     // Verify the module and write it to file
     assert!(codegen.verify());

--- a/llzk_backend/src/codegen.rs
+++ b/llzk_backend/src/codegen.rs
@@ -104,7 +104,7 @@ pub fn generate_llzk(program_archive: &ProgramArchive, filename: &str) -> Result
     let ctx = LlzkContext::new();
     let codegen = LlzkCodegen::new(&ctx, program_archive);
 
-    program_archive.produce_llzk_ir(&codegen).expect("Failed to generate LLZK IR");
+    program_archive.produce_llzk_ir(&codegen).map_err(|err| {eprintln!("Failed to generate LLZK IR: {err}");})?;
 
     // Verify the module and write it to file
     assert!(codegen.verify());


### PR DESCRIPTION
These are the code examples from the documentation at https://docs.circom.io/ (excluding the ones that are intended to demonstrate errors). They are mostly copied verbatim and were only changed to fix seemingly unintentional syntax errors, add a main component if absent, and (in some cases) adding an additional intermediate component when the only one in the example had tags on an input to avoid "Main component cannot have inputs with tags" error. They are currently marked XFAIL until the necessary translations to support each are implemented.