### PR TITLE
[NFC] forces includes to separate lines

### DIFF
--- a/llzk_backend/rustfmt.toml
+++ b/llzk_backend/rustfmt.toml
@@ -6,3 +6,4 @@ max_width = 100
 wrap_comments = true
 normalize_comments = true
 comment_width = 100
+imports_granularity = "Item"

--- a/llzk_backend/src/codegen.rs
+++ b/llzk_backend/src/codegen.rs
@@ -1,10 +1,12 @@
 //! Entry point for LLZK code generation.
 
-use crate::{module::GenerateLLZKInModule as _, shared::LlzkCodegen};
+use crate::module::GenerateLLZKInModule as _;
+use crate::shared::LlzkCodegen;
 use ansi_term::Color;
 use anyhow::Result;
 use llzk::prelude::LlzkContext;
-use melior::ir::{Location, Module};
+use melior::ir::Location;
+use melior::ir::Module;
 use program_structure::program_archive::ProgramArchive;
 
 /// Create a new, empty LLZK `Module` with Location "main" from the `ProgramArchive`.

--- a/llzk_backend/src/function.rs
+++ b/llzk_backend/src/function.rs
@@ -5,29 +5,43 @@
 //! [Expression](program_structure::abstract_syntax_tree::ast::Expression) and
 //! [Statement](program_structure::abstract_syntax_tree::ast::Statement) nodes.
 
-use crate::{
-    gen_context::{BlockContextStack, GenWithCircomScopeHandling},
-    shared::{self, new_felt_const_op, single_result_as_value, IsA, LlzkCodegen},
-};
-use anyhow::{anyhow, Ok, Result};
-use llzk::prelude::{bool, felt, function, FeltType, FuncDefOpRefMut, OperationMutLike};
-use melior::{
-    dialect::{arith, index},
-    ir::{
-        operation::{OperationLike as _, OperationRefMut, WalkOrder, WalkResult},
-        BlockRef, Operation, Type, Value, ValueLike as _,
-    },
-};
-use program_structure::{
-    ast::{
-        Expression, ExpressionInfixOpcode, ExpressionPrefixOpcode, Meta, Statement, VariableType,
-    },
-    error_code::ReportCode,
-};
-use std::{
-    collections::HashMap,
-    ops::{Deref, DerefMut},
-};
+use crate::gen_context::BlockContextStack;
+use crate::gen_context::GenWithCircomScopeHandling;
+use crate::shared::new_felt_const_op;
+use crate::shared::single_result_as_value;
+use crate::shared::IsA;
+use crate::shared::LlzkCodegen;
+use crate::shared::{self};
+use anyhow::anyhow;
+use anyhow::Ok;
+use anyhow::Result;
+use llzk::prelude::bool;
+use llzk::prelude::felt;
+use llzk::prelude::function;
+use llzk::prelude::FeltType;
+use llzk::prelude::FuncDefOpRefMut;
+use llzk::prelude::OperationMutLike;
+use melior::dialect::arith;
+use melior::dialect::index;
+use melior::ir::operation::OperationLike as _;
+use melior::ir::operation::OperationRefMut;
+use melior::ir::operation::WalkOrder;
+use melior::ir::operation::WalkResult;
+use melior::ir::BlockRef;
+use melior::ir::Operation;
+use melior::ir::Type;
+use melior::ir::Value;
+use melior::ir::ValueLike as _;
+use program_structure::ast::Expression;
+use program_structure::ast::ExpressionInfixOpcode;
+use program_structure::ast::ExpressionPrefixOpcode;
+use program_structure::ast::Meta;
+use program_structure::ast::Statement;
+use program_structure::ast::VariableType;
+use program_structure::error_code::ReportCode;
+use std::collections::HashMap;
+use std::ops::Deref;
+use std::ops::DerefMut;
 
 /// Stores ref to the current function while generating LLZK IR for the function.
 ///

--- a/llzk_backend/src/gen_context.rs
+++ b/llzk_backend/src/gen_context.rs
@@ -1,9 +1,18 @@
 //! Handles circom var scoping and LLZK blocks stack management.
 
-use crate::{function::FunctionContext, shared::single_result_as_value};
-use anyhow::{anyhow, Ok, Result};
-use llzk::prelude::{FuncDefOp, OperationLike as _};
-use melior::ir::{BlockLike as _, BlockRef, Operation, OperationRef, RegionLike as _, Value};
+use crate::function::FunctionContext;
+use crate::shared::single_result_as_value;
+use anyhow::anyhow;
+use anyhow::Ok;
+use anyhow::Result;
+use llzk::prelude::FuncDefOp;
+use llzk::prelude::OperationLike as _;
+use melior::ir::BlockLike as _;
+use melior::ir::BlockRef;
+use melior::ir::Operation;
+use melior::ir::OperationRef;
+use melior::ir::RegionLike as _;
+use melior::ir::Value;
 use std::collections::HashMap;
 
 /// Single frame in the [BlockContextStack].

--- a/llzk_backend/src/module.rs
+++ b/llzk_backend/src/module.rs
@@ -1,35 +1,43 @@
 //! Handles the top-level constructs (i.e. circom templates and functions), by delegating
 //! to the [function] and [template] modules to generate the code for each.
 
-use crate::{
-    function::{FunctionContext, GenerateLLZKInFunction as _},
-    shared::{map_name_to_arg_value, LlzkCodegen},
-    template::{GenerateLLZKInTemplate as _, TemplateContext},
-};
+use crate::function::FunctionContext;
+use crate::function::GenerateLLZKInFunction as _;
+use crate::shared::map_name_to_arg_value;
+use crate::shared::LlzkCodegen;
+use crate::template::GenerateLLZKInTemplate as _;
+use crate::template::TemplateContext;
 use anyhow::Result;
-use llzk::{
-    attributes::NamedAttribute,
-    error::Error,
-    prelude::{
-        function,
-        r#struct::{
-            self,
-            helpers::{compute_fn, constrain_fn},
-        },
-        FeltType, FuncDefOpRef, FuncDefOpRefMut, FunctionType, PublicAttribute,
-        StructDefOpLike as _, StructType,
-    },
-};
-use melior::ir::{
-    operation::OperationLike as _, Block, BlockLike as _, Location, Operation, RegionLike, Type,
-};
-use program_structure::{
-    ast::{Expression, Meta, SignalType, Statement, VariableType},
-    function_data::FunctionData,
-    program_archive::ProgramArchive,
-    template_data::TemplateData,
-};
-use std::{collections::HashMap, convert::TryFrom};
+use llzk::attributes::NamedAttribute;
+use llzk::error::Error;
+use llzk::prelude::function;
+use llzk::prelude::r#struct::helpers::compute_fn;
+use llzk::prelude::r#struct::helpers::constrain_fn;
+use llzk::prelude::r#struct::{self};
+use llzk::prelude::FeltType;
+use llzk::prelude::FuncDefOpRef;
+use llzk::prelude::FuncDefOpRefMut;
+use llzk::prelude::FunctionType;
+use llzk::prelude::PublicAttribute;
+use llzk::prelude::StructDefOpLike as _;
+use llzk::prelude::StructType;
+use melior::ir::operation::OperationLike as _;
+use melior::ir::Block;
+use melior::ir::BlockLike as _;
+use melior::ir::Location;
+use melior::ir::Operation;
+use melior::ir::RegionLike;
+use melior::ir::Type;
+use program_structure::ast::Expression;
+use program_structure::ast::Meta;
+use program_structure::ast::SignalType;
+use program_structure::ast::Statement;
+use program_structure::ast::VariableType;
+use program_structure::function_data::FunctionData;
+use program_structure::program_archive::ProgramArchive;
+use program_structure::template_data::TemplateData;
+use std::collections::HashMap;
+use std::convert::TryFrom;
 
 /// Information needed to create an LLZK struct function parameter collected from the input signal
 /// Declaration statements within a circom template.

--- a/llzk_backend/src/shared.rs
+++ b/llzk_backend/src/shared.rs
@@ -1,37 +1,55 @@
 //! Shared code generation utilities.
 
 use ansi_term::Color;
-use anyhow::{anyhow, Ok, Result};
-use llzk::prelude::{
-    felt, undef, verify_operation_with_diags, ArrayType, FeltConstAttribute, FeltType, FuncDefOp,
-    FuncDefOpLike, FuncDefOpRef, FuncDefOpRefMut, IntegerAttribute, LlzkContext, LlzkError,
-    StructDefOp, StructDefOpRef, StructDefOpRefMut,
-};
-use melior::{
-    ir::{
-        operation::OperationLike as _, Attribute, BlockLike, Location, Module, Operation,
-        OperationRef, Type, TypeLike, Value,
-    },
-    pass, utility,
-};
+use anyhow::anyhow;
+use anyhow::Ok;
+use anyhow::Result;
+use llzk::prelude::felt;
+use llzk::prelude::undef;
+use llzk::prelude::verify_operation_with_diags;
+use llzk::prelude::ArrayType;
+use llzk::prelude::FeltConstAttribute;
+use llzk::prelude::FeltType;
+use llzk::prelude::FuncDefOp;
+use llzk::prelude::FuncDefOpLike;
+use llzk::prelude::FuncDefOpRef;
+use llzk::prelude::FuncDefOpRefMut;
+use llzk::prelude::IntegerAttribute;
+use llzk::prelude::LlzkContext;
+use llzk::prelude::LlzkError;
+use llzk::prelude::StructDefOp;
+use llzk::prelude::StructDefOpRef;
+use llzk::prelude::StructDefOpRefMut;
+use melior::ir::operation::OperationLike as _;
+use melior::ir::Attribute;
+use melior::ir::BlockLike;
+use melior::ir::Location;
+use melior::ir::Module;
+use melior::ir::Operation;
+use melior::ir::OperationRef;
+use melior::ir::Type;
+use melior::ir::TypeLike;
+use melior::ir::Value;
+use melior::pass;
+use melior::utility;
 use num_bigint_dig::BigInt;
 use num_traits::cast::ToPrimitive;
-use program_structure::{
-    ast::{Expression, Meta},
-    error_code::ReportCode,
-    error_definition::Report,
-    file_definition::{FileID, FileLocation},
-    program_archive::ProgramArchive,
-};
-use std::{
-    collections::HashMap,
-    convert::{TryFrom, TryInto as _},
-    fs::{self, File},
-    io::Write,
-    ops::Deref,
-    os::raw::c_void,
-    path::Path,
-};
+use program_structure::ast::Expression;
+use program_structure::ast::Meta;
+use program_structure::error_code::ReportCode;
+use program_structure::error_definition::Report;
+use program_structure::file_definition::FileID;
+use program_structure::file_definition::FileLocation;
+use program_structure::program_archive::ProgramArchive;
+use std::collections::HashMap;
+use std::convert::TryFrom;
+use std::convert::TryInto as _;
+use std::fs::File;
+use std::fs::{self};
+use std::io::Write;
+use std::ops::Deref;
+use std::os::raw::c_void;
+use std::path::Path;
 
 /// Stores necessary context for generating LLZK IR.
 ///

--- a/llzk_backend/src/template.rs
+++ b/llzk_backend/src/template.rs
@@ -6,25 +6,30 @@
 //! helper traits like `ExprGenResult` and `Chainable` that implement some boilerplate to make the
 //! actual code generation within [template::GenerateLLZKInTemplate] a lot simpler.
 
-use crate::{
-    function::FunctionContext,
-    gen_context::GenWithCircomScopeHandling,
-    shared::{new_felt_const_op, LlzkCodegen},
-};
-use anyhow::{anyhow, Result};
-use llzk::{
-    builder::OpBuilder,
-    prelude::{
-        constrain, function, r#struct, FeltType, FlatSymbolRefAttribute, FuncDefOpLike as _,
-        StructDefOpRefMut,
-    },
-};
-use melior::ir::{BlockRef, Value};
-use program_structure::{
-    ast::{AssignOp, Expression, Statement},
-    error_code::ReportCode,
-};
-use std::{cell::RefCell, collections::HashMap, ops::Deref, rc::Rc};
+use crate::function::FunctionContext;
+use crate::gen_context::GenWithCircomScopeHandling;
+use crate::shared::new_felt_const_op;
+use crate::shared::LlzkCodegen;
+use anyhow::anyhow;
+use anyhow::Result;
+use llzk::builder::OpBuilder;
+use llzk::prelude::constrain;
+use llzk::prelude::function;
+use llzk::prelude::r#struct;
+use llzk::prelude::FeltType;
+use llzk::prelude::FlatSymbolRefAttribute;
+use llzk::prelude::FuncDefOpLike as _;
+use llzk::prelude::StructDefOpRefMut;
+use melior::ir::BlockRef;
+use melior::ir::Value;
+use program_structure::ast::AssignOp;
+use program_structure::ast::Expression;
+use program_structure::ast::Statement;
+use program_structure::error_code::ReportCode;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::ops::Deref;
+use std::rc::Rc;
 
 /// Alias for `Option<T>` to make it clear what the meaning of the option is within the
 /// [TemplateContext] below.


### PR DESCRIPTION
Change format config so each "use" statement is on an individual line to reduce merge conflicts during active work on the repo. This PR has no functional changes, only changing the format config and applying auto-formatting.