### PR TITLE
avoid process hang on failure

### DIFF
--- a/llzk_backend/src/codegen.rs
+++ b/llzk_backend/src/codegen.rs
@@ -33,6 +33,7 @@ pub fn generate_llzk(
 
     program.gen_llzk(&codegen).map_err(|err| {
         eprintln!("{} {err}", Color::Red.paint("Failed to generate LLZK IR:"));
+        std::process::exit(1); // force exit to avoid hang if MLIR state is inconsistent
     })?;
 
     // Verify the module

--- a/llzk_backend/src/template.rs
+++ b/llzk_backend/src/template.rs
@@ -801,7 +801,7 @@ where
                                 )
                             }
                         } else {
-                            todo!("Generate array write operation in template");
+                            anyhow::bail!("Array write in template not yet supported for AssignVar: {access:?}");
                         }
                     }
                     AssignOp::AssignSignal => {
@@ -871,7 +871,7 @@ where
                                         )
                                     })
                             }
-                            _ => todo!("Generate array write operation in template: {access:?}"),
+                            _ => anyhow::bail!("Array write in template not yet supported for AssignSignal: {access:?}")
                         }
                     }
                     AssignOp::AssignConstraintSignal => {
@@ -964,7 +964,7 @@ where
                                     },
                                 )
                             }
-                            _ => todo!("Generate array write operation in template: {access:?}"),
+                            _ => anyhow::bail!("Array write in template not yet supported for AssignConstraintSignal: {access:?}")
                         }
                     }
                 }


### PR DESCRIPTION
Ran into an issue where one of the removed `todo!` was hit and the process would hang after printing the error. The hang would happen in the C++ code for the `Module` destructor during cleanup.

This PR changes the `todo!` into returning an error and then forces the process to terminate immediately after printing the error.