### PR TITLE
Fix incorrect subcmp signal assignment

### DIFF
--- a/circom/tests/calls/basic_call_01.circom
+++ b/circom/tests/calls/basic_call_01.circom
@@ -1,8 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL:.*
-// TODO: the calls to `@B::*` within `@Call1::*` incorrectly use `(n, undef)` instead of `(m, n)` for the inputs
 
 pragma circom 2.0.0;
 
@@ -61,7 +59,7 @@ component main = Call1();
 // CHECK-LABEL:     function.def @constrain
 // CHECK-SAME:      (%[[V_15:[0-9a-zA-Z_\.]+]]: !struct.type<@Call1<[]>>, %[[V_16:[0-9a-zA-Z_\.]+]]: !felt.type, %[[V_17:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint} {
 // CHECK-NEXT:        %[[V_18:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_15]][@a] : <@Call1<[]>>, !struct.type<@B<[]>>
-// CHECK-NEXT:        function.call @B::@constrain(%[[V_18]], %[[V_15]], %[[V_16]]) : (!struct.type<@B<[]>>, !felt.type, !felt.type) -> ()
+// CHECK-NEXT:        function.call @B::@constrain(%[[V_18]], %[[V_16]], %[[V_17]]) : (!struct.type<@B<[]>>, !felt.type, !felt.type) -> ()
 // CHECK-NEXT:        %[[V_20:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_18]][@x] : <@B<[]>>, !felt.type
 // CHECK-NEXT:        %[[V_21:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_15]][@y] : <@Call1<[]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[V_21]], %[[V_20]] : !felt.type, !felt.type

--- a/circom/tests/circom_doc_examples/37.circom
+++ b/circom/tests/circom_doc_examples/37.circom
@@ -46,10 +46,10 @@ component main = Multiplier3();
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }
-// CHECK-NEXT:    struct.def @Multiplier3<[]> {
-// CHECK-NEXT:      struct.field @out : !felt.type {llzk.pub}
-// CHECK-NEXT:      struct.field @mult2 : !struct.type<@Multiplier2<[]>>
-// CHECK-NEXT:      struct.field @mult1 : !struct.type<@Multiplier2<[]>>
+// CHECK-LABEL:   struct.def @Multiplier3<[]> {
+// CHECK-DAG:       struct.field @out : !felt.type {llzk.pub}
+// CHECK-DAG:       struct.field @mult2 : !struct.type<@Multiplier2<[]>>
+// CHECK-DAG:       struct.field @mult1 : !struct.type<@Multiplier2<[]>>
 // CHECK-NEXT:      function.def @compute(%[[VAL_9:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_10:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_11:[0-9a-zA-Z_\.]+]]: !felt.type) -> !struct.type<@Multiplier3<[]>> attributes {function.allow_witness} {
 // CHECK-NEXT:        %[[VAL_12:[0-9a-zA-Z_\.]+]] = struct.new : <@Multiplier3<[]>>
 // CHECK-NEXT:        %[[VAL_13:[0-9a-zA-Z_\.]+]] = function.call @Multiplier2::@compute(%[[VAL_9]], %[[VAL_10]]) : (!felt.type, !felt.type) -> !struct.type<@Multiplier2<[]>>
@@ -61,9 +61,10 @@ component main = Multiplier3();
 // CHECK-NEXT:        struct.writef %[[VAL_12]][@mult2] = %[[VAL_15]] : <@Multiplier3<[]>>, !struct.type<@Multiplier2<[]>>
 // CHECK-NEXT:        function.return %[[VAL_12]] : !struct.type<@Multiplier3<[]>>
 // CHECK-NEXT:      }
-// CHECK-NEXT:      function.def @constrain(%[[VAL_17:[0-9a-zA-Z_\.]+]]: !struct.type<@Multiplier3<[]>>, %[[VAL_18:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_19:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_20:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint} {
-// CHECK-NEXT:        %[[VAL_21:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_17]][@mult2] : <@Multiplier3<[]>>, !struct.type<@Multiplier2<[]>>
-// CHECK-NEXT:        %[[VAL_22:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_17]][@mult1] : <@Multiplier3<[]>>, !struct.type<@Multiplier2<[]>>
+// CHECK-LABEL:     function.def @constrain(
+// CHECK-SAME:          %[[VAL_17:[0-9a-zA-Z_\.]+]]: !struct.type<@Multiplier3<[]>>, %[[VAL_18:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_19:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_20:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint} {
+// CHECK-DAG:         %[[VAL_21:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_17]][@mult2] : <@Multiplier3<[]>>, !struct.type<@Multiplier2<[]>>
+// CHECK-DAG:         %[[VAL_22:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_17]][@mult1] : <@Multiplier3<[]>>, !struct.type<@Multiplier2<[]>>
 // CHECK-NEXT:        function.call @Multiplier2::@constrain(%[[VAL_22]], %[[VAL_18]], %[[VAL_19]]) : (!struct.type<@Multiplier2<[]>>, !felt.type, !felt.type) -> ()
 // CHECK-NEXT:        %[[VAL_23:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_22]][@out] : <@Multiplier2<[]>>, !felt.type
 // CHECK-NEXT:        function.call @Multiplier2::@constrain(%[[VAL_21]], %[[VAL_23]], %[[VAL_20]]) : (!struct.type<@Multiplier2<[]>>, !felt.type, !felt.type) -> ()

--- a/circom/tests/circom_doc_examples/37.circom
+++ b/circom/tests/circom_doc_examples/37.circom
@@ -1,7 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL:.*
 
 pragma circom 2.0.0;
 
@@ -32,3 +31,47 @@ template Multiplier3() {
 component main = Multiplier3();
 
 // CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-NEXT:    struct.def @Multiplier2<[]> {
+// CHECK-NEXT:      struct.field @out : !felt.type {llzk.pub}
+// CHECK-NEXT:      function.def @compute(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_1:[0-9a-zA-Z_\.]+]]: !felt.type) -> !struct.type<@Multiplier2<[]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = struct.new : <@Multiplier2<[]>>
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_0]], %[[VAL_1]] : !felt.type, !felt.type
+// CHECK-NEXT:        struct.writef %[[VAL_2]][@out] = %[[VAL_3]] : <@Multiplier2<[]>>, !felt.type
+// CHECK-NEXT:        function.return %[[VAL_2]] : !struct.type<@Multiplier2<[]>>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[VAL_4:[0-9a-zA-Z_\.]+]]: !struct.type<@Multiplier2<[]>>, %[[VAL_5:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_6:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_5]], %[[VAL_6]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_4]][@out] : <@Multiplier2<[]>>, !felt.type
+// CHECK-NEXT:        constrain.eq %[[VAL_8]], %[[VAL_7]] : !felt.type, !felt.type
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    struct.def @Multiplier3<[]> {
+// CHECK-NEXT:      struct.field @out : !felt.type {llzk.pub}
+// CHECK-NEXT:      struct.field @mult2 : !struct.type<@Multiplier2<[]>>
+// CHECK-NEXT:      struct.field @mult1 : !struct.type<@Multiplier2<[]>>
+// CHECK-NEXT:      function.def @compute(%[[VAL_9:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_10:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_11:[0-9a-zA-Z_\.]+]]: !felt.type) -> !struct.type<@Multiplier3<[]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_12:[0-9a-zA-Z_\.]+]] = struct.new : <@Multiplier3<[]>>
+// CHECK-NEXT:        %[[VAL_13:[0-9a-zA-Z_\.]+]] = function.call @Multiplier2::@compute(%[[VAL_9]], %[[VAL_10]]) : (!felt.type, !felt.type) -> !struct.type<@Multiplier2<[]>>
+// CHECK-NEXT:        %[[VAL_14:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_13]][@out] : <@Multiplier2<[]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_15:[0-9a-zA-Z_\.]+]] = function.call @Multiplier2::@compute(%[[VAL_14]], %[[VAL_11]]) : (!felt.type, !felt.type) -> !struct.type<@Multiplier2<[]>>
+// CHECK-NEXT:        %[[VAL_16:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_15]][@out] : <@Multiplier2<[]>>, !felt.type
+// CHECK-NEXT:        struct.writef %[[VAL_12]][@out] = %[[VAL_16]] : <@Multiplier3<[]>>, !felt.type
+// CHECK-NEXT:        struct.writef %[[VAL_12]][@mult1] = %[[VAL_13]] : <@Multiplier3<[]>>, !struct.type<@Multiplier2<[]>>
+// CHECK-NEXT:        struct.writef %[[VAL_12]][@mult2] = %[[VAL_15]] : <@Multiplier3<[]>>, !struct.type<@Multiplier2<[]>>
+// CHECK-NEXT:        function.return %[[VAL_12]] : !struct.type<@Multiplier3<[]>>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[VAL_17:[0-9a-zA-Z_\.]+]]: !struct.type<@Multiplier3<[]>>, %[[VAL_18:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_19:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_20:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[VAL_21:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_17]][@mult2] : <@Multiplier3<[]>>, !struct.type<@Multiplier2<[]>>
+// CHECK-NEXT:        %[[VAL_22:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_17]][@mult1] : <@Multiplier3<[]>>, !struct.type<@Multiplier2<[]>>
+// CHECK-NEXT:        function.call @Multiplier2::@constrain(%[[VAL_22]], %[[VAL_18]], %[[VAL_19]]) : (!struct.type<@Multiplier2<[]>>, !felt.type, !felt.type) -> ()
+// CHECK-NEXT:        %[[VAL_23:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_22]][@out] : <@Multiplier2<[]>>, !felt.type
+// CHECK-NEXT:        function.call @Multiplier2::@constrain(%[[VAL_21]], %[[VAL_23]], %[[VAL_20]]) : (!struct.type<@Multiplier2<[]>>, !felt.type, !felt.type) -> ()
+// CHECK-NEXT:        %[[VAL_24:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_21]][@out] : <@Multiplier2<[]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_25:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_17]][@out] : <@Multiplier3<[]>>, !felt.type
+// CHECK-NEXT:        constrain.eq %[[VAL_25]], %[[VAL_24]] : !felt.type, !felt.type
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }
+

--- a/circom/tests/circom_doc_examples/37.circom
+++ b/circom/tests/circom_doc_examples/37.circom
@@ -50,15 +50,16 @@ component main = Multiplier3();
 // CHECK-DAG:       struct.field @out : !felt.type {llzk.pub}
 // CHECK-DAG:       struct.field @mult2 : !struct.type<@Multiplier2<[]>>
 // CHECK-DAG:       struct.field @mult1 : !struct.type<@Multiplier2<[]>>
-// CHECK-NEXT:      function.def @compute(%[[VAL_9:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_10:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_11:[0-9a-zA-Z_\.]+]]: !felt.type) -> !struct.type<@Multiplier3<[]>> attributes {function.allow_witness} {
+// CHECK-LABEL:      function.def @compute(
+// CHECK-SAME:          %[[VAL_9:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_10:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_11:[0-9a-zA-Z_\.]+]]: !felt.type) -> !struct.type<@Multiplier3<[]>> attributes {function.allow_witness} {
 // CHECK-NEXT:        %[[VAL_12:[0-9a-zA-Z_\.]+]] = struct.new : <@Multiplier3<[]>>
 // CHECK-NEXT:        %[[VAL_13:[0-9a-zA-Z_\.]+]] = function.call @Multiplier2::@compute(%[[VAL_9]], %[[VAL_10]]) : (!felt.type, !felt.type) -> !struct.type<@Multiplier2<[]>>
 // CHECK-NEXT:        %[[VAL_14:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_13]][@out] : <@Multiplier2<[]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_15:[0-9a-zA-Z_\.]+]] = function.call @Multiplier2::@compute(%[[VAL_14]], %[[VAL_11]]) : (!felt.type, !felt.type) -> !struct.type<@Multiplier2<[]>>
 // CHECK-NEXT:        %[[VAL_16:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_15]][@out] : <@Multiplier2<[]>>, !felt.type
 // CHECK-NEXT:        struct.writef %[[VAL_12]][@out] = %[[VAL_16]] : <@Multiplier3<[]>>, !felt.type
-// CHECK-NEXT:        struct.writef %[[VAL_12]][@mult1] = %[[VAL_13]] : <@Multiplier3<[]>>, !struct.type<@Multiplier2<[]>>
-// CHECK-NEXT:        struct.writef %[[VAL_12]][@mult2] = %[[VAL_15]] : <@Multiplier3<[]>>, !struct.type<@Multiplier2<[]>>
+// CHECK-DAG:        struct.writef %[[VAL_12]][@mult1] = %[[VAL_13]] : <@Multiplier3<[]>>, !struct.type<@Multiplier2<[]>>
+// CHECK-DAG:        struct.writef %[[VAL_12]][@mult2] = %[[VAL_15]] : <@Multiplier3<[]>>, !struct.type<@Multiplier2<[]>>
 // CHECK-NEXT:        function.return %[[VAL_12]] : !struct.type<@Multiplier3<[]>>
 // CHECK-NEXT:      }
 // CHECK-LABEL:     function.def @constrain(

--- a/circom/tests/misc/signal_index.circom
+++ b/circom/tests/misc/signal_index.circom
@@ -1,8 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL:.*
-// TODO: the calls to `@B::*` within `@A::*` incorrectly use `(b, undef)` instead of `(a, b)` for the inputs
 
 pragma circom 2.0.0;
 

--- a/circom/tests/simple/simple_04.circom
+++ b/circom/tests/simple/simple_04.circom
@@ -1,8 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL:.*
-// TODO: the calls to `@B::*` within `@A::*` incorrectly use `(b, undef)` instead of `(a, b)` for the inputs
 
 pragma circom 2.0.0;
 

--- a/llzk_backend/src/function.rs
+++ b/llzk_backend/src/function.rs
@@ -326,7 +326,8 @@ where
         template_data
             .get_declaration_inputs()
             .iter()
-            .find_map(|(signal, idx)| (subcmp_signal == signal).then_some(*idx))
+            .enumerate()
+            .find_map(|(idx, (signal, _))| (subcmp_signal == signal).then_some(idx))
             .ok_or_else(|| {
                 anyhow::anyhow!(
                     "template '{}' has no input signal '{subcmp_signal}'",


### PR DESCRIPTION
The `usize` that the declarations list returns along with the name is not the index but the number of dimensions. But since that list is guaranteed to be sorted by declaration order we can use `Iterator::enumerate()` instead.

Fixes: #294
