### PR TITLE
return Result not Option from `get_named_value`

### DIFF
--- a/llzk_backend/src/function.rs
+++ b/llzk_backend/src/function.rs
@@ -551,10 +551,7 @@ where
             Expression::Variable { meta, name, access } => {
                 match access.as_slice() {
                     [] => {
-                        let v = function
-                            .block_ctx
-                            .get_named_value(name)
-                            .ok_or_else(|| anyhow!("variable {name} not found"))?;
+                        let v = function.block_ctx.get_named_value(name)?;
                         Ok(*v)
                     }
                     a => {

--- a/llzk_backend/src/gen_context.rs
+++ b/llzk_backend/src/gen_context.rs
@@ -3,7 +3,6 @@
 use crate::function::FunctionContext;
 use crate::shared::single_result_as_value;
 use anyhow::anyhow;
-use anyhow::Ok;
 use anyhow::Result;
 use llzk::prelude::FuncDefOp;
 use llzk::prelude::OperationLike as _;
@@ -201,8 +200,13 @@ where
 
     /// Get the LLZK IR SSA Value for the given circom var name, checking the top block context
     /// and then proceeding down the stack until found (if at all).
-    pub fn get_named_value(&self, name: &str) -> Option<&Value<'ctx, 'val>> {
-        self.other_blocks.iter().rev().find_map(|bc| bc.get(name)).or_else(|| self.root.get(name))
+    pub fn get_named_value(&self, name: &str) -> Result<&Value<'ctx, 'val>> {
+        self.other_blocks
+            .iter()
+            .rev()
+            .find_map(|bc| bc.get(name))
+            .or_else(|| self.root.get(name))
+            .ok_or_else(|| anyhow!("variable {name} not found"))
     }
 
     /// Push a new block onto the stack to make it the current block.

--- a/llzk_backend/src/template.rs
+++ b/llzk_backend/src/template.rs
@@ -10,7 +10,6 @@ use crate::function::FunctionContext;
 use crate::gen_context::GenWithCircomScopeHandling;
 use crate::shared::new_felt_const_op;
 use crate::shared::LlzkCodegen;
-use anyhow::anyhow;
 use anyhow::Result;
 use llzk::builder::OpBuilder;
 use llzk::prelude::constrain;
@@ -744,12 +743,7 @@ where
                 })
             }
             Expression::Variable { meta, name, access } => match access.as_slice() {
-                [] => template.and_then_same(|fc, _| {
-                    fc.block_ctx
-                        .get_named_value(name)
-                        .copied()
-                        .ok_or_else(|| anyhow!("variable {name} not found"))
-                }),
+                [] => template.and_then_same(|fc, _| fc.block_ctx.get_named_value(name).copied()),
                 a => {
                     todo!("Handle accesses in Variable expression in template")
                 }


### PR DESCRIPTION
Avoids each caller needing to use `.ok_or_else(|| anyhow!("variable {name} not found"))`