### PR TITLE
Add verbose output

### DIFF
--- a/circom/src/main.rs
+++ b/circom/src/main.rs
@@ -39,6 +39,7 @@ fn start() -> Result<(), ()> {
             user_input.llzk_file(),
             &user_input.llzk_pass_pipeline(),
             &user_input.prime(),
+            user_input.flag_verbose(),
         );
     }
 
@@ -77,6 +78,7 @@ fn start() -> Result<(), ()> {
             user_input.llzk_file(),
             &user_input.llzk_pass_pipeline(),
             &user_input.prime(),
+            user_input.flag_verbose(),
         );
     }
 

--- a/llzk_backend/src/codegen.rs
+++ b/llzk_backend/src/codegen.rs
@@ -33,27 +33,43 @@ pub fn generate_llzk(
     let mut codegen = LlzkCodegen { program, context: &ctx, module, prime_str: prime, verbose };
 
     program.gen_llzk(&codegen).map_err(|err| {
-        eprintln!("{} {err}", Color::Red.paint("Failed to generate LLZK IR:"));
+        if verbose {
+            eprintln!("{} {err:?}", Color::Red.paint("Failed to generate LLZK IR:"));
+        } else {
+            eprintln!("{} {err}", Color::Red.paint("Failed to generate LLZK IR:"));
+        }
         std::process::exit(1); // force exit to avoid hang if MLIR state is inconsistent
     })?;
 
     // Verify the module
     if let Err(err) = codegen.verify() {
         eprintln!("{}", Color::Red.paint("Generated LLZK IR is invalid"));
-        eprintln!("{err}");
+        if verbose {
+            eprintln!("{err:?}");
+        } else {
+            eprintln!("{err}");
+        }
         eprintln!("{}", codegen.module.as_operation());
         std::process::exit(2); // force exit to avoid hang if MLIR state is inconsistent
     }
 
     // Run user-specified MLIR pass pipeline
     codegen.run_passes(pass_pipeline).map_err(|err| {
-        eprintln!("{} {err}", Color::Red.paint("Failed to run pass pipeline:"));
+        if verbose {
+            eprintln!("{} {err:?}", Color::Red.paint("Failed to run pass pipeline:"));
+        } else {
+            eprintln!("{} {err}", Color::Red.paint("Failed to run pass pipeline:"));
+        }
         std::process::exit(3); // force exit to avoid hang if MLIR state is inconsistent
     })?;
 
     // Write module to file
     codegen.write_to_file(filename).map_err(|err| {
-        eprintln!("{} {err}", Color::Red.paint("Failed to write LLZK IR:"));
+        if verbose {
+            eprintln!("{} {err:?}", Color::Red.paint("Failed to write LLZK IR:"));
+        } else {
+            eprintln!("{} {err}", Color::Red.paint("Failed to write LLZK IR:"));
+        }
         std::process::exit(4); // force exit to avoid hang if MLIR state is inconsistent
     })
 }

--- a/llzk_backend/src/codegen.rs
+++ b/llzk_backend/src/codegen.rs
@@ -26,10 +26,11 @@ pub fn generate_llzk(
     filename: &str,
     pass_pipeline: &str,
     prime: &str,
+    verbose: bool,
 ) -> Result<(), ()> {
     let ctx = LlzkContext::new();
     let module = new_llzk_module(&ctx, program);
-    let mut codegen = LlzkCodegen { program, context: &ctx, module, prime_str: prime };
+    let mut codegen = LlzkCodegen { program, context: &ctx, module, prime_str: prime, verbose };
 
     program.gen_llzk(&codegen).map_err(|err| {
         eprintln!("{} {err}", Color::Red.paint("Failed to generate LLZK IR:"));

--- a/llzk_backend/src/module.rs
+++ b/llzk_backend/src/module.rs
@@ -319,6 +319,9 @@ fn gen_function_llzk<'ast, 'ctx, F: FunctionLike>(
     func_like: &'ast F,
     codegen: &LlzkCodegen<'ast, 'ctx, impl ProgramLike>,
 ) -> Result<()> {
+    if codegen.verbose {
+        println!("Generating LLZK for function {}", func_like.get_name());
+    }
     let location = func_like.get_location(codegen);
     let felt_type = codegen.felt_type().into();
     // TODO: This just uses `felt.type` for param and return types but those must actually be
@@ -353,6 +356,9 @@ fn gen_template_llzk<'ast, 'ctx, T: TemplateLike>(
     template_like: &'ast T,
     codegen: &LlzkCodegen<'ast, 'ctx, impl ProgramLike>,
 ) -> Result<()> {
+    if codegen.verbose {
+        println!("Generating LLZK for template {}", template_like.get_name());
+    }
     // Collect declarations first to determine struct fields and function parameters.
     let mut declarations = template_like.get_declarations(codegen)?;
     let subcmps = declarations.complete();

--- a/llzk_backend/src/shared.rs
+++ b/llzk_backend/src/shared.rs
@@ -90,6 +90,8 @@ pub struct LlzkCodegen<'ast, 'ctx, P: ProgramLike> {
     pub module: Module<'ctx>,
     /// The name of the prime field.
     pub prime_str: &'ctx str,
+    /// State of the `--verbose` flag.
+    pub verbose: bool,
 }
 
 impl<'ast, 'ctx, P: ProgramLike> LlzkCodegen<'ast, 'ctx, P> {


### PR DESCRIPTION
Use state of `--verbose` flag to optionally print:
- current function/template being processed
- stack trace on fatal error