### PR TITLE
Properly handle Err (i.e. BlockArgument) case of `OperationResult::try_from`

### DIFF
--- a/circom/tests/calls/basic_call_01.circom
+++ b/circom/tests/calls/basic_call_01.circom
@@ -2,6 +2,7 @@
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
 // XFAIL:.*
+// TODO: the calls to `@B::*` within `@Call1::*` incorrectly use `(n, undef)` instead of `(m, n)` for the inputs
 
 pragma circom 2.0.0;
 
@@ -28,3 +29,43 @@ template Call1() {
 component main = Call1();
 
 // CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-NEXT:    struct.def @B<[]> {
+// CHECK-NEXT:      struct.field @x : !felt.type {llzk.pub}
+// CHECK-LABEL:     function.def @compute
+// CHECK-SAME:      (%[[V_0:[0-9a-zA-Z_\.]+]]: !felt.type, %[[V_1:[0-9a-zA-Z_\.]+]]: !felt.type) -> !struct.type<@B<[]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[V_2:[0-9a-zA-Z_\.]+]] = struct.new : <@B<[]>>
+// CHECK-NEXT:        %[[V_3:[0-9a-zA-Z_\.]+]] = felt.mul %[[V_0]], %[[V_1]] : !felt.type, !felt.type
+// CHECK-NEXT:        struct.writef %[[V_2]][@x] = %[[V_3]] : <@B<[]>>, !felt.type
+// CHECK-NEXT:        function.return %[[V_2]] : !struct.type<@B<[]>>
+// CHECK-NEXT:      }
+// CHECK-LABEL:     function.def @constrain
+// CHECK-SAME:      (%[[V_4:[0-9a-zA-Z_\.]+]]: !struct.type<@B<[]>>, %[[V_5:[0-9a-zA-Z_\.]+]]: !felt.type, %[[V_6:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[V_7:[0-9a-zA-Z_\.]+]] = felt.mul %[[V_5]], %[[V_6]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[V_8:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_4]][@x] : <@B<[]>>, !felt.type
+// CHECK-NEXT:        constrain.eq %[[V_8]], %[[V_7]] : !felt.type, !felt.type
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    struct.def @Call1<[]> {
+// CHECK-NEXT:      struct.field @y : !felt.type {llzk.pub}
+// CHECK-NEXT:      struct.field @a : !struct.type<@B<[]>>
+// CHECK-LABEL:     function.def @compute
+// CHECK-SAME:      (%[[V_9:[0-9a-zA-Z_\.]+]]: !felt.type, %[[V_10:[0-9a-zA-Z_\.]+]]: !felt.type) -> !struct.type<@Call1<[]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[V_11:[0-9a-zA-Z_\.]+]] = struct.new : <@Call1<[]>>
+// CHECK-NEXT:        %[[V_13:[0-9a-zA-Z_\.]+]] = function.call @B::@compute(%[[V_9]], %[[V_10]]) : (!felt.type, !felt.type) -> !struct.type<@B<[]>>
+// CHECK-NEXT:        %[[V_14:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_13]][@x] : <@B<[]>>, !felt.type
+// CHECK-NEXT:        struct.writef %[[V_11]][@y] = %[[V_14]] : <@Call1<[]>>, !felt.type
+// CHECK-NEXT:        struct.writef %[[V_11]][@a] = %[[V_13]] : <@Call1<[]>>, !struct.type<@B<[]>>
+// CHECK-NEXT:        function.return %[[V_11]] : !struct.type<@Call1<[]>>
+// CHECK-NEXT:      }
+// CHECK-LABEL:     function.def @constrain
+// CHECK-SAME:      (%[[V_15:[0-9a-zA-Z_\.]+]]: !struct.type<@Call1<[]>>, %[[V_16:[0-9a-zA-Z_\.]+]]: !felt.type, %[[V_17:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[V_18:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_15]][@a] : <@Call1<[]>>, !struct.type<@B<[]>>
+// CHECK-NEXT:        function.call @B::@constrain(%[[V_18]], %[[V_15]], %[[V_16]]) : (!struct.type<@B<[]>>, !felt.type, !felt.type) -> ()
+// CHECK-NEXT:        %[[V_20:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_18]][@x] : <@B<[]>>, !felt.type
+// CHECK-NEXT:        %[[V_21:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_15]][@y] : <@Call1<[]>>, !felt.type
+// CHECK-NEXT:        constrain.eq %[[V_21]], %[[V_20]] : !felt.type, !felt.type
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/misc/signal_index.circom
+++ b/circom/tests/misc/signal_index.circom
@@ -2,6 +2,7 @@
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
 // XFAIL:.*
+// TODO: the calls to `@B::*` within `@A::*` incorrectly use `(b, undef)` instead of `(a, b)` for the inputs
 
 pragma circom 2.0.0;
 
@@ -30,3 +31,51 @@ template A() {
 component main {public [a, b]} = A();
 
 // CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-NEXT:    struct.def @A<[]> {
+// CHECK-NEXT:      struct.field @c : !felt.type {llzk.pub}
+// CHECK-NEXT:      struct.field @x : !felt.type
+// CHECK-NEXT:      struct.field @cb : !struct.type<@B<[]>>
+// CHECK-LABEL:     function.def @compute
+// CHECK-SAME:      (%[[V_0:[0-9a-zA-Z_\.]+]]: !felt.type {llzk.pub}, %[[V_1:[0-9a-zA-Z_\.]+]]: !felt.type {llzk.pub}) -> !struct.type<@A<[]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[V_2:[0-9a-zA-Z_\.]+]] = struct.new : <@A<[]>>
+// CHECK-NEXT:        %[[V_4:[0-9a-zA-Z_\.]+]] = function.call @B::@compute(%[[V_0]], %[[V_1]]) : (!felt.type, !felt.type) -> !struct.type<@B<[]>>
+// CHECK-NEXT:        %[[V_5:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_4]][@c] : <@B<[]>>, !felt.type
+// CHECK-NEXT:        struct.writef %[[V_2]][@x] = %[[V_5]] : <@A<[]>>, !felt.type
+// CHECK-NEXT:        %[[V_6:[0-9a-zA-Z_\.]+]] = felt.const  5
+// CHECK-NEXT:        %[[V_7:[0-9a-zA-Z_\.]+]] = felt.mul %[[V_5]], %[[V_6]] : !felt.type, !felt.type
+// CHECK-NEXT:        struct.writef %[[V_2]][@c] = %[[V_7]] : <@A<[]>>, !felt.type
+// CHECK-NEXT:        struct.writef %[[V_2]][@cb] = %[[V_4]] : <@A<[]>>, !struct.type<@B<[]>>
+// CHECK-NEXT:        function.return %[[V_2]] : !struct.type<@A<[]>>
+// CHECK-NEXT:      }
+// CHECK-LABEL:     function.def @constrain
+// CHECK-SAME:      (%[[V_8:[0-9a-zA-Z_\.]+]]: !struct.type<@A<[]>>, %[[V_9:[0-9a-zA-Z_\.]+]]: !felt.type {llzk.pub}, %[[V_10:[0-9a-zA-Z_\.]+]]: !felt.type {llzk.pub}) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[V_11:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_8]][@cb] : <@A<[]>>, !struct.type<@B<[]>>
+// CHECK-NEXT:        function.call @B::@constrain(%[[V_11]], %[[V_9]], %[[V_10]]) : (!struct.type<@B<[]>>, !felt.type, !felt.type) -> ()
+// CHECK-NEXT:        %[[V_13:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_11]][@c] : <@B<[]>>, !felt.type
+// CHECK-NEXT:        %[[V_14:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_8]][@x] : <@A<[]>>, !felt.type
+// CHECK-NEXT:        constrain.eq %[[V_14]], %[[V_13]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[V_15:[0-9a-zA-Z_\.]+]] = felt.const  5
+// CHECK-NEXT:        %[[V_16:[0-9a-zA-Z_\.]+]] = felt.mul %[[V_13]], %[[V_15]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[V_17:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_8]][@c] : <@A<[]>>, !felt.type
+// CHECK-NEXT:        constrain.eq %[[V_17]], %[[V_16]] : !felt.type, !felt.type
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    struct.def @B<[]> {
+// CHECK-NEXT:      struct.field @c : !felt.type {llzk.pub}
+// CHECK-LABEL:     function.def @compute
+// CHECK-SAME:      (%[[V_18:[0-9a-zA-Z_\.]+]]: !felt.type {llzk.pub}, %[[V_19:[0-9a-zA-Z_\.]+]]: !felt.type {llzk.pub}) -> !struct.type<@B<[]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[V_20:[0-9a-zA-Z_\.]+]] = struct.new : <@B<[]>>
+// CHECK-NEXT:        %[[V_21:[0-9a-zA-Z_\.]+]] = felt.mul %[[V_18]], %[[V_19]] : !felt.type, !felt.type
+// CHECK-NEXT:        struct.writef %[[V_20]][@c] = %[[V_21]] : <@B<[]>>, !felt.type
+// CHECK-NEXT:        function.return %[[V_20]] : !struct.type<@B<[]>>
+// CHECK-NEXT:      }
+// CHECK-LABEL:     function.def @constrain
+// CHECK-SAME:      (%[[V_22:[0-9a-zA-Z_\.]+]]: !struct.type<@B<[]>>, %[[V_23:[0-9a-zA-Z_\.]+]]: !felt.type {llzk.pub}, %[[V_24:[0-9a-zA-Z_\.]+]]: !felt.type {llzk.pub}) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[V_25:[0-9a-zA-Z_\.]+]] = felt.mul %[[V_23]], %[[V_24]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[V_26:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_22]][@c] : <@B<[]>>, !felt.type
+// CHECK-NEXT:        constrain.eq %[[V_26]], %[[V_25]] : !felt.type, !felt.type
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/simple/simple_04.circom
+++ b/circom/tests/simple/simple_04.circom
@@ -2,6 +2,7 @@
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
 // XFAIL:.*
+// TODO: the calls to `@B::*` within `@A::*` incorrectly use `(b, undef)` instead of `(a, b)` for the inputs
 
 pragma circom 2.0.0;
 
@@ -31,3 +32,49 @@ template A() {
 component main {public [a, b]} = A();
 
 // CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-NEXT:    struct.def @A<[]> {
+// CHECK-NEXT:      struct.field @c : !felt.type {llzk.pub}
+// CHECK-NEXT:      struct.field @x : !felt.type
+// CHECK-NEXT:      struct.field @cb : !struct.type<@B<[]>>
+// CHECK-LABEL:     function.def @compute
+// CHECK-SAME:      (%[[V_0:[0-9a-zA-Z_\.]+]]: !felt.type {llzk.pub}, %[[V_1:[0-9a-zA-Z_\.]+]]: !felt.type {llzk.pub}, %[[V_2:[0-9a-zA-Z_\.]+]]: !felt.type) -> !struct.type<@A<[]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[V_3:[0-9a-zA-Z_\.]+]] = struct.new : <@A<[]>>
+// CHECK-NEXT:        %[[V_5:[0-9a-zA-Z_\.]+]] = function.call @B::@compute(%[[V_0]], %[[V_1]]) : (!felt.type, !felt.type) -> !struct.type<@B<[]>>
+// CHECK-NEXT:        %[[V_6:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_5]][@c] : <@B<[]>>, !felt.type
+// CHECK-NEXT:        struct.writef %[[V_3]][@x] = %[[V_6]] : <@A<[]>>, !felt.type
+// CHECK-NEXT:        %[[V_7:[0-9a-zA-Z_\.]+]] = felt.mul %[[V_6]], %[[V_2]] : !felt.type, !felt.type
+// CHECK-NEXT:        struct.writef %[[V_3]][@c] = %[[V_7]] : <@A<[]>>, !felt.type
+// CHECK-NEXT:        struct.writef %[[V_3]][@cb] = %[[V_5]] : <@A<[]>>, !struct.type<@B<[]>>
+// CHECK-NEXT:        function.return %[[V_3]] : !struct.type<@A<[]>>
+// CHECK-NEXT:      }
+// CHECK-LABEL:     function.def @constrain
+// CHECK-SAME:      (%[[V_8:[0-9a-zA-Z_\.]+]]: !struct.type<@A<[]>>, %[[V_9:[0-9a-zA-Z_\.]+]]: !felt.type {llzk.pub}, %[[V_10:[0-9a-zA-Z_\.]+]]: !felt.type {llzk.pub}, %[[V_11:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[V_12:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_8]][@cb] : <@A<[]>>, !struct.type<@B<[]>>
+// CHECK-NEXT:        function.call @B::@constrain(%[[V_12]], %[[V_9]], %[[V_10]]) : (!struct.type<@B<[]>>, !felt.type, !felt.type) -> ()
+// CHECK-NEXT:        %[[V_14:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_12]][@c] : <@B<[]>>, !felt.type
+// CHECK-NEXT:        %[[V_15:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_8]][@x] : <@A<[]>>, !felt.type
+// CHECK-NEXT:        constrain.eq %[[V_15]], %[[V_14]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[V_16:[0-9a-zA-Z_\.]+]] = felt.mul %[[V_14]], %[[V_11]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[V_17:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_8]][@c] : <@A<[]>>, !felt.type
+// CHECK-NEXT:        constrain.eq %[[V_17]], %[[V_16]] : !felt.type, !felt.type
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    struct.def @B<[]> {
+// CHECK-NEXT:      struct.field @c : !felt.type {llzk.pub}
+// CHECK-LABEL:     function.def @compute
+// CHECK-SAME:      (%[[V_18:[0-9a-zA-Z_\.]+]]: !felt.type {llzk.pub}, %[[V_19:[0-9a-zA-Z_\.]+]]: !felt.type {llzk.pub}) -> !struct.type<@B<[]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[V_20:[0-9a-zA-Z_\.]+]] = struct.new : <@B<[]>>
+// CHECK-NEXT:        %[[V_21:[0-9a-zA-Z_\.]+]] = felt.mul %[[V_18]], %[[V_19]] : !felt.type, !felt.type
+// CHECK-NEXT:        struct.writef %[[V_20]][@c] = %[[V_21]] : <@B<[]>>, !felt.type
+// CHECK-NEXT:        function.return %[[V_20]] : !struct.type<@B<[]>>
+// CHECK-NEXT:      }
+// CHECK-LABEL:     function.def @constrain
+// CHECK-SAME:      (%[[V_22:[0-9a-zA-Z_\.]+]]: !struct.type<@B<[]>>, %[[V_23:[0-9a-zA-Z_\.]+]]: !felt.type {llzk.pub}, %[[V_24:[0-9a-zA-Z_\.]+]]: !felt.type {llzk.pub}) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[V_25:[0-9a-zA-Z_\.]+]] = felt.mul %[[V_23]], %[[V_24]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[V_26:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_22]][@c] : <@B<[]>>, !felt.type
+// CHECK-NEXT:        constrain.eq %[[V_26]], %[[V_25]] : !felt.type, !felt.type
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/llzk_backend/src/shared.rs
+++ b/llzk_backend/src/shared.rs
@@ -569,12 +569,20 @@ pub fn erase_op<'c: 'a, 'a>(op: impl OperationLike<'c, 'a>) {
     }
 }
 
-/// Return `true` iff the given OperationRef is `scf.yield`.
+/// Return `true` iff the given op is `scf.yield`.
 ///
 /// TODO: `llzk-rs` should provide this directly
 #[inline]
 pub fn is_scf_yield<'c: 'a, 'a>(op: impl OperationLike<'c, 'a>) -> bool {
     op.name().as_string_ref().as_str() == Result::Ok("scf.yield")
+}
+
+/// Return `true` iff the given op is `struct.readf`.
+///
+/// TODO: `llzk-rs` should provide this directly via `llzkOperationIsAStructFieldReadOp`
+#[inline]
+pub fn is_struct_readf<'c: 'a, 'a>(op: impl OperationLike<'c, 'a>) -> bool {
+    op.name().as_string_ref().as_str() == Result::Ok("struct.readf")
 }
 
 /// Get the [FunctionType] from a [FuncDefOpLike].
@@ -606,11 +614,11 @@ pub fn set_operand_if_undef<'ctx, 'op>(
     idx: usize,
     value: impl ValueLike<'ctx>,
 ) -> Result<()> {
-    let arg = OperationResult::try_from(op.operand(idx)?)?;
-    if !undef::is_undef_op(arg.owner()) {
-        anyhow::bail!("Argument {idx} was assigned twice: {arg}");
+    if let Ok(arg) = OperationResult::try_from(op.operand(idx)?) {
+        if !undef::is_undef_op(arg.owner()) {
+            anyhow::bail!("Argument {idx} was assigned twice: {arg}");
+        }
     }
-
     unsafe { mlir_sys::mlirOperationSetOperand(op.to_raw(), idx as isize, value.to_raw()) }
     Ok(())
 }
@@ -660,16 +668,15 @@ pub fn insert_after_if_op_result<'ctx, 'val, 'op>(
     val: Value<'ctx, 'val>,
     op: OperationRef<'ctx, 'op>,
 ) {
-    if val.is_block_argument() {
-        return;
+    if let Ok(binding) = OperationResult::try_from(val) {
+        let mut reference_op = binding.owner();
+        let _ = reference_op.block().expect("reference op must belong to a block");
+        if let Some(op_block) = op.block() {
+            reference_op =
+                find_parent_in_block(op_block, reference_op).expect("parent op not found");
+        };
+        move_op_after(reference_op, op);
     }
-    let binding = OperationResult::try_from(val).unwrap();
-    let mut reference_op = binding.owner();
-    let _ = reference_op.block().expect("reference op must belong to a block");
-    if let Some(op_block) = op.block() {
-        reference_op = find_parent_in_block(op_block, reference_op).expect("parent op not found");
-    };
-    move_op_after(reference_op, op);
 }
 
 /// Returns the op (or a parent op) that belongs to the block.

--- a/llzk_backend/src/template.rs
+++ b/llzk_backend/src/template.rs
@@ -12,6 +12,7 @@ use crate::gen_context::NestedBlockInfo;
 use crate::program_ext::ProgramLike;
 use crate::shared::get_single_user;
 use crate::shared::is_felt;
+use crate::shared::is_struct_readf;
 use crate::shared::replace_all_uses;
 use crate::shared::LlzkCodegen;
 use crate::template_ext::TemplateLike as _;
@@ -783,20 +784,12 @@ where
                                         fc.block_ctx.set_named_value(var.clone(), rhe)
                                     },
                                     |fc, rhe| {
-                                        // Replace value. Ensure that the value comes from a
-                                        // `struct.readf`
+                                        // Replace value
                                         let field_read = fc.block_ctx.get_named_value(var)?;
-                                        let field_read_op = OperationResult::try_from(*field_read)?;
-                                        // Temporary workaround until we have
-                                        // `llzkOperationIsAStructFieldReadOp`
-                                        assert_eq!(
-                                            field_read_op
-                                                .owner()
-                                                .name()
-                                                .as_string_ref()
-                                                .as_str()?,
-                                            "struct.readf"
-                                        );
+                                        // ASSERT: value comes from a `struct.readf`
+                                        assert!(is_struct_readf(
+                                            OperationResult::try_from(*field_read).unwrap().owner()
+                                        ));
                                         replace_all_uses(rhe, *field_read);
                                         fc.subcmp_calls.update_keys(rhe, *field_read);
                                         Ok(())


### PR DESCRIPTION
These tests cases were producing the error:
`operation result expected: <block argument> of type '!felt.type' at index: 0`
It came from `OperationResult::try_from()` when the `Value` was a `BlockArgument` instead of an `OperationResult`.

Issue for the incorrect call arguments mentioned in tests: https://github.com/Veridise/circom/issues/294