### PR TITLE
Add option to generate LLZK from concrete program

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -859,6 +859,7 @@ version = "0.1.0"
 dependencies = [
  "ansi_term",
  "anyhow",
+ "compiler",
  "llzk",
  "melior",
  "melior-macro",

--- a/circom/src/input_user.rs
+++ b/circom/src/input_user.rs
@@ -19,7 +19,7 @@ pub struct Input {
     //pub field: &'static str,
     pub dump_parse_flag: bool,
     pub c_flag: bool,
-    pub llzk_flag: bool,
+    pub llzk_flag: Option<String>,
     pub wasm_flag: bool,
     pub wat_flag: bool,
     pub no_asm_flag: bool,
@@ -54,6 +54,8 @@ const DAT: &'static str = "dat";
 const SYM: &'static str = "sym";
 const JSON: &'static str = "json";
 
+pub const LLZK_KIND_CONCRETE: &'static str = "concrete";
+pub const LLZK_KIND_TEMPLATED: &'static str = "templated";
 
 impl Input {
     pub fn new() -> Result<Input, ()> {
@@ -203,8 +205,8 @@ impl Input {
     pub fn c_flag(&self) -> bool {
         self.c_flag
     }
-    pub fn llzk_flag(&self) -> bool {
-        self.llzk_flag
+    pub fn llzk_flag(&self) -> &Option<String> {
+        &self.llzk_flag
     }
     pub fn no_asm_flag(&self) -> bool {
         self.no_asm_flag
@@ -346,8 +348,14 @@ mod input_processing {
         matches.is_present("print_c")
     }
 
-    pub fn get_llzk(matches: &ArgMatches) -> bool {
-        matches.is_present("print_llzk_ir")
+    pub fn get_llzk(matches: &ArgMatches) -> Option<String> {
+        // Since there's a default value, `matches.is_present()` is
+        // always true so `occurrences_of()` must be used instead.
+        if matches.occurrences_of("gen_llzk_ir") > 0 {
+            matches.value_of("gen_llzk_ir").map(String::from)
+        } else {
+            None
+        }
     }
 
     pub fn get_main_inputs_log(matches: &ArgMatches) -> bool {
@@ -405,6 +413,7 @@ mod input_processing {
             false => Ok(String::from("bn128")),
         }
     }
+
     pub fn get_llzk_pass_pipeline(matches: &ArgMatches) -> Result<String, ()> {
         match matches.is_present("mlir_pass_pipeline") {
             true => Ok(String::from(matches.value_of("mlir_pass_pipeline").unwrap())),
@@ -553,10 +562,12 @@ mod input_processing {
                     .help("Compiles the circuit to C++"),
             )
             .arg(
-                Arg::with_name("print_llzk_ir")
+                Arg::with_name("gen_llzk_ir")
                     .long("llzk")
-                    .takes_value(false)
-                    .display_order(91)
+                    .takes_value(true)
+                    .possible_values(&[super::LLZK_KIND_CONCRETE, super::LLZK_KIND_TEMPLATED])
+                    .default_value(super::LLZK_KIND_TEMPLATED)
+                    .display_order(5001)
                     .help("Compiles the circuit to LLZK-IR"),
             )
             .arg(

--- a/circom/src/input_user.rs
+++ b/circom/src/input_user.rs
@@ -541,7 +541,7 @@ mod input_processing {
                 Arg::with_name("print_dump_parse")
                     .long("dump_parse")
                     .takes_value(false)
-                    .display_order(89)
+                    .display_order(10)
                     .help("Parses the circuit and dumps the program archive"),
             )
             .arg(
@@ -618,7 +618,7 @@ mod input_processing {
                     .long("llzk_passes")
                     .takes_value(true)
                     .default_value("")
-                    .display_order(998)
+                    .display_order(5002)
                     .help("Specify an MLIR pass pipeline to apply on the LLZK IR output"),
             )
             .get_matches()

--- a/circom/src/main.rs
+++ b/circom/src/main.rs
@@ -32,7 +32,8 @@ fn start() -> Result<(), ()> {
         write_to_file(format!("{:#?}", program_archive), user_input.dump_parse_file())?;
     }
     // If requested, generate LLZK IR output with generic templates
-    if Some(crate::input_user::LLZK_KIND_TEMPLATED) == user_input.llzk_flag().as_deref() {
+    let llzk_gen_opt = user_input.llzk_flag().as_deref();
+    if Some(crate::input_user::LLZK_KIND_TEMPLATED) == llzk_gen_opt {
         return llzk_backend::generate_llzk(
             &program_archive,
             user_input.llzk_file(),
@@ -59,12 +60,20 @@ fn start() -> Result<(), ()> {
         json_substitutions: user_input.json_substitutions_file().to_string(),
         prime: user_input.prime(),        
     };
+    let public_inputs =
+        if llzk_gen_opt.is_some_and(|kind| kind == crate::input_user::LLZK_KIND_CONCRETE) {
+            Some(program_archive.get_public_inputs_main_component().clone())
+        } else {
+            None
+        };
+
     let circuit = execution_user::execute_project(program_archive, config)?;
 
     // If requested, generate LLZK IR output after templates have been made concrete
-    if Some(crate::input_user::LLZK_KIND_CONCRETE) == user_input.llzk_flag().as_deref() {
+    if let Some(public_inputs) = public_inputs {
+        let vcp_plus = llzk_backend::VCPPlus::new(&circuit, public_inputs);
         return llzk_backend::generate_llzk(
-            &circuit,
+            &vcp_plus,
             user_input.llzk_file(),
             &user_input.llzk_pass_pipeline(),
             &user_input.prime(),

--- a/circom/src/main.rs
+++ b/circom/src/main.rs
@@ -71,7 +71,7 @@ fn start() -> Result<(), ()> {
 
     // If requested, generate LLZK IR output after templates have been made concrete
     if let Some(public_inputs) = public_inputs {
-        let vcp_plus = llzk_backend::VCPPlus::new(&circuit, public_inputs);
+        let vcp_plus = llzk_backend::VCPPlus { vcp: &circuit, public_inputs };
         return llzk_backend::generate_llzk(
             &vcp_plus,
             user_input.llzk_file(),

--- a/circom/src/main.rs
+++ b/circom/src/main.rs
@@ -31,13 +31,13 @@ fn start() -> Result<(), ()> {
     if user_input.dump_parse_flag() {
         write_to_file(format!("{:#?}", program_archive), user_input.dump_parse_file())?;
     }
-    // Generate LLZK IR output if requested
-    if user_input.llzk_flag() {
+    // If requested, generate LLZK IR output with generic templates
+    if Some(crate::input_user::LLZK_KIND_TEMPLATED) == user_input.llzk_flag().as_deref() {
         return llzk_backend::generate_llzk(
             &program_archive,
             user_input.llzk_file(),
             &user_input.llzk_pass_pipeline(),
-            &user_input.prime()
+            &user_input.prime(),
         );
     }
 
@@ -60,6 +60,17 @@ fn start() -> Result<(), ()> {
         prime: user_input.prime(),        
     };
     let circuit = execution_user::execute_project(program_archive, config)?;
+
+    // If requested, generate LLZK IR output after templates have been made concrete
+    if Some(crate::input_user::LLZK_KIND_CONCRETE) == user_input.llzk_flag().as_deref() {
+        return llzk_backend::generate_llzk(
+            &circuit,
+            user_input.llzk_file(),
+            &user_input.llzk_pass_pipeline(),
+            &user_input.prime(),
+        );
+    }
+
     let compilation_config = CompilerConfig {
         vcp: circuit,
         debug_output: user_input.print_ir_flag(),

--- a/circom/tests/from_concrete/call_and_return.circom
+++ b/circom/tests/from_concrete/call_and_return.circom
@@ -1,0 +1,52 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk=concrete -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
+
+pragma circom 2.0.0;
+
+template C() {
+  signal input in;
+  signal output out;
+  var x = 12;
+  out <-- negative(in);
+}
+
+function negative(n){
+  if (n < 0) {
+    return 1;
+  } else {
+    return 0;
+  }
+}
+
+component main = C();
+
+// CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-NEXT:    function.def @negative_0(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !felt.type) -> !felt.type {
+// CHECK-NEXT:      %[[VAL_1:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:      %[[VAL_2:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_0]], %[[VAL_1]])
+// CHECK-NEXT:      %[[VAL_3:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_2]] -> (!felt.type) {
+// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        scf.yield %[[VAL_4]] : !felt.type
+// CHECK-NEXT:      } else {
+// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        scf.yield %[[VAL_5]] : !felt.type
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.return %[[VAL_3]] : !felt.type
+// CHECK-NEXT:    }
+// CHECK-NEXT:    struct.def @C<[]> {
+// CHECK-NEXT:      struct.field @out : !felt.type {llzk.pub}
+// CHECK-NEXT:      function.def @compute(%[[VAL_6:[0-9a-zA-Z_\.]+]]: !felt.type) -> !struct.type<@C<[]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = struct.new : <@C<[]>>
+// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = felt.const  12
+// CHECK-NEXT:        %[[VAL_9:[0-9a-zA-Z_\.]+]] = function.call @negative_0(%[[VAL_6]]) : (!felt.type) -> !felt.type
+// CHECK-NEXT:        struct.writef %[[VAL_7]][@out] = %[[VAL_9]] : <@C<[]>>, !felt.type
+// CHECK-NEXT:        function.return %[[VAL_7]] : !struct.type<@C<[]>>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[VAL_10:[0-9a-zA-Z_\.]+]]: !struct.type<@C<[]>>, %[[VAL_11:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[VAL_12:[0-9a-zA-Z_\.]+]] = felt.const  12
+// CHECK-NEXT:        %[[VAL_13:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_10]][@out] : <@C<[]>>, !felt.type
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/from_concrete/fib_input.circom
+++ b/circom/tests/from_concrete/fib_input.circom
@@ -1,0 +1,105 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk concrete -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
+
+pragma circom 2.0.0;
+
+template Fibonacci() {
+    signal input nth_fib;
+    signal output out;
+
+    var a = 0;
+    var b = 1;
+    var next = 0;
+
+    var counter = nth_fib;
+    while (counter > 2) { // unknown iteration count
+        next = a + b;
+        a = b;
+        b = next;
+
+        counter--;
+    }
+
+    out <-- (nth_fib == 0) ? 0 : (nth_fib == 1 ? 1 : a + b);
+}
+
+component main = Fibonacci();
+
+// CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-NEXT:    struct.def @Fibonacci<[]> {
+// CHECK-NEXT:      struct.field @out : !felt.type {llzk.pub}
+// CHECK-NEXT:      function.def @compute(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !felt.type) -> !struct.type<@Fibonacci<[]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = struct.new : <@Fibonacci<[]>>
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]]:4 = scf.while (%[[VAL_6:[0-9a-zA-Z_\.]+]] = %[[VAL_2]], %[[VAL_7:[0-9a-zA-Z_\.]+]] = %[[VAL_3]], %[[VAL_8:[0-9a-zA-Z_\.]+]] = %[[VAL_0]], %[[VAL_9:[0-9a-zA-Z_\.]+]] = %[[VAL_4]]) : (!felt.type, !felt.type, !felt.type, !felt.type) -> (!felt.type, !felt.type, !felt.type, !felt.type) {
+// CHECK-NEXT:          %[[VAL_10:[0-9a-zA-Z_\.]+]] = felt.const  2
+// CHECK-NEXT:          %[[VAL_11:[0-9a-zA-Z_\.]+]] = bool.cmp gt(%[[VAL_8]], %[[VAL_10]])
+// CHECK-NEXT:          scf.condition(%[[VAL_11]]) %[[VAL_6]], %[[VAL_7]], %[[VAL_8]], %[[VAL_9]] : !felt.type, !felt.type, !felt.type, !felt.type
+// CHECK-NEXT:        } do {
+// CHECK-NEXT:        ^bb0(%[[VAL_12:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_13:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_14:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_15:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[VAL_16:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_12]], %[[VAL_13]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[VAL_17:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_18:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_14]], %[[VAL_17]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_13]], %[[VAL_16]], %[[VAL_18]], %[[VAL_16]] : !felt.type, !felt.type, !felt.type, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_19:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_20:[0-9a-zA-Z_\.]+]] = bool.cmp eq(%[[VAL_0]], %[[VAL_19]])
+// CHECK-NEXT:        %[[VAL_21:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_20]] -> (!felt.type) {
+// CHECK-NEXT:          %[[VAL_22:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          scf.yield %[[VAL_22]] : !felt.type
+// CHECK-NEXT:        } else {
+// CHECK-NEXT:          %[[VAL_23:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_5]]#0, %[[VAL_5]]#1 : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_23]] : !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_24:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_25:[0-9a-zA-Z_\.]+]] = bool.cmp eq(%[[VAL_0]], %[[VAL_24]])
+// CHECK-NEXT:        %[[VAL_26:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_25]] -> (!felt.type) {
+// CHECK-NEXT:          %[[VAL_27:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:          struct.writef %[[VAL_1]][@out] = %[[VAL_27]] : <@Fibonacci<[]>>, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_27]] : !felt.type
+// CHECK-NEXT:        } else {
+// CHECK-NEXT:          struct.writef %[[VAL_1]][@out] = %[[VAL_21]] : <@Fibonacci<[]>>, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_21]] : !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.return %[[VAL_1]] : !struct.type<@Fibonacci<[]>>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[VAL_28:[0-9a-zA-Z_\.]+]]: !struct.type<@Fibonacci<[]>>, %[[VAL_29:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[VAL_30:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_31:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_32:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_33:[0-9a-zA-Z_\.]+]]:4 = scf.while (%[[VAL_34:[0-9a-zA-Z_\.]+]] = %[[VAL_30]], %[[VAL_35:[0-9a-zA-Z_\.]+]] = %[[VAL_31]], %[[VAL_36:[0-9a-zA-Z_\.]+]] = %[[VAL_29]], %[[VAL_37:[0-9a-zA-Z_\.]+]] = %[[VAL_32]]) : (!felt.type, !felt.type, !felt.type, !felt.type) -> (!felt.type, !felt.type, !felt.type, !felt.type) {
+// CHECK-NEXT:          %[[VAL_38:[0-9a-zA-Z_\.]+]] = felt.const  2
+// CHECK-NEXT:          %[[VAL_39:[0-9a-zA-Z_\.]+]] = bool.cmp gt(%[[VAL_36]], %[[VAL_38]])
+// CHECK-NEXT:          scf.condition(%[[VAL_39]]) %[[VAL_34]], %[[VAL_35]], %[[VAL_36]], %[[VAL_37]] : !felt.type, !felt.type, !felt.type, !felt.type
+// CHECK-NEXT:        } do {
+// CHECK-NEXT:        ^bb0(%[[VAL_40:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_41:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_42:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_43:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[VAL_44:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_40]], %[[VAL_41]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[VAL_45:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_46:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_42]], %[[VAL_45]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_41]], %[[VAL_44]], %[[VAL_46]], %[[VAL_44]] : !felt.type, !felt.type, !felt.type, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_47:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_48:[0-9a-zA-Z_\.]+]] = bool.cmp eq(%[[VAL_29]], %[[VAL_47]])
+// CHECK-NEXT:        %[[VAL_49:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_48]] -> (!felt.type) {
+// CHECK-NEXT:          %[[VAL_50:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          scf.yield %[[VAL_50]] : !felt.type
+// CHECK-NEXT:        } else {
+// CHECK-NEXT:          %[[VAL_51:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_33]]#0, %[[VAL_33]]#1 : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_51]] : !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_52:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_53:[0-9a-zA-Z_\.]+]] = bool.cmp eq(%[[VAL_29]], %[[VAL_52]])
+// CHECK-NEXT:        %[[VAL_54:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_53]] -> (!felt.type) {
+// CHECK-NEXT:          %[[VAL_55:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_28]][@out] : <@Fibonacci<[]>>, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_55]] : !felt.type
+// CHECK-NEXT:        } else {
+// CHECK-NEXT:          %[[VAL_56:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_28]][@out] : <@Fibonacci<[]>>, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_56]] : !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/from_concrete/inner_conditional_03.circom
+++ b/circom/tests/from_concrete/inner_conditional_03.circom
@@ -1,0 +1,80 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk concrete -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
+
+pragma circom 2.0.0;
+
+template InnerConditional3(N) {
+    signal output out;
+    signal input in;
+
+    var acc = 0;
+    for (var i = 1; i <= N; i++) {
+        if (in == 0) { // unknown condition
+            acc += i;
+        } else {
+            acc -= i;
+        }
+    }
+
+    out <-- acc;
+}
+
+component main = InnerConditional3(3);
+
+// CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-NEXT:    struct.def @InnerConditional3<[]> {
+// CHECK-NEXT:      struct.field @out : !felt.type {llzk.pub}
+// CHECK-NEXT:      function.def @compute(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !felt.type) -> !struct.type<@InnerConditional3<[]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = struct.new : <@InnerConditional3<[]>>
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_5:[0-9a-zA-Z_\.]+]] = %[[VAL_2]], %[[VAL_6:[0-9a-zA-Z_\.]+]] = %[[VAL_3]]) : (!felt.type, !felt.type) -> (!felt.type, !felt.type) {
+// CHECK-NEXT:          %[[VAL_7:[0-9a-zA-Z_\.]+]] = felt.const  3
+// CHECK-NEXT:          %[[VAL_8:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_6]], %[[VAL_7]])
+// CHECK-NEXT:          scf.condition(%[[VAL_8]]) %[[VAL_5]], %[[VAL_6]] : !felt.type, !felt.type
+// CHECK-NEXT:        } do {
+// CHECK-NEXT:        ^bb0(%[[VAL_9:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_10:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[VAL_11:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:          %[[VAL_12:[0-9a-zA-Z_\.]+]] = bool.cmp eq(%[[VAL_0]], %[[VAL_11]])
+// CHECK-NEXT:          %[[VAL_13:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_12]] -> (!felt.type) {
+// CHECK-NEXT:            %[[VAL_14:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_2]], %[[VAL_3]] : !felt.type, !felt.type
+// CHECK-NEXT:            scf.yield %[[VAL_14]] : !felt.type
+// CHECK-NEXT:          } else {
+// CHECK-NEXT:            %[[VAL_15:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_2]], %[[VAL_3]] : !felt.type, !felt.type
+// CHECK-NEXT:            scf.yield %[[VAL_15]] : !felt.type
+// CHECK-NEXT:          }
+// CHECK-NEXT:          %[[VAL_16:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_17:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_10]], %[[VAL_16]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_13]], %[[VAL_17]] : !felt.type, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        struct.writef %[[VAL_1]][@out] = %[[VAL_4]]#0 : <@InnerConditional3<[]>>, !felt.type
+// CHECK-NEXT:        function.return %[[VAL_1]] : !struct.type<@InnerConditional3<[]>>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[VAL_18:[0-9a-zA-Z_\.]+]]: !struct.type<@InnerConditional3<[]>>, %[[VAL_19:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[VAL_20:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_21:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_22:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_23:[0-9a-zA-Z_\.]+]] = %[[VAL_20]], %[[VAL_24:[0-9a-zA-Z_\.]+]] = %[[VAL_21]]) : (!felt.type, !felt.type) -> (!felt.type, !felt.type) {
+// CHECK-NEXT:          %[[VAL_25:[0-9a-zA-Z_\.]+]] = felt.const  3
+// CHECK-NEXT:          %[[VAL_26:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_24]], %[[VAL_25]])
+// CHECK-NEXT:          scf.condition(%[[VAL_26]]) %[[VAL_23]], %[[VAL_24]] : !felt.type, !felt.type
+// CHECK-NEXT:        } do {
+// CHECK-NEXT:        ^bb0(%[[VAL_27:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_28:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[VAL_29:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:          %[[VAL_30:[0-9a-zA-Z_\.]+]] = bool.cmp eq(%[[VAL_19]], %[[VAL_29]])
+// CHECK-NEXT:          %[[VAL_31:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_30]] -> (!felt.type) {
+// CHECK-NEXT:            %[[VAL_32:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_20]], %[[VAL_21]] : !felt.type, !felt.type
+// CHECK-NEXT:            scf.yield %[[VAL_32]] : !felt.type
+// CHECK-NEXT:          } else {
+// CHECK-NEXT:            %[[VAL_33:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_20]], %[[VAL_21]] : !felt.type, !felt.type
+// CHECK-NEXT:            scf.yield %[[VAL_33]] : !felt.type
+// CHECK-NEXT:          }
+// CHECK-NEXT:          %[[VAL_34:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_35:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_28]], %[[VAL_34]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_31]], %[[VAL_35]] : !felt.type, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_36:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_18]][@out] : <@InnerConditional3<[]>>, !felt.type
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/compiler/src/hir/very_concrete_program.rs
+++ b/compiler/src/hir/very_concrete_program.rs
@@ -12,7 +12,7 @@ pub type Code = Statement;
 
 pub type TagInfo = BTreeMap<String, Option<BigInt>>;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Argument {
     pub name: String,
     pub values: Vec<BigInt>,
@@ -24,7 +24,7 @@ impl PartialEq for Argument {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum Wire{
     TSignal(Signal),
     TBus(Bus)
@@ -103,7 +103,7 @@ impl Wire {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Signal {
     pub name: String,
     pub lengths: Vec<Length>,
@@ -114,7 +114,7 @@ pub struct Signal {
 }
 
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Bus{
     pub name: String,
     pub lengths: Vec<Length>,
@@ -143,7 +143,7 @@ pub struct BusInstance{
     pub fields: BTreeMap<String, FieldInfo>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Component {
     pub name: String,
     pub lengths: Vec<Length>,
@@ -156,7 +156,7 @@ impl Component {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Trigger {
     pub runs: String,
     pub offset: usize,
@@ -169,12 +169,12 @@ pub struct Trigger {
     pub is_parallel: bool,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum ClusterType {
     Mixed { tmp_name: String },
     Uniform { offset_jump: usize, component_offset_jump:usize, instance_id: usize, header: String },
 }
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct TriggerCluster {
     pub cmp_name: String,
     pub slice: Range<usize>,
@@ -183,7 +183,7 @@ pub struct TriggerCluster {
     pub defined_positions: Vec<Vec<usize>>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct TemplateInstance {
     pub is_parallel: bool,
     pub is_parallel_component: bool,
@@ -263,13 +263,13 @@ impl TemplateInstance {
     }
 }
 
-#[derive(Eq, PartialEq, Clone)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct Param {
     pub name: String,
     pub length: VCT,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct VCF {
     pub name: String,
     pub header: String,
@@ -278,7 +278,7 @@ pub struct VCF {
     pub body: Statement,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Stats {
     pub all_signals: usize,
     pub io_signals: usize,
@@ -299,7 +299,7 @@ pub struct VCPConfig {
     pub has_extern_c: bool,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct VCP {
     pub stats: Stats,
     pub main_id: usize,

--- a/llzk_backend/Cargo.toml
+++ b/llzk_backend/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 program_structure = { path = "../program_structure" }
+compiler = { path = "../compiler" }
 ansi_term = "0.12.1"
 anyhow = "1.0"
 num-bigint-dig = "0.8.4"

--- a/llzk_backend/src/codegen.rs
+++ b/llzk_backend/src/codegen.rs
@@ -1,23 +1,20 @@
 //! Entry point for LLZK code generation.
 
-use crate::module::GenerateLLZKInModule as _;
+use crate::module::GenerateLLZKInModule;
+use crate::module::ProgramLike;
 use crate::shared::LlzkCodegen;
 use ansi_term::Color;
 use anyhow::Result;
 use llzk::prelude::LlzkContext;
 use llzk::prelude::Location;
 use melior::ir::Module;
-use program_structure::program_archive::ProgramArchive;
 
 /// Create a new, empty LLZK `Module` with Location "main" from the `ProgramArchive`.
 ///
 /// 'ctx: lifetime of the `LlzkContext` and generated `Module`
-fn new_llzk_module<'ctx>(
-    context: &'ctx LlzkContext,
-    program_archive: &ProgramArchive,
-) -> Module<'ctx> {
-    let files = &program_archive.file_library;
-    let filename = files.get_filename_or_default(program_archive.get_file_id_main());
+fn new_llzk_module<'ctx>(context: &'ctx LlzkContext, program: &impl ProgramLike) -> Module<'ctx> {
+    let files = program.get_file_library();
+    let filename = files.get_filename_or_default(program.get_main_file_id());
     let main_file_location = Location::new(context, &filename, 0, 0);
     llzk::dialect::module::llzk_module(main_file_location)
 }
@@ -25,16 +22,16 @@ fn new_llzk_module<'ctx>(
 /// Generate LLZK IR from the given `ProgramArchive` and write it to a file with the given filename.
 #[allow(clippy::result_unit_err)]
 pub fn generate_llzk(
-    program_archive: &ProgramArchive,
+    program: &impl ProgramLike,
     filename: &str,
     pass_pipeline: &str,
     prime: &str,
 ) -> Result<(), ()> {
     let ctx = LlzkContext::new();
-    let module = new_llzk_module(&ctx, program_archive);
-    let mut codegen = LlzkCodegen { program_archive, context: &ctx, module, prime };
+    let module = new_llzk_module(&ctx, program);
+    let mut codegen = LlzkCodegen { program, context: &ctx, module, prime };
 
-    program_archive.gen_llzk(&codegen).map_err(|err| {
+    program.gen_llzk(&codegen).map_err(|err| {
         eprintln!("{} {err}", Color::Red.paint("Failed to generate LLZK IR:"));
     })?;
 

--- a/llzk_backend/src/function.rs
+++ b/llzk_backend/src/function.rs
@@ -8,8 +8,8 @@
 use crate::gen_context::BlockContextStack;
 use crate::gen_context::GenWithCircomScopeHandling;
 use crate::gen_context::NestedBlockInfo;
-use crate::shared::LlzkCodegen;
 use crate::module::ProgramLike;
+use crate::shared::LlzkCodegen;
 use crate::shared::erase_op;
 use crate::shared::get_function_type_attribute;
 use crate::shared::is_bool;

--- a/llzk_backend/src/function.rs
+++ b/llzk_backend/src/function.rs
@@ -8,6 +8,7 @@
 use crate::gen_context::BlockContextStack;
 use crate::gen_context::GenWithCircomScopeHandling;
 use crate::gen_context::NestedBlockInfo;
+use crate::module::ProgramLike;
 use crate::shared::erase_op;
 use crate::shared::get_function_type_attribute;
 use crate::shared::is_bool;
@@ -104,7 +105,7 @@ where
 {
     /// Create a new [FunctionContext] for the given function with an initial name-to-value mapping.
     pub fn new<'ast, const FREE_FUNC: bool>(
-        codegen: &LlzkCodegen<'ast, 'ctx>,
+        codegen: &LlzkCodegen<'ast, 'ctx, impl ProgramLike>,
         func: FuncDefOpRefMut<'ctx, 'func>,
         param_name_to_value: HashMap<String, Value<'ctx, 'val>>,
     ) -> Result<Self> {
@@ -115,13 +116,11 @@ where
                 // Get the result type from the free function. It supports exactly 1.
                 let ty = get_function_type_attribute(func)?;
                 assert_eq!(ty.result_count(), 1);
-                codegen.new_nondet_at_location(Location::unknown(codegen.context), ty.result(0)?)
+                codegen.new_nondet_at_location(codegen.location_unknown(), ty.result(0)?)
             })?;
             block_ctx.declare_name_if_not_present(VAR_NAME_NO_RETURN, || {
-                codegen.new_nondet_at_location(
-                    Location::unknown(codegen.context),
-                    codegen.bool_type().into(),
-                )
+                codegen
+                    .new_nondet_at_location(codegen.location_unknown(), codegen.bool_type().into())
             })?;
         }
         Ok(Self { func, block_ctx })
@@ -160,7 +159,7 @@ where
     /// case, it is marked with the [CIRCOM_RETURN_MARKER_ATTR] attribute.
     pub fn append_circom_return<'ast>(
         &mut self,
-        codegen: &LlzkCodegen<'ast, 'ctx>,
+        codegen: &LlzkCodegen<'ast, 'ctx, impl ProgramLike>,
         location: Location<'ctx>,
         value: Value<'ctx, 'val>,
     ) -> Result<()> {
@@ -176,7 +175,7 @@ where
     /// Generate LLZK code in the current function for a circom prefix operation.
     pub fn gen_prefix_op<'ast>(
         &mut self,
-        codegen: &LlzkCodegen<'ast, 'ctx>,
+        codegen: &LlzkCodegen<'ast, 'ctx, impl ProgramLike>,
         meta: &Meta,
         op: &ExpressionPrefixOpcode,
         rhs: Value<'ctx, 'val>,
@@ -294,7 +293,7 @@ where
     /// Generate LLZK code in the current function for an infix operation.
     pub fn gen_infix_op<'ast>(
         &mut self,
-        codegen: &LlzkCodegen<'ast, 'ctx>,
+        codegen: &LlzkCodegen<'ast, 'ctx, impl ProgramLike>,
         meta: &Meta,
         op: &ExpressionInfixOpcode,
         lhs: Value<'ctx, 'val>,
@@ -468,7 +467,7 @@ where
     /// block context with the results of the `scf.if` op mapped to the given names.
     pub fn gen_scf_if<'ast>(
         &mut self,
-        codegen: &LlzkCodegen<'ast, 'ctx>,
+        codegen: &LlzkCodegen<'ast, 'ctx, impl ProgramLike>,
         location: Location<'ctx>,
         condition: Value<'ctx, 'val>,
         mut then_info: NestedBlockInfo<'ctx, 'blk, 'val>,
@@ -589,7 +588,7 @@ where
     /// block context with the results of the `scf.while` op mapped to the given names.
     pub fn gen_scf_while<'ast>(
         &mut self,
-        codegen: &LlzkCodegen<'ast, 'ctx>,
+        codegen: &LlzkCodegen<'ast, 'ctx, impl ProgramLike>,
         location: Location<'ctx>,
         condition: Value<'ctx, 'val>,
         loop_cond_info: NestedBlockInfo<'ctx, 'blk, 'val>,
@@ -750,7 +749,7 @@ where
     /// 'ast: lifetime of the circom AST element
     fn gen_llzk_in_function<'ast>(
         &'ast self,
-        codegen: &LlzkCodegen<'ast, 'ctx>,
+        codegen: &LlzkCodegen<'ast, 'ctx, impl ProgramLike>,
         function: &mut FunctionContext<'ctx, 'func, 'blk, 'val>,
     ) -> Result<Self::Output>;
 }
@@ -765,7 +764,7 @@ where
 
     fn gen_llzk_in_function<'ast>(
         &'ast self,
-        codegen: &LlzkCodegen<'ast, 'ctx>,
+        codegen: &LlzkCodegen<'ast, 'ctx, impl ProgramLike>,
         function: &mut FunctionContext<'ctx, 'func, 'blk, 'val>,
     ) -> Result<Self::Output> {
         for s in self {
@@ -815,7 +814,7 @@ where
 /// when a circom [Statement::IfThenElse] contains a return statement.
 #[allow(clippy::too_many_arguments)]
 fn handle_early_return<'ast, 'ctx, 'func, 'blk, 'val>(
-    codegen: &LlzkCodegen<'ast, 'ctx>,
+    codegen: &LlzkCodegen<'ast, 'ctx, impl ProgramLike>,
     function: &mut FunctionContext<'ctx, 'func, 'blk, 'val>,
     location: Location<'ctx>,
     return_val: Value<'ctx, 'val>,
@@ -872,7 +871,7 @@ where
 ///  function.return VAR_NAME_RETURN_VAL
 /// ```
 fn gen_if_then_else_unbalanced_return_extra<'ast, 'ctx, 'func, 'blk, 'val>(
-    codegen: &LlzkCodegen<'ast, 'ctx>,
+    codegen: &LlzkCodegen<'ast, 'ctx, impl ProgramLike>,
     function: &mut FunctionContext<'ctx, 'func, 'blk, 'val>,
     location: Location<'ctx>,
 ) -> Result<()>
@@ -905,7 +904,7 @@ where
 
 /// Generate LLZK code for a circom [Statement::IfThenElse].
 fn gen_if_then_else<'ast, 'ctx, 'func, 'blk, 'val>(
-    codegen: &LlzkCodegen<'ast, 'ctx>,
+    codegen: &LlzkCodegen<'ast, 'ctx, impl ProgramLike>,
     function: &mut FunctionContext<'ctx, 'func, 'blk, 'val>,
     meta: &Meta,
     cond: &Expression,
@@ -1001,7 +1000,7 @@ where
     #[allow(unused_variables)] // TODO: TEMP
     fn gen_llzk_in_function<'ast>(
         &'ast self,
-        codegen: &LlzkCodegen<'ast, 'ctx>,
+        codegen: &LlzkCodegen<'ast, 'ctx, impl ProgramLike>,
         function: &mut FunctionContext<'ctx, 'func, 'blk, 'val>,
     ) -> Result<Self::Output> {
         match self {
@@ -1102,7 +1101,7 @@ where
     #[allow(unused_variables)] // TODO: TEMP
     fn gen_llzk_in_function<'ast>(
         &'ast self,
-        codegen: &LlzkCodegen<'ast, 'ctx>,
+        codegen: &LlzkCodegen<'ast, 'ctx, impl ProgramLike>,
         function: &mut FunctionContext<'ctx, 'func, 'blk, 'val>,
     ) -> Result<Self::Output> {
         match self {

--- a/llzk_backend/src/function.rs
+++ b/llzk_backend/src/function.rs
@@ -260,7 +260,7 @@ where
     #[inline]
     fn cast_to_bool_if_needed<'ast>(
         &mut self,
-        codegen: &LlzkCodegen<'ast, 'ctx>,
+        codegen: &LlzkCodegen<'ast, 'ctx, impl ProgramLike>,
         location: Location<'ctx>,
         val: Value<'ctx, 'val>,
     ) -> Result<Value<'ctx, 'val>> {
@@ -557,7 +557,7 @@ where
     /// then and else arms do not modify the current block context and only produce values.
     pub fn generate_simple_scf_if<'ast, F1, F2>(
         &mut self,
-        codegen: &LlzkCodegen<'ast, 'ctx>,
+        codegen: &LlzkCodegen<'ast, 'ctx, impl ProgramLike>,
         meta: &Meta,
         condition: Value<'ctx, 'val>,
         then_value_gen: F1,

--- a/llzk_backend/src/function.rs
+++ b/llzk_backend/src/function.rs
@@ -531,7 +531,7 @@ where
     }
 
     /// Generate one region for either the then-arm or else-arm of a simple scf.if operation.
-    /// Used by [generate_simple_scf_if].
+    /// Used by [Self::generate_simple_scf_if].
     /// The `value_gen` function is called to generate the value to be yielded from the arm.
     fn generate_simple_scf_if_arm<'ast, F>(
         &mut self,
@@ -551,7 +551,7 @@ where
     }
 
     /// Generate a simple scf.if operation that yields the given `then_value` or `else_value`
-    /// depending on the `condition` value. Unlike [gen_scf_if], this assumes that the
+    /// depending on the `condition` value. Unlike [Self::gen_scf_if], this assumes that the
     /// then and else arms do not modify the current block context and only produce values.
     pub fn generate_simple_scf_if<'ast, F1, F2>(
         &mut self,

--- a/llzk_backend/src/lib.rs
+++ b/llzk_backend/src/lib.rs
@@ -15,3 +15,4 @@ mod shared;
 mod template;
 
 pub use codegen::generate_llzk;
+pub use module::VCPPlus;

--- a/llzk_backend/src/module.rs
+++ b/llzk_backend/src/module.rs
@@ -433,25 +433,39 @@ impl ProgramLike for ProgramArchive {
     }
 }
 
-impl ProgramLike for VCP {
+/// A wrapper around a VCP that also includes the public inputs for the main component.
+#[derive(Debug)]
+pub struct VCPPlus<'ctx> {
+    vcp: &'ctx VCP,
+    public_inputs: Vec<String>,
+}
+
+impl VCPPlus<'_> {
+    /// Create a new VCPPlus wrapper
+    pub fn new<'ctx>(vcp: &'ctx VCP, public_inputs: Vec<String>) -> VCPPlus<'ctx> {
+        VCPPlus { vcp, public_inputs }
+    }
+}
+
+impl ProgramLike for VCPPlus<'_> {
     fn get_file_library(&self) -> &FileLibrary {
-        &self.file_library
+        &self.vcp.file_library
     }
     fn get_main_file_id(&self) -> &FileID {
-        &self.main_id
+        &self.vcp.main_id
     }
     fn get_main_public_inputs(&self) -> &Vec<String> {
-        todo!("implement getting public inputs from VCP")
+        &self.public_inputs
     }
     fn get_functions(&self, sorted: bool) -> impl IntoIterator<Item = &impl FunctionLike> {
-        let mut functions: Vec<_> = self.functions.iter().collect();
+        let mut functions: Vec<_> = self.vcp.functions.iter().collect();
         if sorted {
             sort_functions_by_name(&mut functions);
         }
         functions
     }
     fn get_templates(&self, sorted: bool) -> impl IntoIterator<Item = &impl TemplateLike> {
-        let mut templates: Vec<_> = self.templates.iter().collect();
+        let mut templates: Vec<_> = self.vcp.templates.iter().collect();
         if sorted {
             sort_templates_by_name(&mut templates);
         }

--- a/llzk_backend/src/module.rs
+++ b/llzk_backend/src/module.rs
@@ -178,13 +178,18 @@ impl<'ctx> DeclarationInfo<'ctx> {
 /// A trait that allows common handling of the structs used to represent a circom
 /// function at different stages in the compilation process.
 pub trait FunctionLike {
+    /// Generate the LLZK Location for the function definition.
     fn get_location<'ctx>(
         &self,
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
     ) -> Location<'ctx>;
+    /// Get the name of the function.
     fn get_name(&self) -> &str;
+    /// Get the number of parameters of the function.
     fn get_num_of_params(&self) -> usize;
+    /// Get the names of the parameters of the function.
     fn get_name_of_params(&self) -> Vec<String>;
+    /// Get the body statements of the function.
     fn get_body(&self) -> &[Statement];
 }
 
@@ -266,12 +271,16 @@ fn gen_function_llzk<'ast, 'ctx, F: FunctionLike>(
 /// A trait that allows common handling of the structs used to represent a circom
 /// template at different stages in the compilation process.
 pub trait TemplateLike {
+    /// Generate the LLZK Location for the template definition.
     fn get_location<'ctx>(
         &self,
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
     ) -> Location<'ctx>;
+    /// Get the name of the template.
     fn get_name(&self) -> &str;
+    /// Get the names of the parameters of the template.
     fn get_name_of_params(&self) -> Vec<String>;
+    /// Get the body statements of the template.
     fn get_body(&self) -> &[Statement];
 }
 
@@ -400,10 +409,15 @@ fn sort_templates_by_name<T: TemplateLike>(templates: &mut [&T]) {
 /// A trait that allows common handling of the structs used to represent a circom
 /// program at different stages in the compilation process.
 pub trait ProgramLike {
+    /// Get the file library of the program.
     fn get_file_library(&self) -> &FileLibrary;
+    /// Get the FileID of the file containing the "main" declaration.
     fn get_main_file_id(&self) -> &FileID;
+    /// Get the names of public inputs of the main component.
     fn get_main_public_inputs(&self) -> &Vec<String>;
+    /// Get an iterator over all functions in the program.
     fn get_functions(&self, sorted: bool) -> impl IntoIterator<Item = &impl FunctionLike>;
+    /// Get an iterator over all templates in the program.
     fn get_templates(&self, sorted: bool) -> impl IntoIterator<Item = &impl TemplateLike>;
 }
 
@@ -436,15 +450,10 @@ impl ProgramLike for ProgramArchive {
 /// A wrapper around a VCP that also includes the public inputs for the main component.
 #[derive(Debug)]
 pub struct VCPPlus<'ctx> {
-    vcp: &'ctx VCP,
-    public_inputs: Vec<String>,
-}
-
-impl VCPPlus<'_> {
-    /// Create a new VCPPlus wrapper
-    pub fn new<'ctx>(vcp: &'ctx VCP, public_inputs: Vec<String>) -> VCPPlus<'ctx> {
-        VCPPlus { vcp, public_inputs }
-    }
+    /// Reference to the [VCP].
+    pub vcp: &'ctx VCP,
+    /// Names of public inputs of the main component.
+    pub public_inputs: Vec<String>,
 }
 
 impl ProgramLike for VCPPlus<'_> {

--- a/llzk_backend/src/module.rs
+++ b/llzk_backend/src/module.rs
@@ -320,7 +320,7 @@ pub trait TemplateLike: std::fmt::Debug {
     /// Get the name of the template.
     fn get_name(&self) -> &str;
     /// Get the names of the parameters of the template.
-    fn get_name_of_params(&self) -> Vec<String>;
+    fn get_name_of_params(&self) -> &[String];
     /// Get the body statements of the template.
     fn get_body(&self) -> &[Statement];
     /// Construct [DeclarationInfo] containing var and signal declarations
@@ -341,8 +341,8 @@ impl TemplateLike for TemplateData {
     fn get_name(&self) -> &str {
         self.get_name()
     }
-    fn get_name_of_params(&self) -> Vec<String> {
-        self.get_name_of_params().clone()
+    fn get_name_of_params(&self) -> &[String] {
+        self.get_name_of_params()
     }
     fn get_body(&self) -> &[Statement] {
         self.get_body_as_vec()
@@ -365,8 +365,8 @@ impl TemplateLike for TemplateInstance {
     fn get_name(&self) -> &str {
         &self.template_name
     }
-    fn get_name_of_params(&self) -> Vec<String> {
-        self.header.iter().map(|a| a.name.clone()).collect()
+    fn get_name_of_params(&self) -> &[String] {
+        &[]
     }
     fn get_body(&self) -> &[Statement] {
         slice::from_ref(&self.code)
@@ -412,8 +412,8 @@ fn gen_template_llzk<'ast, 'ctx, T: TemplateLike>(
 
     // Generate the struct definition, prepopulated with fields.
     let struct_loc = template_like.get_location(codegen);
-    let struct_params = template_like.get_name_of_params();
-    let struct_params: Vec<_> = struct_params.iter().map(String::as_str).collect();
+    let struct_params: Vec<_> =
+        template_like.get_name_of_params().iter().map(String::as_str).collect();
     let struct_def = r#struct::def(
         struct_loc,
         template_like.get_name(),

--- a/llzk_backend/src/module.rs
+++ b/llzk_backend/src/module.rs
@@ -8,6 +8,9 @@ use crate::shared::LlzkCodegen;
 use crate::template::GenerateLLZKInTemplate as _;
 use crate::template::TemplateContext;
 use anyhow::Result;
+use compiler::hir::very_concrete_program::TemplateInstance;
+use compiler::hir::very_concrete_program::VCF;
+use compiler::hir::very_concrete_program::VCP;
 use llzk::attributes::NamedAttribute;
 use llzk::error::Error;
 use llzk::prelude::function;
@@ -33,12 +36,14 @@ use program_structure::ast::Meta;
 use program_structure::ast::SignalType;
 use program_structure::ast::Statement;
 use program_structure::ast::VariableType;
+use program_structure::file_definition::FileID;
+use program_structure::file_definition::FileLibrary;
 use program_structure::function_data::FunctionData;
 use program_structure::program_archive::ProgramArchive;
 use program_structure::template_data::TemplateData;
-use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::convert::TryFrom;
+use std::slice;
 
 /// Information needed to create an LLZK struct function parameter collected from the input signal
 /// Declaration statements within a circom template.
@@ -77,7 +82,7 @@ impl<'ctx> DeclarationInfo<'ctx> {
     /// 'ast: lifetime of the circom AST element
     fn visit<'ast>(
         &mut self,
-        codegen: &LlzkCodegen<'ast, 'ctx>,
+        codegen: &LlzkCodegen<'ast, 'ctx, impl ProgramLike>,
         stmt: &'ast Statement,
     ) -> Result<()> {
         match stmt {
@@ -136,7 +141,7 @@ impl<'ctx> DeclarationInfo<'ctx> {
     /// `visit()` helper for Signal and Bus VariableType.
     fn visit_signal_or_bus(
         &mut self,
-        codegen: &LlzkCodegen<'_, 'ctx>,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
         meta: &Meta,
         name: &String,
         dimensions: &[Expression],
@@ -148,7 +153,7 @@ impl<'ctx> DeclarationInfo<'ctx> {
         if SignalType::Input == *signal_type {
             // self.func_inputs.push((decl_type, location));
             let mut attrs: Vec<NamedAttribute<'_>> = Vec::new();
-            if codegen.program_archive.get_public_inputs_main_component().contains(name) {
+            if codegen.program.get_main_public_inputs().contains(name) {
                 attrs.push(PublicAttribute::new_named_attr(codegen.context));
             }
             self.inputs.push(InputSignalInfo {
@@ -170,126 +175,312 @@ impl<'ctx> DeclarationInfo<'ctx> {
     }
 }
 
+/// A trait that allows common handling of the structs used to represent a circom
+/// function at different stages in the compilation process.
+pub trait FunctionLike {
+    fn get_location<'ctx>(
+        &self,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+    ) -> Location<'ctx>;
+    fn get_name(&self) -> &str;
+    fn get_num_of_params(&self) -> usize;
+    fn get_name_of_params(&self) -> Vec<String>;
+    fn get_body(&self) -> &[Statement];
+}
+
+impl FunctionLike for FunctionData {
+    fn get_location<'ctx>(
+        &self,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+    ) -> Location<'ctx> {
+        codegen.location(self.get_file_id(), self.get_param_location())
+    }
+    fn get_name(&self) -> &str {
+        self.get_name()
+    }
+    fn get_num_of_params(&self) -> usize {
+        self.get_num_of_params()
+    }
+    fn get_name_of_params(&self) -> Vec<String> {
+        self.get_name_of_params().clone()
+    }
+    fn get_body(&self) -> &[Statement] {
+        self.get_body_as_vec()
+    }
+}
+
+impl FunctionLike for VCF {
+    fn get_location<'ctx>(
+        &self,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+    ) -> Location<'ctx> {
+        codegen.location_unknown()
+    }
+    fn get_name(&self) -> &str {
+        &self.name
+    }
+    fn get_num_of_params(&self) -> usize {
+        self.params_types.len()
+    }
+    fn get_name_of_params(&self) -> Vec<String> {
+        self.params_types.iter().map(|p| p.name.clone()).collect()
+    }
+    fn get_body(&self) -> &[Statement] {
+        slice::from_ref(&self.body)
+    }
+}
+
+/// Generate LLZK for a function-like construct. Helper to avoid code duplication.
+fn gen_function_llzk<'ast, 'ctx, F: FunctionLike>(
+    func_like: &'ast F,
+    codegen: &LlzkCodegen<'ast, 'ctx, impl ProgramLike>,
+) -> Result<()> {
+    let location = func_like.get_location(codegen);
+    let felt_type = FeltType::new(codegen.context).into();
+    // TODO: This just uses `felt.type` for param and return types but those must actually be
+    // determined based on the caller. Circom functions cannot accept or return components or
+    // busses so the only types allowed for params and return are `felt.type` and arrays of
+    // `felt.type`. The actual type used here also affects the dimensions of array types and
+    // which array read/write-like ops must be used when translating the body.
+    let inputs = vec![felt_type; func_like.get_num_of_params()];
+    let func_type = FunctionType::new(codegen.context, &inputs, &[felt_type]);
+    let func_def =
+        function::def(location, func_like.get_name(), func_type, &[], None).and_then(|f| {
+            let arguments: Vec<(Type, Location)> =
+                inputs.into_iter().map(|t| (t, location)).collect();
+            f.region(0)?.append_block(Block::new(&arguments));
+            Ok(f)
+        })?;
+
+    // Store function to the module.
+    let func: FuncDefOpRefMut = codegen.add_function(func_def)?;
+
+    // Generate mapping from parameter names to SSA Values.
+    let name_to_value = map_name_to_arg_value(func, func_like.get_name_of_params())?;
+
+    // Visit the body of the function and generate LLZK IR for it.
+    let mut func_context = FunctionContext::new::<true>(codegen, func, name_to_value)?;
+    func_like.get_body().gen_llzk_in_function(codegen, &mut func_context)
+}
+
+/// A trait that allows common handling of the structs used to represent a circom
+/// template at different stages in the compilation process.
+pub trait TemplateLike {
+    fn get_location<'ctx>(
+        &self,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+    ) -> Location<'ctx>;
+    fn get_name(&self) -> &str;
+    fn get_name_of_params(&self) -> Vec<String>;
+    fn get_body(&self) -> &[Statement];
+}
+
+impl TemplateLike for TemplateData {
+    fn get_location<'ctx>(
+        &self,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+    ) -> Location<'ctx> {
+        codegen.location(self.get_file_id(), self.get_param_location())
+    }
+    fn get_name(&self) -> &str {
+        self.get_name()
+    }
+    fn get_name_of_params(&self) -> Vec<String> {
+        self.get_name_of_params().clone()
+    }
+    fn get_body(&self) -> &[Statement] {
+        self.get_body_as_vec()
+    }
+}
+
+impl TemplateLike for TemplateInstance {
+    fn get_location<'ctx>(
+        &self,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+    ) -> Location<'ctx> {
+        codegen.location_unknown()
+    }
+    fn get_name(&self) -> &str {
+        &self.template_name
+    }
+    fn get_name_of_params(&self) -> Vec<String> {
+        self.header.iter().map(|a| a.name.clone()).collect()
+    }
+    fn get_body(&self) -> &[Statement] {
+        slice::from_ref(&self.code)
+    }
+}
+
+/// Generate LLZK for a template-like construct. Helper to avoid code duplication.
+fn gen_template_llzk<'ast, 'ctx, T: TemplateLike>(
+    template_like: &'ast T,
+    codegen: &LlzkCodegen<'ast, 'ctx, impl ProgramLike>,
+) -> Result<()> {
+    // Collect declarations first to determine struct fields and function parameters.
+    let mut declarations = DeclarationInfo::default();
+    for s in template_like.get_body() {
+        declarations.visit(codegen, s)?;
+    }
+
+    // Generate the struct definition, prepopulated with fields.
+    let struct_loc = template_like.get_location(codegen);
+    let struct_params = template_like.get_name_of_params();
+    let struct_params: Vec<_> = struct_params.iter().map(String::as_str).collect();
+    let struct_def = r#struct::def(
+        struct_loc,
+        template_like.get_name(),
+        &struct_params,
+        declarations.struct_fields,
+    )?;
+    let new_struct = codegen.add_struct(struct_def)?;
+
+    // Consume and separate 'declarations.inputs' (to avoid cloning 'attrs' and 'name').
+    let (inputs, arg_attrs, arg_names) = declarations.inputs.into_iter().fold(
+        (Vec::new(), Vec::new(), Vec::new()),
+        |(mut inputs, mut attrs, mut names), v| {
+            inputs.push(v.type_and_loc);
+            attrs.push(v.attrs);
+            names.push(v.name);
+            (inputs, attrs, names)
+        },
+    );
+    // Generate the compute and constrain functions.
+    let new_struct_type = new_struct.r#type();
+    let struct_body = new_struct.body();
+    let compute_func = FuncDefOpRef::try_from(struct_body.append_operation(
+        compute_fn(struct_loc, new_struct_type, &inputs, Some(&arg_attrs))?.into(),
+    ))?
+    .into();
+    let constrain_func = FuncDefOpRef::try_from(struct_body.append_operation(
+        constrain_fn(struct_loc, new_struct_type, &inputs, Some(&arg_attrs))?.into(),
+    ))?
+    .into();
+
+    // Map parameter Values of each LLZK function to the corresponding circom variable names and
+    // then create the FunctionContext for each function. Before creating the FunctionContext
+    // for constrain, add a dummy name at index 0 since the first parameter is the struct ref.
+    let mut compute_ctx = FunctionContext::new::<false>(
+        codegen,
+        compute_func,
+        map_name_to_arg_value(compute_func, arg_names.clone())?,
+    )?;
+    let mut arg_names = arg_names;
+    arg_names.insert(0, "**self**".to_string());
+    let mut constrain_ctx = FunctionContext::new::<false>(
+        codegen,
+        constrain_func,
+        map_name_to_arg_value(constrain_func, arg_names)?,
+    )?;
+    // Insert the Operations created from variable Declaration statements and map the circom
+    // variable name to LLZK op result Value (do this in each function).
+    for (name, op) in declarations.var_decls {
+        // Insert (a clone of) the declaration into the compute function.
+        compute_ctx.block_ctx.declare_name_if_not_present(&name, || Ok(op.clone()))?;
+        // Insert the declaration into the constrain function.
+        constrain_ctx.block_ctx.declare_name_if_not_present(&name, || Ok(op))?;
+    }
+
+    // Visit the body of the template and generate LLZK IR for it within the struct functions.
+    let template_context = TemplateContext::new(new_struct, compute_ctx, constrain_ctx);
+    template_like.get_body().gen_llzk_in_template(codegen, &template_context)
+}
+
+/// Helper function to sort a vector of &FunctionLike by name.
+#[inline]
+fn sort_functions_by_name<T: FunctionLike>(functions: &mut [&T]) {
+    functions.sort_by(|a, b| a.get_name().cmp(b.get_name()));
+}
+
+/// Helper function to sort a vector of &TemplateLike by name.
+#[inline]
+fn sort_templates_by_name<T: TemplateLike>(templates: &mut [&T]) {
+    templates.sort_by(|a, b| a.get_name().cmp(b.get_name()));
+}
+
+/// A trait that allows common handling of the structs used to represent a circom
+/// program at different stages in the compilation process.
+pub trait ProgramLike {
+    fn get_file_library(&self) -> &FileLibrary;
+    fn get_main_file_id(&self) -> &FileID;
+    fn get_main_public_inputs(&self) -> &Vec<String>;
+    fn get_functions(&self, sorted: bool) -> impl IntoIterator<Item = &impl FunctionLike>;
+    fn get_templates(&self, sorted: bool) -> impl IntoIterator<Item = &impl TemplateLike>;
+}
+
+impl ProgramLike for ProgramArchive {
+    fn get_file_library(&self) -> &FileLibrary {
+        &self.file_library
+    }
+    fn get_main_file_id(&self) -> &FileID {
+        self.get_file_id_main()
+    }
+    fn get_main_public_inputs(&self) -> &Vec<String> {
+        self.get_public_inputs_main_component()
+    }
+    fn get_functions(&self, sorted: bool) -> impl IntoIterator<Item = &impl FunctionLike> {
+        let mut functions: Vec<_> = self.functions.values().collect();
+        if sorted {
+            sort_functions_by_name(&mut functions);
+        }
+        functions
+    }
+    fn get_templates(&self, sorted: bool) -> impl IntoIterator<Item = &impl TemplateLike> {
+        let mut templates: Vec<_> = self.templates.values().collect();
+        if sorted {
+            sort_templates_by_name(&mut templates);
+        }
+        templates
+    }
+}
+
+impl ProgramLike for VCP {
+    fn get_file_library(&self) -> &FileLibrary {
+        &self.file_library
+    }
+    fn get_main_file_id(&self) -> &FileID {
+        &self.main_id
+    }
+    fn get_main_public_inputs(&self) -> &Vec<String> {
+        todo!("implement getting public inputs from VCP")
+    }
+    fn get_functions(&self, sorted: bool) -> impl IntoIterator<Item = &impl FunctionLike> {
+        let mut functions: Vec<_> = self.functions.iter().collect();
+        if sorted {
+            sort_functions_by_name(&mut functions);
+        }
+        functions
+    }
+    fn get_templates(&self, sorted: bool) -> impl IntoIterator<Item = &impl TemplateLike> {
+        let mut templates: Vec<_> = self.templates.iter().collect();
+        if sorted {
+            sort_templates_by_name(&mut templates);
+        }
+        templates
+    }
+}
+
 /// A trait to generate LLZK IR for structural elements of the circom AST:
 /// ProgramArchive, TemplateData, and FunctionData.
 ///
 /// 'ctx: lifetime of the `LlzkContext` and generated `Module`
-pub trait GenerateLLZKInModule<'ctx> {
+pub trait GenerateLLZKInModule<'ctx, P: ProgramLike> {
     /// Generates LLZK IR from the circom AST element.
     ///
     /// 'ast: lifetime of the circom AST element
-    fn gen_llzk<'ast>(&'ast self, codegen: &LlzkCodegen<'ast, 'ctx>) -> Result<()>;
+    fn gen_llzk<'ast>(&'ast self, codegen: &LlzkCodegen<'ast, 'ctx, P>) -> Result<()>;
 }
 
-impl<'ctx> GenerateLLZKInModule<'ctx> for ProgramArchive {
-    fn gen_llzk<'ast>(&'ast self, codegen: &LlzkCodegen<'ast, 'ctx>) -> Result<()> {
+impl<'ctx, P: ProgramLike> GenerateLLZKInModule<'ctx, P> for P {
+    fn gen_llzk<'ast>(&'ast self, codegen: &LlzkCodegen<'ast, 'ctx, P>) -> Result<()> {
         // Sort functions and templates by name for deterministic output (this is only needed for
         // the lit tests since the order in a HashMap is non-deterministic and could be triggered
         // only based on a debug flag or similar).
-        for (_, data) in self.functions.iter().collect::<BTreeMap<_, _>>() {
-            data.gen_llzk(codegen)?;
+        for f in self.get_functions(true) {
+            gen_function_llzk(f, codegen)?;
         }
-        for (_, data) in self.templates.iter().collect::<BTreeMap<_, _>>() {
-            data.gen_llzk(codegen)?;
+        for t in self.get_templates(true) {
+            gen_template_llzk(t, codegen)?;
         }
         Ok(())
-    }
-}
-
-impl<'ctx> GenerateLLZKInModule<'ctx> for FunctionData {
-    fn gen_llzk<'ast>(&'ast self, codegen: &LlzkCodegen<'ast, 'ctx>) -> Result<()> {
-        let location = codegen.location(self.get_file_id(), self.get_param_location());
-        let felt_type = FeltType::new(codegen.context).into();
-        // TODO: This just uses `felt.type` for param and return types but those must actually be
-        // determined based on the caller. Circom functions cannot accept or return components or
-        // busses so the only types allowed for params and return are `felt.type` and arrays of
-        // `felt.type`. The actual type used here also affects the dimensions of array types and
-        // which array read/write-like ops must be used when translating the body.
-        let inputs = vec![felt_type; self.get_num_of_params()];
-        let func_type = FunctionType::new(codegen.context, &inputs, &[felt_type]);
-        let func_def =
-            function::def(location, self.get_name(), func_type, &[], None).and_then(|f| {
-                let arguments: Vec<(Type, Location)> =
-                    inputs.into_iter().map(|t| (t, location)).collect();
-                f.region(0)?.append_block(Block::new(&arguments));
-                Ok(f)
-            })?;
-
-        // Store function to the module.
-        let func: FuncDefOpRefMut = codegen.add_function(func_def)?;
-
-        // Generate mapping from parameter names to SSA Values.
-        let name_to_value = map_name_to_arg_value(func, self.get_name_of_params())?;
-
-        // Visit the body of the function and generate LLZK IR for it.
-        let mut func_context = FunctionContext::new::<true>(codegen, func, name_to_value)?;
-        self.get_body_as_vec().gen_llzk_in_function(codegen, &mut func_context)
-    }
-}
-
-impl<'ctx> GenerateLLZKInModule<'ctx> for TemplateData {
-    fn gen_llzk<'ast>(&'ast self, codegen: &LlzkCodegen<'ast, 'ctx>) -> Result<()> {
-        // Collect declarations first to determine struct fields and function parameters.
-        let mut declarations = DeclarationInfo::default();
-        for s in self.get_body_as_vec() {
-            declarations.visit(codegen, s)?;
-        }
-
-        // Generate the struct definition, prepopulated with fields.
-        let struct_loc = codegen.location(self.get_file_id(), self.get_param_location());
-        let struct_params: Vec<_> = self.get_name_of_params().iter().map(String::as_str).collect();
-        let struct_def =
-            r#struct::def(struct_loc, self.get_name(), &struct_params, declarations.struct_fields)?;
-        let new_struct = codegen.add_struct(struct_def)?;
-
-        // Consume and separate 'declarations.inputs' (to avoid cloning 'attrs' and 'name').
-        let (inputs, arg_attrs, arg_names) = declarations.inputs.into_iter().fold(
-            (Vec::new(), Vec::new(), Vec::new()),
-            |(mut inputs, mut attrs, mut names), v| {
-                inputs.push(v.type_and_loc);
-                attrs.push(v.attrs);
-                names.push(v.name);
-                (inputs, attrs, names)
-            },
-        );
-        // Generate the compute and constrain functions.
-        let new_struct_type = new_struct.r#type();
-        let struct_body = new_struct.body();
-        let compute_func = FuncDefOpRef::try_from(struct_body.append_operation(
-            compute_fn(struct_loc, new_struct_type, &inputs, Some(&arg_attrs))?.into(),
-        ))?
-        .into();
-        let constrain_func = FuncDefOpRef::try_from(struct_body.append_operation(
-            constrain_fn(struct_loc, new_struct_type, &inputs, Some(&arg_attrs))?.into(),
-        ))?
-        .into();
-
-        // Map parameter Values of each LLZK function to the corresponding circom variable names and
-        // then create the FunctionContext for each function. Before creating the FunctionContext
-        // for constrain, add a dummy name at index 0 since the first parameter is the struct ref.
-        let mut compute_ctx = FunctionContext::new::<false>(
-            codegen,
-            compute_func,
-            map_name_to_arg_value(compute_func, &arg_names)?,
-        )?;
-        let mut arg_names = arg_names;
-        arg_names.insert(0, "**self**".to_string());
-        let mut constrain_ctx = FunctionContext::new::<false>(
-            codegen,
-            constrain_func,
-            map_name_to_arg_value(constrain_func, &arg_names)?,
-        )?;
-        // Insert the Operations created from variable Declaration statements and map the circom
-        // variable name to LLZK op result Value (do this in each function).
-        for (name, op) in declarations.var_decls {
-            // Insert (a clone of) the declaration into the compute function.
-            compute_ctx.block_ctx.declare_name_if_not_present(&name, || Ok(op.clone()))?;
-            // Insert the declaration into the constrain function.
-            constrain_ctx.block_ctx.declare_name_if_not_present(&name, || Ok(op))?;
-        }
-
-        // Visit the body of the template and generate LLZK IR for it within the struct functions.
-        let template_context = TemplateContext::new(new_struct, compute_ctx, constrain_ctx);
-        self.get_body_as_vec().gen_llzk_in_template(codegen, &template_context)
     }
 }

--- a/llzk_backend/src/module.rs
+++ b/llzk_backend/src/module.rs
@@ -11,6 +11,7 @@ use anyhow::Result;
 use compiler::hir::very_concrete_program::TemplateInstance;
 use compiler::hir::very_concrete_program::VCF;
 use compiler::hir::very_concrete_program::VCP;
+use compiler::hir::very_concrete_program::Wire;
 use llzk::attributes::NamedAttribute;
 use llzk::error::Error;
 use llzk::prelude::Block;
@@ -47,6 +48,7 @@ use std::slice;
 /// Declaration statements within a circom template.
 ///
 /// 'ctx: lifetime of the `LlzkContext` and generated `Module`
+#[derive(Debug)]
 struct InputSignalInfo<'ctx> {
     /// Name of circom input signal that maps to a function parameter.
     name: String,
@@ -60,34 +62,54 @@ struct InputSignalInfo<'ctx> {
 /// struct fields and parameters to the functions with the struct.
 ///
 /// 'ctx: lifetime of the `LlzkContext` and generated `Module`
-#[derive(Default)]
-struct DeclarationInfo<'ctx> {
+#[derive(Debug, Default)]
+pub struct DeclarationInfo<'ctx> {
     /// Input Signal declarations to use as parameters to the LLZK struct functions.
     inputs: Vec<InputSignalInfo<'ctx>>,
     /// Output and Intermediate declarations to use as LLZK struct fields.
     struct_fields: Vec<Result<Operation<'ctx>, Error>>,
-    /// Map `var` name to its LLZK declaration Operation (usually `undef.undef`).
-    var_decls: HashMap<String, Operation<'ctx>>,
+    /// Map var/signal name to its LLZK declaration Operation (usually `undef.undef`).
+    decl_inits: HashMap<String, Operation<'ctx>>,
 }
 
 impl<'ctx> DeclarationInfo<'ctx> {
-    /// Visit a statement and populate this `DeclarationInfo` with any declarations found.
+    /// Visit all statements in the body of the template and return a new [DeclarationInfo]
+    /// with any declarations found.
+    fn from_template(
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+        template: &impl TemplateLike,
+    ) -> Result<DeclarationInfo<'ctx>> {
+        let mut declarations = DeclarationInfo::default();
+        for s in template.get_body() {
+            declarations.visit(codegen, s)?;
+        }
+        Ok(declarations)
+    }
+
+    /// Visit a statement and populate this [DeclarationInfo] with any declarations found.
     ///
     /// TODO: This currently visits only top-level statements within the template body. However,
     /// since circom 2.1.5, signal declarations are allowed inside of blocks and known-condition if
     /// statements. Those nested declarations are not currently processed here.
-    ///
-    /// 'ast: lifetime of the circom AST element
-    fn visit<'ast>(
+    fn visit(
         &mut self,
-        codegen: &LlzkCodegen<'ast, 'ctx, impl ProgramLike>,
-        stmt: &'ast Statement,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+        stmt: &Statement,
     ) -> Result<()> {
         match stmt {
+            Statement::Block { stmts, .. } => {
+                // TemplateInstance (in concrete programs) has Declaration in Block (but only for
+                // var, not signals). The Block contains no additional information beyond the
+                // Declarations that appear within it so just process the inner statements.
+                for init in stmts {
+                    self.visit(codegen, init)?;
+                }
+                Ok(())
+            }
             Statement::InitializationBlock { initializations, .. } => {
-                // The InitializationBlock is just a wrapper that contains no additional information
-                // beyond the Declarations that must appear within it so just process the inner
-                // statements.
+                // TemplateData (in non-concrete programs) has Declaration in InitializationBlock.
+                // The InitializationBlock contains no additional information beyond the
+                // Declarations that appear within it so just process the inner statements.
                 for init in initializations {
                     self.visit(codegen, init)?;
                 }
@@ -101,24 +123,24 @@ impl<'ctx> DeclarationInfo<'ctx> {
                 match xtype {
                     VariableType::Signal(signal_type, ..) => self.visit_signal_or_bus(
                         codegen,
-                        meta,
-                        name,
-                        dimensions,
                         signal_type,
+                        name,
+                        meta,
+                        dimensions,
                         codegen.felt_type().into(),
                     ),
                     VariableType::Bus(bus_name, signal_type, ..) => self.visit_signal_or_bus(
                         codegen,
-                        meta,
-                        name,
-                        dimensions,
                         signal_type,
+                        name,
+                        meta,
+                        dimensions,
                         codegen.struct_type(bus_name).into(),
                     ),
                     VariableType::Var => {
                         // Create an `undef` of the appropriate type. When the actual assignment is
-                        // processed later, replace the `undef` with the appropriate value.
-                        self.var_decls.insert(
+                        // processed later, this is replaced with the appropriate value.
+                        self.decl_inits.insert(
                             name.clone(),
                             codegen.new_nondet_felt_of_dimensions(meta, dimensions)?,
                         );
@@ -137,19 +159,31 @@ impl<'ctx> DeclarationInfo<'ctx> {
     }
 
     /// `visit()` helper for Signal and Bus VariableType.
+    #[inline]
     fn visit_signal_or_bus(
         &mut self,
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        meta: &Meta,
-        name: &String,
-        dimensions: &[Expression],
         signal_type: &SignalType,
+        name: &String,
+        meta: &Meta,
+        dimensions: &[Expression],
         base_type: Type<'ctx>,
     ) -> Result<()> {
         let location = codegen.location_from_meta(meta);
-        let decl_type = codegen.type_with_dimensions(base_type, dimensions)?;
+        let decl_type = codegen.type_from_dimension_exprs(base_type, dimensions)?;
+        self.visit_signal_or_bus_impl(codegen, signal_type, name, location, decl_type)
+    }
+
+    /// `visit()` helper for Signal and Bus VariableType.
+    fn visit_signal_or_bus_impl(
+        &mut self,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+        signal_type: &SignalType,
+        name: &String,
+        location: Location<'ctx>,
+        decl_type: Type<'ctx>,
+    ) -> Result<()> {
         if SignalType::Input == *signal_type {
-            // self.func_inputs.push((decl_type, location));
             let mut attrs: Vec<NamedAttribute<'_>> = Vec::new();
             if codegen.program.get_main_public_inputs().contains(name) {
                 attrs.push(PublicAttribute::new_named_attr(codegen.context));
@@ -167,9 +201,13 @@ impl<'ctx> DeclarationInfo<'ctx> {
                 false,
                 SignalType::Output == *signal_type,
             );
-            self.struct_fields.push(new.map(|f| f.into()));
+            self.struct_fields.push(new.map(Into::into));
         }
-        Ok(())
+        // Create an `undef` of the appropriate type. When the actual assignment is
+        // processed later, this is replaced with the appropriate value.
+        codegen.new_nondet_at_location(location, decl_type).map(|op| {
+            self.decl_inits.insert(name.clone(), op);
+        })
     }
 }
 
@@ -220,7 +258,7 @@ impl FunctionLike for VCF {
         codegen.location_unknown()
     }
     fn get_name(&self) -> &str {
-        &self.name
+        &self.header
     }
     fn get_num_of_params(&self) -> usize {
         self.params_types.len()
@@ -229,7 +267,12 @@ impl FunctionLike for VCF {
         self.params_types.iter().map(|p| p.name.clone()).collect()
     }
     fn get_body(&self) -> &[Statement] {
-        slice::from_ref(&self.body)
+        // In VCF format, the function body is wrapped in a Block that conveys no additional
+        // information but will cause returns to generate `scf.yield`` instead of `function.return`.
+        match &self.body {
+            Statement::Block { stmts, .. } => return stmts,
+            b => slice::from_ref(b),
+        }
     }
 }
 
@@ -268,7 +311,7 @@ fn gen_function_llzk<'ast, 'ctx, F: FunctionLike>(
 
 /// A trait that allows common handling of the structs used to represent a circom
 /// template at different stages in the compilation process.
-pub trait TemplateLike {
+pub trait TemplateLike: std::fmt::Debug {
     /// Generate the LLZK Location for the template definition.
     fn get_location<'ctx>(
         &self,
@@ -280,6 +323,12 @@ pub trait TemplateLike {
     fn get_name_of_params(&self) -> Vec<String>;
     /// Get the body statements of the template.
     fn get_body(&self) -> &[Statement];
+    /// Construct [DeclarationInfo] containing var and signal declarations
+    /// found in this template body.
+    fn get_declarations<'ctx>(
+        &self,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+    ) -> Result<DeclarationInfo<'ctx>>;
 }
 
 impl TemplateLike for TemplateData {
@@ -297,6 +346,12 @@ impl TemplateLike for TemplateData {
     }
     fn get_body(&self) -> &[Statement] {
         self.get_body_as_vec()
+    }
+    fn get_declarations<'ctx>(
+        &self,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+    ) -> Result<DeclarationInfo<'ctx>> {
+        DeclarationInfo::from_template(codegen, self)
     }
 }
 
@@ -316,6 +371,35 @@ impl TemplateLike for TemplateInstance {
     fn get_body(&self) -> &[Statement] {
         slice::from_ref(&self.code)
     }
+    fn get_declarations<'ctx>(
+        &self,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+    ) -> Result<DeclarationInfo<'ctx>> {
+        let mut declarations = DeclarationInfo::from_template(codegen, self)?;
+        for w in &self.wires {
+            match w {
+                Wire::TSignal(signal) => declarations.visit_signal_or_bus_impl(
+                    codegen,
+                    &signal.xtype,
+                    &signal.name,
+                    self.get_location(codegen),
+                    codegen
+                        .type_from_dimension_consts(codegen.felt_type().into(), &signal.lengths)?,
+                )?,
+                Wire::TBus(bus) => declarations.visit_signal_or_bus_impl(
+                    codegen,
+                    &bus.xtype,
+                    &bus.name,
+                    self.get_location(codegen),
+                    codegen.type_from_dimension_consts(
+                        codegen.struct_type(&bus.name).into(),
+                        &bus.lengths,
+                    )?,
+                )?,
+            }
+        }
+        Ok(declarations)
+    }
 }
 
 /// Generate LLZK for a template-like construct. Helper to avoid code duplication.
@@ -324,10 +408,7 @@ fn gen_template_llzk<'ast, 'ctx, T: TemplateLike>(
     codegen: &LlzkCodegen<'ast, 'ctx, impl ProgramLike>,
 ) -> Result<()> {
     // Collect declarations first to determine struct fields and function parameters.
-    let mut declarations = DeclarationInfo::default();
-    for s in template_like.get_body() {
-        declarations.visit(codegen, s)?;
-    }
+    let declarations = template_like.get_declarations(codegen)?;
 
     // Generate the struct definition, prepopulated with fields.
     let struct_loc = template_like.get_location(codegen);
@@ -380,7 +461,7 @@ fn gen_template_llzk<'ast, 'ctx, T: TemplateLike>(
     )?;
     // Insert the Operations created from variable Declaration statements and map the circom
     // variable name to LLZK op result Value (do this in each function).
-    for (name, op) in declarations.var_decls {
+    for (name, op) in declarations.decl_inits {
         // Insert (a clone of) the declaration into the compute function.
         compute_ctx.block_ctx.declare_name_if_not_present(&name, || Ok(op.clone()))?;
         // Insert the declaration into the constrain function.

--- a/llzk_backend/src/shared.rs
+++ b/llzk_backend/src/shared.rs
@@ -1,5 +1,6 @@
 //! Shared code generation utilities.
 
+use crate::module::ProgramLike;
 use ansi_term::Color;
 use anyhow::anyhow;
 use anyhow::Result;
@@ -47,7 +48,6 @@ use program_structure::error_code::ReportCode;
 use program_structure::error_definition::Report;
 use program_structure::file_definition::FileID;
 use program_structure::file_definition::FileLocation;
-use program_structure::program_archive::ProgramArchive;
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::convert::TryInto as _;
@@ -62,9 +62,10 @@ use std::path::Path;
 ///
 /// 'ast: lifetime of the circom AST element
 /// 'ctx: lifetime of the `LlzkContext` and generated `Module`
-pub struct LlzkCodegen<'ast, 'ctx> {
+#[derive(Debug)]
+pub struct LlzkCodegen<'ast, 'ctx, P: ProgramLike> {
     /// The circom program AST.
-    pub program_archive: &'ast ProgramArchive,
+    pub program: &'ast P,
     /// The LLZK (and MLIR) context.
     pub context: &'ctx LlzkContext,
     /// The generated LLZK `Module`.
@@ -73,7 +74,7 @@ pub struct LlzkCodegen<'ast, 'ctx> {
     pub prime: &'ctx str,
 }
 
-impl<'ast, 'ctx> LlzkCodegen<'ast, 'ctx> {
+impl<'ast, 'ctx, P: ProgramLike> LlzkCodegen<'ast, 'ctx, P> {
     /// Get the width of the prime field in bits.
     pub fn prime_field_bits(&self) -> Result<u32> {
         match self.prime {
@@ -93,19 +94,24 @@ impl<'ast, 'ctx> LlzkCodegen<'ast, 'ctx> {
     pub fn emit_circom_warning(&self, meta: &Meta, message: &str, code: ReportCode) {
         let mut report = Report::warning(String::from(message), code);
         report.add_primary(meta.file_location(), meta.get_file_id(), String::from("here"));
-        Report::print_reports(&[report], &self.program_archive.file_library);
+        Report::print_reports(&[report], self.program.get_file_library());
     }
 
     /// Emit a circom-style error.
     pub fn emit_circom_error(&self, meta: &Meta, message: &str, code: ReportCode) {
         let mut report = Report::error(String::from(message), code);
         report.add_primary(meta.file_location(), meta.get_file_id(), String::from("here"));
-        Report::print_reports(&[report], &self.program_archive.file_library);
+        Report::print_reports(&[report], self.program.get_file_library());
+    }
+
+    /// Get the unknown location.
+    pub fn location_unknown(&self) -> Location<'ctx> {
+        Location::unknown(self.context)
     }
 
     /// Convert circom location information to MLIR location.
     pub fn location(&self, file_id: FileID, file_location: FileLocation) -> Location<'ctx> {
-        let files = &self.program_archive.file_library;
+        let files = self.program.get_file_library();
         let filename = files.get_filename_or_default(&file_id);
         let line = files.get_line(file_location.start, file_id).unwrap_or(0);
         let column = files.get_column(file_location.start, file_id).unwrap_or(0);
@@ -117,7 +123,7 @@ impl<'ast, 'ctx> LlzkCodegen<'ast, 'ctx> {
         if let Some(file) = meta.file_id {
             self.location(file, meta.file_location())
         } else {
-            Location::unknown(self.context)
+            self.location_unknown()
         }
     }
 
@@ -304,7 +310,7 @@ impl<'ast, 'ctx> LlzkCodegen<'ast, 'ctx> {
 ///
 /// 'ctx: lifetime of the `LlzkContext` and generated `Module`
 pub fn new_felt_const_op<'ctx>(
-    codegen: &LlzkCodegen<'_, 'ctx>,
+    codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
     meta: &Meta,
     from: &BigInt,
 ) -> Result<Operation<'ctx>> {
@@ -356,13 +362,13 @@ pub fn no_results<'c: 'a, 'a>(op: impl OperationLike<'c, 'a>) -> Result<()> {
 #[inline]
 pub fn map_name_to_arg_value<'ctx, 'val>(
     func: FuncDefOpRefMut<'ctx, 'val>,
-    arg_names: &[String],
+    arg_names: Vec<String>,
 ) -> Result<HashMap<String, Value<'ctx, 'val>>> {
     arg_names
-        .iter()
+        .into_iter()
         .enumerate()
         .map(|(i, name)| {
-            func.deref().argument(i).map(|x| (name.clone(), Value::from(x))).map_err(Into::into)
+            func.deref().argument(i).map_err(Into::into).map(|a| (name, Value::from(a)))
         })
         .collect::<Result<HashMap<_, _>, _>>()
 }

--- a/llzk_backend/src/shared.rs
+++ b/llzk_backend/src/shared.rs
@@ -179,9 +179,31 @@ impl<'ast, 'ctx, P: ProgramLike> LlzkCodegen<'ast, 'ctx, P> {
         }
     }
 
-    /// If `dimensions` is empty, return `base_type`. Otherwise, create ArrayType by converting the
-    /// dimension circom [Expressions](Expression) to LLZK Attributes.
-    pub fn type_with_dimensions(
+    /// If `dimensions` is empty, return `base_type`. Otherwise, create [ArrayType] by
+    /// converting the dimension sizes to LLZK Attributes.
+    pub fn type_from_dimension_consts(
+        &self,
+        base_type: Type<'ctx>,
+        dimensions: &[usize],
+    ) -> Result<Type<'ctx>> {
+        if dimensions.is_empty() {
+            Ok(base_type)
+        } else {
+            dimensions
+                .iter()
+                .map(|c| {
+                    i64::try_from(*c).map_err(Into::into).map(|c| {
+                        Attribute::from(IntegerAttribute::new(Type::index(self.context), c))
+                    })
+                })
+                .collect::<Result<Vec<_>, _>>()
+                .map(|dims| ArrayType::new(base_type, &dims).into())
+        }
+    }
+
+    /// If `dimensions` is empty, return `base_type`. Otherwise, create [ArrayType] by
+    /// converting the dimension circom [Expressions](Expression) to LLZK Attributes.
+    pub fn type_from_dimension_exprs(
         &self,
         base_type: Type<'ctx>,
         dimensions: &[Expression],
@@ -220,7 +242,7 @@ impl<'ast, 'ctx, P: ProgramLike> LlzkCodegen<'ast, 'ctx, P> {
     ) -> Result<Operation<'ctx>> {
         self.new_nondet_at_location(
             location,
-            self.type_with_dimensions(self.felt_type().into(), dimensions)?,
+            self.type_from_dimension_exprs(self.felt_type().into(), dimensions)?,
         )
     }
 

--- a/llzk_backend/src/template.rs
+++ b/llzk_backend/src/template.rs
@@ -697,7 +697,6 @@ where
     where
         'val: 'r;
 
-    #[allow(unused_variables)] // TODO: TEMP
     fn gen_llzk_in_template<'ast, 'r>(
         &'ast self,
         codegen: &LlzkCodegen<'ast, 'ctx, impl ProgramLike>,
@@ -710,7 +709,7 @@ where
             Statement::InitializationBlock { initializations, .. } => {
                 initializations.gen_llzk_in_template(codegen, template)
             }
-            Statement::Declaration { meta, xtype, name, dimensions, .. } => {
+            Statement::Declaration { meta, name, dimensions, .. } => {
                 template.and_then_same(|fc, _| {
                     fc.block_ctx.declare_name_if_not_present(name, || {
                         codegen.new_nondet_felt_of_dimensions(meta, dimensions)
@@ -842,7 +841,7 @@ where
                     }
                 }
             }
-            Statement::UnderscoreSubstitution { meta, op, rhe } => {
+            Statement::UnderscoreSubstitution { op, rhe, .. } => {
                 // The `<--` operator is witness generation only so this should not
                 // generate any code in the constrain function.
                 let template =

--- a/llzk_backend/src/template.rs
+++ b/llzk_backend/src/template.rs
@@ -9,6 +9,7 @@
 use crate::function::FunctionContext;
 use crate::gen_context::GenWithCircomScopeHandling;
 use crate::gen_context::NestedBlockInfo;
+use crate::module::ProgramLike;
 use crate::shared::is_felt;
 use crate::shared::LlzkCodegen;
 use anyhow::Result;
@@ -363,7 +364,7 @@ where
     #[inline]
     fn gen_exprs<'ast, I>(
         template: &'r TemplateContext<'ctx, 'str, 'func, 'blk, 'val>,
-        codegen: &LlzkCodegen<'ast, 'ctx>,
+        codegen: &LlzkCodegen<'ast, 'ctx, impl ProgramLike>,
         exprs: I,
     ) -> Result<Self>
     where
@@ -498,7 +499,7 @@ where
     /// 'ast: lifetime of the circom AST element
     fn gen_llzk_in_template<'ast, 'r>(
         &'ast self,
-        codegen: &LlzkCodegen<'ast, 'ctx>,
+        codegen: &LlzkCodegen<'ast, 'ctx, impl ProgramLike>,
         template: &'r TemplateContext<'ctx, 'str, 'func, 'blk, 'val>,
     ) -> Result<Self::Output<'r>>
     where
@@ -520,7 +521,7 @@ where
 
     fn gen_llzk_in_template<'ast, 'r>(
         &'ast self,
-        codegen: &LlzkCodegen<'ast, 'ctx>,
+        codegen: &LlzkCodegen<'ast, 'ctx, impl ProgramLike>,
         template: &'r TemplateContext<'ctx, 'str, 'func, 'blk, 'val>,
     ) -> Result<Self::Output<'r>>
     where
@@ -542,7 +543,7 @@ where
 
 /// Generate LLZK code for a circom [Statement::IfThenElse].
 fn gen_if_then_else<'ast, 'ctx, 'str, 'func, 'blk, 'val, 'r>(
-    codegen: &LlzkCodegen<'ast, 'ctx>,
+    codegen: &LlzkCodegen<'ast, 'ctx, impl ProgramLike>,
     template: &'r TemplateContext<'ctx, 'str, 'func, 'blk, 'val>,
     meta: &Meta,
     cond: &Expression,
@@ -602,7 +603,7 @@ where
 
 /// Generate LLZK code for a circom [Statement::While].
 fn gen_while<'ast, 'ctx, 'str, 'func, 'blk, 'val, 'r>(
-    codegen: &LlzkCodegen<'ast, 'ctx>,
+    codegen: &LlzkCodegen<'ast, 'ctx, impl ProgramLike>,
     template: &'r TemplateContext<'ctx, 'str, 'func, 'blk, 'val>,
     meta: &Meta,
     cond: &Expression,
@@ -700,7 +701,7 @@ where
     #[allow(unused_variables)] // TODO: TEMP
     fn gen_llzk_in_template<'ast, 'r>(
         &'ast self,
-        codegen: &LlzkCodegen<'ast, 'ctx>,
+        codegen: &LlzkCodegen<'ast, 'ctx, impl ProgramLike>,
         template: &'r TemplateContext<'ctx, 'str, 'func, 'blk, 'val>,
     ) -> Result<Self::Output<'r>>
     where
@@ -919,7 +920,7 @@ where
 
     fn gen_llzk_in_template<'ast, 'r>(
         &'ast self,
-        codegen: &LlzkCodegen<'ast, 'ctx>,
+        codegen: &LlzkCodegen<'ast, 'ctx, impl ProgramLike>,
         template: &'r TemplateContext<'ctx, 'str, 'func, 'blk, 'val>,
     ) -> Result<Self::Output<'r>>
     where


### PR DESCRIPTION
Changes the `llzk` bool flag to an option accepting either "concrete" or "templated" (default). When the "concrete" option is used, LLZK code is generated from the "VCP" (very concrete program) instead of the initial parsed program with templates.