### PR TITLE
A few test updates

### DIFF
--- a/circom/tests/calls/call_diff_array_per_call.circom
+++ b/circom/tests/calls/call_diff_array_per_call.circom
@@ -1,0 +1,24 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// XFAIL:.*
+
+pragma circom 2.1.0;
+
+function f(a) {
+    return a[0][0];
+}
+
+// The two calls to `f()` have different argument types which requires
+// two versions of `f()` to be generated.
+template CallDiffTypeTest() {
+    signal input inA[10][5][5];
+    signal input inB[10][5];
+    signal output outA[5];
+    signal output outB;
+
+    outA <== f(inA); // f: (felt[10][5][5]) -> felt[5]
+    outB <== f(inB); // f: (felt[10][5]) -> felt
+}
+
+component main = CallDiffTypeTest();
+//CHECK-LABEL:  module attributes {veridise.lang = "llzk"} {

--- a/circom/tests/calls/call_diff_array_per_template.circom
+++ b/circom/tests/calls/call_diff_array_per_template.circom
@@ -1,0 +1,49 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// XFAIL:.*
+
+pragma circom 2.1.0;
+
+function f(a) {
+    return a[0][0];
+}
+
+// The two calls to `f()` have different argument types which requires
+// two versions of `f()` to be generated. These functions must also be
+// parametric in the size of the last array dimension. The flattened
+// circuit thus has 4 versions of `f()`.
+template CallDiffTypeTest(N) {
+    signal input inA[8][5][N];
+    signal input inB[8][N];
+    signal output outA[N];
+    signal output outB;
+
+    outA <== f(inA); // f: (felt[8][5][N]) -> felt[N]
+    outB <== f(inB); // f: (felt[8][N]) -> felt
+}
+
+template Main() {
+    signal input inA[8][5][3];
+    signal input inB[8][3];
+    signal input inC[8][5][2];
+    signal input inD[8][2];
+    
+    signal output outA[3];
+    signal output outB;
+    signal output outC[2];
+    signal output outD;
+
+    component crt1 = CallDiffTypeTest(3);
+    crt1.inA <== inA;
+    crt1.inB <== inB;
+    outA <== crt1.outA;
+    outB <== crt1.outB;
+    component crt2 = CallDiffTypeTest(2);
+    crt2.inA <== inC;
+    crt2.inB <== inD;
+    outC <== crt2.outA;
+    outD <== crt2.outB;
+}
+
+component main = Main();
+//CHECK-LABEL:  module attributes {veridise.lang = "llzk"} {

--- a/circom/tests/calls/call_diff_type_per_call.circom
+++ b/circom/tests/calls/call_diff_type_per_call.circom
@@ -1,0 +1,27 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// XFAIL:.*
+
+pragma circom 2.1.0;
+
+function f(a, b) {
+    return a + b;
+}
+
+// In circom, `signal` and `var` are both field elements, so there's
+// actually no difference in the function type between the two calls.
+template CallDiffTypeTest() {
+    signal input in1;
+    signal input in2;
+    signal output out1;
+    signal output out2;
+
+    out1 <== f(in1, in2); // f: (felt, felt) -> felt
+
+    var a = 1;
+    var x = f(a, in2); // f: (felt, felt) -> felt
+    out2 <== x;
+}
+
+component main = CallDiffTypeTest();
+//CHECK-LABEL:  module attributes {veridise.lang = "llzk"} {

--- a/circom/tests/calls/call_ret_array.circom
+++ b/circom/tests/calls/call_ret_array.circom
@@ -6,8 +6,7 @@
 pragma circom 2.1.0;
 
 function sum(a) {
-    var b[4] = a;
-    return b;
+    return a;
 }
 
 template CallRetTest() {

--- a/circom/tests/simple/dump_parse.circom
+++ b/circom/tests/simple/dump_parse.circom
@@ -13,315 +13,315 @@ template HelloWorld() {
 
 component main = HelloWorld();
 //CHECK-LABEL: ProgramArchive {
-//CHECK-NEXT :     id_max: 8,
-//CHECK-NEXT :     file_id_main: [[FD:[0-9]+]],
+// CHECK-NEXT:     id_max: 8,
+// CHECK-NEXT:     file_id_main: [[FD:[0-9]+]],
 //CHECK-LABEL:     file_library: FileLibrary {
-//CHECK-NEXT :       files: SimpleFiles {
-//CHECK-NEXT :           files: [
-//CHECK-NEXT :               SimpleFile {
-//CHECK-NEXT :                   name: "<generated>",
-//CHECK-NEXT :                   source: "",
-//CHECK-NEXT :                   line_starts: [
-//CHECK-NEXT :                       0,
-//CHECK-NEXT :                   ],
-//CHECK-NEXT :               },
-//CHECK-NEXT :               SimpleFile {
-//CHECK-NEXT :                   name: {{.*}}
-//CHECK-NEXT :                   source: {{.*}}
+// CHECK-NEXT:       files: SimpleFiles {
+// CHECK-NEXT:           files: [
+// CHECK-NEXT:               SimpleFile {
+// CHECK-NEXT:                   name: "<generated>",
+// CHECK-NEXT:                   source: "",
+// CHECK-NEXT:                   line_starts: [
+// CHECK-NEXT:                       0,
+// CHECK-NEXT:                   ],
+// CHECK-NEXT:               },
+// CHECK-NEXT:               SimpleFile {
+// CHECK-NEXT:                   name: {{.*}}
+// CHECK-NEXT:                   source: {{.*}}
 //        COM:                      (--match-full-lines ensures this matches to the end to avoid match
 //        COM:                      problems caused by 'source' containing the full content of this file)
-//CHECK-NEXT :                   line_starts: [
+// CHECK-NEXT:                   line_starts: [
 //        COM:                      (skip the long list of "line_starts")
 //CHECK-LABEL:     functions: {},
 //CHECK-LABEL:     templates: {
-//CHECK-NEXT :         "HelloWorld": TemplateData {
-//CHECK-NEXT :             file_id: [[FD]],
-//CHECK-NEXT :             name: "HelloWorld",
-//CHECK-NEXT :             body: Block {
-//CHECK-NEXT :                 meta: Meta {
-//CHECK-NEXT :                     elem_id: [[[0-9]+]],
-//CHECK-NEXT :                     start: [[[0-9]+]],
-//CHECK-NEXT :                     end: [[[0-9]+]],
-//CHECK-NEXT :                     location: [[[0-9]+]]..[[[0-9]+]],
-//CHECK-NEXT :                     file_id: Some(
-//CHECK-NEXT :                         [[FD]],
-//CHECK-NEXT :                     ),
-//CHECK-NEXT :                     component_inference: None,
-//CHECK-NEXT :                     type_knowledge: TypeKnowledge {
-//CHECK-NEXT :                         reduces_to: None,
-//CHECK-NEXT :                     },
-//CHECK-NEXT :                     memory_knowledge: MemoryKnowledge {
-//CHECK-NEXT :                         concrete_dimensions: None,
-//CHECK-NEXT :                         full_length: None,
-//CHECK-NEXT :                         abstract_memory_address: None,
-//CHECK-NEXT :                     },
-//CHECK-NEXT :                 },
-//CHECK-NEXT :                 stmts: [
-//CHECK-NEXT :                     InitializationBlock {
-//CHECK-NEXT :                         meta: Meta {
-//CHECK-NEXT :                             elem_id: [[[0-9]+]],
-//CHECK-NEXT :                             start: [[[0-9]+]],
-//CHECK-NEXT :                             end: [[[0-9]+]],
-//CHECK-NEXT :                             location: [[[0-9]+]]..[[[0-9]+]],
-//CHECK-NEXT :                             file_id: Some(
-//CHECK-NEXT :                                 [[FD]],
-//CHECK-NEXT :                             ),
-//CHECK-NEXT :                             component_inference: None,
-//CHECK-NEXT :                             type_knowledge: TypeKnowledge {
-//CHECK-NEXT :                                 reduces_to: None,
-//CHECK-NEXT :                             },
-//CHECK-NEXT :                             memory_knowledge: MemoryKnowledge {
-//CHECK-NEXT :                                 concrete_dimensions: None,
-//CHECK-NEXT :                                 full_length: None,
-//CHECK-NEXT :                                 abstract_memory_address: None,
-//CHECK-NEXT :                             },
-//CHECK-NEXT :                         },
-//CHECK-NEXT :                         xtype: Var,
-//CHECK-NEXT :                         initializations: [],
-//CHECK-NEXT :                     },
-//CHECK-NEXT :                     InitializationBlock {
-//CHECK-NEXT :                         meta: Meta {
-//CHECK-NEXT :                             elem_id: [[[0-9]+]],
-//CHECK-NEXT :                             start: [[[0-9]+]],
-//CHECK-NEXT :                             end: [[[0-9]+]],
-//CHECK-NEXT :                             location: [[[0-9]+]]..[[[0-9]+]],
-//CHECK-NEXT :                             file_id: Some(
-//CHECK-NEXT :                                 [[FD]],
-//CHECK-NEXT :                             ),
-//CHECK-NEXT :                             component_inference: None,
-//CHECK-NEXT :                             type_knowledge: TypeKnowledge {
-//CHECK-NEXT :                                 reduces_to: None,
-//CHECK-NEXT :                             },
-//CHECK-NEXT :                             memory_knowledge: MemoryKnowledge {
-//CHECK-NEXT :                                 concrete_dimensions: None,
-//CHECK-NEXT :                                 full_length: None,
-//CHECK-NEXT :                                 abstract_memory_address: None,
-//CHECK-NEXT :                             },
-//CHECK-NEXT :                         },
-//CHECK-NEXT :                         xtype: Component,
-//CHECK-NEXT :                         initializations: [],
-//CHECK-NEXT :                     },
-//CHECK-NEXT :                     InitializationBlock {
-//CHECK-NEXT :                         meta: Meta {
-//CHECK-NEXT :                             elem_id: [[[0-9]+]],
-//CHECK-NEXT :                             start: [[[0-9]+]],
-//CHECK-NEXT :                             end: [[[0-9]+]],
-//CHECK-NEXT :                             location: [[[0-9]+]]..[[[0-9]+]],
-//CHECK-NEXT :                             file_id: Some(
-//CHECK-NEXT :                                 [[FD]],
-//CHECK-NEXT :                             ),
-//CHECK-NEXT :                             component_inference: None,
-//CHECK-NEXT :                             type_knowledge: TypeKnowledge {
-//CHECK-NEXT :                                 reduces_to: None,
-//CHECK-NEXT :                             },
-//CHECK-NEXT :                             memory_knowledge: MemoryKnowledge {
-//CHECK-NEXT :                                 concrete_dimensions: None,
-//CHECK-NEXT :                                 full_length: None,
-//CHECK-NEXT :                                 abstract_memory_address: None,
-//CHECK-NEXT :                             },
-//CHECK-NEXT :                         },
-//CHECK-NEXT :                         xtype: Signal(
-//CHECK-NEXT :                             Input,
-//CHECK-NEXT :                             [],
-//CHECK-NEXT :                         ),
-//CHECK-NEXT :                         initializations: [
-//CHECK-NEXT :                             Declaration {
-//CHECK-NEXT :                                 meta: Meta {
-//CHECK-NEXT :                                     elem_id: [[[0-9]+]],
-//CHECK-NEXT :                                     start: [[[0-9]+]],
-//CHECK-NEXT :                                     end: [[[0-9]+]],
-//CHECK-NEXT :                                     location: [[[0-9]+]]..[[[0-9]+]],
-//CHECK-NEXT :                                     file_id: Some(
-//CHECK-NEXT :                                         [[FD]],
-//CHECK-NEXT :                                     ),
-//CHECK-NEXT :                                     component_inference: None,
-//CHECK-NEXT :                                     type_knowledge: TypeKnowledge {
-//CHECK-NEXT :                                         reduces_to: None,
-//CHECK-NEXT :                                     },
-//CHECK-NEXT :                                     memory_knowledge: MemoryKnowledge {
-//CHECK-NEXT :                                         concrete_dimensions: None,
-//CHECK-NEXT :                                         full_length: None,
-//CHECK-NEXT :                                         abstract_memory_address: None,
-//CHECK-NEXT :                                     },
-//CHECK-NEXT :                                 },
-//CHECK-NEXT :                                 xtype: Signal(
-//CHECK-NEXT :                                     Input,
-//CHECK-NEXT :                                     [],
-//CHECK-NEXT :                                 ),
-//CHECK-NEXT :                                 name: "a",
-//CHECK-NEXT :                                 dimensions: [],
-//CHECK-NEXT :                                 is_constant: true,
-//CHECK-NEXT :                                 is_anonymous: false,
-//CHECK-NEXT :                             },
-//CHECK-NEXT :                         ],
-//CHECK-NEXT :                     },
-//CHECK-NEXT :                     InitializationBlock {
-//CHECK-NEXT :                         meta: Meta {
-//CHECK-NEXT :                             elem_id: [[[0-9]+]],
-//CHECK-NEXT :                             start: [[[0-9]+]],
-//CHECK-NEXT :                             end: [[[0-9]+]],
-//CHECK-NEXT :                             location: [[[0-9]+]]..[[[0-9]+]],
-//CHECK-NEXT :                             file_id: Some(
-//CHECK-NEXT :                                 [[FD]],
-//CHECK-NEXT :                             ),
-//CHECK-NEXT :                             component_inference: None,
-//CHECK-NEXT :                             type_knowledge: TypeKnowledge {
-//CHECK-NEXT :                                 reduces_to: None,
-//CHECK-NEXT :                             },
-//CHECK-NEXT :                             memory_knowledge: MemoryKnowledge {
-//CHECK-NEXT :                                 concrete_dimensions: None,
-//CHECK-NEXT :                                 full_length: None,
-//CHECK-NEXT :                                 abstract_memory_address: None,
-//CHECK-NEXT :                             },
-//CHECK-NEXT :                         },
-//CHECK-NEXT :                         xtype: Signal(
-//CHECK-NEXT :                             Output,
-//CHECK-NEXT :                             [],
-//CHECK-NEXT :                         ),
-//CHECK-NEXT :                         initializations: [
-//CHECK-NEXT :                             Declaration {
-//CHECK-NEXT :                                 meta: Meta {
-//CHECK-NEXT :                                     elem_id: [[[0-9]+]],
-//CHECK-NEXT :                                     start: [[[0-9]+]],
-//CHECK-NEXT :                                     end: [[[0-9]+]],
-//CHECK-NEXT :                                     location: [[[0-9]+]]..[[[0-9]+]],
-//CHECK-NEXT :                                     file_id: Some(
-//CHECK-NEXT :                                         [[FD]],
-//CHECK-NEXT :                                     ),
-//CHECK-NEXT :                                     component_inference: None,
-//CHECK-NEXT :                                     type_knowledge: TypeKnowledge {
-//CHECK-NEXT :                                         reduces_to: None,
-//CHECK-NEXT :                                     },
-//CHECK-NEXT :                                     memory_knowledge: MemoryKnowledge {
-//CHECK-NEXT :                                         concrete_dimensions: None,
-//CHECK-NEXT :                                         full_length: None,
-//CHECK-NEXT :                                         abstract_memory_address: None,
-//CHECK-NEXT :                                     },
-//CHECK-NEXT :                                 },
-//CHECK-NEXT :                                 xtype: Signal(
-//CHECK-NEXT :                                     Output,
-//CHECK-NEXT :                                     [],
-//CHECK-NEXT :                                 ),
-//CHECK-NEXT :                                 name: "b",
-//CHECK-NEXT :                                 dimensions: [],
-//CHECK-NEXT :                                 is_constant: true,
-//CHECK-NEXT :                                 is_anonymous: false,
-//CHECK-NEXT :                             },
-//CHECK-NEXT :                         ],
-//CHECK-NEXT :                     },
-//CHECK-NEXT :                     Substitution {
-//CHECK-NEXT :                         meta: Meta {
-//CHECK-NEXT :                             elem_id: [[[0-9]+]],
-//CHECK-NEXT :                             start: [[[0-9]+]],
-//CHECK-NEXT :                             end: [[[0-9]+]],
-//CHECK-NEXT :                             location: [[[0-9]+]]..[[[0-9]+]],
-//CHECK-NEXT :                             file_id: Some(
-//CHECK-NEXT :                                 [[FD]],
-//CHECK-NEXT :                             ),
-//CHECK-NEXT :                             component_inference: None,
-//CHECK-NEXT :                             type_knowledge: TypeKnowledge {
-//CHECK-NEXT :                                 reduces_to: Some(
-//CHECK-NEXT :                                     Signal,
-//CHECK-NEXT :                                 ),
-//CHECK-NEXT :                             },
-//CHECK-NEXT :                             memory_knowledge: MemoryKnowledge {
-//CHECK-NEXT :                                 concrete_dimensions: None,
-//CHECK-NEXT :                                 full_length: None,
-//CHECK-NEXT :                                 abstract_memory_address: None,
-//CHECK-NEXT :                             },
-//CHECK-NEXT :                         },
-//CHECK-NEXT :                         var: "b",
-//CHECK-NEXT :                         access: [],
-//CHECK-NEXT :                         op: AssignConstraintSignal,
-//CHECK-NEXT :                         rhe: Variable {
-//CHECK-NEXT :                             meta: Meta {
-//CHECK-NEXT :                                 elem_id: [[[0-9]+]],
-//CHECK-NEXT :                                 start: [[[0-9]+]],
-//CHECK-NEXT :                                 end: [[[0-9]+]],
-//CHECK-NEXT :                                 location: [[[0-9]+]]..[[[0-9]+]],
-//CHECK-NEXT :                                 file_id: Some(
-//CHECK-NEXT :                                     [[FD]],
-//CHECK-NEXT :                                 ),
-//CHECK-NEXT :                                 component_inference: None,
-//CHECK-NEXT :                                 type_knowledge: TypeKnowledge {
-//CHECK-NEXT :                                     reduces_to: Some(
-//CHECK-NEXT :                                         Signal,
-//CHECK-NEXT :                                     ),
-//CHECK-NEXT :                                 },
-//CHECK-NEXT :                                 memory_knowledge: MemoryKnowledge {
-//CHECK-NEXT :                                     concrete_dimensions: None,
-//CHECK-NEXT :                                     full_length: None,
-//CHECK-NEXT :                                     abstract_memory_address: None,
-//CHECK-NEXT :                                 },
-//CHECK-NEXT :                             },
-//CHECK-NEXT :                             name: "a",
-//CHECK-NEXT :                             access: [],
-//CHECK-NEXT :                         },
-//CHECK-NEXT :                     },
-//CHECK-NEXT :                 ],
-//CHECK-NEXT :             },
-//CHECK-NEXT :             num_of_params: 0,
-//CHECK-NEXT :             name_of_params: [],
-//CHECK-NEXT :             param_location: [[[0-9]+]]..[[[0-9]+]],
-//CHECK-NEXT :             input_wires: {
-//CHECK-NEXT :                 "a": WireData {
-//CHECK-NEXT :                     wire_type: Signal,
-//CHECK-NEXT :                     dimension: 0,
-//CHECK-NEXT :                     tag_info: {},
-//CHECK-NEXT :                 },
-//CHECK-NEXT :             },
-//CHECK-NEXT :             output_wires: {
-//CHECK-NEXT :                 "b": WireData {
-//CHECK-NEXT :                     wire_type: Signal,
-//CHECK-NEXT :                     dimension: 0,
-//CHECK-NEXT :                     tag_info: {},
-//CHECK-NEXT :                 },
-//CHECK-NEXT :             },
-//CHECK-NEXT :             is_parallel: false,
-//CHECK-NEXT :             is_custom_gate: false,
-//CHECK-NEXT :             is_extern_c: false,
-//CHECK-NEXT :             input_declarations: [
-//CHECK-NEXT :                 (
-//CHECK-NEXT :                     "a",
-//CHECK-NEXT :                     0,
-//CHECK-NEXT :                 ),
-//CHECK-NEXT :             ],
-//CHECK-NEXT :             output_declarations: [
-//CHECK-NEXT :                 (
-//CHECK-NEXT :                     "b",
-//CHECK-NEXT :                     0,
-//CHECK-NEXT :                 ),
-//CHECK-NEXT :             ],
-//CHECK-NEXT :         },
-//CHECK-NEXT :     },
-//CHECK-NEXT :     buses: {},
-//CHECK-NEXT :     function_keys: {},
-//CHECK-NEXT :     template_keys: {
-//CHECK-NEXT :         "HelloWorld",
-//CHECK-NEXT :     },
-//CHECK-NEXT :     bus_keys: {},
-//CHECK-NEXT :     public_inputs: [],
-//CHECK-NEXT :     initial_template_call: Call {
-//CHECK-NEXT :         meta: Meta {
-//CHECK-NEXT :             elem_id: [[[0-9]+]],
-//CHECK-NEXT :             start: [[[0-9]+]],
-//CHECK-NEXT :             end: [[[0-9]+]],
-//CHECK-NEXT :             location: [[[0-9]+]]..[[[0-9]+]],
-//CHECK-NEXT :             file_id: Some(
-//CHECK-NEXT :                 [[FD]],
-//CHECK-NEXT :             ),
-//CHECK-NEXT :             component_inference: None,
-//CHECK-NEXT :             type_knowledge: TypeKnowledge {
-//CHECK-NEXT :                 reduces_to: None,
-//CHECK-NEXT :             },
-//CHECK-NEXT :             memory_knowledge: MemoryKnowledge {
-//CHECK-NEXT :                 concrete_dimensions: None,
-//CHECK-NEXT :                 full_length: None,
-//CHECK-NEXT :                 abstract_memory_address: None,
-//CHECK-NEXT :             },
-//CHECK-NEXT :         },
-//CHECK-NEXT :         id: "HelloWorld",
-//CHECK-NEXT :         args: [],
-//CHECK-NEXT :     },
-//CHECK-NEXT :     custom_gates: false,
-//CHECK-NEXT : }
+// CHECK-NEXT:         "HelloWorld": TemplateData {
+// CHECK-NEXT:             file_id: [[FD]],
+// CHECK-NEXT:             name: "HelloWorld",
+// CHECK-NEXT:             body: Block {
+// CHECK-NEXT:                 meta: Meta {
+// CHECK-NEXT:                     elem_id: {{[0-9]+}},
+// CHECK-NEXT:                     start: {{[0-9]+}},
+// CHECK-NEXT:                     end: {{[0-9]+}},
+// CHECK-NEXT:                     location: {{[0-9]+}}..{{[0-9]+}},
+// CHECK-NEXT:                     file_id: Some(
+// CHECK-NEXT:                         [[FD]],
+// CHECK-NEXT:                     ),
+// CHECK-NEXT:                     component_inference: None,
+// CHECK-NEXT:                     type_knowledge: TypeKnowledge {
+// CHECK-NEXT:                         reduces_to: None,
+// CHECK-NEXT:                     },
+// CHECK-NEXT:                     memory_knowledge: MemoryKnowledge {
+// CHECK-NEXT:                         concrete_dimensions: None,
+// CHECK-NEXT:                         full_length: None,
+// CHECK-NEXT:                         abstract_memory_address: None,
+// CHECK-NEXT:                     },
+// CHECK-NEXT:                 },
+// CHECK-NEXT:                 stmts: [
+// CHECK-NEXT:                     InitializationBlock {
+// CHECK-NEXT:                         meta: Meta {
+// CHECK-NEXT:                             elem_id: {{[0-9]+}},
+// CHECK-NEXT:                             start: {{[0-9]+}},
+// CHECK-NEXT:                             end: {{[0-9]+}},
+// CHECK-NEXT:                             location: {{[0-9]+}}..{{[0-9]+}},
+// CHECK-NEXT:                             file_id: Some(
+// CHECK-NEXT:                                 [[FD]],
+// CHECK-NEXT:                             ),
+// CHECK-NEXT:                             component_inference: None,
+// CHECK-NEXT:                             type_knowledge: TypeKnowledge {
+// CHECK-NEXT:                                 reduces_to: None,
+// CHECK-NEXT:                             },
+// CHECK-NEXT:                             memory_knowledge: MemoryKnowledge {
+// CHECK-NEXT:                                 concrete_dimensions: None,
+// CHECK-NEXT:                                 full_length: None,
+// CHECK-NEXT:                                 abstract_memory_address: None,
+// CHECK-NEXT:                             },
+// CHECK-NEXT:                         },
+// CHECK-NEXT:                         xtype: Var,
+// CHECK-NEXT:                         initializations: [],
+// CHECK-NEXT:                     },
+// CHECK-NEXT:                     InitializationBlock {
+// CHECK-NEXT:                         meta: Meta {
+// CHECK-NEXT:                             elem_id: {{[0-9]+}},
+// CHECK-NEXT:                             start: {{[0-9]+}},
+// CHECK-NEXT:                             end: {{[0-9]+}},
+// CHECK-NEXT:                             location: {{[0-9]+}}..{{[0-9]+}},
+// CHECK-NEXT:                             file_id: Some(
+// CHECK-NEXT:                                 [[FD]],
+// CHECK-NEXT:                             ),
+// CHECK-NEXT:                             component_inference: None,
+// CHECK-NEXT:                             type_knowledge: TypeKnowledge {
+// CHECK-NEXT:                                 reduces_to: None,
+// CHECK-NEXT:                             },
+// CHECK-NEXT:                             memory_knowledge: MemoryKnowledge {
+// CHECK-NEXT:                                 concrete_dimensions: None,
+// CHECK-NEXT:                                 full_length: None,
+// CHECK-NEXT:                                 abstract_memory_address: None,
+// CHECK-NEXT:                             },
+// CHECK-NEXT:                         },
+// CHECK-NEXT:                         xtype: Component,
+// CHECK-NEXT:                         initializations: [],
+// CHECK-NEXT:                     },
+// CHECK-NEXT:                     InitializationBlock {
+// CHECK-NEXT:                         meta: Meta {
+// CHECK-NEXT:                             elem_id: {{[0-9]+}},
+// CHECK-NEXT:                             start: {{[0-9]+}},
+// CHECK-NEXT:                             end: {{[0-9]+}},
+// CHECK-NEXT:                             location: {{[0-9]+}}..{{[0-9]+}},
+// CHECK-NEXT:                             file_id: Some(
+// CHECK-NEXT:                                 [[FD]],
+// CHECK-NEXT:                             ),
+// CHECK-NEXT:                             component_inference: None,
+// CHECK-NEXT:                             type_knowledge: TypeKnowledge {
+// CHECK-NEXT:                                 reduces_to: None,
+// CHECK-NEXT:                             },
+// CHECK-NEXT:                             memory_knowledge: MemoryKnowledge {
+// CHECK-NEXT:                                 concrete_dimensions: None,
+// CHECK-NEXT:                                 full_length: None,
+// CHECK-NEXT:                                 abstract_memory_address: None,
+// CHECK-NEXT:                             },
+// CHECK-NEXT:                         },
+// CHECK-NEXT:                         xtype: Signal(
+// CHECK-NEXT:                             Input,
+// CHECK-NEXT:                             [],
+// CHECK-NEXT:                         ),
+// CHECK-NEXT:                         initializations: [
+// CHECK-NEXT:                             Declaration {
+// CHECK-NEXT:                                 meta: Meta {
+// CHECK-NEXT:                                     elem_id: {{[0-9]+}},
+// CHECK-NEXT:                                     start: {{[0-9]+}},
+// CHECK-NEXT:                                     end: {{[0-9]+}},
+// CHECK-NEXT:                                     location: {{[0-9]+}}..{{[0-9]+}},
+// CHECK-NEXT:                                     file_id: Some(
+// CHECK-NEXT:                                         [[FD]],
+// CHECK-NEXT:                                     ),
+// CHECK-NEXT:                                     component_inference: None,
+// CHECK-NEXT:                                     type_knowledge: TypeKnowledge {
+// CHECK-NEXT:                                         reduces_to: None,
+// CHECK-NEXT:                                     },
+// CHECK-NEXT:                                     memory_knowledge: MemoryKnowledge {
+// CHECK-NEXT:                                         concrete_dimensions: None,
+// CHECK-NEXT:                                         full_length: None,
+// CHECK-NEXT:                                         abstract_memory_address: None,
+// CHECK-NEXT:                                     },
+// CHECK-NEXT:                                 },
+// CHECK-NEXT:                                 xtype: Signal(
+// CHECK-NEXT:                                     Input,
+// CHECK-NEXT:                                     [],
+// CHECK-NEXT:                                 ),
+// CHECK-NEXT:                                 name: "a",
+// CHECK-NEXT:                                 dimensions: [],
+// CHECK-NEXT:                                 is_constant: true,
+// CHECK-NEXT:                                 is_anonymous: false,
+// CHECK-NEXT:                             },
+// CHECK-NEXT:                         ],
+// CHECK-NEXT:                     },
+// CHECK-NEXT:                     InitializationBlock {
+// CHECK-NEXT:                         meta: Meta {
+// CHECK-NEXT:                             elem_id: {{[0-9]+}},
+// CHECK-NEXT:                             start: {{[0-9]+}},
+// CHECK-NEXT:                             end: {{[0-9]+}},
+// CHECK-NEXT:                             location: {{[0-9]+}}..{{[0-9]+}},
+// CHECK-NEXT:                             file_id: Some(
+// CHECK-NEXT:                                 [[FD]],
+// CHECK-NEXT:                             ),
+// CHECK-NEXT:                             component_inference: None,
+// CHECK-NEXT:                             type_knowledge: TypeKnowledge {
+// CHECK-NEXT:                                 reduces_to: None,
+// CHECK-NEXT:                             },
+// CHECK-NEXT:                             memory_knowledge: MemoryKnowledge {
+// CHECK-NEXT:                                 concrete_dimensions: None,
+// CHECK-NEXT:                                 full_length: None,
+// CHECK-NEXT:                                 abstract_memory_address: None,
+// CHECK-NEXT:                             },
+// CHECK-NEXT:                         },
+// CHECK-NEXT:                         xtype: Signal(
+// CHECK-NEXT:                             Output,
+// CHECK-NEXT:                             [],
+// CHECK-NEXT:                         ),
+// CHECK-NEXT:                         initializations: [
+// CHECK-NEXT:                             Declaration {
+// CHECK-NEXT:                                 meta: Meta {
+// CHECK-NEXT:                                     elem_id: {{[0-9]+}},
+// CHECK-NEXT:                                     start: {{[0-9]+}},
+// CHECK-NEXT:                                     end: {{[0-9]+}},
+// CHECK-NEXT:                                     location: {{[0-9]+}}..{{[0-9]+}},
+// CHECK-NEXT:                                     file_id: Some(
+// CHECK-NEXT:                                         [[FD]],
+// CHECK-NEXT:                                     ),
+// CHECK-NEXT:                                     component_inference: None,
+// CHECK-NEXT:                                     type_knowledge: TypeKnowledge {
+// CHECK-NEXT:                                         reduces_to: None,
+// CHECK-NEXT:                                     },
+// CHECK-NEXT:                                     memory_knowledge: MemoryKnowledge {
+// CHECK-NEXT:                                         concrete_dimensions: None,
+// CHECK-NEXT:                                         full_length: None,
+// CHECK-NEXT:                                         abstract_memory_address: None,
+// CHECK-NEXT:                                     },
+// CHECK-NEXT:                                 },
+// CHECK-NEXT:                                 xtype: Signal(
+// CHECK-NEXT:                                     Output,
+// CHECK-NEXT:                                     [],
+// CHECK-NEXT:                                 ),
+// CHECK-NEXT:                                 name: "b",
+// CHECK-NEXT:                                 dimensions: [],
+// CHECK-NEXT:                                 is_constant: true,
+// CHECK-NEXT:                                 is_anonymous: false,
+// CHECK-NEXT:                             },
+// CHECK-NEXT:                         ],
+// CHECK-NEXT:                     },
+// CHECK-NEXT:                     Substitution {
+// CHECK-NEXT:                         meta: Meta {
+// CHECK-NEXT:                             elem_id: {{[0-9]+}},
+// CHECK-NEXT:                             start: {{[0-9]+}},
+// CHECK-NEXT:                             end: {{[0-9]+}},
+// CHECK-NEXT:                             location: {{[0-9]+}}..{{[0-9]+}},
+// CHECK-NEXT:                             file_id: Some(
+// CHECK-NEXT:                                 [[FD]],
+// CHECK-NEXT:                             ),
+// CHECK-NEXT:                             component_inference: None,
+// CHECK-NEXT:                             type_knowledge: TypeKnowledge {
+// CHECK-NEXT:                                 reduces_to: Some(
+// CHECK-NEXT:                                     Signal,
+// CHECK-NEXT:                                 ),
+// CHECK-NEXT:                             },
+// CHECK-NEXT:                             memory_knowledge: MemoryKnowledge {
+// CHECK-NEXT:                                 concrete_dimensions: None,
+// CHECK-NEXT:                                 full_length: None,
+// CHECK-NEXT:                                 abstract_memory_address: None,
+// CHECK-NEXT:                             },
+// CHECK-NEXT:                         },
+// CHECK-NEXT:                         var: "b",
+// CHECK-NEXT:                         access: [],
+// CHECK-NEXT:                         op: AssignConstraintSignal,
+// CHECK-NEXT:                         rhe: Variable {
+// CHECK-NEXT:                             meta: Meta {
+// CHECK-NEXT:                                 elem_id: {{[0-9]+}},
+// CHECK-NEXT:                                 start: {{[0-9]+}},
+// CHECK-NEXT:                                 end: {{[0-9]+}},
+// CHECK-NEXT:                                 location: {{[0-9]+}}..{{[0-9]+}},
+// CHECK-NEXT:                                 file_id: Some(
+// CHECK-NEXT:                                     [[FD]],
+// CHECK-NEXT:                                 ),
+// CHECK-NEXT:                                 component_inference: None,
+// CHECK-NEXT:                                 type_knowledge: TypeKnowledge {
+// CHECK-NEXT:                                     reduces_to: Some(
+// CHECK-NEXT:                                         Signal,
+// CHECK-NEXT:                                     ),
+// CHECK-NEXT:                                 },
+// CHECK-NEXT:                                 memory_knowledge: MemoryKnowledge {
+// CHECK-NEXT:                                     concrete_dimensions: None,
+// CHECK-NEXT:                                     full_length: None,
+// CHECK-NEXT:                                     abstract_memory_address: None,
+// CHECK-NEXT:                                 },
+// CHECK-NEXT:                             },
+// CHECK-NEXT:                             name: "a",
+// CHECK-NEXT:                             access: [],
+// CHECK-NEXT:                         },
+// CHECK-NEXT:                     },
+// CHECK-NEXT:                 ],
+// CHECK-NEXT:             },
+// CHECK-NEXT:             num_of_params: 0,
+// CHECK-NEXT:             name_of_params: [],
+// CHECK-NEXT:             param_location: {{[0-9]+}}..{{[0-9]+}},
+// CHECK-NEXT:             input_wires: {
+// CHECK-NEXT:                 "a": WireData {
+// CHECK-NEXT:                     wire_type: Signal,
+// CHECK-NEXT:                     dimension: 0,
+// CHECK-NEXT:                     tag_info: {},
+// CHECK-NEXT:                 },
+// CHECK-NEXT:             },
+// CHECK-NEXT:             output_wires: {
+// CHECK-NEXT:                 "b": WireData {
+// CHECK-NEXT:                     wire_type: Signal,
+// CHECK-NEXT:                     dimension: 0,
+// CHECK-NEXT:                     tag_info: {},
+// CHECK-NEXT:                 },
+// CHECK-NEXT:             },
+// CHECK-NEXT:             is_parallel: false,
+// CHECK-NEXT:             is_custom_gate: false,
+// CHECK-NEXT:             is_extern_c: false,
+// CHECK-NEXT:             input_declarations: [
+// CHECK-NEXT:                 (
+// CHECK-NEXT:                     "a",
+// CHECK-NEXT:                     0,
+// CHECK-NEXT:                 ),
+// CHECK-NEXT:             ],
+// CHECK-NEXT:             output_declarations: [
+// CHECK-NEXT:                 (
+// CHECK-NEXT:                     "b",
+// CHECK-NEXT:                     0,
+// CHECK-NEXT:                 ),
+// CHECK-NEXT:             ],
+// CHECK-NEXT:         },
+// CHECK-NEXT:     },
+// CHECK-NEXT:     buses: {},
+// CHECK-NEXT:     function_keys: {},
+// CHECK-NEXT:     template_keys: {
+// CHECK-NEXT:         "HelloWorld",
+// CHECK-NEXT:     },
+// CHECK-NEXT:     bus_keys: {},
+// CHECK-NEXT:     public_inputs: [],
+// CHECK-NEXT:     initial_template_call: Call {
+// CHECK-NEXT:         meta: Meta {
+// CHECK-NEXT:             elem_id: {{[0-9]+}},
+// CHECK-NEXT:             start: {{[0-9]+}},
+// CHECK-NEXT:             end: {{[0-9]+}},
+// CHECK-NEXT:             location: {{[0-9]+}}..{{[0-9]+}},
+// CHECK-NEXT:             file_id: Some(
+// CHECK-NEXT:                 [[FD]],
+// CHECK-NEXT:             ),
+// CHECK-NEXT:             component_inference: None,
+// CHECK-NEXT:             type_knowledge: TypeKnowledge {
+// CHECK-NEXT:                 reduces_to: None,
+// CHECK-NEXT:             },
+// CHECK-NEXT:             memory_knowledge: MemoryKnowledge {
+// CHECK-NEXT:                 concrete_dimensions: None,
+// CHECK-NEXT:                 full_length: None,
+// CHECK-NEXT:                 abstract_memory_address: None,
+// CHECK-NEXT:             },
+// CHECK-NEXT:         },
+// CHECK-NEXT:         id: "HelloWorld",
+// CHECK-NEXT:         args: [],
+// CHECK-NEXT:     },
+// CHECK-NEXT:     custom_gates: false,
+// CHECK-NEXT: }


### PR DESCRIPTION
- fix test where CHECK lines had a space before the `:` which caused them to be skipped
- add tests (and simplify one test) showing how circom functions are "duck typed" and can be used differently at different call sites as long as the version instantiated for that call site passes type/semantic checks