### PR TITLE
Properly track variable shadowing and overwriting in nested blocks

### DIFF
--- a/circom/tests/simple/blocks_01.circom
+++ b/circom/tests/simple/blocks_01.circom
@@ -1,0 +1,56 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
+
+pragma circom 2.0.0;
+
+// This test demonstrates that variables defined outside a block can be overwritten
+// inside blocks because no "error[T3001]: False assert reached" is raised but if any
+// of the asserts are changed, the error will be raised.
+template B() {
+  var x = 5;
+  {
+    assert(x == 5);
+    x = 10; // overwrites value of x
+    assert(x == 10);
+  }
+  assert(x == 10);
+}
+
+component main = B();
+
+// CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-LABEL:   struct.def @B<[]> {
+// CHECK-LABEL:     function.def @compute
+// CHECK-SAME:      () -> !struct.type<@B<[]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_0:[0-9a-zA-Z_\.]+]] = struct.new : <@B<[]>>
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = felt.const  5
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = felt.const  5
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = bool.cmp eq(%[[VAL_1]], %[[VAL_2]])
+// CHECK-NEXT:        bool.assert %[[VAL_3]], "assertion failed"
+// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = felt.const  10
+// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = felt.const  10
+// CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = bool.cmp eq(%[[VAL_4]], %[[VAL_5]])
+// CHECK-NEXT:        bool.assert %[[VAL_6]], "assertion failed"
+// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = felt.const  10
+// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = bool.cmp eq(%[[VAL_4]], %[[VAL_7]])
+// CHECK-NEXT:        bool.assert %[[VAL_8]], "assertion failed"
+// CHECK-NEXT:        function.return %[[VAL_0]] : !struct.type<@B<[]>>
+// CHECK-NEXT:      }
+// CHECK-LABEL:     function.def @constrain
+// CHECK-SAME:      (%[[VAL_9:[0-9a-zA-Z_\.]+]]: !struct.type<@B<[]>>) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = felt.const  5
+// CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]] = felt.const  5
+// CHECK-NEXT:        %[[VAL_12:[0-9a-zA-Z_\.]+]] = bool.cmp eq(%[[VAL_10]], %[[VAL_11]])
+// CHECK-NEXT:        bool.assert %[[VAL_12]], "assertion failed"
+// CHECK-NEXT:        %[[VAL_13:[0-9a-zA-Z_\.]+]] = felt.const  10
+// CHECK-NEXT:        %[[VAL_14:[0-9a-zA-Z_\.]+]] = felt.const  10
+// CHECK-NEXT:        %[[VAL_15:[0-9a-zA-Z_\.]+]] = bool.cmp eq(%[[VAL_13]], %[[VAL_14]])
+// CHECK-NEXT:        bool.assert %[[VAL_15]], "assertion failed"
+// CHECK-NEXT:        %[[VAL_16:[0-9a-zA-Z_\.]+]] = felt.const  10
+// CHECK-NEXT:        %[[VAL_17:[0-9a-zA-Z_\.]+]] = bool.cmp eq(%[[VAL_13]], %[[VAL_16]])
+// CHECK-NEXT:        bool.assert %[[VAL_17]], "assertion failed"
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/simple/blocks_02.circom
+++ b/circom/tests/simple/blocks_02.circom
@@ -1,0 +1,56 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
+
+pragma circom 2.0.0;
+
+// This test demonstrates that variables can be shadowed inside blocks
+// because no "error[T3001]: False assert reached" is raised but if any
+// of the asserts are changed, the error will be raised.
+template B() {
+  var x = 5;
+  {
+    assert(x == 5);
+    var x = 10; // shadows outer x
+    assert(x == 10);
+  }
+  assert(x == 5);
+}
+
+component main = B();
+
+// CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-LABEL:   struct.def @B<[]> {
+// CHECK-LABEL:     function.def @compute
+// CHECK-SAME:      () -> !struct.type<@B<[]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_0:[0-9a-zA-Z_\.]+]] = struct.new : <@B<[]>>
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = felt.const  5
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = felt.const  5
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = bool.cmp eq(%[[VAL_1]], %[[VAL_2]])
+// CHECK-NEXT:        bool.assert %[[VAL_3]], "assertion failed"
+// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = felt.const  10
+// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = felt.const  10
+// CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = bool.cmp eq(%[[VAL_4]], %[[VAL_5]])
+// CHECK-NEXT:        bool.assert %[[VAL_6]], "assertion failed"
+// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = felt.const  5
+// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = bool.cmp eq(%[[VAL_1]], %[[VAL_7]])
+// CHECK-NEXT:        bool.assert %[[VAL_8]], "assertion failed"
+// CHECK-NEXT:        function.return %[[VAL_0]] : !struct.type<@B<[]>>
+// CHECK-NEXT:      }
+// CHECK-LABEL:     function.def @constrain
+// CHECK-SAME:      (%[[VAL_9:[0-9a-zA-Z_\.]+]]: !struct.type<@B<[]>>) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = felt.const  5
+// CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]] = felt.const  5
+// CHECK-NEXT:        %[[VAL_12:[0-9a-zA-Z_\.]+]] = bool.cmp eq(%[[VAL_10]], %[[VAL_11]])
+// CHECK-NEXT:        bool.assert %[[VAL_12]], "assertion failed"
+// CHECK-NEXT:        %[[VAL_13:[0-9a-zA-Z_\.]+]] = felt.const  10
+// CHECK-NEXT:        %[[VAL_14:[0-9a-zA-Z_\.]+]] = felt.const  10
+// CHECK-NEXT:        %[[VAL_15:[0-9a-zA-Z_\.]+]] = bool.cmp eq(%[[VAL_13]], %[[VAL_14]])
+// CHECK-NEXT:        bool.assert %[[VAL_15]], "assertion failed"
+// CHECK-NEXT:        %[[VAL_16:[0-9a-zA-Z_\.]+]] = felt.const  5
+// CHECK-NEXT:        %[[VAL_17:[0-9a-zA-Z_\.]+]] = bool.cmp eq(%[[VAL_10]], %[[VAL_16]])
+// CHECK-NEXT:        bool.assert %[[VAL_17]], "assertion failed"
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/simple/blocks_03.circom
+++ b/circom/tests/simple/blocks_03.circom
@@ -1,0 +1,66 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
+
+pragma circom 2.0.0;
+
+// This test demonstrates that an inner block can both overwrite and shadow variables
+// defined outside a block because no "error[T3001]: False assert reached" is raised
+// but if any of the asserts are changed, the error will be raised.
+template B() {
+  var x = 5;
+  {
+    assert(x == 5);
+    x = 15; // overwrites value of outer x
+    assert(x == 15);
+    var x = 10; // shadows outer x
+    assert(x == 10);
+  }
+  assert(x == 15);
+}
+
+component main = B();
+
+// CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-LABEL:   struct.def @B<[]> {
+// CHECK-LABEL:     function.def @compute
+// CHECK-SAME:      () -> !struct.type<@B<[]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_0:.*]] = struct.new : <@B<[]>>
+// CHECK-NEXT:        %[[VAL_1:.*]] = felt.const  5
+// CHECK-NEXT:        %[[VAL_2:.*]] = felt.const  5
+// CHECK-NEXT:        %[[VAL_3:.*]] = bool.cmp eq(%[[VAL_1]], %[[VAL_2]])
+// CHECK-NEXT:        bool.assert %[[VAL_3]], "assertion failed"
+// CHECK-NEXT:        %[[VAL_4:.*]] = felt.const  15
+// CHECK-NEXT:        %[[VAL_5:.*]] = felt.const  15
+// CHECK-NEXT:        %[[VAL_6:.*]] = bool.cmp eq(%[[VAL_4]], %[[VAL_5]])
+// CHECK-NEXT:        bool.assert %[[VAL_6]], "assertion failed"
+// CHECK-NEXT:        %[[VAL_7:.*]] = felt.const  10
+// CHECK-NEXT:        %[[VAL_8:.*]] = felt.const  10
+// CHECK-NEXT:        %[[VAL_9:.*]] = bool.cmp eq(%[[VAL_7]], %[[VAL_8]])
+// CHECK-NEXT:        bool.assert %[[VAL_9]], "assertion failed"
+// CHECK-NEXT:        %[[VAL_10:.*]] = felt.const  15
+// CHECK-NEXT:        %[[VAL_11:.*]] = bool.cmp eq(%[[VAL_4]], %[[VAL_10]])
+// CHECK-NEXT:        bool.assert %[[VAL_11]], "assertion failed"
+// CHECK-NEXT:        function.return %[[VAL_0]] : !struct.type<@B<[]>>
+// CHECK-NEXT:      }
+// CHECK-LABEL:     function.def @constrain
+// CHECK-SAME:      (%[[VAL_12:.*]]: !struct.type<@B<[]>>) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[VAL_13:.*]] = felt.const  5
+// CHECK-NEXT:        %[[VAL_14:.*]] = felt.const  5
+// CHECK-NEXT:        %[[VAL_15:.*]] = bool.cmp eq(%[[VAL_13]], %[[VAL_14]])
+// CHECK-NEXT:        bool.assert %[[VAL_15]], "assertion failed"
+// CHECK-NEXT:        %[[VAL_16:.*]] = felt.const  15
+// CHECK-NEXT:        %[[VAL_17:.*]] = felt.const  15
+// CHECK-NEXT:        %[[VAL_18:.*]] = bool.cmp eq(%[[VAL_16]], %[[VAL_17]])
+// CHECK-NEXT:        bool.assert %[[VAL_18]], "assertion failed"
+// CHECK-NEXT:        %[[VAL_19:.*]] = felt.const  10
+// CHECK-NEXT:        %[[VAL_20:.*]] = felt.const  10
+// CHECK-NEXT:        %[[VAL_21:.*]] = bool.cmp eq(%[[VAL_19]], %[[VAL_20]])
+// CHECK-NEXT:        bool.assert %[[VAL_21]], "assertion failed"
+// CHECK-NEXT:        %[[VAL_22:.*]] = felt.const  15
+// CHECK-NEXT:        %[[VAL_23:.*]] = bool.cmp eq(%[[VAL_16]], %[[VAL_22]])
+// CHECK-NEXT:        bool.assert %[[VAL_23]], "assertion failed"
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/llzk_backend/src/codegen.rs
+++ b/llzk_backend/src/codegen.rs
@@ -1,3 +1,5 @@
+//! Entry point for LLZK code generation.
+
 use crate::{module::GenerateLLZKInModule as _, shared::LlzkCodegen};
 use ansi_term::Color;
 use anyhow::Result;

--- a/llzk_backend/src/function.rs
+++ b/llzk_backend/src/function.rs
@@ -1,4 +1,12 @@
+//! Handles function-level LLZK code generation for both free functions and functions within
+//! structs. The [function::FunctionContext] carries information about the current LLZK function
+//! being generated and some helpers related to generating code within the function. The
+//! [function::GenerateLLZKInFunction] trait provides the visitor to generate LLZK IR for all circom
+//! [Expression](program_structure::abstract_syntax_tree::ast::Expression) and
+//! [Statement](program_structure::abstract_syntax_tree::ast::Statement) nodes.
+
 #![allow(unused_variables)] // TODO: TEMP
+
 use crate::{
     gen_context::{BlockContextStack, GenWithCircomScopeHandling},
     shared::{self, new_felt_const_op, single_result_as_value, IsA, LlzkCodegen},

--- a/llzk_backend/src/function.rs
+++ b/llzk_backend/src/function.rs
@@ -86,21 +86,6 @@ where
         Ok(v)
     }
 
-    /// If the given name is not already declared in the current scope, declare it with an
-    /// uninitialized value of type `felt` with the given dimensions.
-    #[inline]
-    pub fn declare_name_uninit<'ast>(
-        &mut self,
-        codegen: &LlzkCodegen<'ast, 'ctx>,
-        name: String,
-        meta: &Meta,
-        dimensions: &[Expression],
-    ) -> Result<()> {
-        self.block_ctx.declare_name_if_not_present(name, || {
-            codegen.new_nondet_value_of_dimensions(meta, dimensions)
-        })
-    }
-
     /// Generate LLZK code in the current function for a circom prefix operation.
     pub fn gen_prefix_op<'ast>(
         &mut self,
@@ -418,7 +403,9 @@ where
                     // per `type_analysis/src/analyzers/functions_free_of_template_elements.rs`
                     unreachable!("Template elements declared inside the function")
                 }
-                function.declare_name_uninit(codegen, name.clone(), meta, dimensions)
+                function.block_ctx.declare_name_if_not_present(name, || {
+                    codegen.new_nondet_value_of_dimensions(meta, dimensions)
+                })
             }
             Statement::Block { stmts, .. } => {
                 function.gen_in_current_block_with_new_circom_scope(|function, _| {

--- a/llzk_backend/src/function.rs
+++ b/llzk_backend/src/function.rs
@@ -1,6 +1,6 @@
 #![allow(unused_variables)] // TODO: TEMP
 use crate::{
-    gen_context::BlockContextStack,
+    gen_context::{BlockContextStack, GenWithCircomScopeHandling},
     shared::{self, new_felt_const_op, single_result_as_value, IsA, LlzkCodegen},
 };
 use anyhow::{anyhow, Ok, Result};
@@ -79,31 +79,6 @@ where
     pub fn append_op_named_result(&mut self, op: Operation<'ctx>, name: String) {
         let v = self.append_op_unnamed_result(op).expect("Expected op to produce a single result");
         self.block_ctx.set_named_value(name, v);
-    }
-
-    /// Use the callback to generate code for a new circom Block scope within the given LLZK block.
-    /// Assignments to new circom vars in this context are dropped after the callback because
-    /// they go out of scope but assignments to existing circom vars in this context persist.
-    pub fn gen_in_given_block_with_new_circom_scope(
-        &mut self,
-        block: BlockRef<'ctx, 'blk>,
-        callback: impl FnOnce(&mut Self, BlockRef<'ctx, 'blk>) -> Result<()>,
-    ) -> Result<()> {
-        self.block_ctx.push(block);
-        let res = callback(self, block);
-        self.block_ctx.pop();
-        res
-    }
-
-    /// Use the callback to generate code for a new circom Block scope but within the current LLZK
-    /// block. Assignments to new circom vars in this context are dropped after the callback because
-    /// they go out of scope but assignments to existing circom vars in this context persist.
-    #[inline]
-    pub fn gen_in_current_block_with_new_circom_scope(
-        &mut self,
-        callback: impl FnOnce(&mut Self, BlockRef<'ctx, 'blk>) -> Result<()>,
-    ) -> Result<()> {
-        self.gen_in_given_block_with_new_circom_scope(*self.block_ctx.top_block(), callback)
     }
 
     /// Generate LLZK code in the current function for a prefix operation.
@@ -301,6 +276,29 @@ where
         );
         codegen.emit_circom_error(meta, err_msg.as_str(), ReportCode::InfixOperatorWithWrongTypes);
         Err(anyhow!(err_msg))
+    }
+}
+
+/// The [FunctionContext] directly accesses a single [BlockContextStack] for circom scope handling.
+impl<'ctx, 'func, 'blk, 'val> GenWithCircomScopeHandling<'ctx, 'blk, 'val>
+    for FunctionContext<'ctx, 'func, 'blk, 'val>
+where
+    'ctx: 'func,
+    'func: 'blk,
+    'blk: 'val,
+{
+    type NewBlock = BlockRef<'ctx, 'blk>;
+
+    fn stack_top(&self) -> Self::NewBlock {
+        *self.block_ctx.top_block()
+    }
+
+    fn stack_push(&mut self, block: Self::NewBlock) {
+        self.block_ctx.push(block)
+    }
+
+    fn stack_pop(&mut self) {
+        self.block_ctx.pop()
     }
 }
 

--- a/llzk_backend/src/function.rs
+++ b/llzk_backend/src/function.rs
@@ -5,8 +5,6 @@
 //! [Expression](program_structure::abstract_syntax_tree::ast::Expression) and
 //! [Statement](program_structure::abstract_syntax_tree::ast::Statement) nodes.
 
-#![allow(unused_variables)] // TODO: TEMP
-
 use crate::{
     gen_context::{BlockContextStack, GenWithCircomScopeHandling},
     shared::{self, new_felt_const_op, single_result_as_value, IsA, LlzkCodegen},
@@ -393,6 +391,7 @@ where
 {
     type Output = ();
 
+    #[allow(unused_variables)] // TODO: TEMP
     fn gen_llzk_in_function<'ast>(
         &'ast self,
         codegen: &LlzkCodegen<'ast, 'ctx>,
@@ -514,6 +513,7 @@ where
 {
     type Output = Value<'ctx, 'val>;
 
+    #[allow(unused_variables)] // TODO: TEMP
     fn gen_llzk_in_function<'ast>(
         &'ast self,
         codegen: &LlzkCodegen<'ast, 'ctx>,

--- a/llzk_backend/src/function.rs
+++ b/llzk_backend/src/function.rs
@@ -18,7 +18,6 @@ use program_structure::{
 };
 use std::{
     collections::HashMap,
-    convert::{TryFrom, TryInto as _},
     ops::{Deref, DerefMut},
 };
 
@@ -29,21 +28,41 @@ use std::{
 ///
 /// 'ctx: lifetime of the `LlzkContext` and generated `Module`
 /// 'blk: lifetime of the generated `Block` instances within functions
+/// 'val: lifetime of the generated `Value` or `Operation` instances within blocks
 #[derive(Debug)]
-pub struct BlockContextStack<'ctx, 'blk>
+pub struct BlockContextStack<'ctx, 'blk, 'val>
 where
     'ctx: 'blk,
+    'blk: 'val,
 {
     /// The function entry block.
-    initial_block: BlockRef<'ctx, 'blk>,
+    root_block: BlockRef<'ctx, 'blk>,
     /// Additional nesting of blocks within the function representing the current insertion point.
     other_blocks: Vec<BlockRef<'ctx, 'blk>>,
+    /// Maps circom var name to the LLZK SSA Value for that named value. Initialized with function
+    /// parameters and extended with any variable-to-variable assignments found.
+    ///
+    /// TODO: extend this to store a map for each level and then search appropriately up the stack
+    /// and merge when popping, etc.
+    name_to_value: HashMap<String, Value<'ctx, 'val>>,
 }
 
-impl<'ctx, 'blk> BlockContextStack<'ctx, 'blk>
+impl<'ctx, 'blk, 'val> BlockContextStack<'ctx, 'blk, 'val>
 where
     'ctx: 'blk,
+    'blk: 'val,
 {
+    /// Create a new [BlockContextStack] for the given function with an initial name-to-value
+    /// mapping containing function parameters.
+    pub fn new(
+        func: &FuncDefOp<'ctx>,
+        name_to_value: HashMap<String, Value<'ctx, 'val>>,
+    ) -> Result<Self> {
+        let root_block =
+            func.region(0)?.first_block().ok_or_else(|| anyhow!("missing function entry block"))?;
+        Ok(BlockContextStack { root_block, other_blocks: Default::default(), name_to_value })
+    }
+
     /// Push a new block onto the stack to make it the current block.
     pub fn push(&mut self, item: BlockRef<'ctx, 'blk>) {
         self.other_blocks.push(item);
@@ -57,13 +76,16 @@ where
     /// Append an operation to the current block (i.e. the top of the stack).
     ///
     /// 'op: lifetime of the `Operation` instance for the reference returned
-    pub fn append_current<'op>(&mut self, operation: Operation<'ctx>) -> OperationRef<'ctx, 'op>
+    pub fn append_current_block<'op>(
+        &mut self,
+        operation: Operation<'ctx>,
+    ) -> OperationRef<'ctx, 'op>
     where
         'blk: 'op,
     {
         let current = match self.other_blocks.last() {
             Some(block) => block,
-            None => &self.initial_block,
+            None => &self.root_block,
         };
         // Account for possible terminator in the current block. For example, the `compute_fn()`
         // and `constrain_fn()` helpers automatically add a return op at the end of the block
@@ -73,16 +95,15 @@ where
             None => current.append_operation(operation),
         }
     }
-}
 
-impl<'ctx> TryFrom<&FuncDefOp<'ctx>> for BlockContextStack<'ctx, '_> {
-    type Error = anyhow::Error;
+    /// TODO: doc
+    pub fn set_named_value(&mut self, name: String, value: Value<'ctx, 'val>) {
+        self.name_to_value.insert(name, value);
+    }
 
-    /// Create a BlockContextStack starting with the function entry block.
-    fn try_from(func: &FuncDefOp<'ctx>) -> Result<Self, Self::Error> {
-        let initial_block =
-            func.region(0)?.first_block().ok_or_else(|| anyhow!("missing function entry block"))?;
-        Ok(BlockContextStack { initial_block, other_blocks: Default::default() })
+    /// TODO: doc
+    pub fn get_named_value(&self, name: &str) -> Option<&Value<'ctx, 'val>> {
+        self.name_to_value.get(name)
     }
 }
 
@@ -102,10 +123,7 @@ where
     /// The function reference.
     pub(crate) func: FuncDefOpRefMut<'ctx, 'func>,
     /// Nested block context within the function.
-    block_ctx: BlockContextStack<'ctx, 'blk>,
-    /// Local name mapped to the SSA Value with that name. Initialized with function
-    /// parameters and extended with any variable-to-variable assignments found.
-    pub(crate) name_to_value: HashMap<String, Value<'ctx, 'val>>,
+    pub(crate) block_ctx: BlockContextStack<'ctx, 'blk, 'val>,
 }
 
 impl<'ctx, 'func, 'blk, 'val> FunctionContext<'ctx, 'func, 'blk, 'val>
@@ -114,17 +132,17 @@ where
     'func: 'blk,
     'blk: 'val,
 {
-    /// Create a new [FunctionContext] for the given function and name-to-value map.
+    /// Create a new [FunctionContext] for the given function with an initial name-to-value mapping.
     pub fn new(
         func: FuncDefOpRefMut<'ctx, 'func>,
         name_to_value: HashMap<String, Value<'ctx, 'val>>,
     ) -> Result<Self> {
-        Ok(Self { func, block_ctx: func.deref().try_into()?, name_to_value })
+        Ok(Self { func, block_ctx: BlockContextStack::new(func.deref(), name_to_value)? })
     }
 
     /// Append an operation that must produce no results.
     pub fn append_op_no_result(&mut self, op: Operation<'ctx>) -> Result<()> {
-        let op_ref = self.block_ctx.append_current(op);
+        let op_ref = self.block_ctx.append_current_block(op);
         if op_ref.result_count() != 0 {
             return Err(anyhow!(
                 "Expected operation to have no results, found {}",
@@ -137,14 +155,27 @@ where
     /// Append an operation that must produce a single result and is NOT associated with a variable
     /// name in the circom code.
     pub fn append_op_unnamed_result(&mut self, op: Operation<'ctx>) -> Result<Value<'ctx, 'val>> {
-        single_result_as_value(self.block_ctx.append_current(op))
+        single_result_as_value(self.block_ctx.append_current_block(op))
     }
 
     /// Append an operation that must produce a single result and store the mapping of the circom
     /// variable name to the result Value.
     pub fn append_op_named_result(&mut self, op: Operation<'ctx>, name: String) {
         let v = self.append_op_unnamed_result(op).expect("Expected op to produce a single result");
-        self.name_to_value.insert(name, v);
+        self.block_ctx.set_named_value(name, v);
+    }
+
+    /// Generate LLZK code in the current function with the given block pushed to the context stack
+    /// before the callback and removed at the end of the callback.
+    pub fn gen_within_augmented_block_context(
+        &mut self,
+        block: BlockRef<'ctx, 'blk>,
+        callback: impl FnOnce(&mut Self, BlockRef<'ctx, 'blk>) -> Result<()>,
+    ) -> Result<()> {
+        self.block_ctx.push(block);
+        let res = callback(self, block);
+        self.block_ctx.pop();
+        res
     }
 
     /// Generate LLZK code in the current function for a prefix operation.
@@ -455,7 +486,7 @@ where
                 if access.is_empty() {
                     // Since there's no simple assignment in LLZK, just update the mapped Value
                     // which essentially propagates the assignment.
-                    function.name_to_value.insert(var.clone(), rhs);
+                    function.block_ctx.set_named_value(var.clone(), rhs);
                     Ok(())
                 } else {
                     todo!("Generate array write operation in function");
@@ -556,8 +587,8 @@ where
                 match access.as_slice() {
                     [] => {
                         let v = function
-                            .name_to_value
-                            .get(name)
+                            .block_ctx
+                            .get_named_value(name)
                             .ok_or_else(|| anyhow!("variable {name} not found"))?;
                         Ok(*v)
                     }

--- a/llzk_backend/src/function.rs
+++ b/llzk_backend/src/function.rs
@@ -1,13 +1,15 @@
 #![allow(unused_variables)] // TODO: TEMP
-use crate::shared::{self, new_felt_const_op, single_result_as_value, IsA, LlzkCodegen};
+use crate::{
+    gen_context::BlockContextStack,
+    shared::{self, new_felt_const_op, single_result_as_value, IsA, LlzkCodegen},
+};
 use anyhow::{anyhow, Ok, Result};
-use llzk::prelude::{bool, felt, function, FeltType, FuncDefOp, FuncDefOpRefMut, OperationMutLike};
+use llzk::prelude::{bool, felt, function, FeltType, FuncDefOpRefMut, OperationMutLike};
 use melior::{
     dialect::{arith, index},
     ir::{
         operation::{OperationLike as _, OperationRefMut, WalkOrder, WalkResult},
-        BlockLike as _, BlockRef, Operation, OperationRef, RegionLike as _, Type, Value,
-        ValueLike as _,
+        BlockRef, Operation, Type, Value, ValueLike as _,
     },
 };
 use program_structure::{
@@ -20,108 +22,6 @@ use std::{
     collections::HashMap,
     ops::{Deref, DerefMut},
 };
-
-/// Single frame in the [BlockContextStack].
-///
-/// 'ctx: lifetime of the `LlzkContext` and generated `Module`
-/// 'blk: lifetime of the generated `Block` instances within functions
-/// 'val: lifetime of the generated `Value` or `Operation` instances within blocks
-#[derive(Debug)]
-pub struct BlockContext<'ctx, 'blk, 'val>
-where
-    'ctx: 'blk,
-    'blk: 'val,
-{
-    /// Reference to a block in LLZK IR.
-    block: BlockRef<'ctx, 'blk>,
-    /// Maps circom var name to the LLZK SSA Value for that var.
-    name_to_value: HashMap<String, Value<'ctx, 'val>>,
-}
-
-/// Stack of blocks where the top block is the current block where code should be appended and the
-/// previous block in the list is the parent of the block after it. When an op containing nested
-/// blocks is encountered, the current block within that op is pushed to the stack so that any code
-/// generated will be placed inside that block and when the nested block is complete, it is popped.
-///
-/// 'ctx: lifetime of the `LlzkContext` and generated `Module`
-/// 'blk: lifetime of the generated `Block` instances within functions
-/// 'val: lifetime of the generated `Value` or `Operation` instances within blocks
-#[derive(Debug)]
-pub struct BlockContextStack<'ctx, 'blk, 'val>
-where
-    'ctx: 'blk,
-    'blk: 'val,
-{
-    /// Context for the function entry block.
-    root: BlockContext<'ctx, 'blk, 'val>,
-    /// Additional nesting of blocks within the function. Tail is the current insertion point.
-    other_blocks: Vec<BlockContext<'ctx, 'blk, 'val>>,
-}
-
-impl<'ctx, 'blk, 'val> BlockContextStack<'ctx, 'blk, 'val>
-where
-    'ctx: 'blk,
-    'blk: 'val,
-{
-    /// Create a new [BlockContextStack] for the given function with an initial name-to-value
-    /// mapping containing function parameters.
-    pub fn new(
-        func: &FuncDefOp<'ctx>,
-        name_to_value: HashMap<String, Value<'ctx, 'val>>,
-    ) -> Result<Self> {
-        let root_block =
-            func.region(0)?.first_block().ok_or_else(|| anyhow!("missing function entry block"))?;
-        Ok(BlockContextStack {
-            root: BlockContext { block: root_block, name_to_value },
-            other_blocks: Default::default(),
-        })
-    }
-
-    /// Get reference to the current block (i.e. the top of the stack).
-    pub fn top_block(&self) -> &BlockRef<'ctx, 'blk> {
-        match self.other_blocks.last() {
-            Some(bc) => &bc.block,
-            None => &self.root.block,
-        }
-    }
-
-    /// Ref to the current block context (i.e. the top of the stack).
-    fn top_mut(&mut self) -> &mut BlockContext<'ctx, 'blk, 'val> {
-        match self.other_blocks.last_mut() {
-            Some(bc) => bc,
-            None => &mut self.root,
-        }
-    }
-
-    /// Append an operation to the current block (i.e. the top of the stack).
-    pub fn append_current_block(&mut self, operation: Operation<'ctx>) -> OperationRef<'ctx, 'val> {
-        let current = &self.top_mut().block;
-        // Account for possible terminator in the current block. For example, the `compute_fn()`
-        // and `constrain_fn()` helpers automatically add a return op at the end of the block
-        // so new ops must be inserted before that terminator.
-        match current.terminator() {
-            Some(terminator) => current.insert_operation_before(terminator, operation),
-            None => current.append_operation(operation),
-        }
-    }
-
-    /// Set the LLZK IR SSA Value for the given circom var name, local to the top block context.
-    pub fn set_named_value(&mut self, name: String, value: Value<'ctx, 'val>) {
-        self.top_mut().name_to_value.insert(name, value);
-    }
-
-    /// Get the LLZK IR SSA Value for the given circom var name, checking the top block context
-    /// and then proceeding down the stack until found (if at all).
-    pub fn get_named_value(&self, name: &str) -> Option<&Value<'ctx, 'val>> {
-        for bc in self.other_blocks.iter().rev() {
-            let lookup = bc.name_to_value.get(name);
-            if lookup.is_some() {
-                return lookup;
-            }
-        }
-        self.root.name_to_value.get(name)
-    }
-}
 
 /// Stores ref to the current function while generating LLZK IR for the function.
 ///
@@ -189,18 +89,9 @@ where
         block: BlockRef<'ctx, 'blk>,
         callback: impl FnOnce(&mut Self, BlockRef<'ctx, 'blk>) -> Result<()>,
     ) -> Result<()> {
-        // Push new context with the given block and run the codegen callback.
-        self.block_ctx.other_blocks.push(BlockContext { block, name_to_value: Default::default() });
+        self.block_ctx.push(block);
         let res = callback(self, block);
-        // After code generation, pop the context and copy mapping for existing vars down
-        // to the lower context while dropping new vars because they go out of scope.
-        let popped = self.block_ctx.other_blocks.pop().expect("There is no block to pop!");
-        for (name, value) in popped.name_to_value.into_iter() {
-            // If var exists in some lower context, copy to current top context.
-            if self.block_ctx.get_named_value(&name).is_some() {
-                self.block_ctx.top_mut().name_to_value.insert(name, value);
-            }
-        }
+        self.block_ctx.pop();
         res
     }
 

--- a/llzk_backend/src/function.rs
+++ b/llzk_backend/src/function.rs
@@ -51,9 +51,9 @@ where
     /// Create a new [FunctionContext] for the given function with an initial name-to-value mapping.
     pub fn new(
         func: FuncDefOpRefMut<'ctx, 'func>,
-        name_to_value: HashMap<String, Value<'ctx, 'val>>,
+        param_name_to_value: HashMap<String, Value<'ctx, 'val>>,
     ) -> Result<Self> {
-        Ok(Self { func, block_ctx: BlockContextStack::new(func.deref(), name_to_value)? })
+        Ok(Self { func, block_ctx: BlockContextStack::new(func.deref(), param_name_to_value)? })
     }
 
     /// Append an operation that must produce no results.
@@ -76,12 +76,32 @@ where
 
     /// Append an operation that must produce a single result and store the mapping of the circom
     /// variable name to the result Value.
-    pub fn append_op_named_result(&mut self, op: Operation<'ctx>, name: String) {
-        let v = self.append_op_unnamed_result(op).expect("Expected op to produce a single result");
-        self.block_ctx.set_named_value(name, v);
+    pub fn append_op_named_result(
+        &mut self,
+        op: Operation<'ctx>,
+        name: String,
+    ) -> Result<Value<'ctx, 'val>> {
+        let v = self.append_op_unnamed_result(op)?;
+        self.block_ctx.set_named_value(name, v)?;
+        Ok(v)
     }
 
-    /// Generate LLZK code in the current function for a prefix operation.
+    /// If the given name is not already declared in the current scope, declare it with an
+    /// uninitialized value of type `felt` with the given dimensions.
+    #[inline]
+    pub fn declare_name_uninit<'ast>(
+        &mut self,
+        codegen: &LlzkCodegen<'ast, 'ctx>,
+        name: String,
+        meta: &Meta,
+        dimensions: &[Expression],
+    ) -> Result<()> {
+        self.block_ctx.declare_name_if_not_present(name, || {
+            codegen.new_nondet_value_of_dimensions(meta, dimensions)
+        })
+    }
+
+    /// Generate LLZK code in the current function for a circom prefix operation.
     pub fn gen_prefix_op<'ast>(
         &mut self,
         codegen: &LlzkCodegen<'ast, 'ctx>,
@@ -398,9 +418,7 @@ where
                     // per `type_analysis/src/analyzers/functions_free_of_template_elements.rs`
                     unreachable!("Template elements declared inside the function")
                 }
-                // TODO: I don't think there's actually anything to do here, unless we
-                //  need to store some info about the declared dimensions of the var.
-                Ok(())
+                function.declare_name_uninit(codegen, name.clone(), meta, dimensions)
             }
             Statement::Block { stmts, .. } => {
                 function.gen_in_current_block_with_new_circom_scope(|function, _| {
@@ -416,8 +434,7 @@ where
                 if access.is_empty() {
                     // Since there's no simple assignment in LLZK, just update the mapped Value
                     // which essentially propagates the assignment.
-                    function.block_ctx.set_named_value(var.clone(), rhs);
-                    Ok(())
+                    function.block_ctx.set_named_value(var.clone(), rhs)
                 } else {
                     todo!("Generate array write operation in function");
                 }

--- a/llzk_backend/src/function.rs
+++ b/llzk_backend/src/function.rs
@@ -21,6 +21,23 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
+/// Single frame in the [BlockContextStack].
+///
+/// 'ctx: lifetime of the `LlzkContext` and generated `Module`
+/// 'blk: lifetime of the generated `Block` instances within functions
+/// 'val: lifetime of the generated `Value` or `Operation` instances within blocks
+#[derive(Debug)]
+pub struct BlockContext<'ctx, 'blk, 'val>
+where
+    'ctx: 'blk,
+    'blk: 'val,
+{
+    /// Reference to a block in LLZK IR.
+    block: BlockRef<'ctx, 'blk>,
+    /// Maps circom var name to the LLZK SSA Value for that var.
+    name_to_value: HashMap<String, Value<'ctx, 'val>>,
+}
+
 /// Stack of blocks where the top block is the current block where code should be appended and the
 /// previous block in the list is the parent of the block after it. When an op containing nested
 /// blocks is encountered, the current block within that op is pushed to the stack so that any code
@@ -35,16 +52,10 @@ where
     'ctx: 'blk,
     'blk: 'val,
 {
-    /// The function entry block.
-    root_block: BlockRef<'ctx, 'blk>,
-    /// Additional nesting of blocks within the function representing the current insertion point.
-    other_blocks: Vec<BlockRef<'ctx, 'blk>>,
-    /// Maps circom var name to the LLZK SSA Value for that named value. Initialized with function
-    /// parameters and extended with any variable-to-variable assignments found.
-    ///
-    /// TODO: extend this to store a map for each level and then search appropriately up the stack
-    /// and merge when popping, etc.
-    name_to_value: HashMap<String, Value<'ctx, 'val>>,
+    /// Context for the function entry block.
+    root: BlockContext<'ctx, 'blk, 'val>,
+    /// Additional nesting of blocks within the function. Tail is the current insertion point.
+    other_blocks: Vec<BlockContext<'ctx, 'blk, 'val>>,
 }
 
 impl<'ctx, 'blk, 'val> BlockContextStack<'ctx, 'blk, 'val>
@@ -60,33 +71,31 @@ where
     ) -> Result<Self> {
         let root_block =
             func.region(0)?.first_block().ok_or_else(|| anyhow!("missing function entry block"))?;
-        Ok(BlockContextStack { root_block, other_blocks: Default::default(), name_to_value })
+        Ok(BlockContextStack {
+            root: BlockContext { block: root_block, name_to_value },
+            other_blocks: Default::default(),
+        })
     }
 
-    /// Push a new block onto the stack to make it the current block.
-    pub fn push(&mut self, item: BlockRef<'ctx, 'blk>) {
-        self.other_blocks.push(item);
+    /// Get reference to the current block (i.e. the top of the stack).
+    pub fn top_block(&self) -> &BlockRef<'ctx, 'blk> {
+        match self.other_blocks.last() {
+            Some(bc) => &bc.block,
+            None => &self.root.block,
+        }
     }
 
-    /// Pop the current block off the stack to return to the previous block.
-    pub fn pop(&mut self) {
-        self.other_blocks.pop().expect("There is no block to pop!");
+    /// Ref to the current block context (i.e. the top of the stack).
+    fn top_mut(&mut self) -> &mut BlockContext<'ctx, 'blk, 'val> {
+        match self.other_blocks.last_mut() {
+            Some(bc) => bc,
+            None => &mut self.root,
+        }
     }
 
     /// Append an operation to the current block (i.e. the top of the stack).
-    ///
-    /// 'op: lifetime of the `Operation` instance for the reference returned
-    pub fn append_current_block<'op>(
-        &mut self,
-        operation: Operation<'ctx>,
-    ) -> OperationRef<'ctx, 'op>
-    where
-        'blk: 'op,
-    {
-        let current = match self.other_blocks.last() {
-            Some(block) => block,
-            None => &self.root_block,
-        };
+    pub fn append_current_block(&mut self, operation: Operation<'ctx>) -> OperationRef<'ctx, 'val> {
+        let current = &self.top_mut().block;
         // Account for possible terminator in the current block. For example, the `compute_fn()`
         // and `constrain_fn()` helpers automatically add a return op at the end of the block
         // so new ops must be inserted before that terminator.
@@ -96,14 +105,21 @@ where
         }
     }
 
-    /// TODO: doc
+    /// Set the LLZK IR SSA Value for the given circom var name, local to the top block context.
     pub fn set_named_value(&mut self, name: String, value: Value<'ctx, 'val>) {
-        self.name_to_value.insert(name, value);
+        self.top_mut().name_to_value.insert(name, value);
     }
 
-    /// TODO: doc
+    /// Get the LLZK IR SSA Value for the given circom var name, checking the top block context
+    /// and then proceeding down the stack until found (if at all).
     pub fn get_named_value(&self, name: &str) -> Option<&Value<'ctx, 'val>> {
-        self.name_to_value.get(name)
+        for bc in self.other_blocks.iter().rev() {
+            let lookup = bc.name_to_value.get(name);
+            if lookup.is_some() {
+                return lookup;
+            }
+        }
+        self.root.name_to_value.get(name)
     }
 }
 
@@ -165,17 +181,38 @@ where
         self.block_ctx.set_named_value(name, v);
     }
 
-    /// Generate LLZK code in the current function with the given block pushed to the context stack
-    /// before the callback and removed at the end of the callback.
-    pub fn gen_within_augmented_block_context(
+    /// Use the callback to generate code for a new circom Block scope within the given LLZK block.
+    /// Assignments to new circom vars in this context are dropped after the callback because
+    /// they go out of scope but assignments to existing circom vars in this context persist.
+    pub fn gen_in_given_block_with_new_circom_scope(
         &mut self,
         block: BlockRef<'ctx, 'blk>,
         callback: impl FnOnce(&mut Self, BlockRef<'ctx, 'blk>) -> Result<()>,
     ) -> Result<()> {
-        self.block_ctx.push(block);
+        // Push new context with the given block and run the codegen callback.
+        self.block_ctx.other_blocks.push(BlockContext { block, name_to_value: Default::default() });
         let res = callback(self, block);
-        self.block_ctx.pop();
+        // After code generation, pop the context and copy mapping for existing vars down
+        // to the lower context while dropping new vars because they go out of scope.
+        let popped = self.block_ctx.other_blocks.pop().expect("There is no block to pop!");
+        for (name, value) in popped.name_to_value.into_iter() {
+            // If var exists in some lower context, copy to current top context.
+            if self.block_ctx.get_named_value(&name).is_some() {
+                self.block_ctx.top_mut().name_to_value.insert(name, value);
+            }
+        }
         res
+    }
+
+    /// Use the callback to generate code for a new circom Block scope but within the current LLZK
+    /// block. Assignments to new circom vars in this context are dropped after the callback because
+    /// they go out of scope but assignments to existing circom vars in this context persist.
+    #[inline]
+    pub fn gen_in_current_block_with_new_circom_scope(
+        &mut self,
+        callback: impl FnOnce(&mut Self, BlockRef<'ctx, 'blk>) -> Result<()>,
+    ) -> Result<()> {
+        self.gen_in_given_block_with_new_circom_scope(*self.block_ctx.top_block(), callback)
     }
 
     /// Generate LLZK code in the current function for a prefix operation.
@@ -476,7 +513,11 @@ where
                 //  need to store some info about the declared dimensions of the var.
                 Ok(())
             }
-            Statement::Block { stmts, .. } => stmts.gen_llzk_in_function(codegen, function),
+            Statement::Block { stmts, .. } => {
+                function.gen_in_current_block_with_new_circom_scope(|function, _| {
+                    stmts.gen_llzk_in_function(codegen, function)
+                })
+            }
             Statement::Substitution { meta, var, access, op, rhe } => {
                 if op.is_signal_operator() {
                     // per `type_analysis/src/analyzers/functions_free_of_template_elements.rs`

--- a/llzk_backend/src/gen_context.rs
+++ b/llzk_backend/src/gen_context.rs
@@ -1,3 +1,4 @@
+use crate::shared::single_result_as_value;
 use anyhow::{anyhow, Ok, Result};
 use llzk::prelude::{FuncDefOp, OperationLike as _};
 use melior::ir::{BlockLike as _, BlockRef, Operation, OperationRef, RegionLike as _, Value};
@@ -16,8 +17,61 @@ where
 {
     /// Reference to a block in LLZK IR.
     block: BlockRef<'ctx, 'blk>,
-    /// Maps circom var name to the LLZK SSA Value for that var.
-    name_to_value: HashMap<String, Value<'ctx, 'val>>,
+    /// For variables declared in the current scope, maps circom variable name to current LLZK SSA
+    /// Value stored for that variable. These are local to the current block and go out of scope
+    /// when the block is popped.
+    scope_local_name_to_value: HashMap<String, Value<'ctx, 'val>>,
+    /// For variables declared in an outer scope, maps circom variable name to current LLZK SSA
+    /// Value stored for that variable. These are preserved when the block is popped because they
+    /// overwrite the value of existing variables in outer scopes.
+    overwriting_name_to_value: HashMap<String, Value<'ctx, 'val>>,
+}
+
+impl<'ctx, 'blk, 'val> BlockContext<'ctx, 'blk, 'val>
+where
+    'ctx: 'blk,
+    'blk: 'val,
+{
+    /// Create a new empty [BlockContext] for the given block.
+    fn new(block: BlockRef<'ctx, 'blk>) -> Self {
+        BlockContext {
+            block,
+            scope_local_name_to_value: Default::default(),
+            overwriting_name_to_value: Default::default(),
+        }
+    }
+
+    /// Create a new [BlockContext] for the given block, initializing the scope local
+    /// declarations with the mapping of parameter names to values.
+    fn new_with_params(
+        block: BlockRef<'ctx, 'blk>,
+        param_name_to_value: HashMap<String, Value<'ctx, 'val>>,
+    ) -> Self {
+        BlockContext {
+            block,
+            scope_local_name_to_value: param_name_to_value,
+            overwriting_name_to_value: Default::default(),
+        }
+    }
+
+    /// Get the LLZK IR SSA Value for the given circom var name. Check the local scope first since
+    /// the names there may shadow the same name from parent scope(s).
+    fn get(&self, name: &str) -> Option<&Value<'ctx, 'val>> {
+        self.scope_local_name_to_value
+            .get(name)
+            .or_else(|| self.overwriting_name_to_value.get(name))
+    }
+
+    /// Set the LLZK IR SSA Value for the given circom var name. If the name is declared in the
+    /// local scope, assign the new value there since it's shadowing the same name from parent
+    /// scope(s). Otherwise, assign the new value in the overwriting map.
+    fn insert(&mut self, name: String, value: Value<'ctx, 'val>) {
+        if let Some(v) = self.scope_local_name_to_value.get_mut(&name) {
+            *v = value;
+        } else {
+            self.overwriting_name_to_value.insert(name, value);
+        }
+    }
 }
 
 /// Stack of blocks where the top block is the current block where code should be appended and the
@@ -49,12 +103,12 @@ where
     /// mapping containing function parameters.
     pub fn new(
         func: &FuncDefOp<'ctx>,
-        name_to_value: HashMap<String, Value<'ctx, 'val>>,
+        param_name_to_value: HashMap<String, Value<'ctx, 'val>>,
     ) -> Result<Self> {
         let root_block =
             func.region(0)?.first_block().ok_or_else(|| anyhow!("missing function entry block"))?;
         Ok(BlockContextStack {
-            root: BlockContext { block: root_block, name_to_value },
+            root: BlockContext::new_with_params(root_block, param_name_to_value),
             other_blocks: Default::default(),
         })
     }
@@ -87,39 +141,57 @@ where
         }
     }
 
+    /// If the given name is not already declared in the current scope, declare it by creating an
+    /// [Operation] via the callback, inserting that into the current block, and using its result.
+    /// The only scenario where a declaration would already be present is when the same Declaration
+    /// statements are visited that were used to produce the parameters of the current function.
+    /// Otherwise, the checks performed earlier in the circom parser pipeline will produce an error
+    /// if a symbol is declared more than once in the same scope.
+    pub fn declare_name_if_not_present(
+        &mut self,
+        name: String,
+        uninit_value: impl FnOnce() -> Result<Operation<'ctx>>,
+    ) -> Result<()> {
+        if !self.top_mut().scope_local_name_to_value.contains_key(&name) {
+            let op = uninit_value()?;
+            let value = single_result_as_value(self.append_current_block(op))?;
+            self.top_mut().scope_local_name_to_value.insert(name, value);
+        }
+        Ok(())
+    }
+
     /// Set the LLZK IR SSA Value for the given circom var name, local to the top block context.
-    pub fn set_named_value(&mut self, name: String, value: Value<'ctx, 'val>) {
-        self.top_mut().name_to_value.insert(name, value);
+    pub fn set_named_value(&mut self, name: String, value: Value<'ctx, 'val>) -> Result<()> {
+        let bc = self.top_mut();
+        bc.insert(name, value);
+        Ok(())
     }
 
     /// Get the LLZK IR SSA Value for the given circom var name, checking the top block context
     /// and then proceeding down the stack until found (if at all).
     pub fn get_named_value(&self, name: &str) -> Option<&Value<'ctx, 'val>> {
         for bc in self.other_blocks.iter().rev() {
-            let lookup = bc.name_to_value.get(name);
+            let lookup = bc.get(name);
             if lookup.is_some() {
                 return lookup;
             }
         }
-        self.root.name_to_value.get(name)
+        self.root.get(name)
     }
 
     /// Push a new block onto the stack to make it the current block.
     pub fn push(&mut self, block: BlockRef<'ctx, 'blk>) {
-        self.other_blocks.push(BlockContext { block, name_to_value: Default::default() });
+        self.other_blocks.push(BlockContext::new(block));
     }
 
-    /// Pop the current block off the stack to return to the previous block. The vars defined in the
-    /// popped frame are dropped unless they were present in the context prior to the current frame,
-    /// in which case the new values assigned to the vars are updated in the previous frame (i.e.
-    /// the new top frame after popping).
+    /// Pop the current block off the stack to return to the previous block. The vars declared in
+    /// the popped frame are dropped and those which are overwrites are written to the context
+    /// prior to the current frame..
     pub fn pop(&mut self) {
         let popped = self.other_blocks.pop().expect("There is no block to pop!");
-        for (name, value) in popped.name_to_value.into_iter() {
-            // If var exists in some lower context, copy to current top context.
-            if self.get_named_value(&name).is_some() {
-                self.top_mut().name_to_value.insert(name, value);
-            }
+        let new_top = self.top_mut();
+        for (name, value) in popped.overwriting_name_to_value.into_iter() {
+            new_top.insert(name, value);
         }
     }
 }

--- a/llzk_backend/src/gen_context.rs
+++ b/llzk_backend/src/gen_context.rs
@@ -72,6 +72,11 @@ where
             self.overwriting_name_to_value.insert(name, value);
         }
     }
+
+    /// Return true iff the given name is declared in the local scope of this block context.
+    fn declares(&self, name: &str) -> bool {
+        self.scope_local_name_to_value.contains_key(name)
+    }
 }
 
 /// Stack of blocks where the top block is the current block where code should be appended and the
@@ -141,7 +146,7 @@ where
         }
     }
 
-    /// If the given name is not already declared in the current scope, declare it by creating an
+    /// If the given name is not already declared in the current scope, declare it by producing an
     /// [Operation] via the callback, inserting that into the current block, and using its result.
     /// The only scenario where a declaration would already be present is when the same Declaration
     /// statements are visited that were used to produce the parameters of the current function.
@@ -149,21 +154,26 @@ where
     /// if a symbol is declared more than once in the same scope.
     pub fn declare_name_if_not_present(
         &mut self,
-        name: String,
+        name: &str,
         uninit_value: impl FnOnce() -> Result<Operation<'ctx>>,
     ) -> Result<()> {
-        if !self.top_mut().scope_local_name_to_value.contains_key(&name) {
+        if !self.top_mut().scope_local_name_to_value.contains_key(name) {
             let op = uninit_value()?;
             let value = single_result_as_value(self.append_current_block(op))?;
-            self.top_mut().scope_local_name_to_value.insert(name, value);
+            self.top_mut().scope_local_name_to_value.insert(name.to_string(), value);
         }
         Ok(())
     }
 
     /// Set the LLZK IR SSA Value for the given circom var name, local to the top block context.
     pub fn set_named_value(&mut self, name: String, value: Value<'ctx, 'val>) -> Result<()> {
-        let bc = self.top_mut();
-        bc.insert(name, value);
+        // This is mainly a sanity check on proper usage of `declare_name_if_not_present()` and
+        // this function to ensure values end up in the correct map in the BlockContext and are
+        // thus scoped correctly.
+        if !self.root.declares(&name) && !self.other_blocks.iter().any(|bc| bc.declares(&name)) {
+            return Err(anyhow!("Variable '{name}' was not declared in any scope"));
+        }
+        self.top_mut().insert(name, value);
         Ok(())
     }
 

--- a/llzk_backend/src/gen_context.rs
+++ b/llzk_backend/src/gen_context.rs
@@ -194,6 +194,11 @@ where
     pub fn pop(&mut self) {
         let popped = self.other_blocks.pop().expect("There is no block to pop!");
         let new_top = self.top_mut();
+        // TODO: This approach works for circom Block because it's flattened into the current LLZK
+        // Block. However, when generating nested LLZK Blocks for IfThenElse and While ops, this
+        // will need to be revised. Due to the SSA form in LLZK, we will have to an a YieldOp to
+        // return these values from the inner block and then capture them in the outer block and
+        // update the block context there with the captured values.
         for (name, value) in popped.overwriting_name_to_value.into_iter() {
             new_top.insert(name, value);
         }

--- a/llzk_backend/src/gen_context.rs
+++ b/llzk_backend/src/gen_context.rs
@@ -1,3 +1,5 @@
+//! Handles circom var scoping and LLZK blocks stack management.
+
 use crate::shared::single_result_as_value;
 use anyhow::{anyhow, Ok, Result};
 use llzk::prelude::{FuncDefOp, OperationLike as _};
@@ -5,7 +7,7 @@ use melior::ir::{BlockLike as _, BlockRef, Operation, OperationRef, RegionLike a
 use std::collections::HashMap;
 
 /// Single frame in the [BlockContextStack].
-/// 
+///
 /// 'ctx: lifetime of the `LlzkContext` and generated `Module`
 /// 'blk: lifetime of the generated `Block` instances within functions
 /// 'val: lifetime of the generated `Value` or `Operation` instances within blocks

--- a/llzk_backend/src/gen_context.rs
+++ b/llzk_backend/src/gen_context.rs
@@ -5,7 +5,7 @@ use melior::ir::{BlockLike as _, BlockRef, Operation, OperationRef, RegionLike a
 use std::collections::HashMap;
 
 /// Single frame in the [BlockContextStack].
-/// ˝
+/// 
 /// 'ctx: lifetime of the `LlzkContext` and generated `Module`
 /// 'blk: lifetime of the generated `Block` instances within functions
 /// 'val: lifetime of the generated `Value` or `Operation` instances within blocks

--- a/llzk_backend/src/gen_context.rs
+++ b/llzk_backend/src/gen_context.rs
@@ -180,13 +180,7 @@ where
     /// Get the LLZK IR SSA Value for the given circom var name, checking the top block context
     /// and then proceeding down the stack until found (if at all).
     pub fn get_named_value(&self, name: &str) -> Option<&Value<'ctx, 'val>> {
-        for bc in self.other_blocks.iter().rev() {
-            let lookup = bc.get(name);
-            if lookup.is_some() {
-                return lookup;
-            }
-        }
-        self.root.get(name)
+        self.other_blocks.iter().rev().find_map(|bc| bc.get(name)).or_else(|| self.root.get(name))
     }
 
     /// Push a new block onto the stack to make it the current block.

--- a/llzk_backend/src/gen_context.rs
+++ b/llzk_backend/src/gen_context.rs
@@ -1,0 +1,125 @@
+use anyhow::{anyhow, Ok, Result};
+use llzk::prelude::{FuncDefOp, OperationLike as _};
+use melior::ir::{BlockLike as _, BlockRef, Operation, OperationRef, RegionLike as _, Value};
+use std::collections::HashMap;
+
+/// Single frame in the [BlockContextStack].
+/// ˝
+/// 'ctx: lifetime of the `LlzkContext` and generated `Module`
+/// 'blk: lifetime of the generated `Block` instances within functions
+/// 'val: lifetime of the generated `Value` or `Operation` instances within blocks
+#[derive(Debug)]
+pub struct BlockContext<'ctx, 'blk, 'val>
+where
+    'ctx: 'blk,
+    'blk: 'val,
+{
+    /// Reference to a block in LLZK IR.
+    block: BlockRef<'ctx, 'blk>,
+    /// Maps circom var name to the LLZK SSA Value for that var.
+    name_to_value: HashMap<String, Value<'ctx, 'val>>,
+}
+
+/// Stack of blocks where the top block is the current block where code should be appended and the
+/// previous block in the list is the parent of the block after it. When an op containing nested
+/// blocks is encountered, the current block within that op is pushed to the stack so that any code
+/// generated will be placed inside that block and when the nested block is complete, it is popped.
+///
+/// 'ctx: lifetime of the `LlzkContext` and generated `Module`
+/// 'blk: lifetime of the generated `Block` instances within functions
+/// 'val: lifetime of the generated `Value` or `Operation` instances within blocks
+#[derive(Debug)]
+pub struct BlockContextStack<'ctx, 'blk, 'val>
+where
+    'ctx: 'blk,
+    'blk: 'val,
+{
+    /// Context for the function entry block.
+    root: BlockContext<'ctx, 'blk, 'val>,
+    /// Additional nesting of blocks within the function. Tail is the current insertion point.
+    other_blocks: Vec<BlockContext<'ctx, 'blk, 'val>>,
+}
+
+impl<'ctx, 'blk, 'val> BlockContextStack<'ctx, 'blk, 'val>
+where
+    'ctx: 'blk,
+    'blk: 'val,
+{
+    /// Create a new [BlockContextStack] for the given function with an initial name-to-value
+    /// mapping containing function parameters.
+    pub fn new(
+        func: &FuncDefOp<'ctx>,
+        name_to_value: HashMap<String, Value<'ctx, 'val>>,
+    ) -> Result<Self> {
+        let root_block =
+            func.region(0)?.first_block().ok_or_else(|| anyhow!("missing function entry block"))?;
+        Ok(BlockContextStack {
+            root: BlockContext { block: root_block, name_to_value },
+            other_blocks: Default::default(),
+        })
+    }
+
+    /// Get reference to the current block (i.e. the top of the stack).
+    pub fn top_block(&self) -> &BlockRef<'ctx, 'blk> {
+        match self.other_blocks.last() {
+            Some(bc) => &bc.block,
+            None => &self.root.block,
+        }
+    }
+
+    /// Ref to the current block context (i.e. the top of the stack).
+    fn top_mut(&mut self) -> &mut BlockContext<'ctx, 'blk, 'val> {
+        match self.other_blocks.last_mut() {
+            Some(bc) => bc,
+            None => &mut self.root,
+        }
+    }
+
+    /// Append an operation to the current block (i.e. the top of the stack).
+    pub fn append_current_block(&mut self, operation: Operation<'ctx>) -> OperationRef<'ctx, 'val> {
+        let current = &self.top_mut().block;
+        // Account for possible terminator in the current block. For example, the `compute_fn()`
+        // and `constrain_fn()` helpers automatically add a return op at the end of the block
+        // so new ops must be inserted before that terminator.
+        match current.terminator() {
+            Some(terminator) => current.insert_operation_before(terminator, operation),
+            None => current.append_operation(operation),
+        }
+    }
+
+    /// Set the LLZK IR SSA Value for the given circom var name, local to the top block context.
+    pub fn set_named_value(&mut self, name: String, value: Value<'ctx, 'val>) {
+        self.top_mut().name_to_value.insert(name, value);
+    }
+
+    /// Get the LLZK IR SSA Value for the given circom var name, checking the top block context
+    /// and then proceeding down the stack until found (if at all).
+    pub fn get_named_value(&self, name: &str) -> Option<&Value<'ctx, 'val>> {
+        for bc in self.other_blocks.iter().rev() {
+            let lookup = bc.name_to_value.get(name);
+            if lookup.is_some() {
+                return lookup;
+            }
+        }
+        self.root.name_to_value.get(name)
+    }
+
+    /// Push a new block onto the stack to make it the current block.
+    pub fn push(&mut self, block: BlockRef<'ctx, 'blk>) {
+        self.other_blocks.push(BlockContext { block, name_to_value: Default::default() });
+    }
+
+    /// Pop the current block off the stack to return to the previous block. The vars defined in the
+    /// popped frame are dropped unless they were present in the context prior to the current frame,
+    /// in which case the new values assigned to the vars are updated in the previous frame (i.e.
+    /// the new top frame after popping).
+    pub fn pop(&mut self) {
+        let popped = self.other_blocks.pop().expect("There is no block to pop!");
+        for (name, value) in popped.name_to_value.into_iter() {
+            // If var exists in some lower context, copy to current top context.
+            if self.get_named_value(&name).is_some() {
+                self.top_mut().name_to_value.insert(name, value);
+            }
+        }
+    }
+}

--- a/llzk_backend/src/gen_context.rs
+++ b/llzk_backend/src/gen_context.rs
@@ -123,3 +123,53 @@ where
         }
     }
 }
+
+/// Provides common functions for generating code that respects circom variable scoping, abstracting
+/// access to the [BlockContextStack] so that functions and templates can share these functions.
+pub trait GenWithCircomScopeHandling<'ctx, 'blk, 'val>
+where
+    'ctx: 'blk,
+    'blk: 'val,
+{
+    /// LLZK block context type. For functions, this is just [BlockRef], but for templates,
+    /// this type holds a [BlockRef] for both the `compute` and `constrain` functions.
+    type NewBlock: Copy;
+
+    /// Retrieve the top block(s) from the [BlockContextStack].
+    fn stack_top(&self) -> Self::NewBlock;
+
+    /// Push new block(s) onto the [BlockContextStack].
+    fn stack_push(&mut self, block: Self::NewBlock);
+
+    /// Pop the top block(s) from the [BlockContextStack].
+    fn stack_pop(&mut self);
+
+    /// Use the callback to generate code for a new circom scope/block within the given LLZK
+    /// `NewBlock`. Assignments to circom variables that are newly introduced in this context go out
+    /// of scope so they are dropped after the callback but overwriting assignments to circom
+    /// variables that already exist prior to this new scope are preserved and written into the
+    /// existing block context
+    fn gen_in_given_block_with_new_circom_scope(
+        &mut self,
+        block: Self::NewBlock,
+        generator: impl FnOnce(&mut Self, Self::NewBlock) -> Result<()>,
+    ) -> Result<()> {
+        self.stack_push(block);
+        let res = generator(self, block);
+        self.stack_pop();
+        res
+    }
+
+    /// Use the callback to generate code for a new circom scope/block but within the current LLZK
+    /// `NewBlock`. Assignments to circom variables that are newly introduced in this context go out
+    /// of scope so they are dropped after the callback but overwriting assignments to circom
+    /// variables that already exist prior to this new scope are preserved and written into the
+    /// existing block context
+    #[inline]
+    fn gen_in_current_block_with_new_circom_scope(
+        &mut self,
+        generator: impl FnOnce(&mut Self, Self::NewBlock) -> Result<()>,
+    ) -> Result<()> {
+        self.gen_in_given_block_with_new_circom_scope(self.stack_top(), generator)
+    }
+}

--- a/llzk_backend/src/lib.rs
+++ b/llzk_backend/src/lib.rs
@@ -6,29 +6,11 @@
 #![deny(rustdoc::broken_intra_doc_links)]
 #![warn(redundant_imports)]
 
-/// Entry point for LLZK code generation.
 mod codegen;
-/// Handles function-level LLZK code generation for both free functions and functions within
-/// structs. The [function::FunctionContext] carries information about the current LLZK function
-/// being generated and some helpers related to generating code within the function. The
-/// [function::GenerateLLZKInFunction] trait provides the visitor to generate LLZK IR for all circom
-/// [Expression](program_structure::abstract_syntax_tree::ast::Expression) and
-/// [Statement](program_structure::abstract_syntax_tree::ast::Statement) nodes.
 mod function;
-/// Handles circom var scoping and LLZK blocks stack management.
 mod gen_context;
-/// Handles the top-level constructs (i.e. circom templates and functions), by delegating
-/// to the [function] and [template] modules to generate the code for each.
 mod module;
-/// Shared code generation utilities.
 mod shared;
-/// Handles template-level LLZK code generation. The [template::TemplateContext] carries information
-/// about the current LLZK struct being generated and some helpers related to generating code within
-/// the struct. The [template::GenerateLLZKInTemplate] trait provides the visitor to generate LLZK
-/// IR for all circom [Expression](program_structure::abstract_syntax_tree::ast::Expression) and
-/// [Statement](program_structure::abstract_syntax_tree::ast::Statement) nodes. There are also a few
-/// helper traits like `ExprGenResult` and `Chainable` that implement some boilerplate to make the
-/// actual code generation within [template::GenerateLLZKInTemplate] a lot simpler.
 mod template;
 
 pub use codegen::generate_llzk;

--- a/llzk_backend/src/lib.rs
+++ b/llzk_backend/src/lib.rs
@@ -15,6 +15,8 @@ mod codegen;
 /// [Expression](program_structure::abstract_syntax_tree::ast::Expression) and
 /// [Statement](program_structure::abstract_syntax_tree::ast::Statement) nodes.
 mod function;
+/// Handles circom var scoping and LLZK blocks stack management.
+mod gen_context;
 /// Handles the top-level constructs (i.e. circom templates and functions), by delegating
 /// to the [function] and [template] modules to generate the code for each.
 mod module;

--- a/llzk_backend/src/module.rs
+++ b/llzk_backend/src/module.rs
@@ -4,7 +4,7 @@ use crate::{
     shared::{map_name_to_arg_value, LlzkCodegen},
     template::{GenerateLLZKInTemplate as _, TemplateContext},
 };
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use llzk::{
     attributes::NamedAttribute,
     error::Error,
@@ -14,15 +14,13 @@ use llzk::{
             self,
             helpers::{compute_fn, constrain_fn},
         },
-        undef, ArrayType, FeltType, FuncDefOpRef, FuncDefOpRefMut, FunctionType, IntegerAttribute,
-        PublicAttribute, StructDefOpLike as _, StructType,
+        undef, FeltType, FuncDefOpRef, FuncDefOpRefMut, FunctionType, PublicAttribute,
+        StructDefOpLike as _, StructType,
     },
 };
 use melior::ir::{
-    operation::OperationLike as _, Attribute, Block, BlockLike as _, Location, Operation,
-    RegionLike, Type,
+    operation::OperationLike as _, Block, BlockLike as _, Location, Operation, RegionLike, Type,
 };
-use num_traits::cast::ToPrimitive;
 use program_structure::{
     ast::{Expression, Meta, SignalType, Statement, VariableType},
     function_data::FunctionData,
@@ -60,6 +58,10 @@ struct DeclarationInfo<'ctx> {
 
 impl<'ctx> DeclarationInfo<'ctx> {
     /// Visit a statement and populate this `DeclarationInfo` with any declarations found.
+    ///
+    /// TODO: This currently visits only top-level statements within the template body. However,
+    /// since circom 2.1.5, signal declarations are allowed inside of blocks and known-condition if
+    /// statements. Those nested declarations are not currently processed here.
     ///
     /// 'ast: lifetime of the circom AST element
     fn visit<'ast>(
@@ -104,8 +106,7 @@ impl<'ctx> DeclarationInfo<'ctx> {
                         // processed later, replace the `undef` with the appropriate value.
                         let op = undef::undef(
                             codegen.location_from_meta(meta),
-                            Self::type_with_dimensions(
-                                codegen,
+                            codegen.type_with_dimensions(
                                 FeltType::new(codegen.context).into(),
                                 dimensions,
                             )?,
@@ -136,7 +137,7 @@ impl<'ctx> DeclarationInfo<'ctx> {
         base_type: Type<'ctx>,
     ) -> Result<()> {
         let location = codegen.location_from_meta(meta);
-        let decl_type = Self::type_with_dimensions(codegen, base_type, dimensions)?;
+        let decl_type = codegen.type_with_dimensions(base_type, dimensions)?;
         if SignalType::Input == *signal_type {
             // self.func_inputs.push((decl_type, location));
             let mut attrs: Vec<NamedAttribute<'_>> = Vec::new();
@@ -159,67 +160,6 @@ impl<'ctx> DeclarationInfo<'ctx> {
             self.struct_fields.push(new.map(|f| f.into()));
         }
         Ok(())
-    }
-
-    /// If `dimensions` is empty, return `base_type`. Otherwise, create ArrayType by converting the
-    /// dimension circom Expressions to LLZK Attributes.
-    fn type_with_dimensions(
-        codegen: &LlzkCodegen<'_, 'ctx>,
-        base_type: Type<'ctx>,
-        dimensions: &[Expression],
-    ) -> Result<Type<'ctx>> {
-        if dimensions.is_empty() {
-            Ok(base_type)
-        } else {
-            dimensions
-                .iter()
-                .map(|e| Self::convert_dim_expr(codegen, e))
-                .collect::<Result<Vec<_>, _>>()
-                .map(|dims| ArrayType::new(base_type, &dims).into())
-        }
-    }
-
-    /// Convert a circom Expression used as an array dimension to an LLZK Attribute.
-    ///
-    /// Note: The LLZK ArrayType can only use the following Attribute types for dimensions:
-    /// IntegerAttr (`index` or `i1`), SymbolRefAttr, or AffineMapAttr (with single result,
-    /// probably an identity map).
-    ///
-    /// 'ast: lifetime of the circom AST element
-    fn convert_dim_expr<'ast>(
-        codegen: &LlzkCodegen<'ast, 'ctx>,
-        expr: &Expression,
-    ) -> Result<Attribute<'ctx>> {
-        match expr {
-            Expression::Number(meta, big_int) => {
-                let int_attr = IntegerAttribute::new(
-                    Type::index(codegen.context),
-                    big_int.to_i64().ok_or_else(|| anyhow!("Array dimension must fit in i64"))?,
-                );
-                Ok(int_attr.into())
-            }
-            Expression::Variable { meta, name, access } => {
-                // TODO: generate AffineMapAttr (with single result) or SymbolRefAttr (from param)
-                todo!("Handle Variable expression in dimension")
-            }
-            Expression::InfixOp { meta, lhe, infix_op, rhe } => {
-                todo!("Handle InfixOp expression in dimension")
-            }
-            Expression::PrefixOp { meta, prefix_op, rhe } => {
-                todo!("Handle PrefixOp expression in dimension")
-            }
-            Expression::InlineSwitchOp { meta, cond, if_true, if_false } => {
-                todo!("Handle InlineSwitchOp expression in dimension")
-            }
-            Expression::Call { meta, id, args } => {
-                todo!("Handle Call expression in dimension")
-            }
-            // The remaining cases do not produce a scalar value.
-            // i.e. ParallelOp, ArrayInLine, UniformArray, BusCall, AnonymousComp, Tuple
-            // Give the same error that the circom type checker gives. The type checker ran
-            // earlier so this should technically be unreachable.
-            _ => Err(anyhow!("Array indexes and lengths must be single arithmetic expressions")),
-        }
     }
 }
 

--- a/llzk_backend/src/module.rs
+++ b/llzk_backend/src/module.rs
@@ -20,7 +20,6 @@ use llzk::{
 };
 use melior::ir::{
     operation::OperationLike as _, Block, BlockLike as _, Location, Operation, RegionLike, Type,
-    Value,
 };
 use program_structure::{
     ast::{Expression, Meta, SignalType, Statement, VariableType},
@@ -264,9 +263,9 @@ impl<'ctx> GenerateLLZKInModule<'ctx> for TemplateData {
         // variable name to LLZK op result Value (do this in each function).
         for (name, op) in declarations.var_decls {
             // Insert (a clone of) the declaration into the compute function.
-            let _: Value = compute_ctx.append_op_named_result(op.clone(), name.clone())?;
+            compute_ctx.block_ctx.declare_name_if_not_present(&name, || Ok(op.clone()))?;
             // Insert the declaration into the constrain function.
-            let _: Value = constrain_ctx.append_op_named_result(op, name)?;
+            constrain_ctx.block_ctx.declare_name_if_not_present(&name, || Ok(op))?;
         }
 
         // Visit the body of the template and generate LLZK IR for it within the struct functions.

--- a/llzk_backend/src/module.rs
+++ b/llzk_backend/src/module.rs
@@ -1,8 +1,6 @@
 //! Handles the top-level constructs (i.e. circom templates and functions), by delegating
 //! to the [function] and [template] modules to generate the code for each.
 
-#![allow(unused_variables)] // TODO: TEMP
-
 use crate::{
     function::{FunctionContext, GenerateLLZKInFunction as _},
     shared::{map_name_to_arg_value, LlzkCodegen},

--- a/llzk_backend/src/module.rs
+++ b/llzk_backend/src/module.rs
@@ -14,12 +14,13 @@ use llzk::{
             self,
             helpers::{compute_fn, constrain_fn},
         },
-        undef, FeltType, FuncDefOpRef, FuncDefOpRefMut, FunctionType, PublicAttribute,
+        FeltType, FuncDefOpRef, FuncDefOpRefMut, FunctionType, PublicAttribute,
         StructDefOpLike as _, StructType,
     },
 };
 use melior::ir::{
     operation::OperationLike as _, Block, BlockLike as _, Location, Operation, RegionLike, Type,
+    Value,
 };
 use program_structure::{
     ast::{Expression, Meta, SignalType, Statement, VariableType},
@@ -104,14 +105,10 @@ impl<'ctx> DeclarationInfo<'ctx> {
                     VariableType::Var => {
                         // Create an `undef` of the appropriate type. When the actual assignment is
                         // processed later, replace the `undef` with the appropriate value.
-                        let op = undef::undef(
-                            codegen.location_from_meta(meta),
-                            codegen.type_with_dimensions(
-                                FeltType::new(codegen.context).into(),
-                                dimensions,
-                            )?,
+                        self.var_decls.insert(
+                            name.clone(),
+                            codegen.new_nondet_value_of_dimensions(meta, dimensions)?,
                         );
-                        self.var_decls.insert(name.clone(), op);
                         Ok(())
                     }
                     VariableType::Component => {
@@ -267,9 +264,9 @@ impl<'ctx> GenerateLLZKInModule<'ctx> for TemplateData {
         // variable name to LLZK op result Value (do this in each function).
         for (name, op) in declarations.var_decls {
             // Insert (a clone of) the declaration into the compute function.
-            compute_ctx.append_op_named_result(op.clone(), name.clone());
+            let _: Value = compute_ctx.append_op_named_result(op.clone(), name.clone())?;
             // Insert the declaration into the constrain function.
-            constrain_ctx.append_op_named_result(op, name);
+            let _: Value = constrain_ctx.append_op_named_result(op, name)?;
         }
 
         // Visit the body of the template and generate LLZK IR for it within the struct functions.

--- a/llzk_backend/src/module.rs
+++ b/llzk_backend/src/module.rs
@@ -1,4 +1,8 @@
+//! Handles the top-level constructs (i.e. circom templates and functions), by delegating
+//! to the [function] and [template] modules to generate the code for each.
+
 #![allow(unused_variables)] // TODO: TEMP
+
 use crate::{
     function::{FunctionContext, GenerateLLZKInFunction as _},
     shared::{map_name_to_arg_value, LlzkCodegen},

--- a/llzk_backend/src/shared.rs
+++ b/llzk_backend/src/shared.rs
@@ -1,7 +1,5 @@
 //! Shared code generation utilities.
 
-#![allow(unused_variables)] // TODO: TEMP
-
 use ansi_term::Color;
 use anyhow::{anyhow, Ok, Result};
 use llzk::prelude::{
@@ -98,6 +96,7 @@ impl<'ast, 'ctx> LlzkCodegen<'ast, 'ctx> {
     /// Note: The LLZK ArrayType can only use the following Attribute types for dimensions:
     /// IntegerAttr (`index` or `i1`), SymbolRefAttr, or AffineMapAttr (with single result,
     /// probably an identity map).
+    #[allow(unused_variables)] // TODO: TEMP
     pub fn convert_dim_expr(&self, expr: &Expression) -> Result<Attribute<'ctx>> {
         match expr {
             Expression::Number(meta, big_int) => {

--- a/llzk_backend/src/shared.rs
+++ b/llzk_backend/src/shared.rs
@@ -1,4 +1,7 @@
+//! Shared code generation utilities.
+
 #![allow(unused_variables)] // TODO: TEMP
+
 use ansi_term::Color;
 use anyhow::{anyhow, Ok, Result};
 use llzk::prelude::{
@@ -95,8 +98,6 @@ impl<'ast, 'ctx> LlzkCodegen<'ast, 'ctx> {
     /// Note: The LLZK ArrayType can only use the following Attribute types for dimensions:
     /// IntegerAttr (`index` or `i1`), SymbolRefAttr, or AffineMapAttr (with single result,
     /// probably an identity map).
-    ///
-    /// 'ast: lifetime of the circom AST element
     pub fn convert_dim_expr(&self, expr: &Expression) -> Result<Attribute<'ctx>> {
         match expr {
             Expression::Number(meta, big_int) => {

--- a/llzk_backend/src/shared.rs
+++ b/llzk_backend/src/shared.rs
@@ -1,19 +1,22 @@
+#![allow(unused_variables)] // TODO: TEMP
 use ansi_term::Color;
 use anyhow::{anyhow, Ok, Result};
 use llzk::prelude::{
-    felt, verify_operation_with_diags, FeltConstAttribute, FuncDefOp, FuncDefOpLike, FuncDefOpRef,
-    FuncDefOpRefMut, LlzkContext, LlzkError, StructDefOp, StructDefOpRef, StructDefOpRefMut,
+    felt, verify_operation_with_diags, ArrayType, FeltConstAttribute, FuncDefOp, FuncDefOpLike,
+    FuncDefOpRef, FuncDefOpRefMut, IntegerAttribute, LlzkContext, LlzkError, StructDefOp,
+    StructDefOpRef, StructDefOpRefMut,
 };
 use melior::{
     ir::{
-        operation::OperationLike as _, BlockLike, Location, Module, Operation, OperationRef, Type,
-        TypeLike, Value,
+        operation::OperationLike as _, Attribute, BlockLike, Location, Module, Operation,
+        OperationRef, Type, TypeLike, Value,
     },
     pass, utility,
 };
 use num_bigint_dig::BigInt;
+use num_traits::cast::ToPrimitive;
 use program_structure::{
-    ast::Meta,
+    ast::{Expression, Meta},
     error_code::ReportCode,
     error_definition::Report,
     file_definition::{FileID, FileLocation},
@@ -85,6 +88,64 @@ impl<'ast, 'ctx> LlzkCodegen<'ast, 'ctx> {
     pub fn add_function(&self, f: FuncDefOp<'ctx>) -> Result<FuncDefOpRefMut<'ctx, '_>> {
         let f: FuncDefOpRef = self.module.body().append_operation(f.into()).try_into()?;
         Ok(f.into())
+    }
+
+    /// Convert a circom [Expression] used as an array dimension to an LLZK Attribute.
+    ///
+    /// Note: The LLZK ArrayType can only use the following Attribute types for dimensions:
+    /// IntegerAttr (`index` or `i1`), SymbolRefAttr, or AffineMapAttr (with single result,
+    /// probably an identity map).
+    ///
+    /// 'ast: lifetime of the circom AST element
+    pub fn convert_dim_expr(&self, expr: &Expression) -> Result<Attribute<'ctx>> {
+        match expr {
+            Expression::Number(meta, big_int) => {
+                let int_attr = IntegerAttribute::new(
+                    Type::index(self.context),
+                    big_int.to_i64().ok_or_else(|| anyhow!("Array dimension must fit in i64"))?,
+                );
+                Ok(int_attr.into())
+            }
+            Expression::Variable { meta, name, access } => {
+                // TODO: generate AffineMapAttr (with single result) or SymbolRefAttr (from param)
+                todo!("Handle Variable expression in dimension")
+            }
+            Expression::InfixOp { meta, lhe, infix_op, rhe } => {
+                todo!("Handle InfixOp expression in dimension")
+            }
+            Expression::PrefixOp { meta, prefix_op, rhe } => {
+                todo!("Handle PrefixOp expression in dimension")
+            }
+            Expression::InlineSwitchOp { meta, cond, if_true, if_false } => {
+                todo!("Handle InlineSwitchOp expression in dimension")
+            }
+            Expression::Call { meta, id, args } => {
+                todo!("Handle Call expression in dimension")
+            }
+            // The remaining cases do not produce a scalar value.
+            // i.e. ParallelOp, ArrayInLine, UniformArray, BusCall, AnonymousComp, Tuple
+            // Give the same error that the circom type checker gives. The type checker ran
+            // earlier so this should technically be unreachable.
+            _ => Err(anyhow!("Array indexes and lengths must be single arithmetic expressions")),
+        }
+    }
+
+    /// If `dimensions` is empty, return `base_type`. Otherwise, create ArrayType by converting the
+    /// dimension circom [Expressions](Expression) to LLZK Attributes.
+    pub fn type_with_dimensions(
+        &self,
+        base_type: Type<'ctx>,
+        dimensions: &[Expression],
+    ) -> Result<Type<'ctx>> {
+        if dimensions.is_empty() {
+            Ok(base_type)
+        } else {
+            dimensions
+                .iter()
+                .map(|e| self.convert_dim_expr(e))
+                .collect::<Result<Vec<_>, _>>()
+                .map(|dims| ArrayType::new(base_type, &dims).into())
+        }
     }
 
     /// Run cleanup passes on the generated `Module`.

--- a/llzk_backend/src/shared.rs
+++ b/llzk_backend/src/shared.rs
@@ -2,9 +2,9 @@
 use ansi_term::Color;
 use anyhow::{anyhow, Ok, Result};
 use llzk::prelude::{
-    felt, verify_operation_with_diags, ArrayType, FeltConstAttribute, FuncDefOp, FuncDefOpLike,
-    FuncDefOpRef, FuncDefOpRefMut, IntegerAttribute, LlzkContext, LlzkError, StructDefOp,
-    StructDefOpRef, StructDefOpRefMut,
+    felt, undef, verify_operation_with_diags, ArrayType, FeltConstAttribute, FeltType, FuncDefOp,
+    FuncDefOpLike, FuncDefOpRef, FuncDefOpRefMut, IntegerAttribute, LlzkContext, LlzkError,
+    StructDefOp, StructDefOpRef, StructDefOpRefMut,
 };
 use melior::{
     ir::{
@@ -146,6 +146,18 @@ impl<'ast, 'ctx> LlzkCodegen<'ast, 'ctx> {
                 .collect::<Result<Vec<_>, _>>()
                 .map(|dims| ArrayType::new(base_type, &dims).into())
         }
+    }
+
+    /// Create an LLZK operation that produces a nondeterministic value of the given `dimensions`.
+    pub fn new_nondet_value_of_dimensions(
+        &self,
+        meta: &Meta,
+        dimensions: &[Expression],
+    ) -> Result<Operation<'ctx>> {
+        Ok(undef::undef(
+            self.location_from_meta(meta),
+            self.type_with_dimensions(FeltType::new(self.context).into(), dimensions)?,
+        ))
     }
 
     /// Run cleanup passes on the generated `Module`.

--- a/llzk_backend/src/template.rs
+++ b/llzk_backend/src/template.rs
@@ -276,7 +276,6 @@ where
     /// a new [ChainResult].
     fn and_then<'ast, F1, F2, CR: ChainResult<'ctx, 'str, 'func, 'blk, 'val, 'r>>(
         &self,
-        codegen: &LlzkCodegen<'ast, 'ctx>,
         gen_compute: F1,
         gen_constrain: F2,
     ) -> Result<CR>
@@ -294,7 +293,6 @@ where
     #[inline]
     fn and_then_same<'ast, F, CR: ChainResult<'ctx, 'str, 'func, 'blk, 'val, 'r>>(
         &self,
-        codegen: &LlzkCodegen<'ast, 'ctx>,
         handle: F,
     ) -> Result<CR>
     where
@@ -303,7 +301,7 @@ where
             &Self::HandlerInput,
         ) -> Result<CR::HandlerOutput>,
     {
-        self.and_then::<&F, &F, CR>(codegen, &handle, &handle)
+        self.and_then::<&F, &F, CR>(&handle, &handle)
     }
 }
 
@@ -369,7 +367,6 @@ where
 
     fn and_then<'ast, F1, F2, CR: ChainResult<'ctx, 'str, 'func, 'blk, 'val, 'r>>(
         &self,
-        codegen: &LlzkCodegen<'ast, 'ctx>,
         gen_compute: F1,
         gen_constrain: F2,
     ) -> Result<CR>
@@ -420,7 +417,6 @@ where
 
     fn and_then<'ast, F1, F2, CR: ChainResult<'ctx, 'str, 'func, 'blk, 'val, 'r>>(
         &self,
-        codegen: &LlzkCodegen<'ast, 'ctx>,
         gen_compute: F1,
         gen_constrain: F2,
     ) -> Result<CR>
@@ -539,7 +535,7 @@ where
                 initializations.gen_llzk_in_template(codegen, template)
             }
             Statement::Declaration { meta, xtype, name, dimensions, .. } => {
-                template.and_then_same(codegen, |fc, _| {
+                template.and_then_same(|fc, _| {
                     fc.block_ctx.declare_name_if_not_present(name, || {
                         codegen.new_nondet_value_of_dimensions(meta, dimensions)
                     })
@@ -556,17 +552,16 @@ where
                     // Since there's no simple assignment in LLZK, just update the mapped Value
                     // which essentially propagates the assignment.
                     match op {
-                        AssignOp::AssignVar => rhe
-                            .gen_llzk_in_template(codegen, template)?
-                            .and_then_same(codegen, |fc, val| {
+                        AssignOp::AssignVar => {
+                            rhe.gen_llzk_in_template(codegen, template)?.and_then_same(|fc, val| {
                                 fc.block_ctx.set_named_value(var.clone(), *val)
-                            }),
+                            })
+                        }
                         AssignOp::AssignSignal => {
                             // The `<--` operator is witness generation only so this should not
                             // generate any code in the constrain function.
                             let template = template.compute_only();
                             rhe.gen_llzk_in_template(codegen, &template)?.and_then_same(
-                                codegen,
                                 |fc, val| {
                                     // Write value to field of "self" struct.
                                     fc.append_op_no_result(
@@ -583,7 +578,6 @@ where
                         }
                         AssignOp::AssignConstraintSignal => {
                             rhe.gen_llzk_in_template(codegen, template)?.and_then(
-                                codegen,
                                 |fc, val| {
                                     // Write value to field of "self" struct.
                                     fc.append_op_no_result(
@@ -640,7 +634,6 @@ where
                 let template = template.constrain_only();
                 // Generate Value for both sides and then generate the constraint op.
                 ExprGenResultMulti::gen_exprs(&template, codegen, [lhe, rhe])?.and_then_same(
-                    codegen,
                     |fc, vals| {
                         fc.append_op_no_result(
                             constrain::eq(codegen.location_from_meta(meta), vals[0], vals[1])
@@ -656,7 +649,7 @@ where
                 todo!("Handle while statement in template")
             }
             Statement::Assert { meta, arg } => {
-                arg.gen_llzk_in_template(codegen, template)?.and_then_same(codegen, |fc, val| {
+                arg.gen_llzk_in_template(codegen, template)?.and_then_same(|fc, val| {
                     fc.append_op_no_result(
                         llzk::dialect::bool::assert(
                             codegen.location_from_meta(meta),
@@ -710,7 +703,7 @@ where
     {
         match self {
             Expression::Number(meta, big_int) => {
-                template.and_then_same(codegen, |fc, _| {
+                template.and_then_same(|fc, _| {
                     // Convert the BigInt to an LLZK `felt.const` op. The user of the Expression is
                     // responsible for converting this `felt.type` value to another type if needed.
                     // This is done in both functions (if the result is unused in one, dce can
@@ -719,7 +712,7 @@ where
                 })
             }
             Expression::Variable { meta, name, access } => match access.as_slice() {
-                [] => template.and_then_same(codegen, |fc, _| {
+                [] => template.and_then_same(|fc, _| {
                     fc.block_ctx
                         .get_named_value(name)
                         .copied()
@@ -731,15 +724,14 @@ where
             },
             Expression::InfixOp { meta, lhe, infix_op, rhe } => {
                 // Generate Value for both sides and then generate the infix op.
-                ExprGenResultMulti::gen_exprs(template, codegen, [&**lhe, &**rhe])?
-                    .and_then_same(codegen, |fc, vals| {
-                        fc.gen_infix_op(codegen, meta, infix_op, vals[0], vals[1])
-                    })
+                ExprGenResultMulti::gen_exprs(template, codegen, [&**lhe, &**rhe])?.and_then_same(
+                    |fc, vals| fc.gen_infix_op(codegen, meta, infix_op, vals[0], vals[1]),
+                )
             }
             Expression::PrefixOp { meta, prefix_op, rhe } => {
                 // Generate Value for operand and then generate the prefix op.
                 rhe.gen_llzk_in_template(codegen, template)?
-                    .and_then_same(codegen, |fc, v| fc.gen_prefix_op(codegen, meta, prefix_op, *v))
+                    .and_then_same(|fc, v| fc.gen_prefix_op(codegen, meta, prefix_op, *v))
             }
             Expression::InlineSwitchOp { meta, cond, if_true, if_false } => {
                 todo!("Handle InlineSwitchOp expression in template")
@@ -758,7 +750,7 @@ where
                 // Visit each argument and collect the resulting LLZK Values for both functions.
                 let res = ExprGenResultMulti::gen_exprs(template, codegen, args)?;
                 // Create the CallOp in each function using the collected args.
-                res.and_then_same(codegen, |fc, vals| {
+                res.and_then_same(|fc, vals| {
                     // TODO: Currently, the LLZK function will always return a `felt.type` but
                     // eventually, this gen function may need an "expected result type"
                     // parameter or use `poly.tvar` with function templates.

--- a/llzk_backend/src/template.rs
+++ b/llzk_backend/src/template.rs
@@ -111,13 +111,21 @@ where
     }
 
     fn stack_push(&mut self, block: Self::NewBlock) {
-        self.compute.as_ref().map(|rc| rc.borrow_mut().block_ctx.push(block.0.unwrap()));
-        self.constrain.as_ref().map(|rc| rc.borrow_mut().block_ctx.push(block.1.unwrap()));
+        if let Some(rc) = self.compute.as_ref() {
+            rc.borrow_mut().block_ctx.push(block.0.unwrap())
+        }
+        if let Some(rc) = self.constrain.as_ref() {
+            rc.borrow_mut().block_ctx.push(block.1.unwrap())
+        }
     }
 
     fn stack_pop(&mut self) {
-        self.compute.as_ref().map(|rc| rc.borrow_mut().block_ctx.pop());
-        self.constrain.as_ref().map(|rc| rc.borrow_mut().block_ctx.pop());
+        if let Some(rc) = self.compute.as_ref() {
+            rc.borrow_mut().block_ctx.pop()
+        }
+        if let Some(rc) = self.constrain.as_ref() {
+            rc.borrow_mut().block_ctx.pop()
+        }
     }
 }
 

--- a/llzk_backend/src/template.rs
+++ b/llzk_backend/src/template.rs
@@ -6,8 +6,6 @@
 //! helper traits like `ExprGenResult` and `Chainable` that implement some boilerplate to make the
 //! actual code generation within [template::GenerateLLZKInTemplate] a lot simpler.
 
-#![allow(unused_variables)] // TODO: TEMP
-
 use crate::{
     function::FunctionContext,
     gen_context::GenWithCircomScopeHandling,
@@ -527,6 +525,7 @@ where
     where
         'val: 'r;
 
+    #[allow(unused_variables)] // TODO: TEMP
     fn gen_llzk_in_template<'ast, 'r>(
         &'ast self,
         codegen: &LlzkCodegen<'ast, 'ctx>,
@@ -700,6 +699,7 @@ where
     where
         'val: 'r;
 
+    #[allow(unused_variables)] // TODO: TEMP
     fn gen_llzk_in_template<'ast, 'r>(
         &'ast self,
         codegen: &LlzkCodegen<'ast, 'ctx>,

--- a/llzk_backend/src/template.rs
+++ b/llzk_backend/src/template.rs
@@ -500,7 +500,7 @@ where
                         AssignOp::AssignVar => rhe
                             .gen_llzk_in_template(codegen, template)?
                             .and_then_same(codegen, |fc, val| {
-                                fc.name_to_value.insert(var.clone(), *val);
+                                fc.block_ctx.set_named_value(var.clone(), *val);
                                 Ok(())
                             }),
                         AssignOp::AssignSignal => {
@@ -661,8 +661,8 @@ where
             }
             Expression::Variable { meta, name, access } => match access.as_slice() {
                 [] => template.and_then_same(codegen, |fc, _| {
-                    fc.name_to_value
-                        .get(name)
+                    fc.block_ctx
+                        .get_named_value(name)
                         .copied()
                         .ok_or_else(|| anyhow!("variable {name} not found"))
                 }),

--- a/llzk_backend/src/template.rs
+++ b/llzk_backend/src/template.rs
@@ -530,10 +530,13 @@ where
             Statement::InitializationBlock { initializations, .. } => {
                 initializations.gen_llzk_in_template(codegen, template)
             }
-            Statement::Declaration { meta, xtype, name, dimensions, .. } => template
-                .and_then_same(codegen, |fc, _| {
-                    fc.declare_name_uninit(codegen, name.clone(), meta, dimensions)
-                }),
+            Statement::Declaration { meta, xtype, name, dimensions, .. } => {
+                template.and_then_same(codegen, |fc, _| {
+                    fc.block_ctx.declare_name_if_not_present(name, || {
+                        codegen.new_nondet_value_of_dimensions(meta, dimensions)
+                    })
+                })
+            }
             Statement::Block { stmts, .. } => {
                 let mut template = template; // satisfy the &mut in `GenWithCircomScopeHandling`
                 template.gen_in_current_block_with_new_circom_scope(|template, _| {

--- a/llzk_backend/src/template.rs
+++ b/llzk_backend/src/template.rs
@@ -530,13 +530,10 @@ where
             Statement::InitializationBlock { initializations, .. } => {
                 initializations.gen_llzk_in_template(codegen, template)
             }
-            Statement::Declaration { meta, xtype, name, dimensions, .. } => {
-                // TODO: we've already handled declarations to create struct fields and function
-                // parameters. Is there any reason to visit them again? If not, then
-                // we don't need the InitializationBlock above either.
-                println!("TODO: anything else to do with declaration? {name} of type {xtype:?}");
-                Ok(())
-            }
+            Statement::Declaration { meta, xtype, name, dimensions, .. } => template
+                .and_then_same(codegen, |fc, _| {
+                    fc.declare_name_uninit(codegen, name.clone(), meta, dimensions)
+                }),
             Statement::Block { stmts, .. } => {
                 let mut template = template; // satisfy the &mut in `GenWithCircomScopeHandling`
                 template.gen_in_current_block_with_new_circom_scope(|template, _| {
@@ -551,8 +548,7 @@ where
                         AssignOp::AssignVar => rhe
                             .gen_llzk_in_template(codegen, template)?
                             .and_then_same(codegen, |fc, val| {
-                                fc.block_ctx.set_named_value(var.clone(), *val);
-                                Ok(())
+                                fc.block_ctx.set_named_value(var.clone(), *val)
                             }),
                         AssignOp::AssignSignal => {
                             // The `<--` operator is witness generation only so this should not

--- a/llzk_backend/src/template.rs
+++ b/llzk_backend/src/template.rs
@@ -1,4 +1,13 @@
+//! Handles template-level LLZK code generation. The [template::TemplateContext] carries information
+//! about the current LLZK struct being generated and some helpers related to generating code within
+//! the struct. The [template::GenerateLLZKInTemplate] trait provides the visitor to generate LLZK
+//! IR for all circom [Expression](program_structure::abstract_syntax_tree::ast::Expression) and
+//! [Statement](program_structure::abstract_syntax_tree::ast::Statement) nodes. There are also a few
+//! helper traits like `ExprGenResult` and `Chainable` that implement some boilerplate to make the
+//! actual code generation within [template::GenerateLLZKInTemplate] a lot simpler.
+
 #![allow(unused_variables)] // TODO: TEMP
+
 use crate::{
     function::FunctionContext,
     gen_context::GenWithCircomScopeHandling,

--- a/llzk_backend/src/template.rs
+++ b/llzk_backend/src/template.rs
@@ -1,6 +1,7 @@
 #![allow(unused_variables)] // TODO: TEMP
 use crate::{
     function::FunctionContext,
+    gen_context::GenWithCircomScopeHandling,
     shared::{new_felt_const_op, LlzkCodegen},
 };
 use anyhow::{anyhow, Result};
@@ -11,7 +12,7 @@ use llzk::{
         StructDefOpRefMut,
     },
 };
-use melior::ir::Value;
+use melior::ir::{BlockRef, Value};
 use program_structure::{
     ast::{AssignOp, Expression, Statement},
     error_code::ReportCode,
@@ -80,6 +81,43 @@ impl<'ctx, 'str, 'func, 'blk, 'val> TemplateContext<'ctx, 'str, 'func, 'blk, 'va
             compute: None,
             constrain: self.constrain.as_ref().map(Rc::clone),
         }
+    }
+}
+
+/// The [TemplateContext] must deal with the block context stack in both functions for circom
+/// scope handling.
+///
+/// Note: The [GenWithCircomScopeHandling] trait requires mutable references in several places to
+/// support `gen_llzk_in_function()` where the [FunctionContext] is passed as a mutable reference.
+/// However, the [TemplateContext] instead uses internal mutability and is passed as an immutable
+/// reference to the `gen_llzk_in_template()` functions. Thus, this trait cannot be implemented for
+/// `TemplateContext` and is instead implemented for `&TemplateContext` which means its functions
+/// must be called via a `&mut &TemplateContext` reference.
+impl<'ctx, 'str, 'func, 'blk, 'val> GenWithCircomScopeHandling<'ctx, 'blk, 'val>
+    for &TemplateContext<'ctx, 'str, 'func, 'blk, 'val>
+where
+    'ctx: 'str,
+    'str: 'func,
+    'func: 'blk,
+    'blk: 'val,
+{
+    type NewBlock = (ShouldGenerate<BlockRef<'ctx, 'blk>>, ShouldGenerate<BlockRef<'ctx, 'blk>>);
+
+    fn stack_top(&self) -> Self::NewBlock {
+        (
+            self.compute.as_ref().map(|rc| *rc.borrow().block_ctx.top_block()),
+            self.constrain.as_ref().map(|rc| *rc.borrow().block_ctx.top_block()),
+        )
+    }
+
+    fn stack_push(&mut self, block: Self::NewBlock) {
+        self.compute.as_ref().map(|rc| rc.borrow_mut().block_ctx.push(block.0.unwrap()));
+        self.constrain.as_ref().map(|rc| rc.borrow_mut().block_ctx.push(block.1.unwrap()));
+    }
+
+    fn stack_pop(&mut self) {
+        self.compute.as_ref().map(|rc| rc.borrow_mut().block_ctx.pop());
+        self.constrain.as_ref().map(|rc| rc.borrow_mut().block_ctx.pop());
     }
 }
 
@@ -491,7 +529,12 @@ where
                 println!("TODO: anything else to do with declaration? {name} of type {xtype:?}");
                 Ok(())
             }
-            Statement::Block { stmts, .. } => stmts.gen_llzk_in_template(codegen, template),
+            Statement::Block { stmts, .. } => {
+                let mut template = template; // satisfy the &mut in `GenWithCircomScopeHandling`
+                template.gen_in_current_block_with_new_circom_scope(|template, _| {
+                    stmts.gen_llzk_in_template(codegen, template)
+                })
+            }
             Statement::Substitution { meta, var, access, op, rhe } => {
                 if access.is_empty() {
                     // Since there's no simple assignment in LLZK, just update the mapped Value


### PR DESCRIPTION
Moves the variable-to-value mapping to the block context stack so a separate mapping can be maintained for each block scope. Also moves a few existing functions and structs to different locations in the code to make them accessible where they are now needed.