### PR TITLE
Make lit emulator handle multi-line RUN script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,7 +219,6 @@ dependencies = [
  "llzk_backend",
  "parser",
  "program_structure",
- "rand 0.9.2",
  "regex",
  "type_analysis",
  "wast",
@@ -931,7 +930,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand",
  "serde",
  "smallvec",
 ]
@@ -1182,18 +1181,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
-dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.3",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -1203,17 +1192,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.3",
+ "rand_core",
 ]
 
 [[package]]
@@ -1223,15 +1202,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.9",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
-dependencies = [
- "getrandom 0.3.3",
 ]
 
 [[package]]

--- a/circom/Cargo.toml
+++ b/circom/Cargo.toml
@@ -30,7 +30,6 @@ assert_cmd = "2.0"
 assert_fs = "1.1"
 regex = "1.11"
 lazy_static = "1.5"
-rand = "0.9"
 
 [build-dependencies]
 glob = "0.3.3"

--- a/circom/tests/arrays/array_copy1_loop.circom
+++ b/circom/tests/arrays/array_copy1_loop.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/arrays/array_copy1_vec.circom
+++ b/circom/tests/arrays/array_copy1_vec.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/arrays/array_copy2_loop.circom
+++ b/circom/tests/arrays/array_copy2_loop.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/arrays/array_copy2_vec.circom
+++ b/circom/tests/arrays/array_copy2_vec.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/arrays/array_copy3_loop.circom
+++ b/circom/tests/arrays/array_copy3_loop.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/arrays/array_copy3_partial.circom
+++ b/circom/tests/arrays/array_copy3_partial.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/arrays/array_copy3_vec.circom
+++ b/circom/tests/arrays/array_copy3_vec.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/arrays/array_copy4_vec.circom
+++ b/circom/tests/arrays/array_copy4_vec.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/arrays/array_size_mismatch_return.circom
+++ b/circom/tests/arrays/array_size_mismatch_return.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/arrays/array_size_mismatch_store.circom
+++ b/circom/tests/arrays/array_size_mismatch_store.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/arrays/basic_array_00.circom
+++ b/circom/tests/arrays/basic_array_00.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/arrays/basic_array_01.circom
+++ b/circom/tests/arrays/basic_array_01.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/arrays/basic_array_02.circom
+++ b/circom/tests/arrays/basic_array_02.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/arrays/basic_array_03.circom
+++ b/circom/tests/arrays/basic_array_03.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/arrays/basic_array_04.circom
+++ b/circom/tests/arrays/basic_array_04.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/arrays/unknown_index_constrained.circom
+++ b/circom/tests/arrays/unknown_index_constrained.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/arrays/unknown_index_load_store.circom
+++ b/circom/tests/arrays/unknown_index_load_store.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/arrays/unknown_index_overwrites_known_A.circom
+++ b/circom/tests/arrays/unknown_index_overwrites_known_A.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/arrays/unknown_index_overwrites_known_B.circom
+++ b/circom/tests/arrays/unknown_index_overwrites_known_B.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/arrays/unknown_index_store.circom
+++ b/circom/tests/arrays/unknown_index_store.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/arrays/unknown_index_unconstrained.circom
+++ b/circom/tests/arrays/unknown_index_unconstrained.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/calls/basic_call_01.circom
+++ b/circom/tests/calls/basic_call_01.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/calls/basic_call_02.circom
+++ b/circom/tests/calls/basic_call_02.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/calls/call_arg_array.circom
+++ b/circom/tests/calls/call_arg_array.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.1.0;

--- a/circom/tests/calls/call_arg_array_array.circom
+++ b/circom/tests/calls/call_arg_array_array.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.1.0;

--- a/circom/tests/calls/call_arg_array_array_scalar.circom
+++ b/circom/tests/calls/call_arg_array_array_scalar.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.1.0;

--- a/circom/tests/calls/call_arg_arraymulti.circom
+++ b/circom/tests/calls/call_arg_arraymulti.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.1.0;

--- a/circom/tests/calls/call_arg_arraymulti_arraymulti.circom
+++ b/circom/tests/calls/call_arg_arraymulti_arraymulti.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.1.0;

--- a/circom/tests/calls/call_arg_arrays_complex_A.circom
+++ b/circom/tests/calls/call_arg_arrays_complex_A.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.1.0;

--- a/circom/tests/calls/call_arg_arrays_complex_B.circom
+++ b/circom/tests/calls/call_arg_arrays_complex_B.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.1.0;

--- a/circom/tests/calls/call_arg_arrays_complex_C.circom
+++ b/circom/tests/calls/call_arg_arrays_complex_C.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.1.0;

--- a/circom/tests/calls/call_arg_arrays_complex_D.circom
+++ b/circom/tests/calls/call_arg_arrays_complex_D.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.1.0;

--- a/circom/tests/calls/call_arg_scalar_array_scalar.circom
+++ b/circom/tests/calls/call_arg_scalar_array_scalar.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.1.0;

--- a/circom/tests/calls/call_ret_array.circom
+++ b/circom/tests/calls/call_ret_array.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.1.0;

--- a/circom/tests/calls/call_ret_arraymulti.circom
+++ b/circom/tests/calls/call_ret_arraymulti.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.1.0;

--- a/circom/tests/calls/call_ret_arraymulti_nonzero.circom
+++ b/circom/tests/calls/call_ret_arraymulti_nonzero.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.3;

--- a/circom/tests/calls/call_ret_scalar.circom
+++ b/circom/tests/calls/call_ret_scalar.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.1.0;

--- a/circom/tests/calls/call_without_arena_gotcha.circom
+++ b/circom/tests/calls/call_without_arena_gotcha.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.1.0;

--- a/circom/tests/calls/circompairing_bigint.circom
+++ b/circom/tests/calls/circompairing_bigint.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // COM: Adapted from `bigint.circom` in https://github.com/yi-sun/circom-pairing
 // XFAIL:.*
 

--- a/circom/tests/calls/circompairing_bigint_func_A.circom
+++ b/circom/tests/calls/circompairing_bigint_func_A.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // COM: Adapted from `bigint_func.circom` in https://github.com/yi-sun/circom-pairing
 // XFAIL:.*
 

--- a/circom/tests/calls/circompairing_bigint_func_B.circom
+++ b/circom/tests/calls/circompairing_bigint_func_B.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // COM: Adapted from `bigint_func.circom` in https://github.com/yi-sun/circom-pairing
 // XFAIL:.*
 

--- a/circom/tests/calls/recurse_known.circom
+++ b/circom/tests/calls/recurse_known.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/calls/recurse_unknown.circom
+++ b/circom/tests/calls/recurse_unknown.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/calls/return_intermediate.circom
+++ b/circom/tests/calls/return_intermediate.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/circom_doc_examples/01.circom
+++ b/circom/tests/circom_doc_examples/01.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/circom_doc_examples/02.circom
+++ b/circom/tests/circom_doc_examples/02.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/circom_doc_examples/03.circom
+++ b/circom/tests/circom_doc_examples/03.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/circom_doc_examples/04.circom
+++ b/circom/tests/circom_doc_examples/04.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/circom_doc_examples/05.circom
+++ b/circom/tests/circom_doc_examples/05.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.6; // note that custom templates are only allowed since version 2.0.6

--- a/circom/tests/circom_doc_examples/06.circom
+++ b/circom/tests/circom_doc_examples/06.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/circom_doc_examples/07.circom
+++ b/circom/tests/circom_doc_examples/07.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/circom_doc_examples/08.circom
+++ b/circom/tests/circom_doc_examples/08.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/circom_doc_examples/09.circom
+++ b/circom/tests/circom_doc_examples/09.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/circom_doc_examples/10.circom
+++ b/circom/tests/circom_doc_examples/10.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/circom_doc_examples/11.circom
+++ b/circom/tests/circom_doc_examples/11.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/circom_doc_examples/12.circom
+++ b/circom/tests/circom_doc_examples/12.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/circom_doc_examples/13.circom
+++ b/circom/tests/circom_doc_examples/13.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/circom_doc_examples/14.circom
+++ b/circom/tests/circom_doc_examples/14.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/circom_doc_examples/15.circom
+++ b/circom/tests/circom_doc_examples/15.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/circom_doc_examples/16.circom
+++ b/circom/tests/circom_doc_examples/16.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/circom_doc_examples/17.circom
+++ b/circom/tests/circom_doc_examples/17.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.1.5;

--- a/circom/tests/circom_doc_examples/18.circom
+++ b/circom/tests/circom_doc_examples/18.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/circom_doc_examples/19.circom
+++ b/circom/tests/circom_doc_examples/19.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.1.0;

--- a/circom/tests/circom_doc_examples/20.circom
+++ b/circom/tests/circom_doc_examples/20.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.1.0;

--- a/circom/tests/circom_doc_examples/21.circom
+++ b/circom/tests/circom_doc_examples/21.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.1.0;

--- a/circom/tests/circom_doc_examples/22.circom
+++ b/circom/tests/circom_doc_examples/22.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.1.0;

--- a/circom/tests/circom_doc_examples/23.circom
+++ b/circom/tests/circom_doc_examples/23.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.1.0;

--- a/circom/tests/circom_doc_examples/24.circom
+++ b/circom/tests/circom_doc_examples/24.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.1.0;

--- a/circom/tests/circom_doc_examples/25.circom
+++ b/circom/tests/circom_doc_examples/25.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.1.0;

--- a/circom/tests/circom_doc_examples/26.circom
+++ b/circom/tests/circom_doc_examples/26.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.1.0;

--- a/circom/tests/circom_doc_examples/27.circom
+++ b/circom/tests/circom_doc_examples/27.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.1.0;

--- a/circom/tests/circom_doc_examples/28.circom
+++ b/circom/tests/circom_doc_examples/28.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.1.0;

--- a/circom/tests/circom_doc_examples/29.circom
+++ b/circom/tests/circom_doc_examples/29.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.1.0;

--- a/circom/tests/circom_doc_examples/30.circom
+++ b/circom/tests/circom_doc_examples/30.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.1.0;

--- a/circom/tests/circom_doc_examples/31.circom
+++ b/circom/tests/circom_doc_examples/31.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.1.0;

--- a/circom/tests/circom_doc_examples/32.circom
+++ b/circom/tests/circom_doc_examples/32.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.2.0;

--- a/circom/tests/circom_doc_examples/33.circom
+++ b/circom/tests/circom_doc_examples/33.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.2.0;

--- a/circom/tests/circom_doc_examples/34.circom
+++ b/circom/tests/circom_doc_examples/34.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.2.0;

--- a/circom/tests/circom_doc_examples/35A.circom
+++ b/circom/tests/circom_doc_examples/35A.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/circom_doc_examples/35B.circom
+++ b/circom/tests/circom_doc_examples/35B.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/circom_doc_examples/36.circom
+++ b/circom/tests/circom_doc_examples/36.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/circom_doc_examples/37.circom
+++ b/circom/tests/circom_doc_examples/37.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/circom_doc_examples/38.circom
+++ b/circom/tests/circom_doc_examples/38.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/constraints/arr_cpy_store.circom
+++ b/circom/tests/constraints/arr_cpy_store.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/constraints/known1.circom
+++ b/circom/tests/constraints/known1.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/constraints/known2.circom
+++ b/circom/tests/constraints/known2.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/constraints/known3.circom
+++ b/circom/tests/constraints/known3.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/constraints/known4.circom
+++ b/circom/tests/constraints/known4.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/constraints/known5.circom
+++ b/circom/tests/constraints/known5.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/constraints/missed_index_simple.circom
+++ b/circom/tests/constraints/missed_index_simple.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/constraints/with_call_scalars.circom
+++ b/circom/tests/constraints/with_call_scalars.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/constraints/with_call_vec_arg.circom
+++ b/circom/tests/constraints/with_call_vec_arg.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/constraints/with_call_vec_ret.circom
+++ b/circom/tests/constraints/with_call_vec_ret.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/controlflow/bigmod_01.circom
+++ b/circom/tests/controlflow/bigmod_01.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/controlflow/bigmod_02.circom
+++ b/circom/tests/controlflow/bigmod_02.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/controlflow/bigmod_03.circom
+++ b/circom/tests/controlflow/bigmod_03.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/controlflow/bigmod_04.circom
+++ b/circom/tests/controlflow/bigmod_04.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/controlflow/bigmod_05.circom
+++ b/circom/tests/controlflow/bigmod_05.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/controlflow/bigmod_06.circom
+++ b/circom/tests/controlflow/bigmod_06.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/controlflow/branch_in_template_01.circom
+++ b/circom/tests/controlflow/branch_in_template_01.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/controlflow/branch_in_template_02.circom
+++ b/circom/tests/controlflow/branch_in_template_02.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/controlflow/early_return_if_1.circom
+++ b/circom/tests/controlflow/early_return_if_1.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/controlflow/early_return_if_2.circom
+++ b/circom/tests/controlflow/early_return_if_2.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/controlflow/early_return_loop_1.circom
+++ b/circom/tests/controlflow/early_return_loop_1.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/controlflow/early_return_loop_2.circom
+++ b/circom/tests/controlflow/early_return_loop_2.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/controlflow/early_return_loop_with_unknown_if.circom
+++ b/circom/tests/controlflow/early_return_loop_with_unknown_if.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.3;

--- a/circom/tests/controlflow/indexing_within_unknown_if.circom
+++ b/circom/tests/controlflow/indexing_within_unknown_if.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/controlflow/multiuse_func_with_loop_diff.circom
+++ b/circom/tests/controlflow/multiuse_func_with_loop_diff.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/controlflow/multiuse_func_with_loop_diff_more.circom
+++ b/circom/tests/controlflow/multiuse_func_with_loop_diff_more.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/controlflow/multiuse_func_with_loop_same.circom
+++ b/circom/tests/controlflow/multiuse_func_with_loop_same.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/lit.rs
+++ b/circom/tests/lit.rs
@@ -26,7 +26,7 @@ fn marked_xfail(content: &str) -> bool {
     return false;
 }
 
-fn extract_runs(content: &str) -> Vec<String> {
+fn extract_runs(content: &str) -> Vec<&str> {
     lazy_static! {
         static ref RE: Regex = Regex::new(r"^//\s*RUN:(.*)$").unwrap();
     }
@@ -34,7 +34,7 @@ fn extract_runs(content: &str) -> Vec<String> {
     for line in content.lines() {
         if let Some(captures) = RE.captures(line) {
             if let Some(group) = captures.get(1) {
-                runs.push(group.as_str().to_string());
+                runs.push(group.as_str());
             }
         }
     }
@@ -52,13 +52,13 @@ fn write_test(content: &str, name: &str) -> LitResult<NamedTempFile> {
 
 struct LitTest<'a> {
     expected_failure: bool,
-    run_commands: Vec<String>,
+    run_commands: Vec<&'a str>,
     test_input: NamedTempFile,
     name: &'a str,
 }
 
 impl<'a> LitTest<'a> {
-    pub fn create(content: &str, name: &'a str) -> LitResult<Self> {
+    pub fn create(content: &'a str, name: &'a str) -> LitResult<Self> {
         Ok(LitTest {
             expected_failure: marked_xfail(content),
             run_commands: extract_runs(content),

--- a/circom/tests/lit.rs
+++ b/circom/tests/lit.rs
@@ -1,12 +1,10 @@
 #![allow(dead_code)]
 
-use std::fs::{self, File};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use assert_cmd::Command;
 use assert_fs::{NamedTempFile, prelude::FileWriteStr};
 use lazy_static::lazy_static;
 use regex::Regex;
-use rand::{distr::Alphanumeric, Rng};
 
 const TEST_INPUT: &'static str = "%s";
 const TMP_FILE: &'static str = "%t";
@@ -77,15 +75,6 @@ impl<'a> LitTest<'a> {
         Ok(())
     }
 
-    fn create_tmp_file(&self) -> LitResult<PathBuf> {
-        let temp = Path::new(env!("CARGO_TARGET_TMPDIR"));
-        let postfix: String =
-            rand::rng().sample_iter(&Alphanumeric).take(10).map(char::from).collect();
-        let tmp_file = temp.join(Path::new(format!("{}.{}", self.name, postfix).as_str()));
-        File::create(tmp_file.clone())?;
-        Ok(tmp_file)
-    }
-
     fn prepare_command(&self, run_command: &str, tmp_file: &Path) -> String {
         run_command
             .replace(
@@ -96,37 +85,22 @@ impl<'a> LitTest<'a> {
             .replace(CIRCOM, env!("CARGO_BIN_EXE_circom"))
     }
 
-    fn cleanup_test(&self, tmp_file: &Path) -> LitResult<()> {
-        if tmp_file.exists() {
-            if tmp_file.is_file() {
-                fs::remove_file(tmp_file)?;
-            } else if tmp_file.is_dir() {
-                fs::remove_dir_all(tmp_file)?;
-            }
-        }
-        Ok(())
-    }
-
     pub fn execute(&self) -> LitResult<()> {
-        // Create a single temp file to be shared across all RUN commands
-        let tmp_file = self.create_tmp_file()?;
+        // Create a single temp file/directory to be shared across all RUN commands
+        // that is deleted when it goes out of scope at the end of this function.
+        let tmp_file = NamedTempFile::new(self.name)?;
 
         // Execute all RUN commands in sequence
         for run_command in &self.run_commands {
-            let cmd = self.prepare_command(run_command, &tmp_file);
+            let cmd = self.prepare_command(run_command, tmp_file.path());
             let mut sh = Command::new("sh");
             sh.arg("-c").arg(cmd);
-            let result = if self.expected_failure {
-                self.execute_expecting_failure(&mut sh)
+            if self.expected_failure {
+                self.execute_expecting_failure(&mut sh)?;
             } else {
-                self.execute_expecting_success(&mut sh)
-            };
-            // Don't cleanup yet - continue to next command
-            result?;
+                self.execute_expecting_success(&mut sh)?;
+            }
         }
-
-        // Cleanup the temp file after all commands have executed
-        self.cleanup_test(&tmp_file)?;
         Ok(())
     }
 }

--- a/circom/tests/lit.rs
+++ b/circom/tests/lit.rs
@@ -14,10 +14,10 @@ type LitResult<T> = Result<T, Box<dyn std::error::Error>>;
 
 fn marked_xfail(content: &str) -> bool {
     lazy_static! {
-        static ref RE: Regex = Regex::new(r"^//\s*XFAIL:.*$").unwrap();
+        static ref XFAIL: Regex = Regex::new(r"^//\s*XFAIL:.*$").unwrap();
     }
     for line in content.lines() {
-        if RE.is_match(line) {
+        if XFAIL.is_match(line) {
             return true;
         }
     }
@@ -26,11 +26,14 @@ fn marked_xfail(content: &str) -> bool {
 
 fn extract_runs(content: &str) -> Vec<&str> {
     lazy_static! {
-        static ref RE: Regex = Regex::new(r"^//\s*RUN:(.*)$").unwrap();
+        static ref RUN: Regex = Regex::new(r"^//\s*RUN:(.*)$").unwrap();
+        static ref END: Regex = Regex::new(r"^//\s*END\.$").unwrap();
     }
     let mut runs = Vec::new();
     for line in content.lines() {
-        if let Some(captures) = RE.captures(line) {
+        if END.is_match(line) {
+            break;
+        } else if let Some(captures) = RUN.captures(line) {
             if let Some(group) = captures.get(1) {
                 runs.push(group.as_str());
             }

--- a/circom/tests/lit.rs
+++ b/circom/tests/lit.rs
@@ -26,18 +26,22 @@ fn marked_xfail(content: &str) -> bool {
     return false;
 }
 
-fn extract_run(content: &str) -> &str {
+fn extract_runs(content: &str) -> Vec<String> {
     lazy_static! {
         static ref RE: Regex = Regex::new(r"^//\s*RUN:(.*)$").unwrap();
     }
+    let mut runs = Vec::new();
     for line in content.lines() {
         if let Some(captures) = RE.captures(line) {
             if let Some(group) = captures.get(1) {
-                return group.as_str();
+                runs.push(group.as_str().to_string());
             }
         }
     }
-    panic!("Unsupported test encountered. RUN declaration missing!")
+    if runs.is_empty() {
+        panic!("Unsupported test encountered. RUN declaration missing!")
+    }
+    runs
 }
 
 fn write_test(content: &str, name: &str) -> LitResult<NamedTempFile> {
@@ -48,16 +52,16 @@ fn write_test(content: &str, name: &str) -> LitResult<NamedTempFile> {
 
 struct LitTest<'a> {
     expected_failure: bool,
-    run_command: &'a str,
+    run_commands: Vec<String>,
     test_input: NamedTempFile,
     name: &'a str,
 }
 
 impl<'a> LitTest<'a> {
-    pub fn create(content: &'a str, name: &'a str) -> LitResult<Self> {
+    pub fn create(content: &str, name: &'a str) -> LitResult<Self> {
         Ok(LitTest {
             expected_failure: marked_xfail(content),
-            run_command: extract_run(content),
+            run_commands: extract_runs(content),
             test_input: write_test(content, name)?,
             name,
         })
@@ -73,22 +77,23 @@ impl<'a> LitTest<'a> {
         Ok(())
     }
 
-    fn prepare_test(&self) -> LitResult<(String, PathBuf)> {
+    fn create_tmp_file(&self) -> LitResult<PathBuf> {
         let temp = Path::new(env!("CARGO_TARGET_TMPDIR"));
         let postfix: String =
             rand::rng().sample_iter(&Alphanumeric).take(10).map(char::from).collect();
         let tmp_file = temp.join(Path::new(format!("{}.{}", self.name, postfix).as_str()));
         File::create(tmp_file.clone())?;
-        let cmd = self
-            .run_command
+        Ok(tmp_file)
+    }
+
+    fn prepare_command(&self, run_command: &str, tmp_file: &Path) -> String {
+        run_command
             .replace(
                 TEST_INPUT,
                 format!("\"{}\"", self.test_input.path().to_str().unwrap()).as_str(),
             )
             .replace(TMP_FILE, format!("\"{}\"", tmp_file.to_str().unwrap()).as_str())
-            .replace(CIRCOM, env!("CARGO_BIN_EXE_circom"));
-
-        Ok((cmd, tmp_file))
+            .replace(CIRCOM, env!("CARGO_BIN_EXE_circom"))
     }
 
     fn cleanup_test(&self, tmp_file: &Path) -> LitResult<()> {
@@ -103,15 +108,26 @@ impl<'a> LitTest<'a> {
     }
 
     pub fn execute(&self) -> LitResult<()> {
-        let (cmd, tmp_file) = self.prepare_test()?;
-        let mut sh = Command::new("sh");
-        sh.arg("-c").arg(cmd);
-        if self.expected_failure {
-            self.execute_expecting_failure(&mut sh)
-        } else {
-            self.execute_expecting_success(&mut sh)
-        }?;
-        self.cleanup_test(&tmp_file)
+        // Create a single temp file to be shared across all RUN commands
+        let tmp_file = self.create_tmp_file()?;
+
+        // Execute all RUN commands in sequence
+        for run_command in &self.run_commands {
+            let cmd = self.prepare_command(run_command, &tmp_file);
+            let mut sh = Command::new("sh");
+            sh.arg("-c").arg(cmd);
+            let result = if self.expected_failure {
+                self.execute_expecting_failure(&mut sh)
+            } else {
+                self.execute_expecting_success(&mut sh)
+            };
+            // Don't cleanup yet - continue to next command
+            result?;
+        }
+
+        // Cleanup the temp file after all commands have executed
+        self.cleanup_test(&tmp_file)?;
+        Ok(())
     }
 }
 

--- a/circom/tests/loops/assign_in_loop_01.circom
+++ b/circom/tests/loops/assign_in_loop_01.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/loops/assign_in_loop_02.circom
+++ b/circom/tests/loops/assign_in_loop_02.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/loops/assign_in_loop_03.circom
+++ b/circom/tests/loops/assign_in_loop_03.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/loops/assign_in_loop_04.circom
+++ b/circom/tests/loops/assign_in_loop_04.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/loops/call_inside_loop.circom
+++ b/circom/tests/loops/call_inside_loop.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/loops/confusing_merge.circom
+++ b/circom/tests/loops/confusing_merge.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/loops/fib_input.circom
+++ b/circom/tests/loops/fib_input.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/loops/fib_template.circom
+++ b/circom/tests/loops/fib_template.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/loops/fixed_idx_nested_lhs.circom
+++ b/circom/tests/loops/fixed_idx_nested_lhs.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/loops/fixed_idx_nested_rhs.circom
+++ b/circom/tests/loops/fixed_idx_nested_rhs.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/loops/for_known.circom
+++ b/circom/tests/loops/for_known.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/loops/for_unknown.circom
+++ b/circom/tests/loops/for_unknown.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/loops/for_unknown_index.circom
+++ b/circom/tests/loops/for_unknown_index.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/loops/init_nonzero.circom
+++ b/circom/tests/loops/init_nonzero.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/loops/inner_conditional_01.circom
+++ b/circom/tests/loops/inner_conditional_01.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/loops/inner_conditional_02.circom
+++ b/circom/tests/loops/inner_conditional_02.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/loops/inner_conditional_03.circom
+++ b/circom/tests/loops/inner_conditional_03.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/loops/inner_conditional_04.circom
+++ b/circom/tests/loops/inner_conditional_04.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/loops/inner_conditional_05.circom
+++ b/circom/tests/loops/inner_conditional_05.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/loops/inner_conditional_06.circom
+++ b/circom/tests/loops/inner_conditional_06.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/loops/inner_conditional_07.circom
+++ b/circom/tests/loops/inner_conditional_07.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/loops/inner_conditional_08.circom
+++ b/circom/tests/loops/inner_conditional_08.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/loops/inner_conditional_09.circom
+++ b/circom/tests/loops/inner_conditional_09.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/loops/inner_conditional_10.circom
+++ b/circom/tests/loops/inner_conditional_10.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/loops/inner_conditional_11.circom
+++ b/circom/tests/loops/inner_conditional_11.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/loops/inner_conditional_12.circom
+++ b/circom/tests/loops/inner_conditional_12.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/loops/inner_loop_00.circom
+++ b/circom/tests/loops/inner_loop_00.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/loops/inner_loop_01.circom
+++ b/circom/tests/loops/inner_loop_01.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/loops/inner_loop_02.circom
+++ b/circom/tests/loops/inner_loop_02.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/loops/inner_loop_03.circom
+++ b/circom/tests/loops/inner_loop_03.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/loops/inner_loop_04.circom
+++ b/circom/tests/loops/inner_loop_04.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/loops/inner_loop_05.circom
+++ b/circom/tests/loops/inner_loop_05.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/loops/inner_loop_06.circom
+++ b/circom/tests/loops/inner_loop_06.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/loops/inner_loop_07.circom
+++ b/circom/tests/loops/inner_loop_07.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/loops/inner_loop_08.circom
+++ b/circom/tests/loops/inner_loop_08.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/loops/inner_loop_09.circom
+++ b/circom/tests/loops/inner_loop_09.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/loops/known_function.circom
+++ b/circom/tests/loops/known_function.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/loops/known_signal_value.circom
+++ b/circom/tests/loops/known_signal_value.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/loops/needs_stack_ctx_A.circom
+++ b/circom/tests/loops/needs_stack_ctx_A.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/loops/needs_stack_ctx_B.circom
+++ b/circom/tests/loops/needs_stack_ctx_B.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/loops/simple_variant_idx.circom
+++ b/circom/tests/loops/simple_variant_idx.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/loops/unknown_index_from_array.circom
+++ b/circom/tests/loops/unknown_index_from_array.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/loops/unknown_index_from_function.circom
+++ b/circom/tests/loops/unknown_index_from_function.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/loops/unknown_local_array_index.circom
+++ b/circom/tests/loops/unknown_local_array_index.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/loops/unknown_loop_component.circom
+++ b/circom/tests/loops/unknown_loop_component.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/loops/unknown_loop_index.circom
+++ b/circom/tests/loops/unknown_loop_index.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/loops/unknown_loop_oob.circom
+++ b/circom/tests/loops/unknown_loop_oob.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/loops/vanguard-uc-comp.circom
+++ b/circom/tests/loops/vanguard-uc-comp.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/loops/variant_idx_in_loop_01.circom
+++ b/circom/tests/loops/variant_idx_in_loop_01.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/loops/variant_idx_in_loop_02.circom
+++ b/circom/tests/loops/variant_idx_in_loop_02.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/loops/variant_idx_in_loop_03.circom
+++ b/circom/tests/loops/variant_idx_in_loop_03.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/misc/array_computation.circom
+++ b/circom/tests/misc/array_computation.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/misc/circomlib_smtprocessor.circom
+++ b/circom/tests/misc/circomlib_smtprocessor.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.6;

--- a/circom/tests/misc/poseidon.circom
+++ b/circom/tests/misc/poseidon.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/misc/signal_index.circom
+++ b/circom/tests/misc/signal_index.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/misc/signal_index2.circom
+++ b/circom/tests/misc/signal_index2.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/misc/unreachable_code_crash.circom
+++ b/circom/tests/misc/unreachable_code_crash.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.2;

--- a/circom/tests/operators/arith1.circom
+++ b/circom/tests/operators/arith1.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/operators/arith2.circom
+++ b/circom/tests/operators/arith2.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/operators/arith_add.circom
+++ b/circom/tests/operators/arith_add.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/operators/arith_div.circom
+++ b/circom/tests/operators/arith_div.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/operators/arith_idiv.circom
+++ b/circom/tests/operators/arith_idiv.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/operators/arith_mod.circom
+++ b/circom/tests/operators/arith_mod.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/operators/arith_neg.circom
+++ b/circom/tests/operators/arith_neg.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/operators/arith_pow.circom
+++ b/circom/tests/operators/arith_pow.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/operators/arith_sub.circom
+++ b/circom/tests/operators/arith_sub.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/operators/bitwise_and.circom
+++ b/circom/tests/operators/bitwise_and.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/operators/bitwise_comp.circom
+++ b/circom/tests/operators/bitwise_comp.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/operators/bitwise_or.circom
+++ b/circom/tests/operators/bitwise_or.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/operators/bitwise_shl.circom
+++ b/circom/tests/operators/bitwise_shl.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/operators/bitwise_shr.circom
+++ b/circom/tests/operators/bitwise_shr.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/operators/bitwise_xor.circom
+++ b/circom/tests/operators/bitwise_xor.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/operators/bool_and.circom
+++ b/circom/tests/operators/bool_and.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/operators/bool_not.circom
+++ b/circom/tests/operators/bool_not.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/operators/bool_or.circom
+++ b/circom/tests/operators/bool_or.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/operators/cmp_eq.circom
+++ b/circom/tests/operators/cmp_eq.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/operators/cmp_ge.circom
+++ b/circom/tests/operators/cmp_ge.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/operators/cmp_gt.circom
+++ b/circom/tests/operators/cmp_gt.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/operators/cmp_le.circom
+++ b/circom/tests/operators/cmp_le.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/operators/cmp_lt.circom
+++ b/circom/tests/operators/cmp_lt.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/simple/assert.circom
+++ b/circom/tests/simple/assert.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/simple/assert_known_false.circom
+++ b/circom/tests/simple/assert_known_false.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/simple/call_and_return.circom
+++ b/circom/tests/simple/call_and_return.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/simple/constraint.circom
+++ b/circom/tests/simple/constraint.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/simple/constraint_constant.circom
+++ b/circom/tests/simple/constraint_constant.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/simple/create_component.circom
+++ b/circom/tests/simple/create_component.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/simple/dump_parse.circom
+++ b/circom/tests/simple/dump_parse.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --dump_parse -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --match-full-lines
+// END.
 
 pragma circom 2.0.0;
 

--- a/circom/tests/simple/load.circom
+++ b/circom/tests/simple/load.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/simple/log.circom
+++ b/circom/tests/simple/log.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/simple/loop_and_block.circom
+++ b/circom/tests/simple/loop_and_block.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/simple/simple_01.circom
+++ b/circom/tests/simple/simple_01.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/simple/simple_02.circom
+++ b/circom/tests/simple/simple_02.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/simple/simple_03.circom
+++ b/circom/tests/simple/simple_03.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/simple/simple_04.circom
+++ b/circom/tests/simple/simple_04.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/simple/simple_05.circom
+++ b/circom/tests/simple/simple_05.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/simple/trivially_empty.circom
+++ b/circom/tests/simple/trivially_empty.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/simple/var_consts.circom
+++ b/circom/tests/simple/var_consts.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/subcmps/array_copy_constraints.circom
+++ b/circom/tests/subcmps/array_copy_constraints.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/subcmps/conv_map2idx_A.circom
+++ b/circom/tests/subcmps/conv_map2idx_A.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.3;

--- a/circom/tests/subcmps/conv_map2idx_B.circom
+++ b/circom/tests/subcmps/conv_map2idx_B.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.3;

--- a/circom/tests/subcmps/conv_map2idx_C.circom
+++ b/circom/tests/subcmps/conv_map2idx_C.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/subcmps/large_array_param.circom
+++ b/circom/tests/subcmps/large_array_param.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/subcmps/mapped_01.circom
+++ b/circom/tests/subcmps/mapped_01.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/subcmps/mapped_02.circom
+++ b/circom/tests/subcmps/mapped_02.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/subcmps/mapped_03.circom
+++ b/circom/tests/subcmps/mapped_03.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/subcmps/mapped_04.circom
+++ b/circom/tests/subcmps/mapped_04.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/subcmps/subcmps0A.circom
+++ b/circom/tests/subcmps/subcmps0A.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/subcmps/subcmps0B.circom
+++ b/circom/tests/subcmps/subcmps0B.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/subcmps/subcmps0C.circom
+++ b/circom/tests/subcmps/subcmps0C.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/subcmps/subcmps0D.circom
+++ b/circom/tests/subcmps/subcmps0D.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/subcmps/subcmps1.circom
+++ b/circom/tests/subcmps/subcmps1.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/subcmps/subcmps2.circom
+++ b/circom/tests/subcmps/subcmps2.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.6;

--- a/circom/tests/subcmps/subcmps3.circom
+++ b/circom/tests/subcmps/subcmps3.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/subcmps/subcmps4.circom
+++ b/circom/tests/subcmps/subcmps4.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/type_conversions/bool_1.circom
+++ b/circom/tests/type_conversions/bool_1.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/type_conversions/bool_2.circom
+++ b/circom/tests/type_conversions/bool_2.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/type_conversions/bool_3.circom
+++ b/circom/tests/type_conversions/bool_3.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;

--- a/circom/tests/type_conversions/bool_4.circom
+++ b/circom/tests/type_conversions/bool_4.circom
@@ -1,5 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
 // XFAIL:.*
 
 pragma circom 2.0.0;


### PR DESCRIPTION
Make the Rust `lit` emulator handle a multi-line RUN script consistent with behavior of LLVM lit. See https://llvm.org/docs/TestingGuide.html

Also support "END" to optimize collection of "RUN" lines (per https://llvm.org/docs/TestingGuide.html#other-features). Use "END" in tests.