### PR TITLE
expression gen is the same in template and function so just delegate

### DIFF
--- a/llzk_backend/src/function.rs
+++ b/llzk_backend/src/function.rs
@@ -943,20 +943,15 @@ where
                 // responsible for converting this `felt.type` value to another type if needed.
                 function.append_op_unnamed_result(new_felt_const_op(codegen, meta, big_int)?)
             }
-            Expression::Variable { meta, name, access } => {
-                match access.as_slice() {
-                    [] => {
-                        let v = function.block_ctx.get_named_value(name)?;
-                        Ok(*v)
-                    }
-                    a => {
-                        // Note: `Access::ComponentAccess` is not legal in functions per
-                        // `type_analysis/src/analyzers/functions_free_of_template_elements.rs`
-                        // so each must be `Access::ArrayAccess` only.
-                        todo!("Handle accesses in variable expression in function")
-                    }
+            Expression::Variable { meta, name, access } => match access.as_slice() {
+                [] => {
+                    let v = function.block_ctx.get_named_value(name)?;
+                    Ok(*v)
                 }
-            }
+                a => {
+                    todo!("Handle accesses in variable expression")
+                }
+            },
             Expression::InfixOp { meta, lhe, infix_op, rhe } => {
                 let lhs = lhe.gen_llzk_in_function(codegen, function)?;
                 let rhs = rhe.gen_llzk_in_function(codegen, function)?;
@@ -967,16 +962,16 @@ where
                 function.gen_prefix_op(codegen, meta, prefix_op, rhs)
             }
             Expression::InlineSwitchOp { meta, cond, if_true, if_false } => {
-                todo!("Handle InlineSwitchOp expression in function")
+                todo!("Handle InlineSwitchOp expression")
             }
             Expression::ParallelOp { meta, rhe } => {
-                todo!("Handle ParallelOp expression in function")
+                todo!("Handle ParallelOp expression")
             }
             Expression::ArrayInLine { meta, values } => {
-                todo!("Handle ArrayInLine expression in function")
+                todo!("Handle ArrayInLine expression")
             }
             Expression::UniformArray { meta, value, dimension } => {
-                todo!("Handle UniformArray expression in function")
+                todo!("Handle UniformArray expression")
             }
             Expression::Call { meta, id, args } => {
                 let builder = OpBuilder::new(codegen.context.deref());
@@ -1004,8 +999,7 @@ where
                 )
             }
             Expression::BusCall { meta, id, args } => {
-                // per `type_analysis/src/analyzers/functions_free_of_template_elements.rs`
-                unreachable!("Template elements declared inside the function")
+                todo!("Handle BusCall expression")
             }
             Expression::AnonymousComp { .. } => unreachable!("removed by 'syntax_sugar_remover'"),
             Expression::Tuple { .. } => unreachable!("removed by 'syntax_sugar_remover'"),

--- a/llzk_backend/src/template.rs
+++ b/llzk_backend/src/template.rs
@@ -10,17 +10,14 @@ use crate::function::FunctionContext;
 use crate::gen_context::GenWithCircomScopeHandling;
 use crate::gen_context::NestedBlockInfo;
 use crate::shared::is_felt;
-use crate::shared::new_felt_const_op;
 use crate::shared::LlzkCodegen;
 use anyhow::Result;
 use llzk::builder::OpBuilder;
 use llzk::dialect::cast;
 use llzk::prelude::constrain;
-use llzk::prelude::function;
 use llzk::prelude::r#struct;
 use llzk::prelude::BlockRef;
 use llzk::prelude::FeltType;
-use llzk::prelude::FlatSymbolRefAttribute;
 use llzk::prelude::FuncDefOpLike as _;
 use llzk::prelude::Location;
 use llzk::prelude::StructDefOpRefMut;
@@ -857,7 +854,6 @@ where
     where
         'val: 'r;
 
-    #[allow(unused_variables)] // TODO: TEMP
     fn gen_llzk_in_template<'ast, 'r>(
         &'ast self,
         codegen: &LlzkCodegen<'ast, 'ctx>,
@@ -866,72 +862,9 @@ where
     where
         'val: 'r,
     {
-        match self {
-            Expression::Number(meta, big_int) => {
-                template.and_then_same(|fc, _| {
-                    // Convert the BigInt to an LLZK `felt.const` op. The user of the Expression is
-                    // responsible for converting this `felt.type` value to another type if needed.
-                    // This is done in both functions (if the result is unused in one, dce can
-                    // remove it).
-                    fc.append_op_unnamed_result(new_felt_const_op(codegen, meta, big_int)?)
-                })
-            }
-            Expression::Variable { meta, name, access } => match access.as_slice() {
-                [] => template.and_then_same(|fc, _| fc.block_ctx.get_named_value(name).copied()),
-                a => {
-                    todo!("Handle accesses in Variable expression in template")
-                }
-            },
-            Expression::InfixOp { meta, lhe, infix_op, rhe } => {
-                // Generate Value for both sides and then generate the infix op.
-                GenResultMultiVal::gen_exprs(template, codegen, [&**lhe, &**rhe])?.and_then_same(
-                    |fc, vals| fc.gen_infix_op(codegen, meta, infix_op, vals[0], vals[1]),
-                )
-            }
-            Expression::PrefixOp { meta, prefix_op, rhe } => {
-                // Generate Value for operand and then generate the prefix op.
-                rhe.gen_llzk_in_template(codegen, template)?
-                    .and_then_same(|fc, v| fc.gen_prefix_op(codegen, meta, prefix_op, v))
-            }
-            Expression::InlineSwitchOp { meta, cond, if_true, if_false } => {
-                todo!("Handle InlineSwitchOp expression in template")
-            }
-            Expression::ParallelOp { meta, rhe } => {
-                todo!("Handle ParallelOp expression in template")
-            }
-            Expression::ArrayInLine { meta, values } => {
-                todo!("Handle ArrayInLine expression in template")
-            }
-            Expression::UniformArray { meta, value, dimension } => {
-                todo!("Handle UniformArray expression in template")
-            }
-            Expression::Call { meta, id, args } => {
-                let builder = OpBuilder::new(codegen.context.deref());
-                // Visit each argument and collect the resulting LLZK Values for both functions.
-                let res = GenResultMultiVal::gen_exprs(template, codegen, args)?;
-                // Create the CallOp in each function using the collected args.
-                res.and_then_same(|fc, vals| {
-                    // TODO: Currently, the LLZK function will always return a `felt.type` but
-                    // eventually, this gen function may need an "expected result type"
-                    // parameter or use `poly.tvar` with function templates.
-                    let return_types = &[FeltType::new(codegen.context)];
-                    fc.append_op_unnamed_result(
-                        function::call(
-                            &builder,
-                            codegen.location_from_meta(meta),
-                            FlatSymbolRefAttribute::new(codegen.context, id),
-                            &vals,
-                            return_types,
-                        )?
-                        .into(),
-                    )
-                })
-            }
-            Expression::BusCall { meta, id, args } => {
-                todo!("Handle BusCall expression in template")
-            }
-            Expression::AnonymousComp { .. } => unreachable!("removed by 'syntax_sugar_remover'"),
-            Expression::Tuple { .. } => unreachable!("removed by 'syntax_sugar_remover'"),
-        }
+        template.and_then_same(|fc, _| {
+            use crate::function::GenerateLLZKInFunction;
+            self.gen_llzk_in_function(codegen, fc)
+        })
     }
 }

--- a/llzk_backend/src/template.rs
+++ b/llzk_backend/src/template.rs
@@ -863,6 +863,8 @@ where
         'val: 'r,
     {
         template.and_then_same(|fc, _| {
+            // The import is here rather than top level because it is very important that
+            // `gen_llzk_in_function()` is not used while translating statements.
             use crate::function::GenerateLLZKInFunction;
             self.gen_llzk_in_function(codegen, fc)
         })


### PR DESCRIPTION
The translation for all Expressions is the same in both "@compute" and "@constrain" functions so, rather than essentially reimplementing for templates, just delegate to the function translation for expressions.

Makes the following irrelevant:
closes #176 
closes #191
closes #192
closes #193
closes #194
closes #195