### PR TITLE
Translate `Statement::While` in functions

### DIFF
--- a/circom/tests/calls/basic_call_02.circom
+++ b/circom/tests/calls/basic_call_02.circom
@@ -1,7 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL:.*
 
 pragma circom 2.0.0;
 
@@ -25,3 +24,35 @@ template Call2() {
 component main = Call2();
 
 // CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-NEXT:    function.def @nbits(%[[V_A:[0-9a-zA-Z_\.]+]]: !felt.type) -> !felt.type {
+// CHECK-NEXT:      %[[V_N0:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:      %[[V_R0:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:      %[[V_3:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_N1:[0-9a-zA-Z_\.]+]] = %[[V_N0]], %[[V_R1:[0-9a-zA-Z_\.]+]] = %[[V_R0]]) : (!felt.type, !felt.type) -> (!felt.type, !felt.type) {
+// CHECK-NEXT:        %[[V_6:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[V_7:[0-9a-zA-Z_\.]+]] = felt.sub %[[V_N1]], %[[V_6]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[V_8:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[V_7]], %[[V_A]])
+// CHECK-NEXT:        scf.condition(%[[V_8]]) %[[V_N1]], %[[V_R1]] : !felt.type, !felt.type
+// CHECK-NEXT:      } do {
+// CHECK-NEXT:      ^bb0(%[[V_N2:[0-9a-zA-Z_\.]+]]: !felt.type, %[[V_R2:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:        %[[V_11:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[V_R3:[0-9a-zA-Z_\.]+]] = felt.add %[[V_R2]], %[[V_11]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[V_13:[0-9a-zA-Z_\.]+]] = felt.const  2
+// CHECK-NEXT:        %[[V_N3:[0-9a-zA-Z_\.]+]] = felt.mul %[[V_N2]], %[[V_13]] : !felt.type, !felt.type
+// CHECK-NEXT:        scf.yield %[[V_N3]], %[[V_R3]] : !felt.type, !felt.type
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.return %[[V_3]]#1 : !felt.type
+// CHECK-NEXT:    }
+// CHECK-NEXT:    struct.def @Call2<[]> {
+// CHECK-NEXT:      struct.field @y : !felt.type {llzk.pub}
+// CHECK-NEXT:      function.def @compute(%[[V_15:[0-9a-zA-Z_\.]+]]: !felt.type) -> !struct.type<@Call2<[]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[V_16:[0-9a-zA-Z_\.]+]] = struct.new : <@Call2<[]>>
+// CHECK-NEXT:        %[[V_17:[0-9a-zA-Z_\.]+]] = function.call @nbits(%[[V_15]]) : (!felt.type) -> !felt.type
+// CHECK-NEXT:        struct.writef %[[V_16]][@y] = %[[V_17]] : <@Call2<[]>>, !felt.type
+// CHECK-NEXT:        function.return %[[V_16]] : !struct.type<@Call2<[]>>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[V_18:[0-9a-zA-Z_\.]+]]: !struct.type<@Call2<[]>>, %[[V_19:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[V_20:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_18]][@y] : <@Call2<[]>>, !felt.type
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/circom_doc_examples/06.circom
+++ b/circom/tests/circom_doc_examples/06.circom
@@ -1,7 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL:.*
 
 pragma circom 2.0.0;
 
@@ -32,3 +31,51 @@ template Caller() {
 component main = Caller();
 
 // CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-NEXT:    function.def @example(%[[V_0:[0-9a-zA-Z_\.]+]]: !felt.type) -> !felt.type {
+// CHECK-NEXT:      %[[V_1:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:      %[[V_2:[0-9a-zA-Z_\.]+]] = bool.cmp ge(%[[V_0]], %[[V_1]])
+// CHECK-NEXT:      %[[V_3:[0-9a-zA-Z_\.]+]] = scf.if %[[V_2]] -> (!felt.type) {
+// CHECK-NEXT:        %[[V_4:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        scf.yield %[[V_4]] : !felt.type
+// CHECK-NEXT:      } else {
+// CHECK-NEXT:        %[[V_5:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        scf.yield %[[V_5]] : !felt.type
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.return %[[V_3]] : !felt.type
+// CHECK-NEXT:    }
+// CHECK-NEXT:    function.def @nbits(%[[V_6:[0-9a-zA-Z_\.]+]]: !felt.type) -> !felt.type {
+// CHECK-NEXT:      %[[V_N0:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:      %[[V_R0:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:      %[[V_9:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_N1:[0-9a-zA-Z_\.]+]] = %[[V_N0]], %[[V_R1:[0-9a-zA-Z_\.]+]] = %[[V_R0]]) : (!felt.type, !felt.type) -> (!felt.type, !felt.type) {
+// CHECK-NEXT:        %[[V_12:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[V_13:[0-9a-zA-Z_\.]+]] = felt.sub %[[V_N1]], %[[V_12]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[V_14:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[V_13]], %[[V_6]])
+// CHECK-NEXT:        scf.condition(%[[V_14]]) %[[V_N1]], %[[V_R1]] : !felt.type, !felt.type
+// CHECK-NEXT:      } do {
+// CHECK-NEXT:      ^bb0(%[[V_N2:[0-9a-zA-Z_\.]+]]: !felt.type, %[[V_R2:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:        %[[V_17:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[V_R3:[0-9a-zA-Z_\.]+]] = felt.add %[[V_R2]], %[[V_17]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[V_19:[0-9a-zA-Z_\.]+]] = felt.const  2
+// CHECK-NEXT:        %[[V_N3:[0-9a-zA-Z_\.]+]] = felt.mul %[[V_N2]], %[[V_19]] : !felt.type, !felt.type
+// CHECK-NEXT:        scf.yield %[[V_N3]], %[[V_R3]] : !felt.type, !felt.type
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.return %[[V_9]]#1 : !felt.type
+// CHECK-NEXT:    }
+// CHECK-NEXT:    struct.def @Caller<[]> {
+// CHECK-NEXT:      struct.field @out : !felt.type {llzk.pub}
+// CHECK-NEXT:      function.def @compute(%[[V_21:[0-9a-zA-Z_\.]+]]: !felt.type) -> !struct.type<@Caller<[]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[V_22:[0-9a-zA-Z_\.]+]] = struct.new : <@Caller<[]>>
+// CHECK-NEXT:        %[[V_23:[0-9a-zA-Z_\.]+]] = function.call @nbits(%[[V_21]]) : (!felt.type) -> !felt.type
+// CHECK-NEXT:        %[[V_24:[0-9a-zA-Z_\.]+]] = function.call @example(%[[V_23]]) : (!felt.type) -> !felt.type
+// CHECK-NEXT:        struct.writef %[[V_22]][@out] = %[[V_24]] : <@Caller<[]>>, !felt.type
+// CHECK-NEXT:        function.return %[[V_22]] : !struct.type<@Caller<[]>>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[V_25:[0-9a-zA-Z_\.]+]]: !struct.type<@Caller<[]>>, %[[V_26:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[V_27:[0-9a-zA-Z_\.]+]] = function.call @nbits(%[[V_26]]) : (!felt.type) -> !felt.type
+// CHECK-NEXT:        %[[V_28:[0-9a-zA-Z_\.]+]] = function.call @example(%[[V_27]]) : (!felt.type) -> !felt.type
+// CHECK-NEXT:        %[[V_29:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_25]][@out] : <@Caller<[]>>, !felt.type
+// CHECK-NEXT:        constrain.eq %[[V_29]], %[[V_28]] : !felt.type, !felt.type
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/controlflow/early_return_if_1.circom
+++ b/circom/tests/controlflow/early_return_if_1.circom
@@ -7,7 +7,7 @@ pragma circom 2.0.0;
 function earlyReturnFn(i, n) {
     if (n == 0) {
         return i;
-        assert(0 == 1); // This can be ignored because of the early return above
+        assert(0 == 1); // Unreachable because of the early return above
     }
     return 0;
 }

--- a/circom/tests/controlflow/early_return_loop_1.circom
+++ b/circom/tests/controlflow/early_return_loop_1.circom
@@ -10,7 +10,7 @@ function earlyReturnFn(in) {
         if (i == 0) {
             return in;
         }
-        assert(0 == 1); // This can be ignored because of the early return above
+        assert(0 == 1); // Unreachable because of the early return above
     }
     return -1;
 }

--- a/circom/tests/controlflow/early_return_loop_2A.circom
+++ b/circom/tests/controlflow/early_return_loop_2A.circom
@@ -8,7 +8,7 @@ pragma circom 2.0.0;
 function earlyReturnFn(in) {
     for (var i = 0; i < 6; i++) {
         return in;
-        assert(0 == 1); // This can be ignored because of the early return above
+        assert(0 == 1); // Unreachable because of the early return above
     }
     return -1;
 }

--- a/circom/tests/controlflow/early_return_loop_2B.circom
+++ b/circom/tests/controlflow/early_return_loop_2B.circom
@@ -1,0 +1,66 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
+
+pragma circom 2.0.0;
+
+// This test is identical to early_return_loop_2A.circom but uses a while loop instead of a for loop.
+// Note that, because of the return inside the loop, the `i++` is unreachable and `i` is not added as a loop-carried variable.
+function earlyReturnFn(in) {
+    var i = 0;
+    while (i < 6) {
+        return in;
+        assert(0 == 1); // Unreachable because of the early return above
+        i++;
+    }
+    return -1;
+}
+
+template EarlyReturn() {
+    signal input inp;
+    signal output outp;
+
+    outp <== earlyReturnFn(inp);
+}
+
+component main = EarlyReturn();
+
+// CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-NEXT:    function.def @earlyReturnFn(%[[V_0:[0-9a-zA-Z_\.]+]]: !felt.type) -> !felt.type {
+// CHECK-NEXT:      %[[V_R0:[0-9a-zA-Z_\.]+]] = undef.undef : !felt.type
+// CHECK-NEXT:      %[[V_I0:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:      %[[V_E0:[0-9a-zA-Z_\.]+]] = arith.constant true
+// CHECK-NEXT:      %[[V_4:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_E1:[0-9a-zA-Z_\.]+]] = %[[V_E0]], %[[V_R1:[0-9a-zA-Z_\.]+]] = %[[V_R0]]) : (i1, !felt.type) -> (i1, !felt.type) {
+// CHECK-NEXT:        %[[V_7:[0-9a-zA-Z_\.]+]] = felt.const  6
+// CHECK-NEXT:        %[[V_8:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[V_I0]], %[[V_7]])
+// CHECK-NEXT:        scf.condition(%[[V_8]]) %[[V_E1]], %[[V_R1]] : i1, !felt.type
+// CHECK-NEXT:      } do {
+// CHECK-NEXT:      ^bb0(%[[V_E2:[0-9a-zA-Z_\.]+]]: i1, %[[V_R2:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:        %[[V_E3:[0-9a-zA-Z_\.]+]] = arith.constant false
+// CHECK-NEXT:        scf.yield %[[V_E3]], %[[V_0]] : i1, !felt.type
+// CHECK-NEXT:      }
+// CHECK-NEXT:      %[[V_12:[0-9a-zA-Z_\.]+]] = scf.if %[[V_4]]#0 -> (!felt.type) {
+// CHECK-NEXT:        %[[V_13:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[V_14:[0-9a-zA-Z_\.]+]] = felt.neg %[[V_13]] : !felt.type
+// CHECK-NEXT:        scf.yield %[[V_14]] : !felt.type
+// CHECK-NEXT:      } else {
+// CHECK-NEXT:        scf.yield %[[V_4]]#1 : !felt.type
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.return %[[V_12]] : !felt.type
+// CHECK-NEXT:    }
+// CHECK-NEXT:    struct.def @EarlyReturn<[]> {
+// CHECK-NEXT:      struct.field @outp : !felt.type {llzk.pub}
+// CHECK-NEXT:      function.def @compute(%[[V_15:[0-9a-zA-Z_\.]+]]: !felt.type) -> !struct.type<@EarlyReturn<[]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[V_16:[0-9a-zA-Z_\.]+]] = struct.new : <@EarlyReturn<[]>>
+// CHECK-NEXT:        %[[V_17:[0-9a-zA-Z_\.]+]] = function.call @earlyReturnFn(%[[V_15]]) : (!felt.type) -> !felt.type
+// CHECK-NEXT:        struct.writef %[[V_16]][@outp] = %[[V_17]] : <@EarlyReturn<[]>>, !felt.type
+// CHECK-NEXT:        function.return %[[V_16]] : !struct.type<@EarlyReturn<[]>>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[V_18:[0-9a-zA-Z_\.]+]]: !struct.type<@EarlyReturn<[]>>, %[[V_19:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[V_20:[0-9a-zA-Z_\.]+]] = function.call @earlyReturnFn(%[[V_19]]) : (!felt.type) -> !felt.type
+// CHECK-NEXT:        %[[V_21:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_18]][@outp] : <@EarlyReturn<[]>>, !felt.type
+// CHECK-NEXT:        constrain.eq %[[V_21]], %[[V_20]] : !felt.type, !felt.type
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/llzk_backend/src/function.rs
+++ b/llzk_backend/src/function.rs
@@ -1104,6 +1104,41 @@ where
     Ok(())
 }
 
+/// Generate LLZK code for a circom [Statement::While].
+fn gen_while<'ast, 'ctx, 'func, 'blk, 'val>(
+    codegen: &LlzkCodegen<'ast, 'ctx, impl ProgramLike>,
+    function: &mut FunctionContext<'ctx, 'func, 'blk, 'val>,
+    meta: &Meta,
+    cond: &Expression,
+    body_stmt: &Box<Statement>,
+) -> Result<()>
+where
+    'ctx: 'func,
+    'func: 'blk,
+    'blk: 'val,
+{
+    // Generate the loop condition (i.e. "before") and body (i.e. "after") blocks naively.
+    let mut loop_cond_info = NestedBlockInfo::default();
+    let cond_result = function.gen_in_given_block_with_new_circom_scope_and_cache_overwrites(
+        loop_cond_info.block,
+        |fc| cond.gen_llzk_in_function(codegen, fc),
+        &mut loop_cond_info,
+    )?;
+    let mut loop_body_info = NestedBlockInfo::default();
+    function.gen_in_given_block_with_new_circom_scope_and_cache_overwrites(
+        loop_body_info.block,
+        |fc| body_stmt.gen_llzk_in_function(codegen, fc),
+        &mut loop_body_info,
+    )?;
+    function.gen_scf_while(
+        codegen,
+        codegen.location_from_meta(meta),
+        cond_result,
+        loop_cond_info,
+        loop_body_info,
+    )
+}
+
 impl<'ctx, 'func, 'blk, 'val> GenerateLLZKInFunction<'ctx, 'func, 'blk, 'val> for Statement
 where
     'ctx: 'func,
@@ -1191,9 +1226,7 @@ where
             Statement::IfThenElse { meta, cond, if_case, else_case } => {
                 gen_if_then_else(codegen, function, meta, cond, if_case, else_case)
             }
-            Statement::While { meta, cond, stmt } => {
-                todo!("Handle while statement in function")
-            }
+            Statement::While { meta, cond, stmt } => gen_while(codegen, function, meta, cond, stmt),
             Statement::Return { meta, value } => {
                 let value = value.gen_llzk_in_function(codegen, function)?;
                 let location = codegen.location_from_meta(meta);

--- a/llzk_backend/src/function.rs
+++ b/llzk_backend/src/function.rs
@@ -909,8 +909,8 @@ where
         // Per `append_circom_return()`, the op generated from a circom return
         // statement has the special attribute `CIRCOM_RETURN_MARKER_ATTR`.
         if term.has_attribute(CIRCOM_RETURN_MARKER_ATTR) {
-            // ASSERT: This must be a `yield` not a `return` since it's generated within
-            // the `else` or `then` block of an `if` statement.
+            // ASSERT: This must be a `yield` not a `return` since it's generated
+            // within a nested block of an `if` or `while` statement.
             assert!(is_scf_yield(term));
             // ASSERT: Per `append_circom_return()` it has exactly one operand.
             assert_eq!(term.operand_count(), 1);
@@ -976,7 +976,7 @@ where
 }
 
 /// Generate LLZK code that follows a circom `if-then-else` statement that has an unbalanced return
-/// (i.e. one branch returns and the other does not). Generates the following LLZK code:
+/// (i.e. one branch returns and the other does not) or `while`. Generates the following LLZK code:
 /// ```llzk
 ///  VAR_NAME_RETURN_VAL = scf.if VAR_NAME_NO_RETURN {
 ///      /* Leave block context stack in this scope for remaining code */
@@ -1055,7 +1055,8 @@ where
     // already ensures `scf.yield` is used instead of `function.return` when not in the root
     // block but the `scf.if` additionally requires that both blocks yield the same number and type
     // of values. Additionally, if one block returns and the other does not (in the circom code),
-    // an additional return state must be added to the values to be yielded from both branches.
+    // an additional return state must be added to the values to be yielded from both branches and
+    // an additional `scf.if` must be added after the main `scf.if` to check the return state flag.
     let then_return_opt = get_val_of_circom_return_and_erase(then_info.block);
     let else_return_opt = get_val_of_circom_return_and_erase(else_info.block);
     if let Some(then_return) = then_return_opt {
@@ -1110,7 +1111,7 @@ fn gen_while<'ast, 'ctx, 'func, 'blk, 'val>(
     function: &mut FunctionContext<'ctx, 'func, 'blk, 'val>,
     meta: &Meta,
     cond: &Expression,
-    body_stmt: &Box<Statement>,
+    body_stmt: &Statement,
 ) -> Result<()>
 where
     'ctx: 'func,
@@ -1130,13 +1131,58 @@ where
         |fc| body_stmt.gen_llzk_in_function(codegen, fc),
         &mut loop_body_info,
     )?;
-    function.gen_scf_while(
-        codegen,
-        codegen.location_from_meta(meta),
-        cond_result,
-        loop_cond_info,
-        loop_body_info,
-    )
+
+    let location = codegen.location_from_meta(meta);
+
+    // Check if loop body block ends with a return in circom. The `scf.while` op used in LLZK cannot
+    // have returns nested within other blocks like circom allows. Use of `append_circom_return()`
+    // already ensures `scf.yield` is used instead of `function.return` when not in the root block
+    // but the `scf.while` additionally requires that both blocks yield the same number and type
+    // of values. Additionally, if the loop body block returns (in the circom code), an additional
+    // return state must be added to the values to be yielded and an additional `scf.if` must be
+    // added after the `scf.while` to check the return state flag.
+    let early_return_opt = get_val_of_circom_return_and_erase(loop_body_info.block);
+    if let Some(early_return) = early_return_opt {
+        // Within the loop body, set `VAR_NAME_NO_RETURN` to `false` since a return occurs.
+        loop_body_info.var_overwrites.insert(
+            VAR_NAME_NO_RETURN.to_string(),
+            single_result_as_value(
+                loop_body_info.block.append_operation(codegen.new_bool_const_op(false, location)),
+            )?,
+        );
+        // In the current block, initialze the `VAR_NAME_NO_RETURN` flag to `true` to capture the
+        // scenario where the loop body does not execute and thus the return within does not occur.
+        function.append_op_named_result(
+            codegen.new_bool_const_op(true, location),
+            VAR_NAME_NO_RETURN.to_string(),
+        )?;
+
+        // Add the return value to the overwrite map of the loop body.
+        loop_body_info.var_overwrites.insert(VAR_NAME_RETURN_VAL.to_string(), early_return);
+        // In the current block, ensure the return value variable is initialized, default to nondet.
+        if function.block_ctx.get_named_value(VAR_NAME_RETURN_VAL).is_err() {
+            function.append_op_named_result(
+                // TODO: just like `gen_function_llzk()`, this must use an array type
+                // if applicable but is currently implemented for scalar `felt.type` only.
+                // In this case, the correct solution (once nondet op is supported for any
+                // type) is to just create the nondet op using
+                // `return_val.getType()`
+                codegen.new_nondet_felt_of_dimensions_at_location(location, &[])?,
+                VAR_NAME_RETURN_VAL.to_string(),
+            )?;
+        }
+    }
+
+    // Generate the loop op.
+    function.gen_scf_while(codegen, location, cond_result, loop_cond_info, loop_body_info)?;
+
+    // Finally, if the loop body contained a return statement, the code following the `scf.while`
+    // needs to be wrapped in an `scf.if` checking `VAR_NAME_NO_RETURN` before generating more code.
+    if early_return_opt.is_some() {
+        gen_if_then_else_unbalanced_return_extra(codegen, function, location)?;
+    }
+
+    Ok(())
 }
 
 impl<'ctx, 'func, 'blk, 'val> GenerateLLZKInFunction<'ctx, 'func, 'blk, 'val> for Statement

--- a/llzk_backend/src/function.rs
+++ b/llzk_backend/src/function.rs
@@ -1150,7 +1150,7 @@ where
                 loop_body_info.block.append_operation(codegen.new_bool_const_op(false, location)),
             )?,
         );
-        // In the current block, initialze the `VAR_NAME_NO_RETURN` flag to `true` to capture the
+        // In the current block, initialize the `VAR_NAME_NO_RETURN` flag to `true` to capture the
         // scenario where the loop body does not execute and thus the return within does not occur.
         function.append_op_named_result(
             codegen.new_bool_const_op(true, location),

--- a/llzk_backend/src/function_ext.rs
+++ b/llzk_backend/src/function_ext.rs
@@ -10,7 +10,7 @@ use std::slice;
 
 /// A trait that allows common handling of the structs used to represent a circom
 /// function at different stages in the compilation process.
-pub trait FunctionLike {
+pub trait FunctionLike: std::fmt::Debug {
     /// Generate the LLZK Location for the function definition.
     fn get_location<'ctx>(
         &self,

--- a/llzk_backend/src/function_ext.rs
+++ b/llzk_backend/src/function_ext.rs
@@ -65,7 +65,7 @@ impl FunctionLike for VCF {
     }
     fn get_body(&self) -> &[Statement] {
         // In VCF format, the function body is wrapped in a Block that conveys no additional
-        // information but will cause returns to generate `scf.yield`` instead of `function.return`.
+        // information but will cause returns to generate `scf.yield` instead of `function.return`.
         match &self.body {
             Statement::Block { stmts, .. } => stmts,
             b => slice::from_ref(b),

--- a/llzk_backend/src/gen_context.rs
+++ b/llzk_backend/src/gen_context.rs
@@ -294,13 +294,13 @@ where
     /// Type of the additional data passed to the overwrite handler.
     type HandlerDataType: Default;
 
-    /// Retrieve the top `NewBlock` from the [BlockContextStack].
+    /// Retrieve the top `BlockType` from the [BlockContextStack].
     fn stack_top(&self) -> Self::BlockType;
 
-    /// Push new `NewBlock` onto the [BlockContextStack].
+    /// Push new `BlockType` onto the [BlockContextStack].
     fn stack_push(&mut self, block: Self::BlockType);
 
-    /// Pop the top `NewBlock` from the [BlockContextStack].
+    /// Pop the top `BlockType` from the [BlockContextStack].
     fn stack_pop<H>(
         &mut self,
         overwrite_handler: H,
@@ -314,7 +314,7 @@ where
         ) -> Result<()>;
 
     /// Use the callback to generate code for a new circom scope/block within the given LLZK
-    /// `NewBlock`. Assignments to circom variables that are newly introduced in this context go
+    /// `BlockType`. Assignments to circom variables that are newly introduced in this context go
     /// out of scope so they are dropped after the callback but overwriting assignments to circom
     /// variables that already exist prior to this new scope are passed to the overwrite handler.
     fn gen_in_given_block_with_new_circom_scope<H, R>(
@@ -338,7 +338,7 @@ where
     }
 
     /// Use the callback to generate code for a new circom scope/block within the given LLZK
-    /// `NewBlock`. Assignments to circom variables that are newly introduced in this context go
+    /// `BlockType`. Assignments to circom variables that are newly introduced in this context go
     /// out of scope so they are dropped after the callback but overwriting assignments to circom
     /// variables that already exist prior to this new scope are cached in the `var_overwrites`
     /// field of the `NestedBlockInfo` struct.
@@ -361,7 +361,7 @@ where
     }
 
     /// Use the callback to generate code for a new circom scope/block within the given LLZK
-    /// `NewBlock`. Assignments to circom variables that are newly introduced in this context go
+    /// `BlockType`. Assignments to circom variables that are newly introduced in this context go
     /// out of scope so they are dropped after the callback but overwriting assignments to circom
     /// variables that already exist prior to this new scope are preserved and written into the
     /// existing block context.
@@ -380,7 +380,7 @@ where
     }
 
     /// Use the callback to generate code for a new circom scope/block but within the current LLZK
-    /// `NewBlock`. Assignments to circom variables that are newly introduced in this context go
+    /// `BlockType`. Assignments to circom variables that are newly introduced in this context go
     /// out of scope so they are dropped after the callback but overwriting assignments to circom
     /// variables that already exist prior to this new scope are preserved and written into the
     /// existing block context.

--- a/llzk_backend/src/program_ext.rs
+++ b/llzk_backend/src/program_ext.rs
@@ -9,7 +9,7 @@ use program_structure::program_archive::ProgramArchive;
 
 /// A trait that allows common handling of the structs used to represent a circom
 /// program at different stages in the compilation process.
-pub trait ProgramLike {
+pub trait ProgramLike: std::fmt::Debug {
     /// Get the file library of the program.
     fn get_file_library(&self) -> &FileLibrary;
     /// Get the FileID of the file containing the "main" declaration.


### PR DESCRIPTION
Resolves #189 

- [x] Translation of basic while loops
- [x] Handle return within while loop
- [x] ~~fix incorrect codegen due to the block wrapping `Statement::While` generated from circom source "for" loop~~

Edit: let's actually go with this PR for now and I'll fix the issue mentioned in a separate PR