### PR TITLE
preserve undef ops that have use sites

### DIFF
--- a/circom/tests/constraints/known1.circom
+++ b/circom/tests/constraints/known1.circom
@@ -1,7 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL:.*
 
 pragma circom 2.0.0;
 
@@ -15,3 +14,24 @@ template A() {
 component main = A();
 
 // CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-LABEL:   struct.def @A<[]> {
+// CHECK-NEXT:      struct.field @val : !felt.type {llzk.pub}
+// CHECK-LABEL:     function.def @compute
+// CHECK-SAME:      () -> !struct.type<@A<[]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_0:[0-9a-zA-Z_\.]+]] = struct.new : <@A<[]>>
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        struct.writef %[[VAL_0]][@val] = %[[VAL_1]] : <@A<[]>>, !felt.type
+// CHECK-NEXT:        function.return %[[VAL_0]] : !struct.type<@A<[]>>
+// CHECK-NEXT:      }
+// CHECK-LABEL:     function.def @constrain
+// CHECK-SAME:      (%[[VAL_2:[0-9a-zA-Z_\.]+]]: !struct.type<@A<[]>>) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_2]][@val] : <@A<[]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_3]], %[[VAL_4]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_3]], %[[VAL_5]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        constrain.eq %[[VAL_6]], %[[VAL_7]] : !felt.type, !felt.type
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/constraints/known2.circom
+++ b/circom/tests/constraints/known2.circom
@@ -1,7 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL:.*
 
 pragma circom 2.0.0;
 
@@ -15,3 +14,24 @@ template A() {
 component main = A();
 
 // CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-LABEL:   struct.def @A<[]> {
+// CHECK-NEXT:      struct.field @val : !felt.type {llzk.pub}
+// CHECK-LABEL:     function.def @compute
+// CHECK-SAME:      () -> !struct.type<@A<[]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_0:[0-9a-zA-Z_\.]+]] = struct.new : <@A<[]>>
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        struct.writef %[[VAL_0]][@val] = %[[VAL_1]] : <@A<[]>>, !felt.type
+// CHECK-NEXT:        function.return %[[VAL_0]] : !struct.type<@A<[]>>
+// CHECK-NEXT:      }
+// CHECK-LABEL:     function.def @constrain
+// CHECK-SAME:      (%[[VAL_2:[0-9a-zA-Z_\.]+]]: !struct.type<@A<[]>>) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_2]][@val] : <@A<[]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_3]], %[[VAL_5]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_3]], %[[VAL_6]] : !felt.type, !felt.type
+// CHECK-NEXT:        constrain.eq %[[VAL_4]], %[[VAL_7]] : !felt.type, !felt.type
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/constraints/known3.circom
+++ b/circom/tests/constraints/known3.circom
@@ -1,7 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL:.*
 
 pragma circom 2.0.0;
 
@@ -15,3 +14,21 @@ template A() {
 component main = A();
 
 // CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-LABEL:   struct.def @A<[]> {
+// CHECK-NEXT:      struct.field @val : !felt.type {llzk.pub}
+// CHECK-LABEL:     function.def @compute
+// CHECK-SAME:      () -> !struct.type<@A<[]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_0:[0-9a-zA-Z_\.]+]] = struct.new : <@A<[]>>
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        struct.writef %[[VAL_0]][@val] = %[[VAL_1]] : <@A<[]>>, !felt.type
+// CHECK-NEXT:        function.return %[[VAL_0]] : !struct.type<@A<[]>>
+// CHECK-NEXT:      }
+// CHECK-LABEL:     function.def @constrain
+// CHECK-SAME:      (%[[VAL_2:[0-9a-zA-Z_\.]+]]: !struct.type<@A<[]>>) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_2]][@val] : <@A<[]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        constrain.eq %[[VAL_3]], %[[VAL_4]] : !felt.type, !felt.type
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/constraints/known4.circom
+++ b/circom/tests/constraints/known4.circom
@@ -1,7 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL:.*
 
 pragma circom 2.0.0;
 
@@ -15,3 +14,21 @@ template A() {
 component main = A();
 
 // CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-LABEL:   struct.def @A<[]> {
+// CHECK-NEXT:      struct.field @val : !felt.type {llzk.pub}
+// CHECK-LABEL:     function.def @compute
+// CHECK-SAME:      () -> !struct.type<@A<[]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_0:[0-9a-zA-Z_\.]+]] = struct.new : <@A<[]>>
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        struct.writef %[[VAL_0]][@val] = %[[VAL_1]] : <@A<[]>>, !felt.type
+// CHECK-NEXT:        function.return %[[VAL_0]] : !struct.type<@A<[]>>
+// CHECK-NEXT:      }
+// CHECK-LABEL:     function.def @constrain
+// CHECK-SAME:      (%[[VAL_2:[0-9a-zA-Z_\.]+]]: !struct.type<@A<[]>>) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_2]][@val] : <@A<[]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        constrain.eq %[[VAL_4]], %[[VAL_3]] : !felt.type, !felt.type
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/constraints/known5.circom
+++ b/circom/tests/constraints/known5.circom
@@ -1,7 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL:.*
 
 pragma circom 2.0.0;
 
@@ -16,3 +15,27 @@ template A() {
 component main = A();
 
 // CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-LABEL:   struct.def @A<[]> {
+// CHECK-NEXT:      struct.field @valA : !felt.type {llzk.pub}
+// CHECK-NEXT:      struct.field @valB : !felt.type {llzk.pub}
+// CHECK-LABEL:     function.def @compute
+// CHECK-SAME:      () -> !struct.type<@A<[]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_0:[0-9a-zA-Z_\.]+]] = struct.new : <@A<[]>>
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        struct.writef %[[VAL_0]][@valA] = %[[VAL_1]] : <@A<[]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_1]], %[[VAL_2]] : !felt.type, !felt.type
+// CHECK-NEXT:        struct.writef %[[VAL_0]][@valB] = %[[VAL_3]] : <@A<[]>>, !felt.type
+// CHECK-NEXT:        function.return %[[VAL_0]] : !struct.type<@A<[]>>
+// CHECK-NEXT:      }
+// CHECK-LABEL:     function.def @constrain
+// CHECK-SAME:      (%[[VAL_4:[0-9a-zA-Z_\.]+]]: !struct.type<@A<[]>>) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_4]][@valA] : <@A<[]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_5]], %[[VAL_6]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_4]][@valB] : <@A<[]>>, !felt.type
+// CHECK-NEXT:        constrain.eq %[[VAL_8]], %[[VAL_7]] : !felt.type, !felt.type
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/operators/bitwise_and.circom
+++ b/circom/tests/operators/bitwise_and.circom
@@ -1,7 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL:.*
 
 pragma circom 2.0.0;
 
@@ -16,3 +15,28 @@ template BitwiseAnd() {
 component main = BitwiseAnd();
 
 // CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-LABEL:   struct.def @BitwiseAnd<[]> {
+// CHECK-NEXT:      struct.field @type : !felt.type {llzk.pub}
+// CHECK-NEXT:      struct.field @check_v : !felt.type
+// CHECK-LABEL:     function.def @compute
+// CHECK-SAME:      (%[[VAL_0:[0-9a-zA-Z_\.]+]]: !felt.type) -> !struct.type<@BitwiseAnd<[]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = struct.new : <@BitwiseAnd<[]>>
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = felt.const  5
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = felt.bit_and %[[VAL_0]], %[[VAL_2]] : !felt.type, !felt.type
+// CHECK-NEXT:        struct.writef %[[VAL_1]][@type] = %[[VAL_3]] : <@BitwiseAnd<[]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = felt.const  32
+// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_3]], %[[VAL_4]] : !felt.type, !felt.type
+// CHECK-NEXT:        struct.writef %[[VAL_1]][@check_v] = %[[VAL_5]] : <@BitwiseAnd<[]>>, !felt.type
+// CHECK-NEXT:        function.return %[[VAL_1]] : !struct.type<@BitwiseAnd<[]>>
+// CHECK-NEXT:      }
+// CHECK-LABEL:     function.def @constrain
+// CHECK-SAME:      (%[[VAL_6:[0-9a-zA-Z_\.]+]]: !struct.type<@BitwiseAnd<[]>>, %[[VAL_7:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_6]][@type] : <@BitwiseAnd<[]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_9:[0-9a-zA-Z_\.]+]] = felt.const  32
+// CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_8]], %[[VAL_9]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_6]][@check_v] : <@BitwiseAnd<[]>>, !felt.type
+// CHECK-NEXT:        constrain.eq %[[VAL_11]], %[[VAL_10]] : !felt.type, !felt.type
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/operators/bitwise_or.circom
+++ b/circom/tests/operators/bitwise_or.circom
@@ -1,7 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL:.*
 
 pragma circom 2.0.0;
 
@@ -16,3 +15,28 @@ template BitwiseOr() {
 component main = BitwiseOr();
 
 // CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-LABEL:   struct.def @BitwiseOr<[]> {
+// CHECK-NEXT:      struct.field @type : !felt.type {llzk.pub}
+// CHECK-NEXT:      struct.field @check_v : !felt.type
+// CHECK-LABEL:     function.def @compute
+// CHECK-SAME:      (%[[VAL_0:[0-9a-zA-Z_\.]+]]: !felt.type) -> !struct.type<@BitwiseOr<[]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = struct.new : <@BitwiseOr<[]>>
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = felt.const  5
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = felt.bit_or %[[VAL_0]], %[[VAL_2]] : !felt.type, !felt.type
+// CHECK-NEXT:        struct.writef %[[VAL_1]][@type] = %[[VAL_3]] : <@BitwiseOr<[]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = felt.const  32
+// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_3]], %[[VAL_4]] : !felt.type, !felt.type
+// CHECK-NEXT:        struct.writef %[[VAL_1]][@check_v] = %[[VAL_5]] : <@BitwiseOr<[]>>, !felt.type
+// CHECK-NEXT:        function.return %[[VAL_1]] : !struct.type<@BitwiseOr<[]>>
+// CHECK-NEXT:      }
+// CHECK-LABEL:     function.def @constrain
+// CHECK-SAME:      (%[[VAL_6:[0-9a-zA-Z_\.]+]]: !struct.type<@BitwiseOr<[]>>, %[[VAL_7:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_6]][@type] : <@BitwiseOr<[]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_9:[0-9a-zA-Z_\.]+]] = felt.const  32
+// CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_8]], %[[VAL_9]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_6]][@check_v] : <@BitwiseOr<[]>>, !felt.type
+// CHECK-NEXT:        constrain.eq %[[VAL_11]], %[[VAL_10]] : !felt.type, !felt.type
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/operators/bitwise_xor.circom
+++ b/circom/tests/operators/bitwise_xor.circom
@@ -1,7 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL:.*
 
 pragma circom 2.0.0;
 
@@ -16,3 +15,28 @@ template BitwiseXOR() {
 component main = BitwiseXOR();
 
 // CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-LABEL:   struct.def @BitwiseXOR<[]> {
+// CHECK-NEXT:      struct.field @type : !felt.type {llzk.pub}
+// CHECK-NEXT:      struct.field @check_v : !felt.type
+// CHECK-LABEL:     function.def @compute
+// CHECK-SAME:      (%[[VAL_0:[0-9a-zA-Z_\.]+]]: !felt.type) -> !struct.type<@BitwiseXOR<[]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = struct.new : <@BitwiseXOR<[]>>
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = felt.const  5
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = felt.bit_xor %[[VAL_0]], %[[VAL_2]] : !felt.type, !felt.type
+// CHECK-NEXT:        struct.writef %[[VAL_1]][@type] = %[[VAL_3]] : <@BitwiseXOR<[]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = felt.const  32
+// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_3]], %[[VAL_4]] : !felt.type, !felt.type
+// CHECK-NEXT:        struct.writef %[[VAL_1]][@check_v] = %[[VAL_5]] : <@BitwiseXOR<[]>>, !felt.type
+// CHECK-NEXT:        function.return %[[VAL_1]] : !struct.type<@BitwiseXOR<[]>>
+// CHECK-NEXT:      }
+// CHECK-LABEL:     function.def @constrain
+// CHECK-SAME:      (%[[VAL_6:[0-9a-zA-Z_\.]+]]: !struct.type<@BitwiseXOR<[]>>, %[[VAL_7:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_6]][@type] : <@BitwiseXOR<[]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_9:[0-9a-zA-Z_\.]+]] = felt.const  32
+// CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_8]], %[[VAL_9]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_6]][@check_v] : <@BitwiseXOR<[]>>, !felt.type
+// CHECK-NEXT:        constrain.eq %[[VAL_11]], %[[VAL_10]] : !felt.type, !felt.type
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/simple/call_in_constraint_gen_06.circom
+++ b/circom/tests/simple/call_in_constraint_gen_06.circom
@@ -1,7 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL:.*
 
 pragma circom 2.0.0;
 
@@ -22,3 +21,26 @@ template T() {
 component main = T();
 
 // CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-LABEL:   function.def @f(
+// CHECK-SAME:                    %[[VAL_0:[0-9a-zA-Z_\.]+]]: !felt.type) -> !felt.type {
+// CHECK-NEXT:      function.return %[[VAL_0]] : !felt.type
+// CHECK-NEXT:    }
+//
+// CHECK-LABEL:   struct.def @T<[]> {
+// CHECK-NEXT:      struct.field @temp : !felt.type
+// CHECK-NEXT:      function.def @compute
+// CHECK-SAME:      (%[[VAL_0:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_1:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_2:[0-9a-zA-Z_\.]+]]: !felt.type) -> !struct.type<@T<[]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = struct.new : <@T<[]>>
+// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = function.call @f(%[[VAL_0]]) : (!felt.type) -> !felt.type
+// CHECK-NEXT:        struct.writef %[[VAL_3]][@temp] = %[[VAL_4]] : <@T<[]>>, !felt.type
+// CHECK-NEXT:        function.return %[[VAL_3]] : !struct.type<@T<[]>>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain
+// CHECK-SAME:      (%[[VAL_5:[0-9a-zA-Z_\.]+]]: !struct.type<@T<[]>>, %[[VAL_6:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_7:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_8:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[VAL_9:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_5]][@temp] : <@T<[]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_7]], %[[VAL_8]] : !felt.type, !felt.type
+// CHECK-NEXT:        constrain.eq %[[VAL_10]], %[[VAL_9]] : !felt.type, !felt.type
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/simple/call_in_constraint_gen_08.circom
+++ b/circom/tests/simple/call_in_constraint_gen_08.circom
@@ -1,7 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL:.*
 
 pragma circom 2.0.0;
 
@@ -22,3 +21,28 @@ template T() {
 component main = T();
 
 // CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-LABEL:   function.def @f(
+// CHECK-SAME:                    %[[VAL_0:[0-9a-zA-Z_\.]+]]: !felt.type) -> !felt.type {
+// CHECK-NEXT:      function.return %[[VAL_0]] : !felt.type
+// CHECK-NEXT:    }
+//
+// CHECK-LABEL:   struct.def @T<[]> {
+// CHECK-NEXT:      struct.field @o1 : !felt.type {llzk.pub}
+// CHECK-NEXT:      function.def @compute
+// CHECK-SAME:      (%[[VAL_0:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_1:[0-9a-zA-Z_\.]+]]: !felt.type) -> !struct.type<@T<[]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = struct.new : <@T<[]>>
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        struct.writef %[[VAL_2]][@o1] = %[[VAL_3]] : <@T<[]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = function.call @f(%[[VAL_0]]) : (!felt.type) -> !felt.type
+// CHECK-NEXT:        function.return %[[VAL_2]] : !struct.type<@T<[]>>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain
+// CHECK-SAME:      (%[[VAL_5:[0-9a-zA-Z_\.]+]]: !struct.type<@T<[]>>, %[[VAL_6:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_7:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_5]][@o1] : <@T<[]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_9:[0-9a-zA-Z_\.]+]] = function.call @f(%[[VAL_6]]) : (!felt.type) -> !felt.type
+// CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_8]], %[[VAL_7]] : !felt.type, !felt.type
+// CHECK-NEXT:        constrain.eq %[[VAL_10]], %[[VAL_9]] : !felt.type, !felt.type
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/simple/call_in_constraint_gen_09.circom
+++ b/circom/tests/simple/call_in_constraint_gen_09.circom
@@ -1,7 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL:.*
 
 pragma circom 2.0.0;
 
@@ -23,3 +22,30 @@ template T() {
 component main = T();
 
 // CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-LABEL:   function.def @f(
+// CHECK-SAME:                    %[[VAL_0:[0-9a-zA-Z_\.]+]]: !felt.type) -> !felt.type {
+// CHECK-NEXT:      function.return %[[VAL_0]] : !felt.type
+// CHECK-NEXT:    }
+//
+// CHECK-LABEL:   struct.def @T<[]> {
+// CHECK-NEXT:      struct.field @o1 : !felt.type {llzk.pub}
+// CHECK-NEXT:      struct.field @temp : !felt.type
+// CHECK-NEXT:      function.def @compute
+// CHECK-SAME:      (%[[VAL_0:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_1:[0-9a-zA-Z_\.]+]]: !felt.type) -> !struct.type<@T<[]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = struct.new : <@T<[]>>
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        struct.writef %[[VAL_2]][@o1] = %[[VAL_3]] : <@T<[]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = function.call @f(%[[VAL_0]]) : (!felt.type) -> !felt.type
+// CHECK-NEXT:        struct.writef %[[VAL_2]][@temp] = %[[VAL_4]] : <@T<[]>>, !felt.type
+// CHECK-NEXT:        function.return %[[VAL_2]] : !struct.type<@T<[]>>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain
+// CHECK-SAME:      (%[[VAL_5:[0-9a-zA-Z_\.]+]]: !struct.type<@T<[]>>, %[[VAL_6:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_7:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_5]][@o1] : <@T<[]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_9:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_5]][@temp] : <@T<[]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_8]], %[[VAL_7]] : !felt.type, !felt.type
+// CHECK-NEXT:        constrain.eq %[[VAL_10]], %[[VAL_9]] : !felt.type, !felt.type
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/simple/simple_03.circom
+++ b/circom/tests/simple/simple_03.circom
@@ -1,7 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL:.*
 
 pragma circom 2.0.0;
 
@@ -22,3 +21,24 @@ template Simple5() {
 component main = Simple5();
 
 // CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-LABEL:   struct.def @Simple5<[]> {
+// CHECK-NEXT:      struct.field @x : !felt.type {llzk.pub}
+// CHECK-NEXT:      struct.field @y : !felt.type {llzk.pub}
+// CHECK-NEXT:      struct.field @z : !felt.type {llzk.pub}
+// CHECK-LABEL:     function.def @compute
+// CHECK-SAME:      (%[[VAL_0:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_1:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_2:[0-9a-zA-Z_\.]+]]: !felt.type) -> !struct.type<@Simple5<[]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = struct.new : <@Simple5<[]>>
+// CHECK-NEXT:        struct.writef %[[VAL_3]][@x] = %[[VAL_0]] : <@Simple5<[]>>, !felt.type
+// CHECK-NEXT:        struct.writef %[[VAL_3]][@y] = %[[VAL_1]] : <@Simple5<[]>>, !felt.type
+// CHECK-NEXT:        function.return %[[VAL_3]] : !struct.type<@Simple5<[]>>
+// CHECK-NEXT:      }
+// CHECK-LABEL:     function.def @constrain
+// CHECK-SAME:      (%[[VAL_4:[0-9a-zA-Z_\.]+]]: !struct.type<@Simple5<[]>>, %[[VAL_5:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_6:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_7:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_4]][@x] : <@Simple5<[]>>, !felt.type
+// CHECK-NEXT:        constrain.eq %[[VAL_8]], %[[VAL_5]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[VAL_9:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_4]][@y] : <@Simple5<[]>>, !felt.type
+// CHECK-NEXT:        constrain.eq %[[VAL_9]], %[[VAL_6]] : !felt.type, !felt.type
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/llzk_backend/src/function.rs
+++ b/llzk_backend/src/function.rs
@@ -13,14 +13,15 @@ use crate::shared::IsA;
 use crate::shared::LlzkCodegen;
 use crate::shared::{self};
 use anyhow::anyhow;
-use anyhow::Ok;
 use anyhow::Result;
 use llzk::prelude::bool;
 use llzk::prelude::felt;
 use llzk::prelude::function;
 use llzk::prelude::FeltType;
 use llzk::prelude::FuncDefOpRefMut;
+use llzk::prelude::Operation;
 use llzk::prelude::OperationMutLike;
+use llzk::prelude::OperationRef;
 use melior::dialect::arith;
 use melior::dialect::index;
 use melior::ir::operation::OperationLike as _;
@@ -28,7 +29,6 @@ use melior::ir::operation::OperationRefMut;
 use melior::ir::operation::WalkOrder;
 use melior::ir::operation::WalkResult;
 use melior::ir::BlockRef;
-use melior::ir::Operation;
 use melior::ir::Type;
 use melior::ir::Value;
 use melior::ir::ValueLike as _;
@@ -339,8 +339,11 @@ where
 /// replaced with actual values when visiting Assignment statements.
 impl Drop for FunctionContext<'_, '_, '_, '_> {
     fn drop(&mut self) {
+        fn undef_has_uses(op: OperationRef) -> bool {
+            shared::has_uses(single_result_as_value(op).unwrap())
+        }
         self.func.walk(WalkOrder::PreOrder, |op| {
-            if llzk::dialect::undef::is_undef_op(op) {
+            if llzk::dialect::undef::is_undef_op(op) && !undef_has_uses(op) {
                 let mut op_ref_mut = unsafe { OperationRefMut::from_raw(op.to_raw()) };
                 OperationMutLike::remove_from_parent(op_ref_mut.deref_mut());
                 WalkResult::Skip

--- a/llzk_backend/src/shared.rs
+++ b/llzk_backend/src/shared.rs
@@ -2,7 +2,6 @@
 
 use ansi_term::Color;
 use anyhow::anyhow;
-use anyhow::Ok;
 use anyhow::Result;
 use llzk::prelude::felt;
 use llzk::prelude::undef;
@@ -20,6 +19,7 @@ use llzk::prelude::LlzkError;
 use llzk::prelude::StructDefOp;
 use llzk::prelude::StructDefOpRef;
 use llzk::prelude::StructDefOpRefMut;
+use llzk::prelude::ValueLike;
 use melior::dialect::arith;
 use melior::ir::attribute::BoolAttribute;
 use melior::ir::operation::OperationLike as _;
@@ -34,6 +34,8 @@ use melior::ir::TypeLike;
 use melior::ir::Value;
 use melior::pass;
 use melior::utility;
+use mlir_sys::mlirOpOperandIsNull;
+use mlir_sys::mlirValueGetFirstUse;
 use num_bigint_dig::BigInt;
 use num_traits::cast::ToPrimitive;
 use program_structure::ast::Expression;
@@ -341,4 +343,15 @@ pub fn is_index(t: Type) -> bool {
 #[inline]
 pub fn is_felt(t: Type) -> bool {
     t.isa::<llzk::prelude::FeltType>()
+}
+
+/// Return `true` iff the given Value has any uses.
+///
+/// TODO: `llzk-rs` should provide this directly
+#[inline]
+pub fn has_uses(val: Value) -> bool {
+    unsafe {
+        let first_use = mlirValueGetFirstUse(val.to_raw());
+        !mlirOpOperandIsNull(first_use)
+    }
 }

--- a/llzk_backend/src/template.rs
+++ b/llzk_backend/src/template.rs
@@ -574,11 +574,12 @@ where
                             })
                         }
                         AssignOp::AssignSignal => {
-                            // The `<--` operator is witness generation only so this should not
-                            // generate any code in the constrain function.
-                            let template = template.compute_only();
-                            rhe.gen_llzk_in_template(codegen, &template)?.and_then_same(
-                                |fc, val| {
+                            // The `<--` operator is witness generation only so code for the RHS
+                            // expression should only be generated in the compute function.
+                            let compute_only = template.compute_only();
+                            let _: () = rhe
+                                .gen_llzk_in_template(codegen, &compute_only)?
+                                .and_then_same(|fc, val| {
                                     // Write value to field of "self" struct.
                                     fc.append_op_no_result(
                                         r#struct::writef(
@@ -588,9 +589,24 @@ where
                                             *val,
                                         )?
                                         .into(),
-                                    )
-                                },
-                            )
+                                    )?;
+                                    fc.block_ctx.set_named_value(var.clone(), *val)
+                                })?;
+                            // The constrain function just reads that field from "self" struct.
+                            let constrain_only = template.constrain_only();
+                            (&constrain_only).and_then_same(|fc, _| {
+                                let val = fc.append_op_unnamed_result(
+                                    r#struct::readf(
+                                        &OpBuilder::new(codegen.context.deref()),
+                                        codegen.location_from_meta(meta),
+                                        FeltType::new(codegen.context).into(),
+                                        fc.func.self_value_of_constrain()?,
+                                        var,
+                                    )?
+                                    .into(),
+                                )?;
+                                fc.block_ctx.set_named_value(var.clone(), val)
+                            })
                         }
                         AssignOp::AssignConstraintSignal => {
                             rhe.gen_llzk_in_template(codegen, template)?.and_then(


### PR DESCRIPTION
Most `undef` ops added during the translation are used to declare a variable initially before an actual `Value` is assigned and end up being unnecessary, thus the `Drop` implementation to remove them. However, removing them without checking for remaining uses could lead to an unhelpful crash.

This PR is based against https://github.com/Veridise/circom/pull/249 because the latter actually addresses an issue that was hidden by the unhelpful crash mentioned above.