### PR TITLE
Enhance handling of `Expression::UniformArray`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -807,7 +807,7 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 [[package]]
 name = "llzk"
 version = "0.1.0"
-source = "git+https://github.com/project-llzk/llzk-rs#30be0c62b12188ebf11f59677bb16de21b492307"
+source = "git+https://github.com/project-llzk/llzk-rs#1fab594b7c7c451d86f8c0bd038adf0fe621f17e"
 dependencies = [
  "llzk-macro",
  "llzk-sys",
@@ -821,7 +821,7 @@ dependencies = [
 [[package]]
 name = "llzk-macro"
 version = "0.1.0"
-source = "git+https://github.com/project-llzk/llzk-rs#30be0c62b12188ebf11f59677bb16de21b492307"
+source = "git+https://github.com/project-llzk/llzk-rs#1fab594b7c7c451d86f8c0bd038adf0fe621f17e"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -833,7 +833,7 @@ dependencies = [
 [[package]]
 name = "llzk-sys"
 version = "0.1.0"
-source = "git+https://github.com/project-llzk/llzk-rs#30be0c62b12188ebf11f59677bb16de21b492307"
+source = "git+https://github.com/project-llzk/llzk-rs#1fab594b7c7c451d86f8c0bd038adf0fe621f17e"
 dependencies = [
  "anyhow",
  "llzk-sys-build-support",
@@ -843,7 +843,7 @@ dependencies = [
 [[package]]
 name = "llzk-sys-build-support"
 version = "0.1.0"
-source = "git+https://github.com/project-llzk/llzk-rs#30be0c62b12188ebf11f59677bb16de21b492307"
+source = "git+https://github.com/project-llzk/llzk-rs#1fab594b7c7c451d86f8c0bd038adf0fe621f17e"
 dependencies = [
  "anyhow",
  "bindgen 0.71.1",

--- a/circom/tests/arrays/array_dimensions_06.circom
+++ b/circom/tests/arrays/array_dimensions_06.circom
@@ -2,13 +2,12 @@
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
 // XFAIL: *
-// COM: Template parameters expressions are currently unsupported as array dimensions.
+// COM: Template parameters expressions are currently unsupported as array dimensions for inputs.
 
 pragma circom 2.0.0;
 
 template ArrayDims(N) {
-    var M = N + 1;
-    var arr[M];
+    signal input arr[N + 1];
 }
 
 component main = ArrayDims(7);

--- a/circom/tests/arrays/array_dimensions_07.circom
+++ b/circom/tests/arrays/array_dimensions_07.circom
@@ -1,0 +1,43 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
+
+pragma circom 2.0.0;
+
+template ArrayDims(N) {
+    var arr[N];
+}
+
+component main = ArrayDims(7);
+
+// CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-NEXT:    struct.def @ArrayDims<[@N]> {
+// CHECK-NEXT:      function.def @compute() -> !struct.type<@ArrayDims<[@N]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_0:[0-9a-zA-Z_\.]+]] = struct.new : <@ArrayDims<[@N]>>
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = array.new  : <@N x !felt.type>
+// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_3]], %[[VAL_4]] : <@N x !felt.type>
+// CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[VAL_8:[0-9a-zA-Z_\.]+]] = %[[VAL_6]] to %[[VAL_5]] step %[[VAL_7]] {
+// CHECK-NEXT:          array.write %[[VAL_3]]{{\[}}%[[VAL_8]]] = %[[VAL_2]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.return %[[VAL_0]] : !struct.type<@ArrayDims<[@N]>>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[VAL_9:[0-9a-zA-Z_\.]+]]: !struct.type<@ArrayDims<[@N]>>) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type
+// CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_12:[0-9a-zA-Z_\.]+]] = array.new  : <@N x !felt.type>
+// CHECK-NEXT:        %[[VAL_13:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_14:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_12]], %[[VAL_13]] : <@N x !felt.type>
+// CHECK-NEXT:        %[[VAL_15:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_16:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[VAL_17:[0-9a-zA-Z_\.]+]] = %[[VAL_15]] to %[[VAL_14]] step %[[VAL_16]] {
+// CHECK-NEXT:          array.write %[[VAL_12]]{{\[}}%[[VAL_17]]] = %[[VAL_11]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/arrays/array_dimensions_08.circom
+++ b/circom/tests/arrays/array_dimensions_08.circom
@@ -1,0 +1,61 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
+
+pragma circom 2.0.0;
+
+template ArrayDims(N, M) {
+    var arr[N][M];
+}
+
+component main = ArrayDims(7, 2);
+
+// CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-NEXT:    struct.def @ArrayDims<[@N, @M]> {
+// CHECK-NEXT:      function.def @compute() -> !struct.type<@ArrayDims<[@N, @M]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_0:[0-9a-zA-Z_\.]+]] = struct.new : <@ArrayDims<[@N, @M]>>
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = poly.read_const @M : !felt.type
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = array.new  : <@M x !felt.type>
+// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_4]], %[[VAL_5]] : <@M x !felt.type>
+// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[VAL_9:[0-9a-zA-Z_\.]+]] = %[[VAL_7]] to %[[VAL_6]] step %[[VAL_8]] {
+// CHECK-NEXT:          array.write %[[VAL_4]]{{\[}}%[[VAL_9]]] = %[[VAL_3]] : <@M x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = array.new  : <@N,@M x !felt.type>
+// CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_12:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_10]], %[[VAL_11]] : <@N,@M x !felt.type>
+// CHECK-NEXT:        %[[VAL_13:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_14:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[VAL_15:[0-9a-zA-Z_\.]+]] = %[[VAL_13]] to %[[VAL_12]] step %[[VAL_14]] {
+// CHECK-NEXT:          array.insert %[[VAL_10]]{{\[}}%[[VAL_15]]] = %[[VAL_4]] : <@N,@M x !felt.type>, <@M x !felt.type>
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.return %[[VAL_0]] : !struct.type<@ArrayDims<[@N, @M]>>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[VAL_16:[0-9a-zA-Z_\.]+]]: !struct.type<@ArrayDims<[@N, @M]>>) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[VAL_17:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type
+// CHECK-NEXT:        %[[VAL_18:[0-9a-zA-Z_\.]+]] = poly.read_const @M : !felt.type
+// CHECK-NEXT:        %[[VAL_19:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_20:[0-9a-zA-Z_\.]+]] = array.new  : <@M x !felt.type>
+// CHECK-NEXT:        %[[VAL_21:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_22:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_20]], %[[VAL_21]] : <@M x !felt.type>
+// CHECK-NEXT:        %[[VAL_23:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_24:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[VAL_25:[0-9a-zA-Z_\.]+]] = %[[VAL_23]] to %[[VAL_22]] step %[[VAL_24]] {
+// CHECK-NEXT:          array.write %[[VAL_20]]{{\[}}%[[VAL_25]]] = %[[VAL_19]] : <@M x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_26:[0-9a-zA-Z_\.]+]] = array.new  : <@N,@M x !felt.type>
+// CHECK-NEXT:        %[[VAL_27:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_28:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_26]], %[[VAL_27]] : <@N,@M x !felt.type>
+// CHECK-NEXT:        %[[VAL_29:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_30:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[VAL_31:[0-9a-zA-Z_\.]+]] = %[[VAL_29]] to %[[VAL_28]] step %[[VAL_30]] {
+// CHECK-NEXT:          array.insert %[[VAL_26]]{{\[}}%[[VAL_31]]] = %[[VAL_20]] : <@N,@M x !felt.type>, <@M x !felt.type>
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/arrays/array_dimensions_09.circom
+++ b/circom/tests/arrays/array_dimensions_09.circom
@@ -1,0 +1,51 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
+
+pragma circom 2.0.0;
+
+template ArrayDims(N, M) {
+    var D = N + M;
+    var arr[D];
+}
+
+component main = ArrayDims(7, 2);
+
+// CHECK: #[[$ATTR_0:[0-9a-zA-Z_\.]+]] = affine_map<()[s0] -> (s0)>
+// CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-NEXT:    struct.def @ArrayDims<[@N, @M]> {
+// CHECK-NEXT:      function.def @compute() -> !struct.type<@ArrayDims<[@N, @M]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_0:[0-9a-zA-Z_\.]+]] = struct.new : <@ArrayDims<[@N, @M]>>
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = poly.read_const @M : !felt.type
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_1]], %[[VAL_2]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_3]]
+// CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = array.new{(){{\[}}%[[VAL_5]]]} : <#[[$ATTR_0]] x !felt.type>
+// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_6]], %[[VAL_7]] : <#[[$ATTR_0]] x !felt.type>
+// CHECK-NEXT:        %[[VAL_9:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[VAL_11:[0-9a-zA-Z_\.]+]] = %[[VAL_9]] to %[[VAL_8]] step %[[VAL_10]] {
+// CHECK-NEXT:          array.write %[[VAL_6]]{{\[}}%[[VAL_11]]] = %[[VAL_4]] : <#[[$ATTR_0]] x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.return %[[VAL_0]] : !struct.type<@ArrayDims<[@N, @M]>>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[VAL_12:[0-9a-zA-Z_\.]+]]: !struct.type<@ArrayDims<[@N, @M]>>) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[VAL_13:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type
+// CHECK-NEXT:        %[[VAL_14:[0-9a-zA-Z_\.]+]] = poly.read_const @M : !felt.type
+// CHECK-NEXT:        %[[VAL_15:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_13]], %[[VAL_14]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[VAL_16:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_17:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_15]]
+// CHECK-NEXT:        %[[VAL_18:[0-9a-zA-Z_\.]+]] = array.new{(){{\[}}%[[VAL_17]]]} : <#[[$ATTR_0]] x !felt.type>
+// CHECK-NEXT:        %[[VAL_19:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_20:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_18]], %[[VAL_19]] : <#[[$ATTR_0]] x !felt.type>
+// CHECK-NEXT:        %[[VAL_21:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_22:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[VAL_23:[0-9a-zA-Z_\.]+]] = %[[VAL_21]] to %[[VAL_20]] step %[[VAL_22]] {
+// CHECK-NEXT:          array.write %[[VAL_18]]{{\[}}%[[VAL_23]]] = %[[VAL_16]] : <#[[$ATTR_0]] x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/circom_doc_examples/18.circom
+++ b/circom/tests/circom_doc_examples/18.circom
@@ -1,7 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL:.*
 
 pragma circom 2.0.0;
 
@@ -14,10 +13,62 @@ template B(n){
    signal input in[n];
    signal out;
    component temp_a = A(n);
-   temp_a.a <== in[0]; 
+   temp_a.a <== in[0];
    temp_a.b <== in[1];
    out <== temp_a.c;
 }
 component main = B(2);
 
 // CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-NEXT:    struct.def @A<[@n]> {
+// CHECK-NEXT:      struct.field @c : !felt.type {llzk.pub}
+// CHECK-NEXT:      function.def @compute(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_1:[0-9a-zA-Z_\.]+]]: !felt.type) -> !struct.type<@A<[@n]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = struct.new : <@A<[@n]>>
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_0]], %[[VAL_1]] : !felt.type, !felt.type
+// CHECK-NEXT:        struct.writef %[[VAL_2]][@c] = %[[VAL_4]] : <@A<[@n]>>, !felt.type
+// CHECK-NEXT:        function.return %[[VAL_2]] : !struct.type<@A<[@n]>>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[VAL_5:[0-9a-zA-Z_\.]+]]: !struct.type<@A<[@n]>>, %[[VAL_6:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_7:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_9:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_6]], %[[VAL_7]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_5]][@c] : <@A<[@n]>>, !felt.type
+// CHECK-NEXT:        constrain.eq %[[VAL_10]], %[[VAL_9]] : !felt.type, !felt.type
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    struct.def @B<[@n]> {
+// CHECK-NEXT:      struct.field @out : !felt.type
+// CHECK-NEXT:      struct.field @temp_a : !struct.type<@A<[@n]>>
+// CHECK-NEXT:      function.def @compute(%[[VAL_11:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) -> !struct.type<@B<[@n]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_12:[0-9a-zA-Z_\.]+]] = struct.new : <@B<[@n]>>
+// CHECK-NEXT:        %[[VAL_13:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_14:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_15:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_14]]
+// CHECK-NEXT:        %[[VAL_16:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_11]]{{\[}}%[[VAL_15]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[VAL_17:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_18:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_17]]
+// CHECK-NEXT:        %[[VAL_19:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_11]]{{\[}}%[[VAL_18]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[VAL_20:[0-9a-zA-Z_\.]+]] = function.call @A::@compute(%[[VAL_16]], %[[VAL_19]]) : (!felt.type, !felt.type) -> !struct.type<@A<[@n]>>
+// CHECK-NEXT:        %[[VAL_21:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_20]][@c] : <@A<[@n]>>, !felt.type
+// CHECK-NEXT:        struct.writef %[[VAL_12]][@out] = %[[VAL_21]] : <@B<[@n]>>, !felt.type
+// CHECK-NEXT:        struct.writef %[[VAL_12]][@temp_a] = %[[VAL_20]] : <@B<[@n]>>, !struct.type<@A<[@n]>>
+// CHECK-NEXT:        function.return %[[VAL_12]] : !struct.type<@B<[@n]>>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[VAL_22:[0-9a-zA-Z_\.]+]]: !struct.type<@B<[@n]>>, %[[VAL_23:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[VAL_24:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_25:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_22]][@temp_a] : <@B<[@n]>>, !struct.type<@A<[@n]>>
+// CHECK-NEXT:        %[[VAL_26:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_27:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_26]]
+// CHECK-NEXT:        %[[VAL_28:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_23]]{{\[}}%[[VAL_27]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[VAL_29:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_30:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_29]]
+// CHECK-NEXT:        %[[VAL_31:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_23]]{{\[}}%[[VAL_30]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:        function.call @A::@constrain(%[[VAL_25]], %[[VAL_28]], %[[VAL_31]]) : (!struct.type<@A<[@n]>>, !felt.type, !felt.type) -> ()
+// CHECK-NEXT:        %[[VAL_32:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_25]][@c] : <@A<[@n]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_33:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_22]][@out] : <@B<[@n]>>, !felt.type
+// CHECK-NEXT:        constrain.eq %[[VAL_33]], %[[VAL_32]] : !felt.type, !felt.type
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/circom_doc_examples/19.circom
+++ b/circom/tests/circom_doc_examples/19.circom
@@ -1,7 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL:.*
 
 pragma circom 2.1.0;
 
@@ -17,3 +16,55 @@ template B(n){
 component main = B(2);
 
 // CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-NEXT:    struct.def @A<[@n]> {
+// CHECK-NEXT:      struct.field @c : !felt.type {llzk.pub}
+// CHECK-NEXT:      function.def @compute(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_1:[0-9a-zA-Z_\.]+]]: !felt.type) -> !struct.type<@A<[@n]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = struct.new : <@A<[@n]>>
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_0]], %[[VAL_1]] : !felt.type, !felt.type
+// CHECK-NEXT:        struct.writef %[[VAL_2]][@c] = %[[VAL_4]] : <@A<[@n]>>, !felt.type
+// CHECK-NEXT:        function.return %[[VAL_2]] : !struct.type<@A<[@n]>>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[VAL_5:[0-9a-zA-Z_\.]+]]: !struct.type<@A<[@n]>>, %[[VAL_6:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_7:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_9:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_6]], %[[VAL_7]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_5]][@c] : <@A<[@n]>>, !felt.type
+// CHECK-NEXT:        constrain.eq %[[VAL_10]], %[[VAL_9]] : !felt.type, !felt.type
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    struct.def @B<[@n]> {
+// CHECK-NEXT:      struct.field @out : !felt.type
+// CHECK-NEXT:      struct.field @[[TEMP:[0-9a-zA-Z_\.]+]] : !struct.type<@A<[@n]>>
+// CHECK-NEXT:      function.def @compute(%[[VAL_11:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) -> !struct.type<@B<[@n]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_12:[0-9a-zA-Z_\.]+]] = struct.new : <@B<[@n]>>
+// CHECK-NEXT:        %[[VAL_13:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_14:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_15:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_14]]
+// CHECK-NEXT:        %[[VAL_16:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_11]]{{\[}}%[[VAL_15]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[VAL_17:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_18:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_17]]
+// CHECK-NEXT:        %[[VAL_19:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_11]]{{\[}}%[[VAL_18]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[VAL_20:[0-9a-zA-Z_\.]+]] = function.call @A::@compute(%[[VAL_16]], %[[VAL_19]]) : (!felt.type, !felt.type) -> !struct.type<@A<[@n]>>
+// CHECK-NEXT:        %[[VAL_21:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_20]][@c] : <@A<[@n]>>, !felt.type
+// CHECK-NEXT:        struct.writef %[[VAL_12]][@out] = %[[VAL_21]] : <@B<[@n]>>, !felt.type
+// CHECK-NEXT:        struct.writef %[[VAL_12]][@[[TEMP]]] = %[[VAL_20]] : <@B<[@n]>>, !struct.type<@A<[@n]>>
+// CHECK-NEXT:        function.return %[[VAL_12]] : !struct.type<@B<[@n]>>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[VAL_22:[0-9a-zA-Z_\.]+]]: !struct.type<@B<[@n]>>, %[[VAL_23:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[VAL_24:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_25:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_22]][@[[TEMP]]] : <@B<[@n]>>, !struct.type<@A<[@n]>>
+// CHECK-NEXT:        %[[VAL_26:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_27:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_26]]
+// CHECK-NEXT:        %[[VAL_28:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_23]]{{\[}}%[[VAL_27]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[VAL_29:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_30:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_29]]
+// CHECK-NEXT:        %[[VAL_31:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_23]]{{\[}}%[[VAL_30]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:        function.call @A::@constrain(%[[VAL_25]], %[[VAL_28]], %[[VAL_31]]) : (!struct.type<@A<[@n]>>, !felt.type, !felt.type) -> ()
+// CHECK-NEXT:        %[[VAL_32:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_25]][@c] : <@A<[@n]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_33:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_22]][@out] : <@B<[@n]>>, !felt.type
+// CHECK-NEXT:        constrain.eq %[[VAL_33]], %[[VAL_32]] : !felt.type, !felt.type
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/circom_doc_examples/20.circom
+++ b/circom/tests/circom_doc_examples/20.circom
@@ -1,7 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL:.*
 
 pragma circom 2.1.0;
 
@@ -17,3 +16,55 @@ template B(n){
 component main = B(2);
 
 // CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-NEXT:    struct.def @A<[@n]> {
+// CHECK-NEXT:      struct.field @c : !felt.type {llzk.pub}
+// CHECK-NEXT:      function.def @compute(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_1:[0-9a-zA-Z_\.]+]]: !felt.type) -> !struct.type<@A<[@n]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = struct.new : <@A<[@n]>>
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_0]], %[[VAL_1]] : !felt.type, !felt.type
+// CHECK-NEXT:        struct.writef %[[VAL_2]][@c] = %[[VAL_4]] : <@A<[@n]>>, !felt.type
+// CHECK-NEXT:        function.return %[[VAL_2]] : !struct.type<@A<[@n]>>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[VAL_5:[0-9a-zA-Z_\.]+]]: !struct.type<@A<[@n]>>, %[[VAL_6:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_7:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_9:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_6]], %[[VAL_7]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_5]][@c] : <@A<[@n]>>, !felt.type
+// CHECK-NEXT:        constrain.eq %[[VAL_10]], %[[VAL_9]] : !felt.type, !felt.type
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    struct.def @B<[@n]> {
+// CHECK-NEXT:      struct.field @out : !felt.type
+// CHECK-NEXT:      struct.field @[[TEMP:[0-9a-zA-Z_\.]+]] : !struct.type<@A<[@n]>>
+// CHECK-NEXT:      function.def @compute(%[[VAL_11:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) -> !struct.type<@B<[@n]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_12:[0-9a-zA-Z_\.]+]] = struct.new : <@B<[@n]>>
+// CHECK-NEXT:        %[[VAL_13:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_14:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_15:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_14]]
+// CHECK-NEXT:        %[[VAL_16:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_11]]{{\[}}%[[VAL_15]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[VAL_17:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_18:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_17]]
+// CHECK-NEXT:        %[[VAL_19:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_11]]{{\[}}%[[VAL_18]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[VAL_20:[0-9a-zA-Z_\.]+]] = function.call @A::@compute(%[[VAL_16]], %[[VAL_19]]) : (!felt.type, !felt.type) -> !struct.type<@A<[@n]>>
+// CHECK-NEXT:        %[[VAL_21:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_20]][@c] : <@A<[@n]>>, !felt.type
+// CHECK-NEXT:        struct.writef %[[VAL_12]][@out] = %[[VAL_21]] : <@B<[@n]>>, !felt.type
+// CHECK-NEXT:        struct.writef %[[VAL_12]][@[[TEMP]]] = %[[VAL_20]] : <@B<[@n]>>, !struct.type<@A<[@n]>>
+// CHECK-NEXT:        function.return %[[VAL_12]] : !struct.type<@B<[@n]>>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[VAL_22:[0-9a-zA-Z_\.]+]]: !struct.type<@B<[@n]>>, %[[VAL_23:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[VAL_24:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_25:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_22]][@[[TEMP]]] : <@B<[@n]>>, !struct.type<@A<[@n]>>
+// CHECK-NEXT:        %[[VAL_26:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_27:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_26]]
+// CHECK-NEXT:        %[[VAL_28:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_23]]{{\[}}%[[VAL_27]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[VAL_29:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_30:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_29]]
+// CHECK-NEXT:        %[[VAL_31:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_23]]{{\[}}%[[VAL_30]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:        function.call @A::@constrain(%[[VAL_25]], %[[VAL_28]], %[[VAL_31]]) : (!struct.type<@A<[@n]>>, !felt.type, !felt.type) -> ()
+// CHECK-NEXT:        %[[VAL_32:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_25]][@c] : <@A<[@n]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_33:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_22]][@out] : <@B<[@n]>>, !felt.type
+// CHECK-NEXT:        constrain.eq %[[VAL_33]], %[[VAL_32]] : !felt.type, !felt.type
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/circom_doc_examples/25.circom
+++ b/circom/tests/circom_doc_examples/25.circom
@@ -1,7 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL:.*
 
 pragma circom 2.1.0;
 
@@ -18,3 +17,61 @@ template B(n){
 component main = B(3);
 
 // CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-NEXT:    struct.def @A<[@n]> {
+// CHECK-NEXT:      struct.field @d : !felt.type {llzk.pub}
+// CHECK-NEXT:      function.def @compute(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_1:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_2:[0-9a-zA-Z_\.]+]]: !felt.type) -> !struct.type<@A<[@n]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = struct.new : <@A<[@n]>>
+// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_0]], %[[VAL_1]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_5]], %[[VAL_2]] : !felt.type, !felt.type
+// CHECK-NEXT:        struct.writef %[[VAL_3]][@d] = %[[VAL_6]] : <@A<[@n]>>, !felt.type
+// CHECK-NEXT:        function.return %[[VAL_3]] : !struct.type<@A<[@n]>>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[VAL_7:[0-9a-zA-Z_\.]+]]: !struct.type<@A<[@n]>>, %[[VAL_8:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_9:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_10:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_12:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_8]], %[[VAL_9]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[VAL_13:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_12]], %[[VAL_10]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[VAL_14:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_7]][@d] : <@A<[@n]>>, !felt.type
+// CHECK-NEXT:        constrain.eq %[[VAL_14]], %[[VAL_13]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[VAL_15:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_8]], %[[VAL_9]] : !felt.type, !felt.type
+// CHECK-NEXT:        constrain.eq %[[VAL_15]], %[[VAL_10]] : !felt.type, !felt.type
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    struct.def @B<[@n]> {
+// CHECK-NEXT:      struct.field @[[TEMP:[0-9a-zA-Z_\.]+]] : !struct.type<@A<[@n]>>
+// CHECK-NEXT:      function.def @compute(%[[VAL_16:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) -> !struct.type<@B<[@n]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_17:[0-9a-zA-Z_\.]+]] = struct.new : <@B<[@n]>>
+// CHECK-NEXT:        %[[VAL_18:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_19:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_20:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_19]]
+// CHECK-NEXT:        %[[VAL_21:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_16]]{{\[}}%[[VAL_20]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[VAL_22:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_23:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_22]]
+// CHECK-NEXT:        %[[VAL_24:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_16]]{{\[}}%[[VAL_23]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[VAL_25:[0-9a-zA-Z_\.]+]] = felt.const  2
+// CHECK-NEXT:        %[[VAL_26:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_25]]
+// CHECK-NEXT:        %[[VAL_27:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_16]]{{\[}}%[[VAL_26]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[VAL_28:[0-9a-zA-Z_\.]+]] = function.call @A::@compute(%[[VAL_21]], %[[VAL_24]], %[[VAL_27]]) : (!felt.type, !felt.type, !felt.type) -> !struct.type<@A<[@n]>>
+// CHECK-NEXT:        %[[VAL_29:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_28]][@d] : <@A<[@n]>>, !felt.type
+// CHECK-NEXT:        struct.writef %[[VAL_17]][@[[TEMP]]] = %[[VAL_28]] : <@B<[@n]>>, !struct.type<@A<[@n]>>
+// CHECK-NEXT:        function.return %[[VAL_17]] : !struct.type<@B<[@n]>>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[VAL_30:[0-9a-zA-Z_\.]+]]: !struct.type<@B<[@n]>>, %[[VAL_31:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[VAL_32:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_33:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_30]][@[[TEMP]]] : <@B<[@n]>>, !struct.type<@A<[@n]>>
+// CHECK-NEXT:        %[[VAL_34:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_35:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_34]]
+// CHECK-NEXT:        %[[VAL_36:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_31]]{{\[}}%[[VAL_35]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[VAL_37:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_38:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_37]]
+// CHECK-NEXT:        %[[VAL_39:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_31]]{{\[}}%[[VAL_38]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[VAL_40:[0-9a-zA-Z_\.]+]] = felt.const  2
+// CHECK-NEXT:        %[[VAL_41:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_40]]
+// CHECK-NEXT:        %[[VAL_42:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_31]]{{\[}}%[[VAL_41]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:        function.call @A::@constrain(%[[VAL_33]], %[[VAL_36]], %[[VAL_39]], %[[VAL_42]]) : (!struct.type<@A<[@n]>>, !felt.type, !felt.type, !felt.type) -> ()
+// CHECK-NEXT:        %[[VAL_43:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_33]][@d] : <@A<[@n]>>, !felt.type
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/circom_doc_examples/26.circom
+++ b/circom/tests/circom_doc_examples/26.circom
@@ -1,7 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL:.*
 
 pragma circom 2.1.0;
 
@@ -20,3 +19,65 @@ template B(n){
 component main = B(3);
 
 // CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-NEXT:    struct.def @A<[@n]> {
+// CHECK-NEXT:      struct.field @b : !felt.type {llzk.pub}
+// CHECK-NEXT:      struct.field @c : !felt.type {llzk.pub}
+// CHECK-NEXT:      struct.field @d : !felt.type {llzk.pub}
+// CHECK-NEXT:      function.def @compute(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !felt.type) -> !struct.type<@A<[@n]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = struct.new : <@A<[@n]>>
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_0]], %[[VAL_0]] : !felt.type, !felt.type
+// CHECK-NEXT:        struct.writef %[[VAL_1]][@b] = %[[VAL_3]] : <@A<[@n]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = felt.const  2
+// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_0]], %[[VAL_4]] : !felt.type, !felt.type
+// CHECK-NEXT:        struct.writef %[[VAL_1]][@c] = %[[VAL_5]] : <@A<[@n]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_0]], %[[VAL_0]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = felt.const  2
+// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_6]], %[[VAL_7]] : !felt.type, !felt.type
+// CHECK-NEXT:        struct.writef %[[VAL_1]][@d] = %[[VAL_8]] : <@A<[@n]>>, !felt.type
+// CHECK-NEXT:        function.return %[[VAL_1]] : !struct.type<@A<[@n]>>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[VAL_9:[0-9a-zA-Z_\.]+]]: !struct.type<@A<[@n]>>, %[[VAL_10:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_12:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_10]], %[[VAL_10]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[VAL_13:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_9]][@b] : <@A<[@n]>>, !felt.type
+// CHECK-NEXT:        constrain.eq %[[VAL_13]], %[[VAL_12]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[VAL_14:[0-9a-zA-Z_\.]+]] = felt.const  2
+// CHECK-NEXT:        %[[VAL_15:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_10]], %[[VAL_14]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[VAL_16:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_9]][@c] : <@A<[@n]>>, !felt.type
+// CHECK-NEXT:        constrain.eq %[[VAL_16]], %[[VAL_15]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[VAL_17:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_10]], %[[VAL_10]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[VAL_18:[0-9a-zA-Z_\.]+]] = felt.const  2
+// CHECK-NEXT:        %[[VAL_19:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_17]], %[[VAL_18]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[VAL_20:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_9]][@d] : <@A<[@n]>>, !felt.type
+// CHECK-NEXT:        constrain.eq %[[VAL_20]], %[[VAL_19]] : !felt.type, !felt.type
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    struct.def @B<[@n]> {
+// CHECK-NEXT:      struct.field @out1 : !felt.type {llzk.pub}
+// CHECK-NEXT:      struct.field @[[TEMP:[0-9a-zA-Z_\.]+]] : !struct.type<@A<[@n]>>
+// CHECK-NEXT:      function.def @compute(%[[VAL_21:[0-9a-zA-Z_\.]+]]: !felt.type) -> !struct.type<@B<[@n]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_22:[0-9a-zA-Z_\.]+]] = struct.new : <@B<[@n]>>
+// CHECK-NEXT:        %[[VAL_23:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_24:[0-9a-zA-Z_\.]+]] = function.call @A::@compute(%[[VAL_21]]) : (!felt.type) -> !struct.type<@A<[@n]>>
+// CHECK-NEXT:        %[[VAL_25:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_24]][@b] : <@A<[@n]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_26:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_24]][@c] : <@A<[@n]>>, !felt.type
+// CHECK-NEXT:        struct.writef %[[VAL_22]][@out1] = %[[VAL_26]] : <@B<[@n]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_27:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_24]][@d] : <@A<[@n]>>, !felt.type
+// CHECK-NEXT:        struct.writef %[[VAL_22]][@[[TEMP]]] = %[[VAL_24]] : <@B<[@n]>>, !struct.type<@A<[@n]>>
+// CHECK-NEXT:        function.return %[[VAL_22]] : !struct.type<@B<[@n]>>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[VAL_28:[0-9a-zA-Z_\.]+]]: !struct.type<@B<[@n]>>, %[[VAL_29:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[VAL_30:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_31:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_28]][@[[TEMP]]] : <@B<[@n]>>, !struct.type<@A<[@n]>>
+// CHECK-NEXT:        function.call @A::@constrain(%[[VAL_31]], %[[VAL_29]]) : (!struct.type<@A<[@n]>>, !felt.type) -> ()
+// CHECK-NEXT:        %[[VAL_32:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_31]][@b] : <@A<[@n]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_33:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_31]][@c] : <@A<[@n]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_34:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_28]][@out1] : <@B<[@n]>>, !felt.type
+// CHECK-NEXT:        constrain.eq %[[VAL_34]], %[[VAL_33]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[VAL_35:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_31]][@d] : <@A<[@n]>>, !felt.type
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/circom_doc_examples/40A.circom
+++ b/circom/tests/circom_doc_examples/40A.circom
@@ -1,7 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL:.*
 
 pragma circom 2.0.0;
 
@@ -30,3 +29,84 @@ template check_bits(n) {
 component main = check_bits(10);
 
 // CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-NEXT:    struct.def @Num2Bits<[@n]> {
+// CHECK-NEXT:      struct.field @out : !array.type<@n x !felt.type> {llzk.pub}
+// CHECK-NEXT:      function.def @compute(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !felt.type) -> !struct.type<@Num2Bits<[@n]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = struct.new : <@Num2Bits<[@n]>>
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = undef.undef : !array.type<@n x !felt.type>
+// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]]:3 = scf.while (%[[VAL_8:[0-9a-zA-Z_\.]+]] = %[[VAL_5]], %[[VAL_9:[0-9a-zA-Z_\.]+]] = %[[VAL_6]], %[[VAL_10:[0-9a-zA-Z_\.]+]] = %[[VAL_4]]) : (!felt.type, !felt.type, !felt.type) -> (!felt.type, !felt.type, !felt.type) {
+// CHECK-NEXT:          %[[VAL_11:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_9]], %[[VAL_2]])
+// CHECK-NEXT:          scf.condition(%[[VAL_11]]) %[[VAL_8]], %[[VAL_9]], %[[VAL_10]] : !felt.type, !felt.type, !felt.type
+// CHECK-NEXT:        } do {
+// CHECK-NEXT:        ^bb0(%[[VAL_12:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_13:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_14:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[VAL_15:[0-9a-zA-Z_\.]+]] = felt.shr %[[VAL_0]], %[[VAL_13]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[VAL_16:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_17:[0-9a-zA-Z_\.]+]] = felt.bit_and %[[VAL_15]], %[[VAL_16]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[VAL_18:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_13]]
+// CHECK-NEXT:          array.write %[[VAL_3]]{{\[}}%[[VAL_18]]] = %[[VAL_17]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_19:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_13]]
+// CHECK-NEXT:          %[[VAL_20:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_3]]{{\[}}%[[VAL_19]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_21:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_20]], %[[VAL_5]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[VAL_22:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_14]], %[[VAL_21]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[VAL_23:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_12]], %[[VAL_12]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[VAL_24:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_25:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_13]], %[[VAL_24]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_23]], %[[VAL_25]], %[[VAL_22]] : !felt.type, !felt.type, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        struct.writef %[[VAL_1]][@out] = %[[VAL_3]] : <@Num2Bits<[@n]>>, !array.type<@n x !felt.type>
+// CHECK-NEXT:        function.return %[[VAL_1]] : !struct.type<@Num2Bits<[@n]>>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[VAL_26:[0-9a-zA-Z_\.]+]]: !struct.type<@Num2Bits<[@n]>>, %[[VAL_27:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[VAL_28:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_29:[0-9a-zA-Z_\.]+]] = undef.undef : !array.type<@n x !felt.type>
+// CHECK-NEXT:        %[[VAL_30:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_31:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_32:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_33:[0-9a-zA-Z_\.]+]]:3 = scf.while (%[[VAL_34:[0-9a-zA-Z_\.]+]] = %[[VAL_31]], %[[VAL_35:[0-9a-zA-Z_\.]+]] = %[[VAL_32]], %[[VAL_36:[0-9a-zA-Z_\.]+]] = %[[VAL_30]]) : (!felt.type, !felt.type, !felt.type) -> (!felt.type, !felt.type, !felt.type) {
+// CHECK-NEXT:          %[[VAL_37:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_35]], %[[VAL_28]])
+// CHECK-NEXT:          scf.condition(%[[VAL_37]]) %[[VAL_34]], %[[VAL_35]], %[[VAL_36]] : !felt.type, !felt.type, !felt.type
+// CHECK-NEXT:        } do {
+// CHECK-NEXT:        ^bb0(%[[VAL_38:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_39:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_40:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[VAL_41:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_39]]
+// CHECK-NEXT:          %[[VAL_42:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_29]]{{\[}}%[[VAL_41]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_43:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_39]]
+// CHECK-NEXT:          %[[VAL_44:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_29]]{{\[}}%[[VAL_43]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_45:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_46:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_44]], %[[VAL_45]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[VAL_47:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_42]], %[[VAL_46]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[VAL_48:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:          constrain.eq %[[VAL_47]], %[[VAL_48]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[VAL_49:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_39]]
+// CHECK-NEXT:          %[[VAL_50:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_29]]{{\[}}%[[VAL_49]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_51:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_50]], %[[VAL_31]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[VAL_52:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_40]], %[[VAL_51]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[VAL_53:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_38]], %[[VAL_38]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[VAL_54:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_55:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_39]], %[[VAL_54]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_53]], %[[VAL_55]], %[[VAL_52]] : !felt.type, !felt.type, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        constrain.eq %[[VAL_33]]#2, %[[VAL_27]] : !felt.type, !felt.type
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    struct.def @check_bits<[@n]> {
+// CHECK-NEXT:      struct.field @check : !struct.type<@Num2Bits<[@n]>>
+// CHECK-NEXT:      function.def @compute(%[[VAL_56:[0-9a-zA-Z_\.]+]]: !felt.type) -> !struct.type<@check_bits<[@n]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_57:[0-9a-zA-Z_\.]+]] = struct.new : <@check_bits<[@n]>>
+// CHECK-NEXT:        %[[VAL_58:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_59:[0-9a-zA-Z_\.]+]] = function.call @Num2Bits::@compute(%[[VAL_56]]) : (!felt.type) -> !struct.type<@Num2Bits<[@n]>>
+// CHECK-NEXT:        struct.writef %[[VAL_57]][@check] = %[[VAL_59]] : <@check_bits<[@n]>>, !struct.type<@Num2Bits<[@n]>>
+// CHECK-NEXT:        function.return %[[VAL_57]] : !struct.type<@check_bits<[@n]>>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[VAL_60:[0-9a-zA-Z_\.]+]]: !struct.type<@check_bits<[@n]>>, %[[VAL_61:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[VAL_62:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_63:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_60]][@check] : <@check_bits<[@n]>>, !struct.type<@Num2Bits<[@n]>>
+// CHECK-NEXT:        function.call @Num2Bits::@constrain(%[[VAL_63]], %[[VAL_61]]) : (!struct.type<@Num2Bits<[@n]>>, !felt.type) -> ()
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/constraints/arr_cpy_store.circom
+++ b/circom/tests/constraints/arr_cpy_store.circom
@@ -1,7 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL:.*
 
 pragma circom 2.0.0;
 
@@ -22,3 +21,49 @@ template Foo(N) {
 component main = Foo(2);
 
 // CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-NEXT:    struct.def @Foo<[@N]> {
+// CHECK-NEXT:      struct.field @c : !struct.type<@Sum<[@N]>>
+// CHECK-NEXT:      function.def @compute(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[VAL_1:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>) -> !struct.type<@Foo<[@N]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = struct.new : <@Foo<[@N]>>
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type
+// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = function.call @Sum::@compute(%[[VAL_0]]) : (!array.type<@N x !felt.type>) -> !struct.type<@Sum<[@N]>>
+// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_6:[0-9a-zA-Z_\.]+]] = %[[VAL_3]]) : (!felt.type) -> !felt.type {
+// CHECK-NEXT:          %[[VAL_7:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_6]], %[[VAL_6]])
+// CHECK-NEXT:          scf.condition(%[[VAL_7]]) %[[VAL_6]] : !felt.type
+// CHECK-NEXT:        } do {
+// CHECK-NEXT:        ^bb0(%[[VAL_8:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[VAL_9:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_10:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_8]], %[[VAL_9]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_10]] : !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        struct.writef %[[VAL_2]][@c] = %[[VAL_4]] : <@Foo<[@N]>>, !struct.type<@Sum<[@N]>>
+// CHECK-NEXT:        function.return %[[VAL_2]] : !struct.type<@Foo<[@N]>>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[VAL_11:[0-9a-zA-Z_\.]+]]: !struct.type<@Foo<[@N]>>, %[[VAL_12:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[VAL_13:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[VAL_14:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type
+// CHECK-NEXT:        %[[VAL_15:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_11]][@c] : <@Foo<[@N]>>, !struct.type<@Sum<[@N]>>
+// CHECK-NEXT:        function.call @Sum::@constrain(%[[VAL_15]], %[[VAL_12]]) : (!struct.type<@Sum<[@N]>>, !array.type<@N x !felt.type>) -> ()
+// CHECK-NEXT:        %[[VAL_16:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_17:[0-9a-zA-Z_\.]+]] = %[[VAL_14]]) : (!felt.type) -> !felt.type {
+// CHECK-NEXT:          %[[VAL_18:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_17]], %[[VAL_17]])
+// CHECK-NEXT:          scf.condition(%[[VAL_18]]) %[[VAL_17]] : !felt.type
+// CHECK-NEXT:        } do {
+// CHECK-NEXT:        ^bb0(%[[VAL_19:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[VAL_20:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_21:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_19]], %[[VAL_20]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_21]] : !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    struct.def @Sum<[@N]> {
+// CHECK-NEXT:      function.def @compute(%[[VAL_22:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>) -> !struct.type<@Sum<[@N]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_23:[0-9a-zA-Z_\.]+]] = struct.new : <@Sum<[@N]>>
+// CHECK-NEXT:        %[[VAL_24:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type
+// CHECK-NEXT:        function.return %[[VAL_23]] : !struct.type<@Sum<[@N]>>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[VAL_25:[0-9a-zA-Z_\.]+]]: !struct.type<@Sum<[@N]>>, %[[VAL_26:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[VAL_27:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/declaration_in_template/array_dim_expr_param.circom
+++ b/circom/tests/declaration_in_template/array_dim_expr_param.circom
@@ -1,7 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL:.*
 
 pragma circom 2.0.0;
 
@@ -13,3 +12,33 @@ template A(s) {
 component main = A(12);
 
 // CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-NEXT:    struct.def @A<[@s]> {
+// CHECK-NEXT:      function.def @compute(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !array.type<@s x !felt.type>) -> !struct.type<@A<[@s]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = struct.new : <@A<[@s]>>
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = poly.read_const @s : !felt.type
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = array.new  : <@s x !felt.type>
+// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_4]], %[[VAL_5]] : <@s x !felt.type>
+// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[VAL_9:[0-9a-zA-Z_\.]+]] = %[[VAL_7]] to %[[VAL_6]] step %[[VAL_8]] {
+// CHECK-NEXT:          array.write %[[VAL_4]]{{\[}}%[[VAL_9]]] = %[[VAL_3]] : <@s x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.return %[[VAL_1]] : !struct.type<@A<[@s]>>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[VAL_10:[0-9a-zA-Z_\.]+]]: !struct.type<@A<[@s]>>, %[[VAL_11:[0-9a-zA-Z_\.]+]]: !array.type<@s x !felt.type>) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[VAL_12:[0-9a-zA-Z_\.]+]] = poly.read_const @s : !felt.type
+// CHECK-NEXT:        %[[VAL_13:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_14:[0-9a-zA-Z_\.]+]] = array.new  : <@s x !felt.type>
+// CHECK-NEXT:        %[[VAL_15:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_16:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_14]], %[[VAL_15]] : <@s x !felt.type>
+// CHECK-NEXT:        %[[VAL_17:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_18:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[VAL_19:[0-9a-zA-Z_\.]+]] = %[[VAL_17]] to %[[VAL_16]] step %[[VAL_18]] {
+// CHECK-NEXT:          array.write %[[VAL_14]]{{\[}}%[[VAL_19]]] = %[[VAL_13]] : <@s x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/loops/inner_conditional_07.circom
+++ b/circom/tests/loops/inner_conditional_07.circom
@@ -1,7 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL:.*
 
 pragma circom 2.0.0;
 
@@ -30,3 +29,121 @@ template InnerConditional7(N) {
 component main = InnerConditional7(3);
 
 // CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-NEXT:    struct.def @InnerConditional7<[@N]> {
+// CHECK-NEXT:      struct.field @out : !felt.type {llzk.pub}
+// CHECK-NEXT:      function.def @compute() -> !struct.type<@InnerConditional7<[@N]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_0:[0-9a-zA-Z_\.]+]] = struct.new : <@InnerConditional7<[@N]>>
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = array.new  : <@N x !felt.type>
+// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_3]], %[[VAL_4]] : <@N x !felt.type>
+// CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[VAL_8:[0-9a-zA-Z_\.]+]] = %[[VAL_6]] to %[[VAL_5]] step %[[VAL_7]] {
+// CHECK-NEXT:          array.write %[[VAL_3]]{{\[}}%[[VAL_8]]] = %[[VAL_2]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_9:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_11:[0-9a-zA-Z_\.]+]] = %[[VAL_3]], %[[VAL_12:[0-9a-zA-Z_\.]+]] = %[[VAL_9]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[VAL_13:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_12]], %[[VAL_1]])
+// CHECK-NEXT:          scf.condition(%[[VAL_13]]) %[[VAL_11]], %[[VAL_12]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:        } do {
+// CHECK-NEXT:        ^bb0(%[[VAL_14:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[VAL_15:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[VAL_16:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:          %[[VAL_17:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_18:[0-9a-zA-Z_\.]+]] = %[[VAL_14]], %[[VAL_19:[0-9a-zA-Z_\.]+]] = %[[VAL_16]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
+// CHECK-NEXT:            %[[VAL_20:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_19]], %[[VAL_1]])
+// CHECK-NEXT:            scf.condition(%[[VAL_20]]) %[[VAL_18]], %[[VAL_19]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:          } do {
+// CHECK-NEXT:          ^bb0(%[[VAL_21:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[VAL_22:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:            %[[VAL_23:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:            %[[VAL_24:[0-9a-zA-Z_\.]+]] = bool.cmp gt(%[[VAL_15]], %[[VAL_23]])
+// CHECK-NEXT:            %[[VAL_25:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_24]] -> (!array.type<@N x !felt.type>) {
+// CHECK-NEXT:              %[[VAL_26:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_22]]
+// CHECK-NEXT:              %[[VAL_27:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_21]]{{\[}}%[[VAL_26]]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              %[[VAL_28:[0-9a-zA-Z_\.]+]] = felt.const  999
+// CHECK-NEXT:              %[[VAL_29:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_27]], %[[VAL_28]] : !felt.type, !felt.type
+// CHECK-NEXT:              %[[VAL_30:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_22]]
+// CHECK-NEXT:              array.write %[[VAL_21]]{{\[}}%[[VAL_30]]] = %[[VAL_29]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              scf.yield %[[VAL_21]] : !array.type<@N x !felt.type>
+// CHECK-NEXT:            } else {
+// CHECK-NEXT:              %[[VAL_31:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_22]]
+// CHECK-NEXT:              %[[VAL_32:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_21]]{{\[}}%[[VAL_31]]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              %[[VAL_33:[0-9a-zA-Z_\.]+]] = felt.const  111
+// CHECK-NEXT:              %[[VAL_34:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_32]], %[[VAL_33]] : !felt.type, !felt.type
+// CHECK-NEXT:              %[[VAL_35:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_22]]
+// CHECK-NEXT:              array.write %[[VAL_21]]{{\[}}%[[VAL_35]]] = %[[VAL_34]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              scf.yield %[[VAL_21]] : !array.type<@N x !felt.type>
+// CHECK-NEXT:            }
+// CHECK-NEXT:            %[[VAL_36:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:            %[[VAL_37:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_22]], %[[VAL_36]] : !felt.type, !felt.type
+// CHECK-NEXT:            scf.yield %[[VAL_25]], %[[VAL_37]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:          }
+// CHECK-NEXT:          %[[VAL_38:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_39:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_15]], %[[VAL_38]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_17]]#0, %[[VAL_39]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_40:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_41:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_40]]
+// CHECK-NEXT:        %[[VAL_42:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_10]]#0{{\[}}%[[VAL_41]]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[VAL_43:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_44:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_43]]
+// CHECK-NEXT:        %[[VAL_45:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_10]]#0{{\[}}%[[VAL_44]]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[VAL_46:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_42]], %[[VAL_45]] : !felt.type, !felt.type
+// CHECK-NEXT:        struct.writef %[[VAL_0]][@out] = %[[VAL_46]] : <@InnerConditional7<[@N]>>, !felt.type
+// CHECK-NEXT:        function.return %[[VAL_0]] : !struct.type<@InnerConditional7<[@N]>>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[VAL_47:[0-9a-zA-Z_\.]+]]: !struct.type<@InnerConditional7<[@N]>>) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[VAL_48:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type
+// CHECK-NEXT:        %[[VAL_49:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_50:[0-9a-zA-Z_\.]+]] = array.new  : <@N x !felt.type>
+// CHECK-NEXT:        %[[VAL_51:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_52:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_50]], %[[VAL_51]] : <@N x !felt.type>
+// CHECK-NEXT:        %[[VAL_53:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_54:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[VAL_55:[0-9a-zA-Z_\.]+]] = %[[VAL_53]] to %[[VAL_52]] step %[[VAL_54]] {
+// CHECK-NEXT:          array.write %[[VAL_50]]{{\[}}%[[VAL_55]]] = %[[VAL_49]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_56:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_57:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_58:[0-9a-zA-Z_\.]+]] = %[[VAL_50]], %[[VAL_59:[0-9a-zA-Z_\.]+]] = %[[VAL_56]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[VAL_60:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_59]], %[[VAL_48]])
+// CHECK-NEXT:          scf.condition(%[[VAL_60]]) %[[VAL_58]], %[[VAL_59]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:        } do {
+// CHECK-NEXT:        ^bb0(%[[VAL_61:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[VAL_62:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[VAL_63:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:          %[[VAL_64:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_65:[0-9a-zA-Z_\.]+]] = %[[VAL_61]], %[[VAL_66:[0-9a-zA-Z_\.]+]] = %[[VAL_63]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
+// CHECK-NEXT:            %[[VAL_67:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_66]], %[[VAL_48]])
+// CHECK-NEXT:            scf.condition(%[[VAL_67]]) %[[VAL_65]], %[[VAL_66]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:          } do {
+// CHECK-NEXT:          ^bb0(%[[VAL_68:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[VAL_69:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:            %[[VAL_70:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:            %[[VAL_71:[0-9a-zA-Z_\.]+]] = bool.cmp gt(%[[VAL_62]], %[[VAL_70]])
+// CHECK-NEXT:            %[[VAL_72:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_71]] -> (!array.type<@N x !felt.type>) {
+// CHECK-NEXT:              %[[VAL_73:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_69]]
+// CHECK-NEXT:              %[[VAL_74:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_68]]{{\[}}%[[VAL_73]]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              %[[VAL_75:[0-9a-zA-Z_\.]+]] = felt.const  999
+// CHECK-NEXT:              %[[VAL_76:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_74]], %[[VAL_75]] : !felt.type, !felt.type
+// CHECK-NEXT:              %[[VAL_77:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_69]]
+// CHECK-NEXT:              array.write %[[VAL_68]]{{\[}}%[[VAL_77]]] = %[[VAL_76]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              scf.yield %[[VAL_68]] : !array.type<@N x !felt.type>
+// CHECK-NEXT:            } else {
+// CHECK-NEXT:              %[[VAL_78:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_69]]
+// CHECK-NEXT:              %[[VAL_79:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_68]]{{\[}}%[[VAL_78]]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              %[[VAL_80:[0-9a-zA-Z_\.]+]] = felt.const  111
+// CHECK-NEXT:              %[[VAL_81:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_79]], %[[VAL_80]] : !felt.type, !felt.type
+// CHECK-NEXT:              %[[VAL_82:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_69]]
+// CHECK-NEXT:              array.write %[[VAL_68]]{{\[}}%[[VAL_82]]] = %[[VAL_81]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              scf.yield %[[VAL_68]] : !array.type<@N x !felt.type>
+// CHECK-NEXT:            }
+// CHECK-NEXT:            %[[VAL_83:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:            %[[VAL_84:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_69]], %[[VAL_83]] : !felt.type, !felt.type
+// CHECK-NEXT:            scf.yield %[[VAL_72]], %[[VAL_84]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:          }
+// CHECK-NEXT:          %[[VAL_85:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_86:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_62]], %[[VAL_85]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_64]]#0, %[[VAL_86]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_87:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_47]][@out] : <@InnerConditional7<[@N]>>, !felt.type
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/loops/inner_conditional_07.circom
+++ b/circom/tests/loops/inner_conditional_07.circom
@@ -31,118 +31,120 @@ component main = InnerConditional7(3);
 // CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
 // CHECK-NEXT:    struct.def @InnerConditional7<[@N]> {
 // CHECK-NEXT:      struct.field @out : !felt.type {llzk.pub}
-// CHECK-NEXT:      function.def @compute() -> !struct.type<@InnerConditional7<[@N]>> attributes {function.allow_witness} {
-// CHECK-NEXT:        %[[VAL_0:[0-9a-zA-Z_\.]+]] = struct.new : <@InnerConditional7<[@N]>>
-// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type
-// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = array.new  : <@N x !felt.type>
-// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_3]], %[[VAL_4]] : <@N x !felt.type>
-// CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:        scf.for %[[VAL_8:[0-9a-zA-Z_\.]+]] = %[[VAL_6]] to %[[VAL_5]] step %[[VAL_7]] {
-// CHECK-NEXT:          array.write %[[VAL_3]]{{\[}}%[[VAL_8]]] = %[[VAL_2]] : <@N x !felt.type>, !felt.type
+// CHECK-LABEL:     function.def @compute
+// CHECK-SAME:      () -> !struct.type<@InnerConditional7<[@N]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[V_0:[0-9a-zA-Z_\.]+]] = struct.new : <@InnerConditional7<[@N]>>
+// CHECK-NEXT:        %[[V_N:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type
+// CHECK-NEXT:        %[[V_2:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_A:[0-9a-zA-Z_\.]+]] = array.new  : <@N x !felt.type>
+// CHECK-NEXT:        %[[V_4:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[V_5:[0-9a-zA-Z_\.]+]] = array.len %[[V_A]], %[[V_4]] : <@N x !felt.type>
+// CHECK-NEXT:        %[[V_6:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[V_7:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[V_8:[0-9a-zA-Z_\.]+]] = %[[V_6]] to %[[V_5]] step %[[V_7]] {
+// CHECK-NEXT:          array.write %[[V_A]]{{\[}}%[[V_8]]] = %[[V_2]] : <@N x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_9:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_11:[0-9a-zA-Z_\.]+]] = %[[VAL_3]], %[[VAL_12:[0-9a-zA-Z_\.]+]] = %[[VAL_9]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
-// CHECK-NEXT:          %[[VAL_13:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_12]], %[[VAL_1]])
-// CHECK-NEXT:          scf.condition(%[[VAL_13]]) %[[VAL_11]], %[[VAL_12]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[V_I0:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_10:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_A1:[0-9a-zA-Z_\.]+]] = %[[V_A]], %[[V_I1:[0-9a-zA-Z_\.]+]] = %[[V_I0]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[V_13:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[V_I1]], %[[V_N]])
+// CHECK-NEXT:          scf.condition(%[[V_13]]) %[[V_A1]], %[[V_I1]] : !array.type<@N x !felt.type>, !felt.type
 // CHECK-NEXT:        } do {
-// CHECK-NEXT:        ^bb0(%[[VAL_14:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[VAL_15:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:          %[[VAL_16:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:          %[[VAL_17:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_18:[0-9a-zA-Z_\.]+]] = %[[VAL_14]], %[[VAL_19:[0-9a-zA-Z_\.]+]] = %[[VAL_16]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
-// CHECK-NEXT:            %[[VAL_20:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_19]], %[[VAL_1]])
-// CHECK-NEXT:            scf.condition(%[[VAL_20]]) %[[VAL_18]], %[[VAL_19]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:        ^bb0(%[[V_A2:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[V_I2:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[V_J0:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:          %[[V_17:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_A3:[0-9a-zA-Z_\.]+]] = %[[V_A2]], %[[V_J1:[0-9a-zA-Z_\.]+]] = %[[V_J0]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
+// CHECK-NEXT:            %[[V_20:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[V_J1]], %[[V_N]])
+// CHECK-NEXT:            scf.condition(%[[V_20]]) %[[V_A3]], %[[V_J1]] : !array.type<@N x !felt.type>, !felt.type
 // CHECK-NEXT:          } do {
-// CHECK-NEXT:          ^bb0(%[[VAL_21:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[VAL_22:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:            %[[VAL_23:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:            %[[VAL_24:[0-9a-zA-Z_\.]+]] = bool.cmp gt(%[[VAL_15]], %[[VAL_23]])
-// CHECK-NEXT:            %[[VAL_25:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_24]] -> (!array.type<@N x !felt.type>) {
-// CHECK-NEXT:              %[[VAL_26:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_22]]
-// CHECK-NEXT:              %[[VAL_27:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_21]]{{\[}}%[[VAL_26]]] : <@N x !felt.type>, !felt.type
-// CHECK-NEXT:              %[[VAL_28:[0-9a-zA-Z_\.]+]] = felt.const  999
-// CHECK-NEXT:              %[[VAL_29:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_27]], %[[VAL_28]] : !felt.type, !felt.type
-// CHECK-NEXT:              %[[VAL_30:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_22]]
-// CHECK-NEXT:              array.write %[[VAL_21]]{{\[}}%[[VAL_30]]] = %[[VAL_29]] : <@N x !felt.type>, !felt.type
-// CHECK-NEXT:              scf.yield %[[VAL_21]] : !array.type<@N x !felt.type>
+// CHECK-NEXT:          ^bb0(%[[V_A4:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[V_J2:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:            %[[V_23:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:            %[[V_24:[0-9a-zA-Z_\.]+]] = bool.cmp gt(%[[V_I2]], %[[V_23]])
+// CHECK-NEXT:            %[[V_A5:[0-9a-zA-Z_\.]+]] = scf.if %[[V_24]] -> (!array.type<@N x !felt.type>) {
+// CHECK-NEXT:              %[[V_26:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_J2]]
+// CHECK-NEXT:              %[[V_27:[0-9a-zA-Z_\.]+]] = array.read %[[V_A4]]{{\[}}%[[V_26]]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              %[[V_28:[0-9a-zA-Z_\.]+]] = felt.const  999
+// CHECK-NEXT:              %[[V_29:[0-9a-zA-Z_\.]+]] = felt.add %[[V_27]], %[[V_28]] : !felt.type, !felt.type
+// CHECK-NEXT:              %[[V_30:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_J2]]
+// CHECK-NEXT:              array.write %[[V_A4]]{{\[}}%[[V_30]]] = %[[V_29]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              scf.yield %[[V_A4]] : !array.type<@N x !felt.type>
 // CHECK-NEXT:            } else {
-// CHECK-NEXT:              %[[VAL_31:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_22]]
-// CHECK-NEXT:              %[[VAL_32:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_21]]{{\[}}%[[VAL_31]]] : <@N x !felt.type>, !felt.type
-// CHECK-NEXT:              %[[VAL_33:[0-9a-zA-Z_\.]+]] = felt.const  111
-// CHECK-NEXT:              %[[VAL_34:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_32]], %[[VAL_33]] : !felt.type, !felt.type
-// CHECK-NEXT:              %[[VAL_35:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_22]]
-// CHECK-NEXT:              array.write %[[VAL_21]]{{\[}}%[[VAL_35]]] = %[[VAL_34]] : <@N x !felt.type>, !felt.type
-// CHECK-NEXT:              scf.yield %[[VAL_21]] : !array.type<@N x !felt.type>
+// CHECK-NEXT:              %[[V_31:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_J2]]
+// CHECK-NEXT:              %[[V_32:[0-9a-zA-Z_\.]+]] = array.read %[[V_A4]]{{\[}}%[[V_31]]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              %[[V_33:[0-9a-zA-Z_\.]+]] = felt.const  111
+// CHECK-NEXT:              %[[V_34:[0-9a-zA-Z_\.]+]] = felt.sub %[[V_32]], %[[V_33]] : !felt.type, !felt.type
+// CHECK-NEXT:              %[[V_35:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_J2]]
+// CHECK-NEXT:              array.write %[[V_A4]]{{\[}}%[[V_35]]] = %[[V_34]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              scf.yield %[[V_A4]] : !array.type<@N x !felt.type>
 // CHECK-NEXT:            }
-// CHECK-NEXT:            %[[VAL_36:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:            %[[VAL_37:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_22]], %[[VAL_36]] : !felt.type, !felt.type
-// CHECK-NEXT:            scf.yield %[[VAL_25]], %[[VAL_37]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:            %[[V_36:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:            %[[V_J3:[0-9a-zA-Z_\.]+]] = felt.add %[[V_J2]], %[[V_36]] : !felt.type, !felt.type
+// CHECK-NEXT:            scf.yield %[[V_A5]], %[[V_J3]] : !array.type<@N x !felt.type>, !felt.type
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[VAL_38:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:          %[[VAL_39:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_15]], %[[VAL_38]] : !felt.type, !felt.type
-// CHECK-NEXT:          scf.yield %[[VAL_17]]#0, %[[VAL_39]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_38:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[V_I3:[0-9a-zA-Z_\.]+]] = felt.add %[[V_I2]], %[[V_38]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[V_17]]#0, %[[V_I3]] : !array.type<@N x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_40:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_41:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_40]]
-// CHECK-NEXT:        %[[VAL_42:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_10]]#0{{\[}}%[[VAL_41]]] : <@N x !felt.type>, !felt.type
-// CHECK-NEXT:        %[[VAL_43:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:        %[[VAL_44:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_43]]
-// CHECK-NEXT:        %[[VAL_45:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_10]]#0{{\[}}%[[VAL_44]]] : <@N x !felt.type>, !felt.type
-// CHECK-NEXT:        %[[VAL_46:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_42]], %[[VAL_45]] : !felt.type, !felt.type
-// CHECK-NEXT:        struct.writef %[[VAL_0]][@out] = %[[VAL_46]] : <@InnerConditional7<[@N]>>, !felt.type
-// CHECK-NEXT:        function.return %[[VAL_0]] : !struct.type<@InnerConditional7<[@N]>>
+// CHECK-NEXT:        %[[V_40:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_41:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_40]]
+// CHECK-NEXT:        %[[V_42:[0-9a-zA-Z_\.]+]] = array.read %[[V_10]]#0{{\[}}%[[V_41]]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[V_43:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[V_44:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_43]]
+// CHECK-NEXT:        %[[V_45:[0-9a-zA-Z_\.]+]] = array.read %[[V_10]]#0{{\[}}%[[V_44]]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[V_46:[0-9a-zA-Z_\.]+]] = felt.add %[[V_42]], %[[V_45]] : !felt.type, !felt.type
+// CHECK-NEXT:        struct.writef %[[V_0]][@out] = %[[V_46]] : <@InnerConditional7<[@N]>>, !felt.type
+// CHECK-NEXT:        function.return %[[V_0]] : !struct.type<@InnerConditional7<[@N]>>
 // CHECK-NEXT:      }
-// CHECK-NEXT:      function.def @constrain(%[[VAL_47:[0-9a-zA-Z_\.]+]]: !struct.type<@InnerConditional7<[@N]>>) attributes {function.allow_constraint} {
-// CHECK-NEXT:        %[[VAL_48:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type
-// CHECK-NEXT:        %[[VAL_49:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_50:[0-9a-zA-Z_\.]+]] = array.new  : <@N x !felt.type>
-// CHECK-NEXT:        %[[VAL_51:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_52:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_50]], %[[VAL_51]] : <@N x !felt.type>
-// CHECK-NEXT:        %[[VAL_53:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_54:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:        scf.for %[[VAL_55:[0-9a-zA-Z_\.]+]] = %[[VAL_53]] to %[[VAL_52]] step %[[VAL_54]] {
-// CHECK-NEXT:          array.write %[[VAL_50]]{{\[}}%[[VAL_55]]] = %[[VAL_49]] : <@N x !felt.type>, !felt.type
+// CHECK-LABEL:     function.def @constrain
+// CHECK-SAME:      (%[[V_47:[0-9a-zA-Z_\.]+]]: !struct.type<@InnerConditional7<[@N]>>) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[V_N:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type
+// CHECK-NEXT:        %[[V_49:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_A:[0-9a-zA-Z_\.]+]] = array.new  : <@N x !felt.type>
+// CHECK-NEXT:        %[[V_51:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[V_52:[0-9a-zA-Z_\.]+]] = array.len %[[V_A]], %[[V_51]] : <@N x !felt.type>
+// CHECK-NEXT:        %[[V_53:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[V_54:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[V_55:[0-9a-zA-Z_\.]+]] = %[[V_53]] to %[[V_52]] step %[[V_54]] {
+// CHECK-NEXT:          array.write %[[V_A]]{{\[}}%[[V_55]]] = %[[V_49]] : <@N x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_56:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_57:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_58:[0-9a-zA-Z_\.]+]] = %[[VAL_50]], %[[VAL_59:[0-9a-zA-Z_\.]+]] = %[[VAL_56]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
-// CHECK-NEXT:          %[[VAL_60:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_59]], %[[VAL_48]])
-// CHECK-NEXT:          scf.condition(%[[VAL_60]]) %[[VAL_58]], %[[VAL_59]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[V_I0:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_57:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_A1:[0-9a-zA-Z_\.]+]] = %[[V_A]], %[[V_I1:[0-9a-zA-Z_\.]+]] = %[[V_I0]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[V_60:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[V_I1]], %[[V_N]])
+// CHECK-NEXT:          scf.condition(%[[V_60]]) %[[V_A1]], %[[V_I1]] : !array.type<@N x !felt.type>, !felt.type
 // CHECK-NEXT:        } do {
-// CHECK-NEXT:        ^bb0(%[[VAL_61:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[VAL_62:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:          %[[VAL_63:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:          %[[VAL_64:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_65:[0-9a-zA-Z_\.]+]] = %[[VAL_61]], %[[VAL_66:[0-9a-zA-Z_\.]+]] = %[[VAL_63]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
-// CHECK-NEXT:            %[[VAL_67:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_66]], %[[VAL_48]])
-// CHECK-NEXT:            scf.condition(%[[VAL_67]]) %[[VAL_65]], %[[VAL_66]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:        ^bb0(%[[V_A2:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[V_I2:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[V_J0:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:          %[[V_64:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_A3:[0-9a-zA-Z_\.]+]] = %[[V_A2]], %[[V_J1:[0-9a-zA-Z_\.]+]] = %[[V_J0]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
+// CHECK-NEXT:            %[[V_67:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[V_J1]], %[[V_N]])
+// CHECK-NEXT:            scf.condition(%[[V_67]]) %[[V_A3]], %[[V_J1]] : !array.type<@N x !felt.type>, !felt.type
 // CHECK-NEXT:          } do {
-// CHECK-NEXT:          ^bb0(%[[VAL_68:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[VAL_69:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:            %[[VAL_70:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:            %[[VAL_71:[0-9a-zA-Z_\.]+]] = bool.cmp gt(%[[VAL_62]], %[[VAL_70]])
-// CHECK-NEXT:            %[[VAL_72:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_71]] -> (!array.type<@N x !felt.type>) {
-// CHECK-NEXT:              %[[VAL_73:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_69]]
-// CHECK-NEXT:              %[[VAL_74:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_68]]{{\[}}%[[VAL_73]]] : <@N x !felt.type>, !felt.type
-// CHECK-NEXT:              %[[VAL_75:[0-9a-zA-Z_\.]+]] = felt.const  999
-// CHECK-NEXT:              %[[VAL_76:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_74]], %[[VAL_75]] : !felt.type, !felt.type
-// CHECK-NEXT:              %[[VAL_77:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_69]]
-// CHECK-NEXT:              array.write %[[VAL_68]]{{\[}}%[[VAL_77]]] = %[[VAL_76]] : <@N x !felt.type>, !felt.type
-// CHECK-NEXT:              scf.yield %[[VAL_68]] : !array.type<@N x !felt.type>
+// CHECK-NEXT:          ^bb0(%[[V_A4:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[V_J2:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:            %[[V_70:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:            %[[V_71:[0-9a-zA-Z_\.]+]] = bool.cmp gt(%[[V_I2]], %[[V_70]])
+// CHECK-NEXT:            %[[V_A5:[0-9a-zA-Z_\.]+]] = scf.if %[[V_71]] -> (!array.type<@N x !felt.type>) {
+// CHECK-NEXT:              %[[V_73:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_J2]]
+// CHECK-NEXT:              %[[V_74:[0-9a-zA-Z_\.]+]] = array.read %[[V_A4]]{{\[}}%[[V_73]]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              %[[V_75:[0-9a-zA-Z_\.]+]] = felt.const  999
+// CHECK-NEXT:              %[[V_76:[0-9a-zA-Z_\.]+]] = felt.add %[[V_74]], %[[V_75]] : !felt.type, !felt.type
+// CHECK-NEXT:              %[[V_77:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_J2]]
+// CHECK-NEXT:              array.write %[[V_A4]]{{\[}}%[[V_77]]] = %[[V_76]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              scf.yield %[[V_A4]] : !array.type<@N x !felt.type>
 // CHECK-NEXT:            } else {
-// CHECK-NEXT:              %[[VAL_78:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_69]]
-// CHECK-NEXT:              %[[VAL_79:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_68]]{{\[}}%[[VAL_78]]] : <@N x !felt.type>, !felt.type
-// CHECK-NEXT:              %[[VAL_80:[0-9a-zA-Z_\.]+]] = felt.const  111
-// CHECK-NEXT:              %[[VAL_81:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_79]], %[[VAL_80]] : !felt.type, !felt.type
-// CHECK-NEXT:              %[[VAL_82:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_69]]
-// CHECK-NEXT:              array.write %[[VAL_68]]{{\[}}%[[VAL_82]]] = %[[VAL_81]] : <@N x !felt.type>, !felt.type
-// CHECK-NEXT:              scf.yield %[[VAL_68]] : !array.type<@N x !felt.type>
+// CHECK-NEXT:              %[[V_78:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_J2]]
+// CHECK-NEXT:              %[[V_79:[0-9a-zA-Z_\.]+]] = array.read %[[V_A4]]{{\[}}%[[V_78]]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              %[[V_80:[0-9a-zA-Z_\.]+]] = felt.const  111
+// CHECK-NEXT:              %[[V_81:[0-9a-zA-Z_\.]+]] = felt.sub %[[V_79]], %[[V_80]] : !felt.type, !felt.type
+// CHECK-NEXT:              %[[V_82:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_J2]]
+// CHECK-NEXT:              array.write %[[V_A4]]{{\[}}%[[V_82]]] = %[[V_81]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              scf.yield %[[V_A4]] : !array.type<@N x !felt.type>
 // CHECK-NEXT:            }
-// CHECK-NEXT:            %[[VAL_83:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:            %[[VAL_84:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_69]], %[[VAL_83]] : !felt.type, !felt.type
-// CHECK-NEXT:            scf.yield %[[VAL_72]], %[[VAL_84]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:            %[[V_83:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:            %[[V_J3:[0-9a-zA-Z_\.]+]] = felt.add %[[V_J2]], %[[V_83]] : !felt.type, !felt.type
+// CHECK-NEXT:            scf.yield %[[V_A5]], %[[V_J3]] : !array.type<@N x !felt.type>, !felt.type
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[VAL_85:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:          %[[VAL_86:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_62]], %[[VAL_85]] : !felt.type, !felt.type
-// CHECK-NEXT:          scf.yield %[[VAL_64]]#0, %[[VAL_86]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_85:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[V_I3:[0-9a-zA-Z_\.]+]] = felt.add %[[V_I2]], %[[V_85]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[V_64]]#0, %[[V_I3]] : !array.type<@N x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_87:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_47]][@out] : <@InnerConditional7<[@N]>>, !felt.type
+// CHECK-NEXT:        %[[V_87:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_47]][@out] : <@InnerConditional7<[@N]>>, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }

--- a/circom/tests/loops/inner_conditional_08.circom
+++ b/circom/tests/loops/inner_conditional_08.circom
@@ -1,7 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL:.*
 
 pragma circom 2.0.0;
 
@@ -31,3 +30,121 @@ template InnerConditional8(N) {
 component main = InnerConditional8(4);
 
 // CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-NEXT:    struct.def @InnerConditional8<[@N]> {
+// CHECK-NEXT:      struct.field @out : !felt.type {llzk.pub}
+// CHECK-NEXT:      function.def @compute() -> !struct.type<@InnerConditional8<[@N]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_0:[0-9a-zA-Z_\.]+]] = struct.new : <@InnerConditional8<[@N]>>
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = array.new  : <@N x !felt.type>
+// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_3]], %[[VAL_4]] : <@N x !felt.type>
+// CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[VAL_8:[0-9a-zA-Z_\.]+]] = %[[VAL_6]] to %[[VAL_5]] step %[[VAL_7]] {
+// CHECK-NEXT:          array.write %[[VAL_3]]{{\[}}%[[VAL_8]]] = %[[VAL_2]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_9:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_11:[0-9a-zA-Z_\.]+]] = %[[VAL_3]], %[[VAL_12:[0-9a-zA-Z_\.]+]] = %[[VAL_9]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[VAL_13:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_12]], %[[VAL_1]])
+// CHECK-NEXT:          scf.condition(%[[VAL_13]]) %[[VAL_11]], %[[VAL_12]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:        } do {
+// CHECK-NEXT:        ^bb0(%[[VAL_14:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[VAL_15:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[VAL_16:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:          %[[VAL_17:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_18:[0-9a-zA-Z_\.]+]] = %[[VAL_14]], %[[VAL_19:[0-9a-zA-Z_\.]+]] = %[[VAL_16]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
+// CHECK-NEXT:            %[[VAL_20:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_19]], %[[VAL_1]])
+// CHECK-NEXT:            scf.condition(%[[VAL_20]]) %[[VAL_18]], %[[VAL_19]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:          } do {
+// CHECK-NEXT:          ^bb0(%[[VAL_21:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[VAL_22:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:            %[[VAL_23:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:            %[[VAL_24:[0-9a-zA-Z_\.]+]] = bool.cmp gt(%[[VAL_22]], %[[VAL_23]])
+// CHECK-NEXT:            %[[VAL_25:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_24]] -> (!array.type<@N x !felt.type>) {
+// CHECK-NEXT:              %[[VAL_26:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_15]]
+// CHECK-NEXT:              %[[VAL_27:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_21]]{{\[}}%[[VAL_26]]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              %[[VAL_28:[0-9a-zA-Z_\.]+]] = felt.const  999
+// CHECK-NEXT:              %[[VAL_29:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_27]], %[[VAL_28]] : !felt.type, !felt.type
+// CHECK-NEXT:              %[[VAL_30:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_15]]
+// CHECK-NEXT:              array.write %[[VAL_21]]{{\[}}%[[VAL_30]]] = %[[VAL_29]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              scf.yield %[[VAL_21]] : !array.type<@N x !felt.type>
+// CHECK-NEXT:            } else {
+// CHECK-NEXT:              %[[VAL_31:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_15]]
+// CHECK-NEXT:              %[[VAL_32:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_21]]{{\[}}%[[VAL_31]]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              %[[VAL_33:[0-9a-zA-Z_\.]+]] = felt.const  111
+// CHECK-NEXT:              %[[VAL_34:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_32]], %[[VAL_33]] : !felt.type, !felt.type
+// CHECK-NEXT:              %[[VAL_35:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_15]]
+// CHECK-NEXT:              array.write %[[VAL_21]]{{\[}}%[[VAL_35]]] = %[[VAL_34]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              scf.yield %[[VAL_21]] : !array.type<@N x !felt.type>
+// CHECK-NEXT:            }
+// CHECK-NEXT:            %[[VAL_36:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:            %[[VAL_37:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_22]], %[[VAL_36]] : !felt.type, !felt.type
+// CHECK-NEXT:            scf.yield %[[VAL_25]], %[[VAL_37]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:          }
+// CHECK-NEXT:          %[[VAL_38:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_39:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_15]], %[[VAL_38]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_17]]#0, %[[VAL_39]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_40:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_41:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_40]]
+// CHECK-NEXT:        %[[VAL_42:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_10]]#0{{\[}}%[[VAL_41]]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[VAL_43:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_44:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_43]]
+// CHECK-NEXT:        %[[VAL_45:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_10]]#0{{\[}}%[[VAL_44]]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[VAL_46:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_42]], %[[VAL_45]] : !felt.type, !felt.type
+// CHECK-NEXT:        struct.writef %[[VAL_0]][@out] = %[[VAL_46]] : <@InnerConditional8<[@N]>>, !felt.type
+// CHECK-NEXT:        function.return %[[VAL_0]] : !struct.type<@InnerConditional8<[@N]>>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[VAL_47:[0-9a-zA-Z_\.]+]]: !struct.type<@InnerConditional8<[@N]>>) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[VAL_48:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type
+// CHECK-NEXT:        %[[VAL_49:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_50:[0-9a-zA-Z_\.]+]] = array.new  : <@N x !felt.type>
+// CHECK-NEXT:        %[[VAL_51:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_52:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_50]], %[[VAL_51]] : <@N x !felt.type>
+// CHECK-NEXT:        %[[VAL_53:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_54:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[VAL_55:[0-9a-zA-Z_\.]+]] = %[[VAL_53]] to %[[VAL_52]] step %[[VAL_54]] {
+// CHECK-NEXT:          array.write %[[VAL_50]]{{\[}}%[[VAL_55]]] = %[[VAL_49]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_56:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_57:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_58:[0-9a-zA-Z_\.]+]] = %[[VAL_50]], %[[VAL_59:[0-9a-zA-Z_\.]+]] = %[[VAL_56]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[VAL_60:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_59]], %[[VAL_48]])
+// CHECK-NEXT:          scf.condition(%[[VAL_60]]) %[[VAL_58]], %[[VAL_59]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:        } do {
+// CHECK-NEXT:        ^bb0(%[[VAL_61:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[VAL_62:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[VAL_63:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:          %[[VAL_64:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_65:[0-9a-zA-Z_\.]+]] = %[[VAL_61]], %[[VAL_66:[0-9a-zA-Z_\.]+]] = %[[VAL_63]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
+// CHECK-NEXT:            %[[VAL_67:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_66]], %[[VAL_48]])
+// CHECK-NEXT:            scf.condition(%[[VAL_67]]) %[[VAL_65]], %[[VAL_66]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:          } do {
+// CHECK-NEXT:          ^bb0(%[[VAL_68:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[VAL_69:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:            %[[VAL_70:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:            %[[VAL_71:[0-9a-zA-Z_\.]+]] = bool.cmp gt(%[[VAL_69]], %[[VAL_70]])
+// CHECK-NEXT:            %[[VAL_72:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_71]] -> (!array.type<@N x !felt.type>) {
+// CHECK-NEXT:              %[[VAL_73:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_62]]
+// CHECK-NEXT:              %[[VAL_74:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_68]]{{\[}}%[[VAL_73]]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              %[[VAL_75:[0-9a-zA-Z_\.]+]] = felt.const  999
+// CHECK-NEXT:              %[[VAL_76:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_74]], %[[VAL_75]] : !felt.type, !felt.type
+// CHECK-NEXT:              %[[VAL_77:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_62]]
+// CHECK-NEXT:              array.write %[[VAL_68]]{{\[}}%[[VAL_77]]] = %[[VAL_76]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              scf.yield %[[VAL_68]] : !array.type<@N x !felt.type>
+// CHECK-NEXT:            } else {
+// CHECK-NEXT:              %[[VAL_78:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_62]]
+// CHECK-NEXT:              %[[VAL_79:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_68]]{{\[}}%[[VAL_78]]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              %[[VAL_80:[0-9a-zA-Z_\.]+]] = felt.const  111
+// CHECK-NEXT:              %[[VAL_81:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_79]], %[[VAL_80]] : !felt.type, !felt.type
+// CHECK-NEXT:              %[[VAL_82:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_62]]
+// CHECK-NEXT:              array.write %[[VAL_68]]{{\[}}%[[VAL_82]]] = %[[VAL_81]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              scf.yield %[[VAL_68]] : !array.type<@N x !felt.type>
+// CHECK-NEXT:            }
+// CHECK-NEXT:            %[[VAL_83:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:            %[[VAL_84:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_69]], %[[VAL_83]] : !felt.type, !felt.type
+// CHECK-NEXT:            scf.yield %[[VAL_72]], %[[VAL_84]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:          }
+// CHECK-NEXT:          %[[VAL_85:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_86:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_62]], %[[VAL_85]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_64]]#0, %[[VAL_86]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_87:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_47]][@out] : <@InnerConditional8<[@N]>>, !felt.type
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/loops/inner_conditional_08.circom
+++ b/circom/tests/loops/inner_conditional_08.circom
@@ -32,118 +32,120 @@ component main = InnerConditional8(4);
 // CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
 // CHECK-NEXT:    struct.def @InnerConditional8<[@N]> {
 // CHECK-NEXT:      struct.field @out : !felt.type {llzk.pub}
-// CHECK-NEXT:      function.def @compute() -> !struct.type<@InnerConditional8<[@N]>> attributes {function.allow_witness} {
-// CHECK-NEXT:        %[[VAL_0:[0-9a-zA-Z_\.]+]] = struct.new : <@InnerConditional8<[@N]>>
-// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type
-// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = array.new  : <@N x !felt.type>
-// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_3]], %[[VAL_4]] : <@N x !felt.type>
-// CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:        scf.for %[[VAL_8:[0-9a-zA-Z_\.]+]] = %[[VAL_6]] to %[[VAL_5]] step %[[VAL_7]] {
-// CHECK-NEXT:          array.write %[[VAL_3]]{{\[}}%[[VAL_8]]] = %[[VAL_2]] : <@N x !felt.type>, !felt.type
+// CHECK-LABEL:     function.def @compute
+// CHECK-SAME:      () -> !struct.type<@InnerConditional8<[@N]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[V_0:[0-9a-zA-Z_\.]+]] = struct.new : <@InnerConditional8<[@N]>>
+// CHECK-NEXT:        %[[V_N:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type
+// CHECK-NEXT:        %[[V_2:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_A:[0-9a-zA-Z_\.]+]] = array.new  : <@N x !felt.type>
+// CHECK-NEXT:        %[[V_4:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[V_5:[0-9a-zA-Z_\.]+]] = array.len %[[V_A]], %[[V_4]] : <@N x !felt.type>
+// CHECK-NEXT:        %[[V_6:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[V_7:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[V_8:[0-9a-zA-Z_\.]+]] = %[[V_6]] to %[[V_5]] step %[[V_7]] {
+// CHECK-NEXT:          array.write %[[V_A]]{{\[}}%[[V_8]]] = %[[V_2]] : <@N x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_9:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_11:[0-9a-zA-Z_\.]+]] = %[[VAL_3]], %[[VAL_12:[0-9a-zA-Z_\.]+]] = %[[VAL_9]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
-// CHECK-NEXT:          %[[VAL_13:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_12]], %[[VAL_1]])
-// CHECK-NEXT:          scf.condition(%[[VAL_13]]) %[[VAL_11]], %[[VAL_12]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[V_I0:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_10:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_A1:[0-9a-zA-Z_\.]+]] = %[[V_A]], %[[V_I1:[0-9a-zA-Z_\.]+]] = %[[V_I0]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[V_13:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[V_I1]], %[[V_N]])
+// CHECK-NEXT:          scf.condition(%[[V_13]]) %[[V_A1]], %[[V_I1]] : !array.type<@N x !felt.type>, !felt.type
 // CHECK-NEXT:        } do {
-// CHECK-NEXT:        ^bb0(%[[VAL_14:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[VAL_15:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:          %[[VAL_16:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:          %[[VAL_17:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_18:[0-9a-zA-Z_\.]+]] = %[[VAL_14]], %[[VAL_19:[0-9a-zA-Z_\.]+]] = %[[VAL_16]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
-// CHECK-NEXT:            %[[VAL_20:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_19]], %[[VAL_1]])
-// CHECK-NEXT:            scf.condition(%[[VAL_20]]) %[[VAL_18]], %[[VAL_19]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:        ^bb0(%[[V_A2:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[V_I2:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[V_J0:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:          %[[V_17:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_A3:[0-9a-zA-Z_\.]+]] = %[[V_A2]], %[[V_J1:[0-9a-zA-Z_\.]+]] = %[[V_J0]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
+// CHECK-NEXT:            %[[V_20:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[V_J1]], %[[V_N]])
+// CHECK-NEXT:            scf.condition(%[[V_20]]) %[[V_A3]], %[[V_J1]] : !array.type<@N x !felt.type>, !felt.type
 // CHECK-NEXT:          } do {
-// CHECK-NEXT:          ^bb0(%[[VAL_21:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[VAL_22:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:            %[[VAL_23:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:            %[[VAL_24:[0-9a-zA-Z_\.]+]] = bool.cmp gt(%[[VAL_22]], %[[VAL_23]])
-// CHECK-NEXT:            %[[VAL_25:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_24]] -> (!array.type<@N x !felt.type>) {
-// CHECK-NEXT:              %[[VAL_26:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_15]]
-// CHECK-NEXT:              %[[VAL_27:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_21]]{{\[}}%[[VAL_26]]] : <@N x !felt.type>, !felt.type
-// CHECK-NEXT:              %[[VAL_28:[0-9a-zA-Z_\.]+]] = felt.const  999
-// CHECK-NEXT:              %[[VAL_29:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_27]], %[[VAL_28]] : !felt.type, !felt.type
-// CHECK-NEXT:              %[[VAL_30:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_15]]
-// CHECK-NEXT:              array.write %[[VAL_21]]{{\[}}%[[VAL_30]]] = %[[VAL_29]] : <@N x !felt.type>, !felt.type
-// CHECK-NEXT:              scf.yield %[[VAL_21]] : !array.type<@N x !felt.type>
+// CHECK-NEXT:          ^bb0(%[[V_A4:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[V_J2:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:            %[[V_23:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:            %[[V_24:[0-9a-zA-Z_\.]+]] = bool.cmp gt(%[[V_J2]], %[[V_23]])
+// CHECK-NEXT:            %[[V_A5:[0-9a-zA-Z_\.]+]] = scf.if %[[V_24]] -> (!array.type<@N x !felt.type>) {
+// CHECK-NEXT:              %[[V_26:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_I2]]
+// CHECK-NEXT:              %[[V_27:[0-9a-zA-Z_\.]+]] = array.read %[[V_A4]]{{\[}}%[[V_26]]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              %[[V_28:[0-9a-zA-Z_\.]+]] = felt.const  999
+// CHECK-NEXT:              %[[V_29:[0-9a-zA-Z_\.]+]] = felt.add %[[V_27]], %[[V_28]] : !felt.type, !felt.type
+// CHECK-NEXT:              %[[V_30:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_I2]]
+// CHECK-NEXT:              array.write %[[V_A4]]{{\[}}%[[V_30]]] = %[[V_29]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              scf.yield %[[V_A4]] : !array.type<@N x !felt.type>
 // CHECK-NEXT:            } else {
-// CHECK-NEXT:              %[[VAL_31:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_15]]
-// CHECK-NEXT:              %[[VAL_32:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_21]]{{\[}}%[[VAL_31]]] : <@N x !felt.type>, !felt.type
-// CHECK-NEXT:              %[[VAL_33:[0-9a-zA-Z_\.]+]] = felt.const  111
-// CHECK-NEXT:              %[[VAL_34:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_32]], %[[VAL_33]] : !felt.type, !felt.type
-// CHECK-NEXT:              %[[VAL_35:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_15]]
-// CHECK-NEXT:              array.write %[[VAL_21]]{{\[}}%[[VAL_35]]] = %[[VAL_34]] : <@N x !felt.type>, !felt.type
-// CHECK-NEXT:              scf.yield %[[VAL_21]] : !array.type<@N x !felt.type>
+// CHECK-NEXT:              %[[V_31:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_I2]]
+// CHECK-NEXT:              %[[V_32:[0-9a-zA-Z_\.]+]] = array.read %[[V_A4]]{{\[}}%[[V_31]]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              %[[V_33:[0-9a-zA-Z_\.]+]] = felt.const  111
+// CHECK-NEXT:              %[[V_34:[0-9a-zA-Z_\.]+]] = felt.sub %[[V_32]], %[[V_33]] : !felt.type, !felt.type
+// CHECK-NEXT:              %[[V_35:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_I2]]
+// CHECK-NEXT:              array.write %[[V_A4]]{{\[}}%[[V_35]]] = %[[V_34]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              scf.yield %[[V_A4]] : !array.type<@N x !felt.type>
 // CHECK-NEXT:            }
-// CHECK-NEXT:            %[[VAL_36:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:            %[[VAL_37:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_22]], %[[VAL_36]] : !felt.type, !felt.type
-// CHECK-NEXT:            scf.yield %[[VAL_25]], %[[VAL_37]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:            %[[V_36:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:            %[[V_J3:[0-9a-zA-Z_\.]+]] = felt.add %[[V_J2]], %[[V_36]] : !felt.type, !felt.type
+// CHECK-NEXT:            scf.yield %[[V_A5]], %[[V_J3]] : !array.type<@N x !felt.type>, !felt.type
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[VAL_38:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:          %[[VAL_39:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_15]], %[[VAL_38]] : !felt.type, !felt.type
-// CHECK-NEXT:          scf.yield %[[VAL_17]]#0, %[[VAL_39]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_38:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[V_I3:[0-9a-zA-Z_\.]+]] = felt.add %[[V_I2]], %[[V_38]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[V_17]]#0, %[[V_I3]] : !array.type<@N x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_40:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_41:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_40]]
-// CHECK-NEXT:        %[[VAL_42:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_10]]#0{{\[}}%[[VAL_41]]] : <@N x !felt.type>, !felt.type
-// CHECK-NEXT:        %[[VAL_43:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:        %[[VAL_44:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_43]]
-// CHECK-NEXT:        %[[VAL_45:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_10]]#0{{\[}}%[[VAL_44]]] : <@N x !felt.type>, !felt.type
-// CHECK-NEXT:        %[[VAL_46:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_42]], %[[VAL_45]] : !felt.type, !felt.type
-// CHECK-NEXT:        struct.writef %[[VAL_0]][@out] = %[[VAL_46]] : <@InnerConditional8<[@N]>>, !felt.type
-// CHECK-NEXT:        function.return %[[VAL_0]] : !struct.type<@InnerConditional8<[@N]>>
+// CHECK-NEXT:        %[[V_40:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_41:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_40]]
+// CHECK-NEXT:        %[[V_42:[0-9a-zA-Z_\.]+]] = array.read %[[V_10]]#0{{\[}}%[[V_41]]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[V_43:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[V_44:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_43]]
+// CHECK-NEXT:        %[[V_45:[0-9a-zA-Z_\.]+]] = array.read %[[V_10]]#0{{\[}}%[[V_44]]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[V_46:[0-9a-zA-Z_\.]+]] = felt.add %[[V_42]], %[[V_45]] : !felt.type, !felt.type
+// CHECK-NEXT:        struct.writef %[[V_0]][@out] = %[[V_46]] : <@InnerConditional8<[@N]>>, !felt.type
+// CHECK-NEXT:        function.return %[[V_0]] : !struct.type<@InnerConditional8<[@N]>>
 // CHECK-NEXT:      }
-// CHECK-NEXT:      function.def @constrain(%[[VAL_47:[0-9a-zA-Z_\.]+]]: !struct.type<@InnerConditional8<[@N]>>) attributes {function.allow_constraint} {
-// CHECK-NEXT:        %[[VAL_48:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type
-// CHECK-NEXT:        %[[VAL_49:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_50:[0-9a-zA-Z_\.]+]] = array.new  : <@N x !felt.type>
-// CHECK-NEXT:        %[[VAL_51:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_52:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_50]], %[[VAL_51]] : <@N x !felt.type>
-// CHECK-NEXT:        %[[VAL_53:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_54:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:        scf.for %[[VAL_55:[0-9a-zA-Z_\.]+]] = %[[VAL_53]] to %[[VAL_52]] step %[[VAL_54]] {
-// CHECK-NEXT:          array.write %[[VAL_50]]{{\[}}%[[VAL_55]]] = %[[VAL_49]] : <@N x !felt.type>, !felt.type
+// CHECK-LABEL:     function.def @constrain
+// CHECK-SAME:      (%[[V_47:[0-9a-zA-Z_\.]+]]: !struct.type<@InnerConditional8<[@N]>>) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[V_N:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type
+// CHECK-NEXT:        %[[V_49:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_A:[0-9a-zA-Z_\.]+]] = array.new  : <@N x !felt.type>
+// CHECK-NEXT:        %[[V_51:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[V_52:[0-9a-zA-Z_\.]+]] = array.len %[[V_A]], %[[V_51]] : <@N x !felt.type>
+// CHECK-NEXT:        %[[V_53:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[V_54:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[V_55:[0-9a-zA-Z_\.]+]] = %[[V_53]] to %[[V_52]] step %[[V_54]] {
+// CHECK-NEXT:          array.write %[[V_A]]{{\[}}%[[V_55]]] = %[[V_49]] : <@N x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_56:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_57:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_58:[0-9a-zA-Z_\.]+]] = %[[VAL_50]], %[[VAL_59:[0-9a-zA-Z_\.]+]] = %[[VAL_56]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
-// CHECK-NEXT:          %[[VAL_60:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_59]], %[[VAL_48]])
-// CHECK-NEXT:          scf.condition(%[[VAL_60]]) %[[VAL_58]], %[[VAL_59]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[V_56:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_57:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_58:[0-9a-zA-Z_\.]+]] = %[[V_A]], %[[V_59:[0-9a-zA-Z_\.]+]] = %[[V_56]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[V_60:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[V_59]], %[[V_N]])
+// CHECK-NEXT:          scf.condition(%[[V_60]]) %[[V_58]], %[[V_59]] : !array.type<@N x !felt.type>, !felt.type
 // CHECK-NEXT:        } do {
-// CHECK-NEXT:        ^bb0(%[[VAL_61:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[VAL_62:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:          %[[VAL_63:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:          %[[VAL_64:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_65:[0-9a-zA-Z_\.]+]] = %[[VAL_61]], %[[VAL_66:[0-9a-zA-Z_\.]+]] = %[[VAL_63]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
-// CHECK-NEXT:            %[[VAL_67:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_66]], %[[VAL_48]])
-// CHECK-NEXT:            scf.condition(%[[VAL_67]]) %[[VAL_65]], %[[VAL_66]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:        ^bb0(%[[V_61:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[V_62:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[V_63:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:          %[[V_64:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_65:[0-9a-zA-Z_\.]+]] = %[[V_61]], %[[V_66:[0-9a-zA-Z_\.]+]] = %[[V_63]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
+// CHECK-NEXT:            %[[V_67:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[V_66]], %[[V_N]])
+// CHECK-NEXT:            scf.condition(%[[V_67]]) %[[V_65]], %[[V_66]] : !array.type<@N x !felt.type>, !felt.type
 // CHECK-NEXT:          } do {
-// CHECK-NEXT:          ^bb0(%[[VAL_68:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[VAL_69:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:            %[[VAL_70:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:            %[[VAL_71:[0-9a-zA-Z_\.]+]] = bool.cmp gt(%[[VAL_69]], %[[VAL_70]])
-// CHECK-NEXT:            %[[VAL_72:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_71]] -> (!array.type<@N x !felt.type>) {
-// CHECK-NEXT:              %[[VAL_73:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_62]]
-// CHECK-NEXT:              %[[VAL_74:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_68]]{{\[}}%[[VAL_73]]] : <@N x !felt.type>, !felt.type
-// CHECK-NEXT:              %[[VAL_75:[0-9a-zA-Z_\.]+]] = felt.const  999
-// CHECK-NEXT:              %[[VAL_76:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_74]], %[[VAL_75]] : !felt.type, !felt.type
-// CHECK-NEXT:              %[[VAL_77:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_62]]
-// CHECK-NEXT:              array.write %[[VAL_68]]{{\[}}%[[VAL_77]]] = %[[VAL_76]] : <@N x !felt.type>, !felt.type
-// CHECK-NEXT:              scf.yield %[[VAL_68]] : !array.type<@N x !felt.type>
+// CHECK-NEXT:          ^bb0(%[[V_68:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[V_69:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:            %[[V_70:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:            %[[V_71:[0-9a-zA-Z_\.]+]] = bool.cmp gt(%[[V_69]], %[[V_70]])
+// CHECK-NEXT:            %[[V_72:[0-9a-zA-Z_\.]+]] = scf.if %[[V_71]] -> (!array.type<@N x !felt.type>) {
+// CHECK-NEXT:              %[[V_73:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_62]]
+// CHECK-NEXT:              %[[V_74:[0-9a-zA-Z_\.]+]] = array.read %[[V_68]]{{\[}}%[[V_73]]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              %[[V_75:[0-9a-zA-Z_\.]+]] = felt.const  999
+// CHECK-NEXT:              %[[V_76:[0-9a-zA-Z_\.]+]] = felt.add %[[V_74]], %[[V_75]] : !felt.type, !felt.type
+// CHECK-NEXT:              %[[V_77:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_62]]
+// CHECK-NEXT:              array.write %[[V_68]]{{\[}}%[[V_77]]] = %[[V_76]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              scf.yield %[[V_68]] : !array.type<@N x !felt.type>
 // CHECK-NEXT:            } else {
-// CHECK-NEXT:              %[[VAL_78:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_62]]
-// CHECK-NEXT:              %[[VAL_79:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_68]]{{\[}}%[[VAL_78]]] : <@N x !felt.type>, !felt.type
-// CHECK-NEXT:              %[[VAL_80:[0-9a-zA-Z_\.]+]] = felt.const  111
-// CHECK-NEXT:              %[[VAL_81:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_79]], %[[VAL_80]] : !felt.type, !felt.type
-// CHECK-NEXT:              %[[VAL_82:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_62]]
-// CHECK-NEXT:              array.write %[[VAL_68]]{{\[}}%[[VAL_82]]] = %[[VAL_81]] : <@N x !felt.type>, !felt.type
-// CHECK-NEXT:              scf.yield %[[VAL_68]] : !array.type<@N x !felt.type>
+// CHECK-NEXT:              %[[V_78:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_62]]
+// CHECK-NEXT:              %[[V_79:[0-9a-zA-Z_\.]+]] = array.read %[[V_68]]{{\[}}%[[V_78]]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              %[[V_80:[0-9a-zA-Z_\.]+]] = felt.const  111
+// CHECK-NEXT:              %[[V_81:[0-9a-zA-Z_\.]+]] = felt.sub %[[V_79]], %[[V_80]] : !felt.type, !felt.type
+// CHECK-NEXT:              %[[V_82:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_62]]
+// CHECK-NEXT:              array.write %[[V_68]]{{\[}}%[[V_82]]] = %[[V_81]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              scf.yield %[[V_68]] : !array.type<@N x !felt.type>
 // CHECK-NEXT:            }
-// CHECK-NEXT:            %[[VAL_83:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:            %[[VAL_84:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_69]], %[[VAL_83]] : !felt.type, !felt.type
-// CHECK-NEXT:            scf.yield %[[VAL_72]], %[[VAL_84]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:            %[[V_83:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:            %[[V_84:[0-9a-zA-Z_\.]+]] = felt.add %[[V_69]], %[[V_83]] : !felt.type, !felt.type
+// CHECK-NEXT:            scf.yield %[[V_72]], %[[V_84]] : !array.type<@N x !felt.type>, !felt.type
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[VAL_85:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:          %[[VAL_86:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_62]], %[[VAL_85]] : !felt.type, !felt.type
-// CHECK-NEXT:          scf.yield %[[VAL_64]]#0, %[[VAL_86]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_85:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[V_86:[0-9a-zA-Z_\.]+]] = felt.add %[[V_62]], %[[V_85]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[V_64]]#0, %[[V_86]] : !array.type<@N x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_87:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_47]][@out] : <@InnerConditional8<[@N]>>, !felt.type
+// CHECK-NEXT:        %[[V_87:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_47]][@out] : <@InnerConditional8<[@N]>>, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }

--- a/circom/tests/loops/inner_conditional_09.circom
+++ b/circom/tests/loops/inner_conditional_09.circom
@@ -35,138 +35,140 @@ component main = InnerConditional9(4);
 // CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
 // CHECK-NEXT:    struct.def @InnerConditional9<[@N]> {
 // CHECK-NEXT:      struct.field @out : !felt.type {llzk.pub}
-// CHECK-NEXT:      function.def @compute() -> !struct.type<@InnerConditional9<[@N]>> attributes {function.allow_witness} {
-// CHECK-NEXT:        %[[VAL_0:[0-9a-zA-Z_\.]+]] = struct.new : <@InnerConditional9<[@N]>>
-// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type
-// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = array.new  : <@N x !felt.type>
-// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_3]], %[[VAL_4]] : <@N x !felt.type>
-// CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:        scf.for %[[VAL_8:[0-9a-zA-Z_\.]+]] = %[[VAL_6]] to %[[VAL_5]] step %[[VAL_7]] {
-// CHECK-NEXT:          array.write %[[VAL_3]]{{\[}}%[[VAL_8]]] = %[[VAL_2]] : <@N x !felt.type>, !felt.type
+// CHECK-LABEL:     function.def @compute
+// CHECK-SAME:      () -> !struct.type<@InnerConditional9<[@N]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[V_0:[0-9a-zA-Z_\.]+]] = struct.new : <@InnerConditional9<[@N]>>
+// CHECK-NEXT:        %[[V_N:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type
+// CHECK-NEXT:        %[[V_2:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_3:[0-9a-zA-Z_\.]+]] = array.new  : <@N x !felt.type>
+// CHECK-NEXT:        %[[V_4:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[V_5:[0-9a-zA-Z_\.]+]] = array.len %[[V_3]], %[[V_4]] : <@N x !felt.type>
+// CHECK-NEXT:        %[[V_6:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[V_7:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[V_8:[0-9a-zA-Z_\.]+]] = %[[V_6]] to %[[V_5]] step %[[V_7]] {
+// CHECK-NEXT:          array.write %[[V_3]]{{\[}}%[[V_8]]] = %[[V_2]] : <@N x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_9:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_11:[0-9a-zA-Z_\.]+]] = %[[VAL_3]], %[[VAL_12:[0-9a-zA-Z_\.]+]] = %[[VAL_9]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
-// CHECK-NEXT:          %[[VAL_13:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_12]], %[[VAL_1]])
-// CHECK-NEXT:          scf.condition(%[[VAL_13]]) %[[VAL_11]], %[[VAL_12]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[V_9:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_10:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_11:[0-9a-zA-Z_\.]+]] = %[[V_3]], %[[V_12:[0-9a-zA-Z_\.]+]] = %[[V_9]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[V_13:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[V_12]], %[[V_N]])
+// CHECK-NEXT:          scf.condition(%[[V_13]]) %[[V_11]], %[[V_12]] : !array.type<@N x !felt.type>, !felt.type
 // CHECK-NEXT:        } do {
-// CHECK-NEXT:        ^bb0(%[[VAL_14:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[VAL_15:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:          %[[VAL_16:[0-9a-zA-Z_\.]+]] = felt.const  2
-// CHECK-NEXT:          %[[VAL_17:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_15]], %[[VAL_16]])
-// CHECK-NEXT:          %[[VAL_18:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_17]] -> (!array.type<@N x !felt.type>) {
-// CHECK-NEXT:            %[[VAL_19:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:            %[[VAL_20:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_21:[0-9a-zA-Z_\.]+]] = %[[VAL_14]], %[[VAL_22:[0-9a-zA-Z_\.]+]] = %[[VAL_19]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
-// CHECK-NEXT:              %[[VAL_23:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_22]], %[[VAL_1]])
-// CHECK-NEXT:              scf.condition(%[[VAL_23]]) %[[VAL_21]], %[[VAL_22]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:        ^bb0(%[[V_14:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[V_15:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[V_16:[0-9a-zA-Z_\.]+]] = felt.const  2
+// CHECK-NEXT:          %[[V_17:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[V_15]], %[[V_16]])
+// CHECK-NEXT:          %[[V_18:[0-9a-zA-Z_\.]+]] = scf.if %[[V_17]] -> (!array.type<@N x !felt.type>) {
+// CHECK-NEXT:            %[[V_19:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:            %[[V_20:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_21:[0-9a-zA-Z_\.]+]] = %[[V_14]], %[[V_22:[0-9a-zA-Z_\.]+]] = %[[V_19]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
+// CHECK-NEXT:              %[[V_23:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[V_22]], %[[V_N]])
+// CHECK-NEXT:              scf.condition(%[[V_23]]) %[[V_21]], %[[V_22]] : !array.type<@N x !felt.type>, !felt.type
 // CHECK-NEXT:            } do {
-// CHECK-NEXT:            ^bb0(%[[VAL_24:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[VAL_25:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:              %[[VAL_26:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_15]]
-// CHECK-NEXT:              %[[VAL_27:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_24]]{{\[}}%[[VAL_26]]] : <@N x !felt.type>, !felt.type
-// CHECK-NEXT:              %[[VAL_28:[0-9a-zA-Z_\.]+]] = felt.const  999
-// CHECK-NEXT:              %[[VAL_29:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_27]], %[[VAL_28]] : !felt.type, !felt.type
-// CHECK-NEXT:              %[[VAL_30:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_15]]
-// CHECK-NEXT:              array.write %[[VAL_24]]{{\[}}%[[VAL_30]]] = %[[VAL_29]] : <@N x !felt.type>, !felt.type
-// CHECK-NEXT:              %[[VAL_31:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:              %[[VAL_32:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_25]], %[[VAL_31]] : !felt.type, !felt.type
-// CHECK-NEXT:              scf.yield %[[VAL_24]], %[[VAL_32]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:            ^bb0(%[[V_24:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[V_25:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:              %[[V_26:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_15]]
+// CHECK-NEXT:              %[[V_27:[0-9a-zA-Z_\.]+]] = array.read %[[V_24]]{{\[}}%[[V_26]]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              %[[V_28:[0-9a-zA-Z_\.]+]] = felt.const  999
+// CHECK-NEXT:              %[[V_29:[0-9a-zA-Z_\.]+]] = felt.add %[[V_27]], %[[V_28]] : !felt.type, !felt.type
+// CHECK-NEXT:              %[[V_30:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_15]]
+// CHECK-NEXT:              array.write %[[V_24]]{{\[}}%[[V_30]]] = %[[V_29]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              %[[V_31:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:              %[[V_32:[0-9a-zA-Z_\.]+]] = felt.add %[[V_25]], %[[V_31]] : !felt.type, !felt.type
+// CHECK-NEXT:              scf.yield %[[V_24]], %[[V_32]] : !array.type<@N x !felt.type>, !felt.type
 // CHECK-NEXT:            }
-// CHECK-NEXT:            scf.yield %[[VAL_20]]#0 : !array.type<@N x !felt.type>
+// CHECK-NEXT:            scf.yield %[[V_20]]#0 : !array.type<@N x !felt.type>
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[VAL_33:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:            %[[VAL_34:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_35:[0-9a-zA-Z_\.]+]] = %[[VAL_14]], %[[VAL_36:[0-9a-zA-Z_\.]+]] = %[[VAL_33]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
-// CHECK-NEXT:              %[[VAL_37:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_36]], %[[VAL_1]])
-// CHECK-NEXT:              scf.condition(%[[VAL_37]]) %[[VAL_35]], %[[VAL_36]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:            %[[V_33:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:            %[[V_34:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_35:[0-9a-zA-Z_\.]+]] = %[[V_14]], %[[V_36:[0-9a-zA-Z_\.]+]] = %[[V_33]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
+// CHECK-NEXT:              %[[V_37:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[V_36]], %[[V_N]])
+// CHECK-NEXT:              scf.condition(%[[V_37]]) %[[V_35]], %[[V_36]] : !array.type<@N x !felt.type>, !felt.type
 // CHECK-NEXT:            } do {
-// CHECK-NEXT:            ^bb0(%[[VAL_38:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[VAL_39:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:              %[[VAL_40:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_15]]
-// CHECK-NEXT:              %[[VAL_41:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_38]]{{\[}}%[[VAL_40]]] : <@N x !felt.type>, !felt.type
-// CHECK-NEXT:              %[[VAL_42:[0-9a-zA-Z_\.]+]] = felt.const  888
-// CHECK-NEXT:              %[[VAL_43:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_41]], %[[VAL_42]] : !felt.type, !felt.type
-// CHECK-NEXT:              %[[VAL_44:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_15]]
-// CHECK-NEXT:              array.write %[[VAL_38]]{{\[}}%[[VAL_44]]] = %[[VAL_43]] : <@N x !felt.type>, !felt.type
-// CHECK-NEXT:              %[[VAL_45:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:              %[[VAL_46:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_39]], %[[VAL_45]] : !felt.type, !felt.type
-// CHECK-NEXT:              scf.yield %[[VAL_38]], %[[VAL_46]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:            ^bb0(%[[V_38:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[V_39:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:              %[[V_40:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_15]]
+// CHECK-NEXT:              %[[V_41:[0-9a-zA-Z_\.]+]] = array.read %[[V_38]]{{\[}}%[[V_40]]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              %[[V_42:[0-9a-zA-Z_\.]+]] = felt.const  888
+// CHECK-NEXT:              %[[V_43:[0-9a-zA-Z_\.]+]] = felt.add %[[V_41]], %[[V_42]] : !felt.type, !felt.type
+// CHECK-NEXT:              %[[V_44:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_15]]
+// CHECK-NEXT:              array.write %[[V_38]]{{\[}}%[[V_44]]] = %[[V_43]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              %[[V_45:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:              %[[V_46:[0-9a-zA-Z_\.]+]] = felt.add %[[V_39]], %[[V_45]] : !felt.type, !felt.type
+// CHECK-NEXT:              scf.yield %[[V_38]], %[[V_46]] : !array.type<@N x !felt.type>, !felt.type
 // CHECK-NEXT:            }
-// CHECK-NEXT:            scf.yield %[[VAL_34]]#0 : !array.type<@N x !felt.type>
+// CHECK-NEXT:            scf.yield %[[V_34]]#0 : !array.type<@N x !felt.type>
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[VAL_47:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:          %[[VAL_48:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_15]], %[[VAL_47]] : !felt.type, !felt.type
-// CHECK-NEXT:          scf.yield %[[VAL_18]], %[[VAL_48]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_47:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[V_48:[0-9a-zA-Z_\.]+]] = felt.add %[[V_15]], %[[V_47]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[V_18]], %[[V_48]] : !array.type<@N x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_49:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_50:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_49]]
-// CHECK-NEXT:        %[[VAL_51:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_10]]#0{{\[}}%[[VAL_50]]] : <@N x !felt.type>, !felt.type
-// CHECK-NEXT:        %[[VAL_52:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:        %[[VAL_53:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_52]]
-// CHECK-NEXT:        %[[VAL_54:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_10]]#0{{\[}}%[[VAL_53]]] : <@N x !felt.type>, !felt.type
-// CHECK-NEXT:        %[[VAL_55:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_51]], %[[VAL_54]] : !felt.type, !felt.type
-// CHECK-NEXT:        struct.writef %[[VAL_0]][@out] = %[[VAL_55]] : <@InnerConditional9<[@N]>>, !felt.type
-// CHECK-NEXT:        function.return %[[VAL_0]] : !struct.type<@InnerConditional9<[@N]>>
+// CHECK-NEXT:        %[[V_49:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_50:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_49]]
+// CHECK-NEXT:        %[[V_51:[0-9a-zA-Z_\.]+]] = array.read %[[V_10]]#0{{\[}}%[[V_50]]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[V_52:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[V_53:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_52]]
+// CHECK-NEXT:        %[[V_54:[0-9a-zA-Z_\.]+]] = array.read %[[V_10]]#0{{\[}}%[[V_53]]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[V_55:[0-9a-zA-Z_\.]+]] = felt.add %[[V_51]], %[[V_54]] : !felt.type, !felt.type
+// CHECK-NEXT:        struct.writef %[[V_0]][@out] = %[[V_55]] : <@InnerConditional9<[@N]>>, !felt.type
+// CHECK-NEXT:        function.return %[[V_0]] : !struct.type<@InnerConditional9<[@N]>>
 // CHECK-NEXT:      }
-// CHECK-NEXT:      function.def @constrain(%[[VAL_56:[0-9a-zA-Z_\.]+]]: !struct.type<@InnerConditional9<[@N]>>) attributes {function.allow_constraint} {
-// CHECK-NEXT:        %[[VAL_57:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type
-// CHECK-NEXT:        %[[VAL_58:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_59:[0-9a-zA-Z_\.]+]] = array.new  : <@N x !felt.type>
-// CHECK-NEXT:        %[[VAL_60:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_61:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_59]], %[[VAL_60]] : <@N x !felt.type>
-// CHECK-NEXT:        %[[VAL_62:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_63:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:        scf.for %[[VAL_64:[0-9a-zA-Z_\.]+]] = %[[VAL_62]] to %[[VAL_61]] step %[[VAL_63]] {
-// CHECK-NEXT:          array.write %[[VAL_59]]{{\[}}%[[VAL_64]]] = %[[VAL_58]] : <@N x !felt.type>, !felt.type
+// CHECK-LABEL:     function.def @constrain
+// CHECK-SAME:      (%[[V_56:[0-9a-zA-Z_\.]+]]: !struct.type<@InnerConditional9<[@N]>>) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[V_N:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type
+// CHECK-NEXT:        %[[V_58:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_A:[0-9a-zA-Z_\.]+]] = array.new  : <@N x !felt.type>
+// CHECK-NEXT:        %[[V_60:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[V_61:[0-9a-zA-Z_\.]+]] = array.len %[[V_A]], %[[V_60]] : <@N x !felt.type>
+// CHECK-NEXT:        %[[V_62:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[V_63:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[V_64:[0-9a-zA-Z_\.]+]] = %[[V_62]] to %[[V_61]] step %[[V_63]] {
+// CHECK-NEXT:          array.write %[[V_A]]{{\[}}%[[V_64]]] = %[[V_58]] : <@N x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_65:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_66:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_67:[0-9a-zA-Z_\.]+]] = %[[VAL_59]], %[[VAL_68:[0-9a-zA-Z_\.]+]] = %[[VAL_65]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
-// CHECK-NEXT:          %[[VAL_69:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_68]], %[[VAL_57]])
-// CHECK-NEXT:          scf.condition(%[[VAL_69]]) %[[VAL_67]], %[[VAL_68]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[V_65:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_66:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_67:[0-9a-zA-Z_\.]+]] = %[[V_A]], %[[V_68:[0-9a-zA-Z_\.]+]] = %[[V_65]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[V_69:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[V_68]], %[[V_N]])
+// CHECK-NEXT:          scf.condition(%[[V_69]]) %[[V_67]], %[[V_68]] : !array.type<@N x !felt.type>, !felt.type
 // CHECK-NEXT:        } do {
-// CHECK-NEXT:        ^bb0(%[[VAL_70:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[VAL_71:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:          %[[VAL_72:[0-9a-zA-Z_\.]+]] = felt.const  2
-// CHECK-NEXT:          %[[VAL_73:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_71]], %[[VAL_72]])
-// CHECK-NEXT:          %[[VAL_74:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_73]] -> (!array.type<@N x !felt.type>) {
-// CHECK-NEXT:            %[[VAL_75:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:            %[[VAL_76:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_77:[0-9a-zA-Z_\.]+]] = %[[VAL_70]], %[[VAL_78:[0-9a-zA-Z_\.]+]] = %[[VAL_75]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
-// CHECK-NEXT:              %[[VAL_79:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_78]], %[[VAL_57]])
-// CHECK-NEXT:              scf.condition(%[[VAL_79]]) %[[VAL_77]], %[[VAL_78]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:        ^bb0(%[[V_70:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[V_71:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[V_72:[0-9a-zA-Z_\.]+]] = felt.const  2
+// CHECK-NEXT:          %[[V_73:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[V_71]], %[[V_72]])
+// CHECK-NEXT:          %[[V_74:[0-9a-zA-Z_\.]+]] = scf.if %[[V_73]] -> (!array.type<@N x !felt.type>) {
+// CHECK-NEXT:            %[[V_75:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:            %[[V_76:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_77:[0-9a-zA-Z_\.]+]] = %[[V_70]], %[[V_78:[0-9a-zA-Z_\.]+]] = %[[V_75]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
+// CHECK-NEXT:              %[[V_79:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[V_78]], %[[V_N]])
+// CHECK-NEXT:              scf.condition(%[[V_79]]) %[[V_77]], %[[V_78]] : !array.type<@N x !felt.type>, !felt.type
 // CHECK-NEXT:            } do {
-// CHECK-NEXT:            ^bb0(%[[VAL_80:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[VAL_81:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:              %[[VAL_82:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_71]]
-// CHECK-NEXT:              %[[VAL_83:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_80]]{{\[}}%[[VAL_82]]] : <@N x !felt.type>, !felt.type
-// CHECK-NEXT:              %[[VAL_84:[0-9a-zA-Z_\.]+]] = felt.const  999
-// CHECK-NEXT:              %[[VAL_85:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_83]], %[[VAL_84]] : !felt.type, !felt.type
-// CHECK-NEXT:              %[[VAL_86:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_71]]
-// CHECK-NEXT:              array.write %[[VAL_80]]{{\[}}%[[VAL_86]]] = %[[VAL_85]] : <@N x !felt.type>, !felt.type
-// CHECK-NEXT:              %[[VAL_87:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:              %[[VAL_88:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_81]], %[[VAL_87]] : !felt.type, !felt.type
-// CHECK-NEXT:              scf.yield %[[VAL_80]], %[[VAL_88]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:            ^bb0(%[[V_80:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[V_81:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:              %[[V_82:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_71]]
+// CHECK-NEXT:              %[[V_83:[0-9a-zA-Z_\.]+]] = array.read %[[V_80]]{{\[}}%[[V_82]]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              %[[V_84:[0-9a-zA-Z_\.]+]] = felt.const  999
+// CHECK-NEXT:              %[[V_85:[0-9a-zA-Z_\.]+]] = felt.add %[[V_83]], %[[V_84]] : !felt.type, !felt.type
+// CHECK-NEXT:              %[[V_86:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_71]]
+// CHECK-NEXT:              array.write %[[V_80]]{{\[}}%[[V_86]]] = %[[V_85]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              %[[V_87:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:              %[[V_88:[0-9a-zA-Z_\.]+]] = felt.add %[[V_81]], %[[V_87]] : !felt.type, !felt.type
+// CHECK-NEXT:              scf.yield %[[V_80]], %[[V_88]] : !array.type<@N x !felt.type>, !felt.type
 // CHECK-NEXT:            }
-// CHECK-NEXT:            scf.yield %[[VAL_76]]#0 : !array.type<@N x !felt.type>
+// CHECK-NEXT:            scf.yield %[[V_76]]#0 : !array.type<@N x !felt.type>
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[VAL_89:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:            %[[VAL_90:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_91:[0-9a-zA-Z_\.]+]] = %[[VAL_70]], %[[VAL_92:[0-9a-zA-Z_\.]+]] = %[[VAL_89]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
-// CHECK-NEXT:              %[[VAL_93:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_92]], %[[VAL_57]])
-// CHECK-NEXT:              scf.condition(%[[VAL_93]]) %[[VAL_91]], %[[VAL_92]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:            %[[V_89:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:            %[[V_90:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_91:[0-9a-zA-Z_\.]+]] = %[[V_70]], %[[V_92:[0-9a-zA-Z_\.]+]] = %[[V_89]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
+// CHECK-NEXT:              %[[V_93:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[V_92]], %[[V_N]])
+// CHECK-NEXT:              scf.condition(%[[V_93]]) %[[V_91]], %[[V_92]] : !array.type<@N x !felt.type>, !felt.type
 // CHECK-NEXT:            } do {
-// CHECK-NEXT:            ^bb0(%[[VAL_94:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[VAL_95:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:              %[[VAL_96:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_71]]
-// CHECK-NEXT:              %[[VAL_97:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_94]]{{\[}}%[[VAL_96]]] : <@N x !felt.type>, !felt.type
-// CHECK-NEXT:              %[[VAL_98:[0-9a-zA-Z_\.]+]] = felt.const  888
-// CHECK-NEXT:              %[[VAL_99:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_97]], %[[VAL_98]] : !felt.type, !felt.type
-// CHECK-NEXT:              %[[VAL_100:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_71]]
-// CHECK-NEXT:              array.write %[[VAL_94]]{{\[}}%[[VAL_100]]] = %[[VAL_99]] : <@N x !felt.type>, !felt.type
-// CHECK-NEXT:              %[[VAL_101:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:              %[[VAL_102:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_95]], %[[VAL_101]] : !felt.type, !felt.type
-// CHECK-NEXT:              scf.yield %[[VAL_94]], %[[VAL_102]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:            ^bb0(%[[V_94:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[V_95:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:              %[[V_96:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_71]]
+// CHECK-NEXT:              %[[V_97:[0-9a-zA-Z_\.]+]] = array.read %[[V_94]]{{\[}}%[[V_96]]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              %[[V_98:[0-9a-zA-Z_\.]+]] = felt.const  888
+// CHECK-NEXT:              %[[V_99:[0-9a-zA-Z_\.]+]] = felt.add %[[V_97]], %[[V_98]] : !felt.type, !felt.type
+// CHECK-NEXT:              %[[V_100:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_71]]
+// CHECK-NEXT:              array.write %[[V_94]]{{\[}}%[[V_100]]] = %[[V_99]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              %[[V_101:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:              %[[V_102:[0-9a-zA-Z_\.]+]] = felt.add %[[V_95]], %[[V_101]] : !felt.type, !felt.type
+// CHECK-NEXT:              scf.yield %[[V_94]], %[[V_102]] : !array.type<@N x !felt.type>, !felt.type
 // CHECK-NEXT:            }
-// CHECK-NEXT:            scf.yield %[[VAL_90]]#0 : !array.type<@N x !felt.type>
+// CHECK-NEXT:            scf.yield %[[V_90]]#0 : !array.type<@N x !felt.type>
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[VAL_103:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:          %[[VAL_104:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_71]], %[[VAL_103]] : !felt.type, !felt.type
-// CHECK-NEXT:          scf.yield %[[VAL_74]], %[[VAL_104]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_103:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[V_104:[0-9a-zA-Z_\.]+]] = felt.add %[[V_71]], %[[V_103]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[V_74]], %[[V_104]] : !array.type<@N x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_105:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_56]][@out] : <@InnerConditional9<[@N]>>, !felt.type
+// CHECK-NEXT:        %[[V_105:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_56]][@out] : <@InnerConditional9<[@N]>>, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }

--- a/circom/tests/loops/inner_conditional_09.circom
+++ b/circom/tests/loops/inner_conditional_09.circom
@@ -1,7 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL:.*
 
 pragma circom 2.0.0;
 
@@ -34,3 +33,141 @@ template InnerConditional9(N) {
 component main = InnerConditional9(4);
 
 // CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-NEXT:    struct.def @InnerConditional9<[@N]> {
+// CHECK-NEXT:      struct.field @out : !felt.type {llzk.pub}
+// CHECK-NEXT:      function.def @compute() -> !struct.type<@InnerConditional9<[@N]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_0:[0-9a-zA-Z_\.]+]] = struct.new : <@InnerConditional9<[@N]>>
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = array.new  : <@N x !felt.type>
+// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_3]], %[[VAL_4]] : <@N x !felt.type>
+// CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[VAL_8:[0-9a-zA-Z_\.]+]] = %[[VAL_6]] to %[[VAL_5]] step %[[VAL_7]] {
+// CHECK-NEXT:          array.write %[[VAL_3]]{{\[}}%[[VAL_8]]] = %[[VAL_2]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_9:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_11:[0-9a-zA-Z_\.]+]] = %[[VAL_3]], %[[VAL_12:[0-9a-zA-Z_\.]+]] = %[[VAL_9]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[VAL_13:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_12]], %[[VAL_1]])
+// CHECK-NEXT:          scf.condition(%[[VAL_13]]) %[[VAL_11]], %[[VAL_12]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:        } do {
+// CHECK-NEXT:        ^bb0(%[[VAL_14:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[VAL_15:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[VAL_16:[0-9a-zA-Z_\.]+]] = felt.const  2
+// CHECK-NEXT:          %[[VAL_17:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_15]], %[[VAL_16]])
+// CHECK-NEXT:          %[[VAL_18:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_17]] -> (!array.type<@N x !felt.type>) {
+// CHECK-NEXT:            %[[VAL_19:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:            %[[VAL_20:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_21:[0-9a-zA-Z_\.]+]] = %[[VAL_14]], %[[VAL_22:[0-9a-zA-Z_\.]+]] = %[[VAL_19]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
+// CHECK-NEXT:              %[[VAL_23:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_22]], %[[VAL_1]])
+// CHECK-NEXT:              scf.condition(%[[VAL_23]]) %[[VAL_21]], %[[VAL_22]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:            } do {
+// CHECK-NEXT:            ^bb0(%[[VAL_24:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[VAL_25:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:              %[[VAL_26:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_15]]
+// CHECK-NEXT:              %[[VAL_27:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_24]]{{\[}}%[[VAL_26]]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              %[[VAL_28:[0-9a-zA-Z_\.]+]] = felt.const  999
+// CHECK-NEXT:              %[[VAL_29:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_27]], %[[VAL_28]] : !felt.type, !felt.type
+// CHECK-NEXT:              %[[VAL_30:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_15]]
+// CHECK-NEXT:              array.write %[[VAL_24]]{{\[}}%[[VAL_30]]] = %[[VAL_29]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              %[[VAL_31:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:              %[[VAL_32:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_25]], %[[VAL_31]] : !felt.type, !felt.type
+// CHECK-NEXT:              scf.yield %[[VAL_24]], %[[VAL_32]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:            }
+// CHECK-NEXT:            scf.yield %[[VAL_20]]#0 : !array.type<@N x !felt.type>
+// CHECK-NEXT:          } else {
+// CHECK-NEXT:            %[[VAL_33:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:            %[[VAL_34:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_35:[0-9a-zA-Z_\.]+]] = %[[VAL_14]], %[[VAL_36:[0-9a-zA-Z_\.]+]] = %[[VAL_33]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
+// CHECK-NEXT:              %[[VAL_37:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_36]], %[[VAL_1]])
+// CHECK-NEXT:              scf.condition(%[[VAL_37]]) %[[VAL_35]], %[[VAL_36]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:            } do {
+// CHECK-NEXT:            ^bb0(%[[VAL_38:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[VAL_39:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:              %[[VAL_40:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_15]]
+// CHECK-NEXT:              %[[VAL_41:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_38]]{{\[}}%[[VAL_40]]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              %[[VAL_42:[0-9a-zA-Z_\.]+]] = felt.const  888
+// CHECK-NEXT:              %[[VAL_43:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_41]], %[[VAL_42]] : !felt.type, !felt.type
+// CHECK-NEXT:              %[[VAL_44:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_15]]
+// CHECK-NEXT:              array.write %[[VAL_38]]{{\[}}%[[VAL_44]]] = %[[VAL_43]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              %[[VAL_45:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:              %[[VAL_46:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_39]], %[[VAL_45]] : !felt.type, !felt.type
+// CHECK-NEXT:              scf.yield %[[VAL_38]], %[[VAL_46]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:            }
+// CHECK-NEXT:            scf.yield %[[VAL_34]]#0 : !array.type<@N x !felt.type>
+// CHECK-NEXT:          }
+// CHECK-NEXT:          %[[VAL_47:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_48:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_15]], %[[VAL_47]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_18]], %[[VAL_48]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_49:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_50:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_49]]
+// CHECK-NEXT:        %[[VAL_51:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_10]]#0{{\[}}%[[VAL_50]]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[VAL_52:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_53:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_52]]
+// CHECK-NEXT:        %[[VAL_54:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_10]]#0{{\[}}%[[VAL_53]]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[VAL_55:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_51]], %[[VAL_54]] : !felt.type, !felt.type
+// CHECK-NEXT:        struct.writef %[[VAL_0]][@out] = %[[VAL_55]] : <@InnerConditional9<[@N]>>, !felt.type
+// CHECK-NEXT:        function.return %[[VAL_0]] : !struct.type<@InnerConditional9<[@N]>>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[VAL_56:[0-9a-zA-Z_\.]+]]: !struct.type<@InnerConditional9<[@N]>>) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[VAL_57:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type
+// CHECK-NEXT:        %[[VAL_58:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_59:[0-9a-zA-Z_\.]+]] = array.new  : <@N x !felt.type>
+// CHECK-NEXT:        %[[VAL_60:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_61:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_59]], %[[VAL_60]] : <@N x !felt.type>
+// CHECK-NEXT:        %[[VAL_62:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_63:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[VAL_64:[0-9a-zA-Z_\.]+]] = %[[VAL_62]] to %[[VAL_61]] step %[[VAL_63]] {
+// CHECK-NEXT:          array.write %[[VAL_59]]{{\[}}%[[VAL_64]]] = %[[VAL_58]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_65:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_66:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_67:[0-9a-zA-Z_\.]+]] = %[[VAL_59]], %[[VAL_68:[0-9a-zA-Z_\.]+]] = %[[VAL_65]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[VAL_69:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_68]], %[[VAL_57]])
+// CHECK-NEXT:          scf.condition(%[[VAL_69]]) %[[VAL_67]], %[[VAL_68]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:        } do {
+// CHECK-NEXT:        ^bb0(%[[VAL_70:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[VAL_71:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[VAL_72:[0-9a-zA-Z_\.]+]] = felt.const  2
+// CHECK-NEXT:          %[[VAL_73:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_71]], %[[VAL_72]])
+// CHECK-NEXT:          %[[VAL_74:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_73]] -> (!array.type<@N x !felt.type>) {
+// CHECK-NEXT:            %[[VAL_75:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:            %[[VAL_76:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_77:[0-9a-zA-Z_\.]+]] = %[[VAL_70]], %[[VAL_78:[0-9a-zA-Z_\.]+]] = %[[VAL_75]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
+// CHECK-NEXT:              %[[VAL_79:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_78]], %[[VAL_57]])
+// CHECK-NEXT:              scf.condition(%[[VAL_79]]) %[[VAL_77]], %[[VAL_78]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:            } do {
+// CHECK-NEXT:            ^bb0(%[[VAL_80:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[VAL_81:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:              %[[VAL_82:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_71]]
+// CHECK-NEXT:              %[[VAL_83:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_80]]{{\[}}%[[VAL_82]]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              %[[VAL_84:[0-9a-zA-Z_\.]+]] = felt.const  999
+// CHECK-NEXT:              %[[VAL_85:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_83]], %[[VAL_84]] : !felt.type, !felt.type
+// CHECK-NEXT:              %[[VAL_86:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_71]]
+// CHECK-NEXT:              array.write %[[VAL_80]]{{\[}}%[[VAL_86]]] = %[[VAL_85]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              %[[VAL_87:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:              %[[VAL_88:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_81]], %[[VAL_87]] : !felt.type, !felt.type
+// CHECK-NEXT:              scf.yield %[[VAL_80]], %[[VAL_88]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:            }
+// CHECK-NEXT:            scf.yield %[[VAL_76]]#0 : !array.type<@N x !felt.type>
+// CHECK-NEXT:          } else {
+// CHECK-NEXT:            %[[VAL_89:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:            %[[VAL_90:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_91:[0-9a-zA-Z_\.]+]] = %[[VAL_70]], %[[VAL_92:[0-9a-zA-Z_\.]+]] = %[[VAL_89]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
+// CHECK-NEXT:              %[[VAL_93:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_92]], %[[VAL_57]])
+// CHECK-NEXT:              scf.condition(%[[VAL_93]]) %[[VAL_91]], %[[VAL_92]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:            } do {
+// CHECK-NEXT:            ^bb0(%[[VAL_94:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[VAL_95:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:              %[[VAL_96:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_71]]
+// CHECK-NEXT:              %[[VAL_97:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_94]]{{\[}}%[[VAL_96]]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              %[[VAL_98:[0-9a-zA-Z_\.]+]] = felt.const  888
+// CHECK-NEXT:              %[[VAL_99:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_97]], %[[VAL_98]] : !felt.type, !felt.type
+// CHECK-NEXT:              %[[VAL_100:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_71]]
+// CHECK-NEXT:              array.write %[[VAL_94]]{{\[}}%[[VAL_100]]] = %[[VAL_99]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              %[[VAL_101:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:              %[[VAL_102:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_95]], %[[VAL_101]] : !felt.type, !felt.type
+// CHECK-NEXT:              scf.yield %[[VAL_94]], %[[VAL_102]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:            }
+// CHECK-NEXT:            scf.yield %[[VAL_90]]#0 : !array.type<@N x !felt.type>
+// CHECK-NEXT:          }
+// CHECK-NEXT:          %[[VAL_103:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_104:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_71]], %[[VAL_103]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_74]], %[[VAL_104]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_105:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_56]][@out] : <@InnerConditional9<[@N]>>, !felt.type
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/loops/inner_conditional_12.circom
+++ b/circom/tests/loops/inner_conditional_12.circom
@@ -1,7 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL:.*
 
 pragma circom 2.0.0;
 
@@ -30,3 +29,141 @@ template InnerConditional12(N) {
 component main = InnerConditional12(4);
 
 // CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-NEXT:    struct.def @InnerConditional12<[@N]> {
+// CHECK-NEXT:      struct.field @out : !felt.type {llzk.pub}
+// CHECK-NEXT:      function.def @compute() -> !struct.type<@InnerConditional12<[@N]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_0:[0-9a-zA-Z_\.]+]] = struct.new : <@InnerConditional12<[@N]>>
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = array.new  : <@N x !felt.type>
+// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_3]], %[[VAL_4]] : <@N x !felt.type>
+// CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[VAL_8:[0-9a-zA-Z_\.]+]] = %[[VAL_6]] to %[[VAL_5]] step %[[VAL_7]] {
+// CHECK-NEXT:          array.write %[[VAL_3]]{{\[}}%[[VAL_8]]] = %[[VAL_2]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_9:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_11:[0-9a-zA-Z_\.]+]] = %[[VAL_3]], %[[VAL_12:[0-9a-zA-Z_\.]+]] = %[[VAL_9]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[VAL_13:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_12]], %[[VAL_1]])
+// CHECK-NEXT:          scf.condition(%[[VAL_13]]) %[[VAL_11]], %[[VAL_12]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:        } do {
+// CHECK-NEXT:        ^bb0(%[[VAL_14:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[VAL_15:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[VAL_16:[0-9a-zA-Z_\.]+]] = felt.const  2
+// CHECK-NEXT:          %[[VAL_17:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_15]], %[[VAL_16]])
+// CHECK-NEXT:          %[[VAL_18:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_17]] -> (!array.type<@N x !felt.type>) {
+// CHECK-NEXT:            %[[VAL_19:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:            %[[VAL_20:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_21:[0-9a-zA-Z_\.]+]] = %[[VAL_14]], %[[VAL_22:[0-9a-zA-Z_\.]+]] = %[[VAL_19]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
+// CHECK-NEXT:              %[[VAL_23:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_22]], %[[VAL_1]])
+// CHECK-NEXT:              scf.condition(%[[VAL_23]]) %[[VAL_21]], %[[VAL_22]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:            } do {
+// CHECK-NEXT:            ^bb0(%[[VAL_24:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[VAL_25:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:              %[[VAL_26:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_15]]
+// CHECK-NEXT:              %[[VAL_27:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_24]]{{\[}}%[[VAL_26]]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              %[[VAL_28:[0-9a-zA-Z_\.]+]] = felt.const  999
+// CHECK-NEXT:              %[[VAL_29:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_27]], %[[VAL_28]] : !felt.type, !felt.type
+// CHECK-NEXT:              %[[VAL_30:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_15]]
+// CHECK-NEXT:              array.write %[[VAL_24]]{{\[}}%[[VAL_30]]] = %[[VAL_29]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              %[[VAL_31:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:              %[[VAL_32:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_25]], %[[VAL_31]] : !felt.type, !felt.type
+// CHECK-NEXT:              scf.yield %[[VAL_24]], %[[VAL_32]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:            }
+// CHECK-NEXT:            scf.yield %[[VAL_20]]#0 : !array.type<@N x !felt.type>
+// CHECK-NEXT:          } else {
+// CHECK-NEXT:            %[[VAL_33:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:            %[[VAL_34:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_35:[0-9a-zA-Z_\.]+]] = %[[VAL_14]], %[[VAL_36:[0-9a-zA-Z_\.]+]] = %[[VAL_33]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
+// CHECK-NEXT:              %[[VAL_37:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_36]], %[[VAL_15]])
+// CHECK-NEXT:              scf.condition(%[[VAL_37]]) %[[VAL_35]], %[[VAL_36]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:            } do {
+// CHECK-NEXT:            ^bb0(%[[VAL_38:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[VAL_39:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:              %[[VAL_40:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_15]]
+// CHECK-NEXT:              %[[VAL_41:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_38]]{{\[}}%[[VAL_40]]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              %[[VAL_42:[0-9a-zA-Z_\.]+]] = felt.const  888
+// CHECK-NEXT:              %[[VAL_43:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_41]], %[[VAL_42]] : !felt.type, !felt.type
+// CHECK-NEXT:              %[[VAL_44:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_15]]
+// CHECK-NEXT:              array.write %[[VAL_38]]{{\[}}%[[VAL_44]]] = %[[VAL_43]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              %[[VAL_45:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:              %[[VAL_46:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_39]], %[[VAL_45]] : !felt.type, !felt.type
+// CHECK-NEXT:              scf.yield %[[VAL_38]], %[[VAL_46]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:            }
+// CHECK-NEXT:            scf.yield %[[VAL_34]]#0 : !array.type<@N x !felt.type>
+// CHECK-NEXT:          }
+// CHECK-NEXT:          %[[VAL_47:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_48:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_15]], %[[VAL_47]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_18]], %[[VAL_48]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_49:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_50:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_49]]
+// CHECK-NEXT:        %[[VAL_51:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_10]]#0{{\[}}%[[VAL_50]]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[VAL_52:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_53:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_52]]
+// CHECK-NEXT:        %[[VAL_54:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_10]]#0{{\[}}%[[VAL_53]]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[VAL_55:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_51]], %[[VAL_54]] : !felt.type, !felt.type
+// CHECK-NEXT:        struct.writef %[[VAL_0]][@out] = %[[VAL_55]] : <@InnerConditional12<[@N]>>, !felt.type
+// CHECK-NEXT:        function.return %[[VAL_0]] : !struct.type<@InnerConditional12<[@N]>>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[VAL_56:[0-9a-zA-Z_\.]+]]: !struct.type<@InnerConditional12<[@N]>>) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[VAL_57:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type
+// CHECK-NEXT:        %[[VAL_58:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_59:[0-9a-zA-Z_\.]+]] = array.new  : <@N x !felt.type>
+// CHECK-NEXT:        %[[VAL_60:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_61:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_59]], %[[VAL_60]] : <@N x !felt.type>
+// CHECK-NEXT:        %[[VAL_62:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_63:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[VAL_64:[0-9a-zA-Z_\.]+]] = %[[VAL_62]] to %[[VAL_61]] step %[[VAL_63]] {
+// CHECK-NEXT:          array.write %[[VAL_59]]{{\[}}%[[VAL_64]]] = %[[VAL_58]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_65:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_66:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_67:[0-9a-zA-Z_\.]+]] = %[[VAL_59]], %[[VAL_68:[0-9a-zA-Z_\.]+]] = %[[VAL_65]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[VAL_69:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_68]], %[[VAL_57]])
+// CHECK-NEXT:          scf.condition(%[[VAL_69]]) %[[VAL_67]], %[[VAL_68]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:        } do {
+// CHECK-NEXT:        ^bb0(%[[VAL_70:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[VAL_71:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[VAL_72:[0-9a-zA-Z_\.]+]] = felt.const  2
+// CHECK-NEXT:          %[[VAL_73:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_71]], %[[VAL_72]])
+// CHECK-NEXT:          %[[VAL_74:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_73]] -> (!array.type<@N x !felt.type>) {
+// CHECK-NEXT:            %[[VAL_75:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:            %[[VAL_76:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_77:[0-9a-zA-Z_\.]+]] = %[[VAL_70]], %[[VAL_78:[0-9a-zA-Z_\.]+]] = %[[VAL_75]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
+// CHECK-NEXT:              %[[VAL_79:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_78]], %[[VAL_57]])
+// CHECK-NEXT:              scf.condition(%[[VAL_79]]) %[[VAL_77]], %[[VAL_78]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:            } do {
+// CHECK-NEXT:            ^bb0(%[[VAL_80:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[VAL_81:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:              %[[VAL_82:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_71]]
+// CHECK-NEXT:              %[[VAL_83:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_80]]{{\[}}%[[VAL_82]]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              %[[VAL_84:[0-9a-zA-Z_\.]+]] = felt.const  999
+// CHECK-NEXT:              %[[VAL_85:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_83]], %[[VAL_84]] : !felt.type, !felt.type
+// CHECK-NEXT:              %[[VAL_86:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_71]]
+// CHECK-NEXT:              array.write %[[VAL_80]]{{\[}}%[[VAL_86]]] = %[[VAL_85]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              %[[VAL_87:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:              %[[VAL_88:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_81]], %[[VAL_87]] : !felt.type, !felt.type
+// CHECK-NEXT:              scf.yield %[[VAL_80]], %[[VAL_88]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:            }
+// CHECK-NEXT:            scf.yield %[[VAL_76]]#0 : !array.type<@N x !felt.type>
+// CHECK-NEXT:          } else {
+// CHECK-NEXT:            %[[VAL_89:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:            %[[VAL_90:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_91:[0-9a-zA-Z_\.]+]] = %[[VAL_70]], %[[VAL_92:[0-9a-zA-Z_\.]+]] = %[[VAL_89]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
+// CHECK-NEXT:              %[[VAL_93:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_92]], %[[VAL_71]])
+// CHECK-NEXT:              scf.condition(%[[VAL_93]]) %[[VAL_91]], %[[VAL_92]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:            } do {
+// CHECK-NEXT:            ^bb0(%[[VAL_94:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[VAL_95:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:              %[[VAL_96:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_71]]
+// CHECK-NEXT:              %[[VAL_97:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_94]]{{\[}}%[[VAL_96]]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              %[[VAL_98:[0-9a-zA-Z_\.]+]] = felt.const  888
+// CHECK-NEXT:              %[[VAL_99:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_97]], %[[VAL_98]] : !felt.type, !felt.type
+// CHECK-NEXT:              %[[VAL_100:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_71]]
+// CHECK-NEXT:              array.write %[[VAL_94]]{{\[}}%[[VAL_100]]] = %[[VAL_99]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              %[[VAL_101:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:              %[[VAL_102:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_95]], %[[VAL_101]] : !felt.type, !felt.type
+// CHECK-NEXT:              scf.yield %[[VAL_94]], %[[VAL_102]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:            }
+// CHECK-NEXT:            scf.yield %[[VAL_90]]#0 : !array.type<@N x !felt.type>
+// CHECK-NEXT:          }
+// CHECK-NEXT:          %[[VAL_103:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_104:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_71]], %[[VAL_103]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_74]], %[[VAL_104]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_105:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_56]][@out] : <@InnerConditional12<[@N]>>, !felt.type
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/loops/inner_conditional_12.circom
+++ b/circom/tests/loops/inner_conditional_12.circom
@@ -31,138 +31,140 @@ component main = InnerConditional12(4);
 // CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
 // CHECK-NEXT:    struct.def @InnerConditional12<[@N]> {
 // CHECK-NEXT:      struct.field @out : !felt.type {llzk.pub}
-// CHECK-NEXT:      function.def @compute() -> !struct.type<@InnerConditional12<[@N]>> attributes {function.allow_witness} {
-// CHECK-NEXT:        %[[VAL_0:[0-9a-zA-Z_\.]+]] = struct.new : <@InnerConditional12<[@N]>>
-// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type
-// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = array.new  : <@N x !felt.type>
-// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_3]], %[[VAL_4]] : <@N x !felt.type>
-// CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:        scf.for %[[VAL_8:[0-9a-zA-Z_\.]+]] = %[[VAL_6]] to %[[VAL_5]] step %[[VAL_7]] {
-// CHECK-NEXT:          array.write %[[VAL_3]]{{\[}}%[[VAL_8]]] = %[[VAL_2]] : <@N x !felt.type>, !felt.type
+// CHECK-LABEL:     function.def @compute
+// CHECK-SAME:      () -> !struct.type<@InnerConditional12<[@N]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[V_0:[0-9a-zA-Z_\.]+]] = struct.new : <@InnerConditional12<[@N]>>
+// CHECK-NEXT:        %[[V_N:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type
+// CHECK-NEXT:        %[[V_2:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_A:[0-9a-zA-Z_\.]+]] = array.new  : <@N x !felt.type>
+// CHECK-NEXT:        %[[V_4:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[V_5:[0-9a-zA-Z_\.]+]] = array.len %[[V_A]], %[[V_4]] : <@N x !felt.type>
+// CHECK-NEXT:        %[[V_6:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[V_7:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[V_8:[0-9a-zA-Z_\.]+]] = %[[V_6]] to %[[V_5]] step %[[V_7]] {
+// CHECK-NEXT:          array.write %[[V_A]]{{\[}}%[[V_8]]] = %[[V_2]] : <@N x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_9:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_11:[0-9a-zA-Z_\.]+]] = %[[VAL_3]], %[[VAL_12:[0-9a-zA-Z_\.]+]] = %[[VAL_9]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
-// CHECK-NEXT:          %[[VAL_13:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_12]], %[[VAL_1]])
-// CHECK-NEXT:          scf.condition(%[[VAL_13]]) %[[VAL_11]], %[[VAL_12]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[V_I0:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_10:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_11:[0-9a-zA-Z_\.]+]] = %[[V_A]], %[[V_I1:[0-9a-zA-Z_\.]+]] = %[[V_I0]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[V_13:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[V_I1]], %[[V_N]])
+// CHECK-NEXT:          scf.condition(%[[V_13]]) %[[V_11]], %[[V_I1]] : !array.type<@N x !felt.type>, !felt.type
 // CHECK-NEXT:        } do {
-// CHECK-NEXT:        ^bb0(%[[VAL_14:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[VAL_15:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:          %[[VAL_16:[0-9a-zA-Z_\.]+]] = felt.const  2
-// CHECK-NEXT:          %[[VAL_17:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_15]], %[[VAL_16]])
-// CHECK-NEXT:          %[[VAL_18:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_17]] -> (!array.type<@N x !felt.type>) {
-// CHECK-NEXT:            %[[VAL_19:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:            %[[VAL_20:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_21:[0-9a-zA-Z_\.]+]] = %[[VAL_14]], %[[VAL_22:[0-9a-zA-Z_\.]+]] = %[[VAL_19]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
-// CHECK-NEXT:              %[[VAL_23:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_22]], %[[VAL_1]])
-// CHECK-NEXT:              scf.condition(%[[VAL_23]]) %[[VAL_21]], %[[VAL_22]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:        ^bb0(%[[V_14:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[V_I2:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[V_16:[0-9a-zA-Z_\.]+]] = felt.const  2
+// CHECK-NEXT:          %[[V_17:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[V_I2]], %[[V_16]])
+// CHECK-NEXT:          %[[V_18:[0-9a-zA-Z_\.]+]] = scf.if %[[V_17]] -> (!array.type<@N x !felt.type>) {
+// CHECK-NEXT:            %[[V_19:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:            %[[V_20:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_21:[0-9a-zA-Z_\.]+]] = %[[V_14]], %[[V_22:[0-9a-zA-Z_\.]+]] = %[[V_19]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
+// CHECK-NEXT:              %[[V_23:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[V_22]], %[[V_N]])
+// CHECK-NEXT:              scf.condition(%[[V_23]]) %[[V_21]], %[[V_22]] : !array.type<@N x !felt.type>, !felt.type
 // CHECK-NEXT:            } do {
-// CHECK-NEXT:            ^bb0(%[[VAL_24:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[VAL_25:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:              %[[VAL_26:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_15]]
-// CHECK-NEXT:              %[[VAL_27:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_24]]{{\[}}%[[VAL_26]]] : <@N x !felt.type>, !felt.type
-// CHECK-NEXT:              %[[VAL_28:[0-9a-zA-Z_\.]+]] = felt.const  999
-// CHECK-NEXT:              %[[VAL_29:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_27]], %[[VAL_28]] : !felt.type, !felt.type
-// CHECK-NEXT:              %[[VAL_30:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_15]]
-// CHECK-NEXT:              array.write %[[VAL_24]]{{\[}}%[[VAL_30]]] = %[[VAL_29]] : <@N x !felt.type>, !felt.type
-// CHECK-NEXT:              %[[VAL_31:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:              %[[VAL_32:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_25]], %[[VAL_31]] : !felt.type, !felt.type
-// CHECK-NEXT:              scf.yield %[[VAL_24]], %[[VAL_32]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:            ^bb0(%[[V_24:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[V_25:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:              %[[V_26:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_I2]]
+// CHECK-NEXT:              %[[V_27:[0-9a-zA-Z_\.]+]] = array.read %[[V_24]]{{\[}}%[[V_26]]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              %[[V_28:[0-9a-zA-Z_\.]+]] = felt.const  999
+// CHECK-NEXT:              %[[V_29:[0-9a-zA-Z_\.]+]] = felt.add %[[V_27]], %[[V_28]] : !felt.type, !felt.type
+// CHECK-NEXT:              %[[V_30:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_I2]]
+// CHECK-NEXT:              array.write %[[V_24]]{{\[}}%[[V_30]]] = %[[V_29]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              %[[V_31:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:              %[[V_32:[0-9a-zA-Z_\.]+]] = felt.add %[[V_25]], %[[V_31]] : !felt.type, !felt.type
+// CHECK-NEXT:              scf.yield %[[V_24]], %[[V_32]] : !array.type<@N x !felt.type>, !felt.type
 // CHECK-NEXT:            }
-// CHECK-NEXT:            scf.yield %[[VAL_20]]#0 : !array.type<@N x !felt.type>
+// CHECK-NEXT:            scf.yield %[[V_20]]#0 : !array.type<@N x !felt.type>
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[VAL_33:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:            %[[VAL_34:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_35:[0-9a-zA-Z_\.]+]] = %[[VAL_14]], %[[VAL_36:[0-9a-zA-Z_\.]+]] = %[[VAL_33]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
-// CHECK-NEXT:              %[[VAL_37:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_36]], %[[VAL_15]])
-// CHECK-NEXT:              scf.condition(%[[VAL_37]]) %[[VAL_35]], %[[VAL_36]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:            %[[V_33:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:            %[[V_34:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_35:[0-9a-zA-Z_\.]+]] = %[[V_14]], %[[V_36:[0-9a-zA-Z_\.]+]] = %[[V_33]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
+// CHECK-NEXT:              %[[V_37:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[V_36]], %[[V_I2]])
+// CHECK-NEXT:              scf.condition(%[[V_37]]) %[[V_35]], %[[V_36]] : !array.type<@N x !felt.type>, !felt.type
 // CHECK-NEXT:            } do {
-// CHECK-NEXT:            ^bb0(%[[VAL_38:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[VAL_39:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:              %[[VAL_40:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_15]]
-// CHECK-NEXT:              %[[VAL_41:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_38]]{{\[}}%[[VAL_40]]] : <@N x !felt.type>, !felt.type
-// CHECK-NEXT:              %[[VAL_42:[0-9a-zA-Z_\.]+]] = felt.const  888
-// CHECK-NEXT:              %[[VAL_43:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_41]], %[[VAL_42]] : !felt.type, !felt.type
-// CHECK-NEXT:              %[[VAL_44:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_15]]
-// CHECK-NEXT:              array.write %[[VAL_38]]{{\[}}%[[VAL_44]]] = %[[VAL_43]] : <@N x !felt.type>, !felt.type
-// CHECK-NEXT:              %[[VAL_45:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:              %[[VAL_46:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_39]], %[[VAL_45]] : !felt.type, !felt.type
-// CHECK-NEXT:              scf.yield %[[VAL_38]], %[[VAL_46]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:            ^bb0(%[[V_38:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[V_39:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:              %[[V_40:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_I2]]
+// CHECK-NEXT:              %[[V_41:[0-9a-zA-Z_\.]+]] = array.read %[[V_38]]{{\[}}%[[V_40]]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              %[[V_42:[0-9a-zA-Z_\.]+]] = felt.const  888
+// CHECK-NEXT:              %[[V_43:[0-9a-zA-Z_\.]+]] = felt.add %[[V_41]], %[[V_42]] : !felt.type, !felt.type
+// CHECK-NEXT:              %[[V_44:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_I2]]
+// CHECK-NEXT:              array.write %[[V_38]]{{\[}}%[[V_44]]] = %[[V_43]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              %[[V_45:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:              %[[V_46:[0-9a-zA-Z_\.]+]] = felt.add %[[V_39]], %[[V_45]] : !felt.type, !felt.type
+// CHECK-NEXT:              scf.yield %[[V_38]], %[[V_46]] : !array.type<@N x !felt.type>, !felt.type
 // CHECK-NEXT:            }
-// CHECK-NEXT:            scf.yield %[[VAL_34]]#0 : !array.type<@N x !felt.type>
+// CHECK-NEXT:            scf.yield %[[V_34]]#0 : !array.type<@N x !felt.type>
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[VAL_47:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:          %[[VAL_48:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_15]], %[[VAL_47]] : !felt.type, !felt.type
-// CHECK-NEXT:          scf.yield %[[VAL_18]], %[[VAL_48]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_47:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[V_48:[0-9a-zA-Z_\.]+]] = felt.add %[[V_I2]], %[[V_47]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[V_18]], %[[V_48]] : !array.type<@N x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_49:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_50:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_49]]
-// CHECK-NEXT:        %[[VAL_51:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_10]]#0{{\[}}%[[VAL_50]]] : <@N x !felt.type>, !felt.type
-// CHECK-NEXT:        %[[VAL_52:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:        %[[VAL_53:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_52]]
-// CHECK-NEXT:        %[[VAL_54:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_10]]#0{{\[}}%[[VAL_53]]] : <@N x !felt.type>, !felt.type
-// CHECK-NEXT:        %[[VAL_55:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_51]], %[[VAL_54]] : !felt.type, !felt.type
-// CHECK-NEXT:        struct.writef %[[VAL_0]][@out] = %[[VAL_55]] : <@InnerConditional12<[@N]>>, !felt.type
-// CHECK-NEXT:        function.return %[[VAL_0]] : !struct.type<@InnerConditional12<[@N]>>
+// CHECK-NEXT:        %[[V_49:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_50:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_49]]
+// CHECK-NEXT:        %[[V_51:[0-9a-zA-Z_\.]+]] = array.read %[[V_10]]#0{{\[}}%[[V_50]]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[V_52:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[V_53:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_52]]
+// CHECK-NEXT:        %[[V_54:[0-9a-zA-Z_\.]+]] = array.read %[[V_10]]#0{{\[}}%[[V_53]]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[V_55:[0-9a-zA-Z_\.]+]] = felt.add %[[V_51]], %[[V_54]] : !felt.type, !felt.type
+// CHECK-NEXT:        struct.writef %[[V_0]][@out] = %[[V_55]] : <@InnerConditional12<[@N]>>, !felt.type
+// CHECK-NEXT:        function.return %[[V_0]] : !struct.type<@InnerConditional12<[@N]>>
 // CHECK-NEXT:      }
-// CHECK-NEXT:      function.def @constrain(%[[VAL_56:[0-9a-zA-Z_\.]+]]: !struct.type<@InnerConditional12<[@N]>>) attributes {function.allow_constraint} {
-// CHECK-NEXT:        %[[VAL_57:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type
-// CHECK-NEXT:        %[[VAL_58:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_59:[0-9a-zA-Z_\.]+]] = array.new  : <@N x !felt.type>
-// CHECK-NEXT:        %[[VAL_60:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_61:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_59]], %[[VAL_60]] : <@N x !felt.type>
-// CHECK-NEXT:        %[[VAL_62:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_63:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:        scf.for %[[VAL_64:[0-9a-zA-Z_\.]+]] = %[[VAL_62]] to %[[VAL_61]] step %[[VAL_63]] {
-// CHECK-NEXT:          array.write %[[VAL_59]]{{\[}}%[[VAL_64]]] = %[[VAL_58]] : <@N x !felt.type>, !felt.type
+// CHECK-LABEL:     function.def @constrain
+// CHECK-SAME:      (%[[V_56:[0-9a-zA-Z_\.]+]]: !struct.type<@InnerConditional12<[@N]>>) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[V_N:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type
+// CHECK-NEXT:        %[[V_58:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_A:[0-9a-zA-Z_\.]+]] = array.new  : <@N x !felt.type>
+// CHECK-NEXT:        %[[V_60:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[V_61:[0-9a-zA-Z_\.]+]] = array.len %[[V_A]], %[[V_60]] : <@N x !felt.type>
+// CHECK-NEXT:        %[[V_62:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[V_63:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[V_64:[0-9a-zA-Z_\.]+]] = %[[V_62]] to %[[V_61]] step %[[V_63]] {
+// CHECK-NEXT:          array.write %[[V_A]]{{\[}}%[[V_64]]] = %[[V_58]] : <@N x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_65:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_66:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_67:[0-9a-zA-Z_\.]+]] = %[[VAL_59]], %[[VAL_68:[0-9a-zA-Z_\.]+]] = %[[VAL_65]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
-// CHECK-NEXT:          %[[VAL_69:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_68]], %[[VAL_57]])
-// CHECK-NEXT:          scf.condition(%[[VAL_69]]) %[[VAL_67]], %[[VAL_68]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[V_65:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_66:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_67:[0-9a-zA-Z_\.]+]] = %[[V_A]], %[[V_68:[0-9a-zA-Z_\.]+]] = %[[V_65]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[V_69:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[V_68]], %[[V_N]])
+// CHECK-NEXT:          scf.condition(%[[V_69]]) %[[V_67]], %[[V_68]] : !array.type<@N x !felt.type>, !felt.type
 // CHECK-NEXT:        } do {
-// CHECK-NEXT:        ^bb0(%[[VAL_70:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[VAL_71:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:          %[[VAL_72:[0-9a-zA-Z_\.]+]] = felt.const  2
-// CHECK-NEXT:          %[[VAL_73:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_71]], %[[VAL_72]])
-// CHECK-NEXT:          %[[VAL_74:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_73]] -> (!array.type<@N x !felt.type>) {
-// CHECK-NEXT:            %[[VAL_75:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:            %[[VAL_76:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_77:[0-9a-zA-Z_\.]+]] = %[[VAL_70]], %[[VAL_78:[0-9a-zA-Z_\.]+]] = %[[VAL_75]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
-// CHECK-NEXT:              %[[VAL_79:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_78]], %[[VAL_57]])
-// CHECK-NEXT:              scf.condition(%[[VAL_79]]) %[[VAL_77]], %[[VAL_78]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:        ^bb0(%[[V_70:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[V_71:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[V_72:[0-9a-zA-Z_\.]+]] = felt.const  2
+// CHECK-NEXT:          %[[V_73:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[V_71]], %[[V_72]])
+// CHECK-NEXT:          %[[V_74:[0-9a-zA-Z_\.]+]] = scf.if %[[V_73]] -> (!array.type<@N x !felt.type>) {
+// CHECK-NEXT:            %[[V_75:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:            %[[V_76:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_77:[0-9a-zA-Z_\.]+]] = %[[V_70]], %[[V_78:[0-9a-zA-Z_\.]+]] = %[[V_75]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
+// CHECK-NEXT:              %[[V_79:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[V_78]], %[[V_N]])
+// CHECK-NEXT:              scf.condition(%[[V_79]]) %[[V_77]], %[[V_78]] : !array.type<@N x !felt.type>, !felt.type
 // CHECK-NEXT:            } do {
-// CHECK-NEXT:            ^bb0(%[[VAL_80:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[VAL_81:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:              %[[VAL_82:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_71]]
-// CHECK-NEXT:              %[[VAL_83:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_80]]{{\[}}%[[VAL_82]]] : <@N x !felt.type>, !felt.type
-// CHECK-NEXT:              %[[VAL_84:[0-9a-zA-Z_\.]+]] = felt.const  999
-// CHECK-NEXT:              %[[VAL_85:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_83]], %[[VAL_84]] : !felt.type, !felt.type
-// CHECK-NEXT:              %[[VAL_86:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_71]]
-// CHECK-NEXT:              array.write %[[VAL_80]]{{\[}}%[[VAL_86]]] = %[[VAL_85]] : <@N x !felt.type>, !felt.type
-// CHECK-NEXT:              %[[VAL_87:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:              %[[VAL_88:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_81]], %[[VAL_87]] : !felt.type, !felt.type
-// CHECK-NEXT:              scf.yield %[[VAL_80]], %[[VAL_88]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:            ^bb0(%[[V_80:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[V_81:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:              %[[V_82:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_71]]
+// CHECK-NEXT:              %[[V_83:[0-9a-zA-Z_\.]+]] = array.read %[[V_80]]{{\[}}%[[V_82]]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              %[[V_84:[0-9a-zA-Z_\.]+]] = felt.const  999
+// CHECK-NEXT:              %[[V_85:[0-9a-zA-Z_\.]+]] = felt.add %[[V_83]], %[[V_84]] : !felt.type, !felt.type
+// CHECK-NEXT:              %[[V_86:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_71]]
+// CHECK-NEXT:              array.write %[[V_80]]{{\[}}%[[V_86]]] = %[[V_85]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              %[[V_87:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:              %[[V_88:[0-9a-zA-Z_\.]+]] = felt.add %[[V_81]], %[[V_87]] : !felt.type, !felt.type
+// CHECK-NEXT:              scf.yield %[[V_80]], %[[V_88]] : !array.type<@N x !felt.type>, !felt.type
 // CHECK-NEXT:            }
-// CHECK-NEXT:            scf.yield %[[VAL_76]]#0 : !array.type<@N x !felt.type>
+// CHECK-NEXT:            scf.yield %[[V_76]]#0 : !array.type<@N x !felt.type>
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[VAL_89:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:            %[[VAL_90:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_91:[0-9a-zA-Z_\.]+]] = %[[VAL_70]], %[[VAL_92:[0-9a-zA-Z_\.]+]] = %[[VAL_89]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
-// CHECK-NEXT:              %[[VAL_93:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_92]], %[[VAL_71]])
-// CHECK-NEXT:              scf.condition(%[[VAL_93]]) %[[VAL_91]], %[[VAL_92]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:            %[[V_89:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:            %[[V_90:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_91:[0-9a-zA-Z_\.]+]] = %[[V_70]], %[[V_92:[0-9a-zA-Z_\.]+]] = %[[V_89]]) : (!array.type<@N x !felt.type>, !felt.type) -> (!array.type<@N x !felt.type>, !felt.type) {
+// CHECK-NEXT:              %[[V_93:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[V_92]], %[[V_71]])
+// CHECK-NEXT:              scf.condition(%[[V_93]]) %[[V_91]], %[[V_92]] : !array.type<@N x !felt.type>, !felt.type
 // CHECK-NEXT:            } do {
-// CHECK-NEXT:            ^bb0(%[[VAL_94:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[VAL_95:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:              %[[VAL_96:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_71]]
-// CHECK-NEXT:              %[[VAL_97:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_94]]{{\[}}%[[VAL_96]]] : <@N x !felt.type>, !felt.type
-// CHECK-NEXT:              %[[VAL_98:[0-9a-zA-Z_\.]+]] = felt.const  888
-// CHECK-NEXT:              %[[VAL_99:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_97]], %[[VAL_98]] : !felt.type, !felt.type
-// CHECK-NEXT:              %[[VAL_100:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_71]]
-// CHECK-NEXT:              array.write %[[VAL_94]]{{\[}}%[[VAL_100]]] = %[[VAL_99]] : <@N x !felt.type>, !felt.type
-// CHECK-NEXT:              %[[VAL_101:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:              %[[VAL_102:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_95]], %[[VAL_101]] : !felt.type, !felt.type
-// CHECK-NEXT:              scf.yield %[[VAL_94]], %[[VAL_102]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:            ^bb0(%[[V_94:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>, %[[V_95:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:              %[[V_96:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_71]]
+// CHECK-NEXT:              %[[V_97:[0-9a-zA-Z_\.]+]] = array.read %[[V_94]]{{\[}}%[[V_96]]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              %[[V_98:[0-9a-zA-Z_\.]+]] = felt.const  888
+// CHECK-NEXT:              %[[V_99:[0-9a-zA-Z_\.]+]] = felt.add %[[V_97]], %[[V_98]] : !felt.type, !felt.type
+// CHECK-NEXT:              %[[V_100:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_71]]
+// CHECK-NEXT:              array.write %[[V_94]]{{\[}}%[[V_100]]] = %[[V_99]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:              %[[V_101:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:              %[[V_102:[0-9a-zA-Z_\.]+]] = felt.add %[[V_95]], %[[V_101]] : !felt.type, !felt.type
+// CHECK-NEXT:              scf.yield %[[V_94]], %[[V_102]] : !array.type<@N x !felt.type>, !felt.type
 // CHECK-NEXT:            }
-// CHECK-NEXT:            scf.yield %[[VAL_90]]#0 : !array.type<@N x !felt.type>
+// CHECK-NEXT:            scf.yield %[[V_90]]#0 : !array.type<@N x !felt.type>
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[VAL_103:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:          %[[VAL_104:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_71]], %[[VAL_103]] : !felt.type, !felt.type
-// CHECK-NEXT:          scf.yield %[[VAL_74]], %[[VAL_104]] : !array.type<@N x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_103:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[V_104:[0-9a-zA-Z_\.]+]] = felt.add %[[V_71]], %[[V_103]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[V_74]], %[[V_104]] : !array.type<@N x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_105:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_56]][@out] : <@InnerConditional12<[@N]>>, !felt.type
+// CHECK-NEXT:        %[[V_105:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_56]][@out] : <@InnerConditional12<[@N]>>, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }

--- a/circom/tests/loops/inner_loop_00.circom
+++ b/circom/tests/loops/inner_loop_00.circom
@@ -1,7 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL:.*
 
 pragma circom 2.0.0;
 
@@ -21,3 +20,89 @@ template InnerLoops(n, m) {
 component main = InnerLoops(2, 3);
 
 // CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-NEXT:    struct.def @InnerLoops<[@n, @m]> {
+// CHECK-NEXT:      struct.field @out : !felt.type {llzk.pub}
+// CHECK-NEXT:      function.def @compute(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !array.type<@m x !felt.type>) -> !struct.type<@InnerLoops<[@n, @m]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = struct.new : <@InnerLoops<[@n, @m]>>
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = poly.read_const @m : !felt.type
+// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !felt.type>
+// CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_5]], %[[VAL_6]] : <@n x !felt.type>
+// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_9:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[VAL_10:[0-9a-zA-Z_\.]+]] = %[[VAL_8]] to %[[VAL_7]] step %[[VAL_9]] {
+// CHECK-NEXT:          array.write %[[VAL_5]]{{\[}}%[[VAL_10]]] = %[[VAL_4]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_12:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_13:[0-9a-zA-Z_\.]+]] = %[[VAL_5]], %[[VAL_14:[0-9a-zA-Z_\.]+]] = %[[VAL_11]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[VAL_15:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_14]], %[[VAL_2]])
+// CHECK-NEXT:          scf.condition(%[[VAL_15]]) %[[VAL_13]], %[[VAL_14]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        } do {
+// CHECK-NEXT:        ^bb0(%[[VAL_16:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_17:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[VAL_18:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:          %[[VAL_19:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_20:[0-9a-zA-Z_\.]+]] = %[[VAL_16]], %[[VAL_21:[0-9a-zA-Z_\.]+]] = %[[VAL_18]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:            %[[VAL_22:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_21]], %[[VAL_3]])
+// CHECK-NEXT:            scf.condition(%[[VAL_22]]) %[[VAL_20]], %[[VAL_21]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:          } do {
+// CHECK-NEXT:          ^bb0(%[[VAL_23:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_24:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:            %[[VAL_25:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_24]]
+// CHECK-NEXT:            %[[VAL_26:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_0]]{{\[}}%[[VAL_25]]] : <@m x !felt.type>, !felt.type
+// CHECK-NEXT:            %[[VAL_27:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_17]]
+// CHECK-NEXT:            array.write %[[VAL_23]]{{\[}}%[[VAL_27]]] = %[[VAL_26]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:            %[[VAL_28:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:            %[[VAL_29:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_24]], %[[VAL_28]] : !felt.type, !felt.type
+// CHECK-NEXT:            scf.yield %[[VAL_23]], %[[VAL_29]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:          }
+// CHECK-NEXT:          %[[VAL_30:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_31:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_17]], %[[VAL_30]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_19]]#0, %[[VAL_31]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_32:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_33:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_32]]
+// CHECK-NEXT:        %[[VAL_34:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_12]]#0{{\[}}%[[VAL_33]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:        struct.writef %[[VAL_1]][@out] = %[[VAL_34]] : <@InnerLoops<[@n, @m]>>, !felt.type
+// CHECK-NEXT:        function.return %[[VAL_1]] : !struct.type<@InnerLoops<[@n, @m]>>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[VAL_35:[0-9a-zA-Z_\.]+]]: !struct.type<@InnerLoops<[@n, @m]>>, %[[VAL_36:[0-9a-zA-Z_\.]+]]: !array.type<@m x !felt.type>) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[VAL_37:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_38:[0-9a-zA-Z_\.]+]] = poly.read_const @m : !felt.type
+// CHECK-NEXT:        %[[VAL_39:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_40:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !felt.type>
+// CHECK-NEXT:        %[[VAL_41:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_42:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_40]], %[[VAL_41]] : <@n x !felt.type>
+// CHECK-NEXT:        %[[VAL_43:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_44:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[VAL_45:[0-9a-zA-Z_\.]+]] = %[[VAL_43]] to %[[VAL_42]] step %[[VAL_44]] {
+// CHECK-NEXT:          array.write %[[VAL_40]]{{\[}}%[[VAL_45]]] = %[[VAL_39]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_46:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_47:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_48:[0-9a-zA-Z_\.]+]] = %[[VAL_40]], %[[VAL_49:[0-9a-zA-Z_\.]+]] = %[[VAL_46]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[VAL_50:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_49]], %[[VAL_37]])
+// CHECK-NEXT:          scf.condition(%[[VAL_50]]) %[[VAL_48]], %[[VAL_49]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        } do {
+// CHECK-NEXT:        ^bb0(%[[VAL_51:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_52:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[VAL_53:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:          %[[VAL_54:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_55:[0-9a-zA-Z_\.]+]] = %[[VAL_51]], %[[VAL_56:[0-9a-zA-Z_\.]+]] = %[[VAL_53]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:            %[[VAL_57:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_56]], %[[VAL_38]])
+// CHECK-NEXT:            scf.condition(%[[VAL_57]]) %[[VAL_55]], %[[VAL_56]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:          } do {
+// CHECK-NEXT:          ^bb0(%[[VAL_58:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_59:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:            %[[VAL_60:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_59]]
+// CHECK-NEXT:            %[[VAL_61:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_36]]{{\[}}%[[VAL_60]]] : <@m x !felt.type>, !felt.type
+// CHECK-NEXT:            %[[VAL_62:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_52]]
+// CHECK-NEXT:            array.write %[[VAL_58]]{{\[}}%[[VAL_62]]] = %[[VAL_61]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:            %[[VAL_63:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:            %[[VAL_64:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_59]], %[[VAL_63]] : !felt.type, !felt.type
+// CHECK-NEXT:            scf.yield %[[VAL_58]], %[[VAL_64]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:          }
+// CHECK-NEXT:          %[[VAL_65:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_66:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_52]], %[[VAL_65]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_54]]#0, %[[VAL_66]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_67:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_35]][@out] : <@InnerLoops<[@n, @m]>>, !felt.type
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/loops/inner_loop_00.circom
+++ b/circom/tests/loops/inner_loop_00.circom
@@ -22,86 +22,88 @@ component main = InnerLoops(2, 3);
 // CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
 // CHECK-NEXT:    struct.def @InnerLoops<[@n, @m]> {
 // CHECK-NEXT:      struct.field @out : !felt.type {llzk.pub}
-// CHECK-NEXT:      function.def @compute(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !array.type<@m x !felt.type>) -> !struct.type<@InnerLoops<[@n, @m]>> attributes {function.allow_witness} {
-// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = struct.new : <@InnerLoops<[@n, @m]>>
-// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
-// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = poly.read_const @m : !felt.type
-// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !felt.type>
-// CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_5]], %[[VAL_6]] : <@n x !felt.type>
-// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_9:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:        scf.for %[[VAL_10:[0-9a-zA-Z_\.]+]] = %[[VAL_8]] to %[[VAL_7]] step %[[VAL_9]] {
-// CHECK-NEXT:          array.write %[[VAL_5]]{{\[}}%[[VAL_10]]] = %[[VAL_4]] : <@n x !felt.type>, !felt.type
+// CHECK-LABEL:     function.def @compute
+// CHECK-SAME:      (%[[V_IN:[0-9a-zA-Z_\.]+]]: !array.type<@m x !felt.type>) -> !struct.type<@InnerLoops<[@n, @m]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[V_1:[0-9a-zA-Z_\.]+]] = struct.new : <@InnerLoops<[@n, @m]>>
+// CHECK-NEXT:        %[[V_N:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[V_M:[0-9a-zA-Z_\.]+]] = poly.read_const @m : !felt.type
+// CHECK-NEXT:        %[[V_4:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_B:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !felt.type>
+// CHECK-NEXT:        %[[V_6:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[V_7:[0-9a-zA-Z_\.]+]] = array.len %[[V_B]], %[[V_6]] : <@n x !felt.type>
+// CHECK-NEXT:        %[[V_8:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[V_9:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[V_10:[0-9a-zA-Z_\.]+]] = %[[V_8]] to %[[V_7]] step %[[V_9]] {
+// CHECK-NEXT:          array.write %[[V_B]]{{\[}}%[[V_10]]] = %[[V_4]] : <@n x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_12:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_13:[0-9a-zA-Z_\.]+]] = %[[VAL_5]], %[[VAL_14:[0-9a-zA-Z_\.]+]] = %[[VAL_11]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
-// CHECK-NEXT:          %[[VAL_15:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_14]], %[[VAL_2]])
-// CHECK-NEXT:          scf.condition(%[[VAL_15]]) %[[VAL_13]], %[[VAL_14]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[V_I0:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_12:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_B1:[0-9a-zA-Z_\.]+]] = %[[V_B]], %[[V_I1:[0-9a-zA-Z_\.]+]] = %[[V_I0]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[V_15:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[V_I1]], %[[V_N]])
+// CHECK-NEXT:          scf.condition(%[[V_15]]) %[[V_B1]], %[[V_I1]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        } do {
-// CHECK-NEXT:        ^bb0(%[[VAL_16:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_17:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:          %[[VAL_18:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:          %[[VAL_19:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_20:[0-9a-zA-Z_\.]+]] = %[[VAL_16]], %[[VAL_21:[0-9a-zA-Z_\.]+]] = %[[VAL_18]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
-// CHECK-NEXT:            %[[VAL_22:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_21]], %[[VAL_3]])
-// CHECK-NEXT:            scf.condition(%[[VAL_22]]) %[[VAL_20]], %[[VAL_21]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        ^bb0(%[[V_B2:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[V_I3:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[V_J0:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:          %[[V_19:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_20:[0-9a-zA-Z_\.]+]] = %[[V_B2]], %[[V_J1:[0-9a-zA-Z_\.]+]] = %[[V_J0]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:            %[[V_22:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[V_J1]], %[[V_M]])
+// CHECK-NEXT:            scf.condition(%[[V_22]]) %[[V_20]], %[[V_J1]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:          } do {
-// CHECK-NEXT:          ^bb0(%[[VAL_23:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_24:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:            %[[VAL_25:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_24]]
-// CHECK-NEXT:            %[[VAL_26:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_0]]{{\[}}%[[VAL_25]]] : <@m x !felt.type>, !felt.type
-// CHECK-NEXT:            %[[VAL_27:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_17]]
-// CHECK-NEXT:            array.write %[[VAL_23]]{{\[}}%[[VAL_27]]] = %[[VAL_26]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:            %[[VAL_28:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:            %[[VAL_29:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_24]], %[[VAL_28]] : !felt.type, !felt.type
-// CHECK-NEXT:            scf.yield %[[VAL_23]], %[[VAL_29]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:          ^bb0(%[[V_23:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[V_J2:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:            %[[V_25:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_J2]]
+// CHECK-NEXT:            %[[V_26:[0-9a-zA-Z_\.]+]] = array.read %[[V_IN]]{{\[}}%[[V_25]]] : <@m x !felt.type>, !felt.type
+// CHECK-NEXT:            %[[V_27:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_I3]]
+// CHECK-NEXT:            array.write %[[V_23]]{{\[}}%[[V_27]]] = %[[V_26]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:            %[[V_28:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:            %[[V_29:[0-9a-zA-Z_\.]+]] = felt.add %[[V_J2]], %[[V_28]] : !felt.type, !felt.type
+// CHECK-NEXT:            scf.yield %[[V_23]], %[[V_29]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[VAL_30:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:          %[[VAL_31:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_17]], %[[VAL_30]] : !felt.type, !felt.type
-// CHECK-NEXT:          scf.yield %[[VAL_19]]#0, %[[VAL_31]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_30:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[V_31:[0-9a-zA-Z_\.]+]] = felt.add %[[V_I3]], %[[V_30]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[V_19]]#0, %[[V_31]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_32:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_33:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_32]]
-// CHECK-NEXT:        %[[VAL_34:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_12]]#0{{\[}}%[[VAL_33]]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:        struct.writef %[[VAL_1]][@out] = %[[VAL_34]] : <@InnerLoops<[@n, @m]>>, !felt.type
-// CHECK-NEXT:        function.return %[[VAL_1]] : !struct.type<@InnerLoops<[@n, @m]>>
+// CHECK-NEXT:        %[[V_32:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_33:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_32]]
+// CHECK-NEXT:        %[[V_34:[0-9a-zA-Z_\.]+]] = array.read %[[V_12]]#0{{\[}}%[[V_33]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:        struct.writef %[[V_1]][@out] = %[[V_34]] : <@InnerLoops<[@n, @m]>>, !felt.type
+// CHECK-NEXT:        function.return %[[V_1]] : !struct.type<@InnerLoops<[@n, @m]>>
 // CHECK-NEXT:      }
-// CHECK-NEXT:      function.def @constrain(%[[VAL_35:[0-9a-zA-Z_\.]+]]: !struct.type<@InnerLoops<[@n, @m]>>, %[[VAL_36:[0-9a-zA-Z_\.]+]]: !array.type<@m x !felt.type>) attributes {function.allow_constraint} {
-// CHECK-NEXT:        %[[VAL_37:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
-// CHECK-NEXT:        %[[VAL_38:[0-9a-zA-Z_\.]+]] = poly.read_const @m : !felt.type
-// CHECK-NEXT:        %[[VAL_39:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_40:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !felt.type>
-// CHECK-NEXT:        %[[VAL_41:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_42:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_40]], %[[VAL_41]] : <@n x !felt.type>
-// CHECK-NEXT:        %[[VAL_43:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_44:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:        scf.for %[[VAL_45:[0-9a-zA-Z_\.]+]] = %[[VAL_43]] to %[[VAL_42]] step %[[VAL_44]] {
-// CHECK-NEXT:          array.write %[[VAL_40]]{{\[}}%[[VAL_45]]] = %[[VAL_39]] : <@n x !felt.type>, !felt.type
+// CHECK-LABEL:     function.def @constrain
+// CHECK-SAME:      (%[[V_IN:[0-9a-zA-Z_\.]+]]: !struct.type<@InnerLoops<[@n, @m]>>, %[[V_36:[0-9a-zA-Z_\.]+]]: !array.type<@m x !felt.type>) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[V_N:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[V_M:[0-9a-zA-Z_\.]+]] = poly.read_const @m : !felt.type
+// CHECK-NEXT:        %[[V_39:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_B:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !felt.type>
+// CHECK-NEXT:        %[[V_41:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[V_42:[0-9a-zA-Z_\.]+]] = array.len %[[V_B]], %[[V_41]] : <@n x !felt.type>
+// CHECK-NEXT:        %[[V_43:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[V_44:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[V_45:[0-9a-zA-Z_\.]+]] = %[[V_43]] to %[[V_42]] step %[[V_44]] {
+// CHECK-NEXT:          array.write %[[V_B]]{{\[}}%[[V_45]]] = %[[V_39]] : <@n x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_46:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_47:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_48:[0-9a-zA-Z_\.]+]] = %[[VAL_40]], %[[VAL_49:[0-9a-zA-Z_\.]+]] = %[[VAL_46]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
-// CHECK-NEXT:          %[[VAL_50:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_49]], %[[VAL_37]])
-// CHECK-NEXT:          scf.condition(%[[VAL_50]]) %[[VAL_48]], %[[VAL_49]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[V_46:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_47:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_48:[0-9a-zA-Z_\.]+]] = %[[V_B]], %[[V_49:[0-9a-zA-Z_\.]+]] = %[[V_46]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[V_50:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[V_49]], %[[V_N]])
+// CHECK-NEXT:          scf.condition(%[[V_50]]) %[[V_48]], %[[V_49]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        } do {
-// CHECK-NEXT:        ^bb0(%[[VAL_51:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_52:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:          %[[VAL_53:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:          %[[VAL_54:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_55:[0-9a-zA-Z_\.]+]] = %[[VAL_51]], %[[VAL_56:[0-9a-zA-Z_\.]+]] = %[[VAL_53]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
-// CHECK-NEXT:            %[[VAL_57:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_56]], %[[VAL_38]])
-// CHECK-NEXT:            scf.condition(%[[VAL_57]]) %[[VAL_55]], %[[VAL_56]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        ^bb0(%[[V_51:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[V_52:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[V_53:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:          %[[V_54:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_55:[0-9a-zA-Z_\.]+]] = %[[V_51]], %[[V_56:[0-9a-zA-Z_\.]+]] = %[[V_53]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:            %[[V_57:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[V_56]], %[[V_M]])
+// CHECK-NEXT:            scf.condition(%[[V_57]]) %[[V_55]], %[[V_56]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:          } do {
-// CHECK-NEXT:          ^bb0(%[[VAL_58:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_59:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:            %[[VAL_60:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_59]]
-// CHECK-NEXT:            %[[VAL_61:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_36]]{{\[}}%[[VAL_60]]] : <@m x !felt.type>, !felt.type
-// CHECK-NEXT:            %[[VAL_62:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_52]]
-// CHECK-NEXT:            array.write %[[VAL_58]]{{\[}}%[[VAL_62]]] = %[[VAL_61]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:            %[[VAL_63:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:            %[[VAL_64:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_59]], %[[VAL_63]] : !felt.type, !felt.type
-// CHECK-NEXT:            scf.yield %[[VAL_58]], %[[VAL_64]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:          ^bb0(%[[V_58:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[V_59:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:            %[[V_60:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_59]]
+// CHECK-NEXT:            %[[V_61:[0-9a-zA-Z_\.]+]] = array.read %[[V_36]]{{\[}}%[[V_60]]] : <@m x !felt.type>, !felt.type
+// CHECK-NEXT:            %[[V_62:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_52]]
+// CHECK-NEXT:            array.write %[[V_58]]{{\[}}%[[V_62]]] = %[[V_61]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:            %[[V_63:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:            %[[V_64:[0-9a-zA-Z_\.]+]] = felt.add %[[V_59]], %[[V_63]] : !felt.type, !felt.type
+// CHECK-NEXT:            scf.yield %[[V_58]], %[[V_64]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[VAL_65:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:          %[[VAL_66:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_52]], %[[VAL_65]] : !felt.type, !felt.type
-// CHECK-NEXT:          scf.yield %[[VAL_54]]#0, %[[VAL_66]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_65:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[V_66:[0-9a-zA-Z_\.]+]] = felt.add %[[V_52]], %[[V_65]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[V_54]]#0, %[[V_66]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_67:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_35]][@out] : <@InnerLoops<[@n, @m]>>, !felt.type
+// CHECK-NEXT:        %[[V_67:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_IN]][@out] : <@InnerLoops<[@n, @m]>>, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }

--- a/circom/tests/loops/inner_loop_01.circom
+++ b/circom/tests/loops/inner_loop_01.circom
@@ -19,86 +19,88 @@ component main = InnerLoops(2);
 
 // CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
 // CHECK-NEXT:    struct.def @InnerLoops<[@n]> {
-// CHECK-NEXT:      function.def @compute(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) -> !struct.type<@InnerLoops<[@n]>> attributes {function.allow_witness} {
-// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = struct.new : <@InnerLoops<[@n]>>
-// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
-// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !felt.type>
-// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_4]], %[[VAL_5]] : <@n x !felt.type>
-// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:        scf.for %[[VAL_9:[0-9a-zA-Z_\.]+]] = %[[VAL_7]] to %[[VAL_6]] step %[[VAL_8]] {
-// CHECK-NEXT:          array.write %[[VAL_4]]{{\[}}%[[VAL_9]]] = %[[VAL_3]] : <@n x !felt.type>, !felt.type
+// CHECK-LABEL:     function.def @compute
+// CHECK-SAME:      (%[[V_A:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) -> !struct.type<@InnerLoops<[@n]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[V_1:[0-9a-zA-Z_\.]+]] = struct.new : <@InnerLoops<[@n]>>
+// CHECK-NEXT:        %[[V_N:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[V_3:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_B:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !felt.type>
+// CHECK-NEXT:        %[[V_5:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[V_6:[0-9a-zA-Z_\.]+]] = array.len %[[V_B]], %[[V_5]] : <@n x !felt.type>
+// CHECK-NEXT:        %[[V_7:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[V_8:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[V_9:[0-9a-zA-Z_\.]+]] = %[[V_7]] to %[[V_6]] step %[[V_8]] {
+// CHECK-NEXT:          array.write %[[V_B]]{{\[}}%[[V_9]]] = %[[V_3]] : <@n x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_12:[0-9a-zA-Z_\.]+]] = %[[VAL_4]], %[[VAL_13:[0-9a-zA-Z_\.]+]] = %[[VAL_10]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
-// CHECK-NEXT:          %[[VAL_14:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_13]], %[[VAL_2]])
-// CHECK-NEXT:          scf.condition(%[[VAL_14]]) %[[VAL_12]], %[[VAL_13]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[V_I0:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_11:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_B1:[0-9a-zA-Z_\.]+]] = %[[V_B]], %[[V_I1:[0-9a-zA-Z_\.]+]] = %[[V_I0]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[V_14:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[V_I1]], %[[V_N]])
+// CHECK-NEXT:          scf.condition(%[[V_14]]) %[[V_B1]], %[[V_I1]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        } do {
-// CHECK-NEXT:        ^bb0(%[[VAL_15:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_16:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:          %[[VAL_17:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:          %[[VAL_18:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_19:[0-9a-zA-Z_\.]+]] = %[[VAL_15]], %[[VAL_20:[0-9a-zA-Z_\.]+]] = %[[VAL_17]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
-// CHECK-NEXT:            %[[VAL_21:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_20]], %[[VAL_16]])
-// CHECK-NEXT:            scf.condition(%[[VAL_21]]) %[[VAL_19]], %[[VAL_20]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        ^bb0(%[[V_B2:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[V_I2:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[V_J0:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:          %[[V_18:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_B3:[0-9a-zA-Z_\.]+]] = %[[V_B2]], %[[V_J2:[0-9a-zA-Z_\.]+]] = %[[V_J0]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:            %[[V_21:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[V_J2]], %[[V_I2]])
+// CHECK-NEXT:            scf.condition(%[[V_21]]) %[[V_B3]], %[[V_J2]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:          } do {
-// CHECK-NEXT:          ^bb0(%[[VAL_22:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_23:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:            %[[VAL_24:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_16]]
-// CHECK-NEXT:            %[[VAL_25:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_22]]{{\[}}%[[VAL_24]]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:            %[[VAL_26:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_16]], %[[VAL_23]] : !felt.type, !felt.type
-// CHECK-NEXT:            %[[VAL_27:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_26]]
-// CHECK-NEXT:            %[[VAL_28:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_0]]{{\[}}%[[VAL_27]]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:            %[[VAL_29:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_25]], %[[VAL_28]] : !felt.type, !felt.type
-// CHECK-NEXT:            %[[VAL_30:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_16]]
-// CHECK-NEXT:            array.write %[[VAL_22]]{{\[}}%[[VAL_30]]] = %[[VAL_29]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:            %[[VAL_31:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:            %[[VAL_32:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_23]], %[[VAL_31]] : !felt.type, !felt.type
-// CHECK-NEXT:            scf.yield %[[VAL_22]], %[[VAL_32]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:          ^bb0(%[[V_B4:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[V_J3:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:            %[[V_24:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_I2]]
+// CHECK-NEXT:            %[[V_25:[0-9a-zA-Z_\.]+]] = array.read %[[V_B4]]{{\[}}%[[V_24]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:            %[[V_26:[0-9a-zA-Z_\.]+]] = felt.sub %[[V_I2]], %[[V_J3]] : !felt.type, !felt.type
+// CHECK-NEXT:            %[[V_27:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_26]]
+// CHECK-NEXT:            %[[V_28:[0-9a-zA-Z_\.]+]] = array.read %[[V_A]]{{\[}}%[[V_27]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:            %[[V_29:[0-9a-zA-Z_\.]+]] = felt.add %[[V_25]], %[[V_28]] : !felt.type, !felt.type
+// CHECK-NEXT:            %[[V_30:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_I2]]
+// CHECK-NEXT:            array.write %[[V_B4]]{{\[}}%[[V_30]]] = %[[V_29]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:            %[[V_31:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:            %[[V_32:[0-9a-zA-Z_\.]+]] = felt.add %[[V_J3]], %[[V_31]] : !felt.type, !felt.type
+// CHECK-NEXT:            scf.yield %[[V_B4]], %[[V_32]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[VAL_33:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:          %[[VAL_34:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_16]], %[[VAL_33]] : !felt.type, !felt.type
-// CHECK-NEXT:          scf.yield %[[VAL_18]]#0, %[[VAL_34]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_33:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[V_34:[0-9a-zA-Z_\.]+]] = felt.add %[[V_I2]], %[[V_33]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[V_18]]#0, %[[V_34]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        function.return %[[VAL_1]] : !struct.type<@InnerLoops<[@n]>>
+// CHECK-NEXT:        function.return %[[V_1]] : !struct.type<@InnerLoops<[@n]>>
 // CHECK-NEXT:      }
-// CHECK-NEXT:      function.def @constrain(%[[VAL_35:[0-9a-zA-Z_\.]+]]: !struct.type<@InnerLoops<[@n]>>, %[[VAL_36:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) attributes {function.allow_constraint} {
-// CHECK-NEXT:        %[[VAL_37:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
-// CHECK-NEXT:        %[[VAL_38:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_39:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !felt.type>
-// CHECK-NEXT:        %[[VAL_40:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_41:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_39]], %[[VAL_40]] : <@n x !felt.type>
-// CHECK-NEXT:        %[[VAL_42:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_43:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:        scf.for %[[VAL_44:[0-9a-zA-Z_\.]+]] = %[[VAL_42]] to %[[VAL_41]] step %[[VAL_43]] {
-// CHECK-NEXT:          array.write %[[VAL_39]]{{\[}}%[[VAL_44]]] = %[[VAL_38]] : <@n x !felt.type>, !felt.type
+// CHECK-LABEL:     function.def @constrain
+// CHECK-SAME:      (%[[V_A:[0-9a-zA-Z_\.]+]]: !struct.type<@InnerLoops<[@n]>>, %[[V_36:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[V_N:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[V_38:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_B:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !felt.type>
+// CHECK-NEXT:        %[[V_40:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[V_41:[0-9a-zA-Z_\.]+]] = array.len %[[V_B]], %[[V_40]] : <@n x !felt.type>
+// CHECK-NEXT:        %[[V_42:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[V_43:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[V_44:[0-9a-zA-Z_\.]+]] = %[[V_42]] to %[[V_41]] step %[[V_43]] {
+// CHECK-NEXT:          array.write %[[V_B]]{{\[}}%[[V_44]]] = %[[V_38]] : <@n x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_45:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_46:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_47:[0-9a-zA-Z_\.]+]] = %[[VAL_39]], %[[VAL_48:[0-9a-zA-Z_\.]+]] = %[[VAL_45]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
-// CHECK-NEXT:          %[[VAL_49:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_48]], %[[VAL_37]])
-// CHECK-NEXT:          scf.condition(%[[VAL_49]]) %[[VAL_47]], %[[VAL_48]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[V_45:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_46:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_47:[0-9a-zA-Z_\.]+]] = %[[V_B]], %[[V_48:[0-9a-zA-Z_\.]+]] = %[[V_45]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[V_49:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[V_48]], %[[V_N]])
+// CHECK-NEXT:          scf.condition(%[[V_49]]) %[[V_47]], %[[V_48]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        } do {
-// CHECK-NEXT:        ^bb0(%[[VAL_50:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_51:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:          %[[VAL_52:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:          %[[VAL_53:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_54:[0-9a-zA-Z_\.]+]] = %[[VAL_50]], %[[VAL_55:[0-9a-zA-Z_\.]+]] = %[[VAL_52]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
-// CHECK-NEXT:            %[[VAL_56:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_55]], %[[VAL_51]])
-// CHECK-NEXT:            scf.condition(%[[VAL_56]]) %[[VAL_54]], %[[VAL_55]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        ^bb0(%[[V_50:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[V_51:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[V_52:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:          %[[V_53:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_54:[0-9a-zA-Z_\.]+]] = %[[V_50]], %[[V_55:[0-9a-zA-Z_\.]+]] = %[[V_52]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:            %[[V_56:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[V_55]], %[[V_51]])
+// CHECK-NEXT:            scf.condition(%[[V_56]]) %[[V_54]], %[[V_55]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:          } do {
-// CHECK-NEXT:          ^bb0(%[[VAL_57:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_58:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:            %[[VAL_59:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_51]]
-// CHECK-NEXT:            %[[VAL_60:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_57]]{{\[}}%[[VAL_59]]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:            %[[VAL_61:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_51]], %[[VAL_58]] : !felt.type, !felt.type
-// CHECK-NEXT:            %[[VAL_62:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_61]]
-// CHECK-NEXT:            %[[VAL_63:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_36]]{{\[}}%[[VAL_62]]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:            %[[VAL_64:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_60]], %[[VAL_63]] : !felt.type, !felt.type
-// CHECK-NEXT:            %[[VAL_65:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_51]]
-// CHECK-NEXT:            array.write %[[VAL_57]]{{\[}}%[[VAL_65]]] = %[[VAL_64]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:            %[[VAL_66:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:            %[[VAL_67:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_58]], %[[VAL_66]] : !felt.type, !felt.type
-// CHECK-NEXT:            scf.yield %[[VAL_57]], %[[VAL_67]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:          ^bb0(%[[V_57:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[V_58:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:            %[[V_59:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_51]]
+// CHECK-NEXT:            %[[V_60:[0-9a-zA-Z_\.]+]] = array.read %[[V_57]]{{\[}}%[[V_59]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:            %[[V_61:[0-9a-zA-Z_\.]+]] = felt.sub %[[V_51]], %[[V_58]] : !felt.type, !felt.type
+// CHECK-NEXT:            %[[V_62:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_61]]
+// CHECK-NEXT:            %[[V_63:[0-9a-zA-Z_\.]+]] = array.read %[[V_36]]{{\[}}%[[V_62]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:            %[[V_64:[0-9a-zA-Z_\.]+]] = felt.add %[[V_60]], %[[V_63]] : !felt.type, !felt.type
+// CHECK-NEXT:            %[[V_65:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_51]]
+// CHECK-NEXT:            array.write %[[V_57]]{{\[}}%[[V_65]]] = %[[V_64]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:            %[[V_66:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:            %[[V_67:[0-9a-zA-Z_\.]+]] = felt.add %[[V_58]], %[[V_66]] : !felt.type, !felt.type
+// CHECK-NEXT:            scf.yield %[[V_57]], %[[V_67]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[VAL_68:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:          %[[VAL_69:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_51]], %[[VAL_68]] : !felt.type, !felt.type
-// CHECK-NEXT:          scf.yield %[[VAL_53]]#0, %[[VAL_69]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_68:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[V_69:[0-9a-zA-Z_\.]+]] = felt.add %[[V_51]], %[[V_68]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[V_53]]#0, %[[V_69]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        }
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/loops/inner_loop_01.circom
+++ b/circom/tests/loops/inner_loop_01.circom
@@ -1,7 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL:.*
 
 pragma circom 2.0.0;
 
@@ -19,3 +18,89 @@ template InnerLoops(n) {
 component main = InnerLoops(2);
 
 // CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-NEXT:    struct.def @InnerLoops<[@n]> {
+// CHECK-NEXT:      function.def @compute(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) -> !struct.type<@InnerLoops<[@n]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = struct.new : <@InnerLoops<[@n]>>
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !felt.type>
+// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_4]], %[[VAL_5]] : <@n x !felt.type>
+// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[VAL_9:[0-9a-zA-Z_\.]+]] = %[[VAL_7]] to %[[VAL_6]] step %[[VAL_8]] {
+// CHECK-NEXT:          array.write %[[VAL_4]]{{\[}}%[[VAL_9]]] = %[[VAL_3]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_12:[0-9a-zA-Z_\.]+]] = %[[VAL_4]], %[[VAL_13:[0-9a-zA-Z_\.]+]] = %[[VAL_10]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[VAL_14:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_13]], %[[VAL_2]])
+// CHECK-NEXT:          scf.condition(%[[VAL_14]]) %[[VAL_12]], %[[VAL_13]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        } do {
+// CHECK-NEXT:        ^bb0(%[[VAL_15:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_16:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[VAL_17:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:          %[[VAL_18:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_19:[0-9a-zA-Z_\.]+]] = %[[VAL_15]], %[[VAL_20:[0-9a-zA-Z_\.]+]] = %[[VAL_17]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:            %[[VAL_21:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_20]], %[[VAL_16]])
+// CHECK-NEXT:            scf.condition(%[[VAL_21]]) %[[VAL_19]], %[[VAL_20]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:          } do {
+// CHECK-NEXT:          ^bb0(%[[VAL_22:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_23:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:            %[[VAL_24:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_16]]
+// CHECK-NEXT:            %[[VAL_25:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_22]]{{\[}}%[[VAL_24]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:            %[[VAL_26:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_16]], %[[VAL_23]] : !felt.type, !felt.type
+// CHECK-NEXT:            %[[VAL_27:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_26]]
+// CHECK-NEXT:            %[[VAL_28:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_0]]{{\[}}%[[VAL_27]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:            %[[VAL_29:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_25]], %[[VAL_28]] : !felt.type, !felt.type
+// CHECK-NEXT:            %[[VAL_30:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_16]]
+// CHECK-NEXT:            array.write %[[VAL_22]]{{\[}}%[[VAL_30]]] = %[[VAL_29]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:            %[[VAL_31:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:            %[[VAL_32:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_23]], %[[VAL_31]] : !felt.type, !felt.type
+// CHECK-NEXT:            scf.yield %[[VAL_22]], %[[VAL_32]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:          }
+// CHECK-NEXT:          %[[VAL_33:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_34:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_16]], %[[VAL_33]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_18]]#0, %[[VAL_34]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.return %[[VAL_1]] : !struct.type<@InnerLoops<[@n]>>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[VAL_35:[0-9a-zA-Z_\.]+]]: !struct.type<@InnerLoops<[@n]>>, %[[VAL_36:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[VAL_37:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_38:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_39:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !felt.type>
+// CHECK-NEXT:        %[[VAL_40:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_41:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_39]], %[[VAL_40]] : <@n x !felt.type>
+// CHECK-NEXT:        %[[VAL_42:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_43:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[VAL_44:[0-9a-zA-Z_\.]+]] = %[[VAL_42]] to %[[VAL_41]] step %[[VAL_43]] {
+// CHECK-NEXT:          array.write %[[VAL_39]]{{\[}}%[[VAL_44]]] = %[[VAL_38]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_45:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_46:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_47:[0-9a-zA-Z_\.]+]] = %[[VAL_39]], %[[VAL_48:[0-9a-zA-Z_\.]+]] = %[[VAL_45]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[VAL_49:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_48]], %[[VAL_37]])
+// CHECK-NEXT:          scf.condition(%[[VAL_49]]) %[[VAL_47]], %[[VAL_48]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        } do {
+// CHECK-NEXT:        ^bb0(%[[VAL_50:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_51:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[VAL_52:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:          %[[VAL_53:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_54:[0-9a-zA-Z_\.]+]] = %[[VAL_50]], %[[VAL_55:[0-9a-zA-Z_\.]+]] = %[[VAL_52]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:            %[[VAL_56:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_55]], %[[VAL_51]])
+// CHECK-NEXT:            scf.condition(%[[VAL_56]]) %[[VAL_54]], %[[VAL_55]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:          } do {
+// CHECK-NEXT:          ^bb0(%[[VAL_57:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_58:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:            %[[VAL_59:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_51]]
+// CHECK-NEXT:            %[[VAL_60:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_57]]{{\[}}%[[VAL_59]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:            %[[VAL_61:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_51]], %[[VAL_58]] : !felt.type, !felt.type
+// CHECK-NEXT:            %[[VAL_62:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_61]]
+// CHECK-NEXT:            %[[VAL_63:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_36]]{{\[}}%[[VAL_62]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:            %[[VAL_64:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_60]], %[[VAL_63]] : !felt.type, !felt.type
+// CHECK-NEXT:            %[[VAL_65:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_51]]
+// CHECK-NEXT:            array.write %[[VAL_57]]{{\[}}%[[VAL_65]]] = %[[VAL_64]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:            %[[VAL_66:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:            %[[VAL_67:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_58]], %[[VAL_66]] : !felt.type, !felt.type
+// CHECK-NEXT:            scf.yield %[[VAL_57]], %[[VAL_67]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:          }
+// CHECK-NEXT:          %[[VAL_68:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_69:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_51]], %[[VAL_68]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_53]]#0, %[[VAL_69]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/loops/inner_loop_02.circom
+++ b/circom/tests/loops/inner_loop_02.circom
@@ -1,7 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL:.*
 
 pragma circom 2.0.0;
 
@@ -38,3 +37,205 @@ template InnerLoops(n) {
 component main = InnerLoops(5);
 
 // CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-NEXT:    struct.def @InnerLoops<[@n]> {
+// CHECK-NEXT:      function.def @compute(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) -> !struct.type<@InnerLoops<[@n]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = struct.new : <@InnerLoops<[@n]>>
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !felt.type>
+// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_4]], %[[VAL_5]] : <@n x !felt.type>
+// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[VAL_9:[0-9a-zA-Z_\.]+]] = %[[VAL_7]] to %[[VAL_6]] step %[[VAL_8]] {
+// CHECK-NEXT:          array.write %[[VAL_4]]{{\[}}%[[VAL_9]]] = %[[VAL_3]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_12:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_13:[0-9a-zA-Z_\.]+]] = %[[VAL_4]], %[[VAL_14:[0-9a-zA-Z_\.]+]] = %[[VAL_11]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[VAL_15:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_14]], %[[VAL_10]])
+// CHECK-NEXT:          scf.condition(%[[VAL_15]]) %[[VAL_13]], %[[VAL_14]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        } do {
+// CHECK-NEXT:        ^bb0(%[[VAL_16:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_17:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[VAL_18:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_10]], %[[VAL_17]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[VAL_19:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_18]]
+// CHECK-NEXT:          %[[VAL_20:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_0]]{{\[}}%[[VAL_19]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_21:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_10]]
+// CHECK-NEXT:          array.write %[[VAL_16]]{{\[}}%[[VAL_21]]] = %[[VAL_20]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_22:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_23:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_17]], %[[VAL_22]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_16]], %[[VAL_23]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_24:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_25:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_10]], %[[VAL_24]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[VAL_26:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_27:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_28:[0-9a-zA-Z_\.]+]] = %[[VAL_12]]#0, %[[VAL_29:[0-9a-zA-Z_\.]+]] = %[[VAL_26]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[VAL_30:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_29]], %[[VAL_25]])
+// CHECK-NEXT:          scf.condition(%[[VAL_30]]) %[[VAL_28]], %[[VAL_29]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        } do {
+// CHECK-NEXT:        ^bb0(%[[VAL_31:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_32:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[VAL_33:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_25]], %[[VAL_32]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[VAL_34:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_33]]
+// CHECK-NEXT:          %[[VAL_35:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_0]]{{\[}}%[[VAL_34]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_36:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_25]]
+// CHECK-NEXT:          array.write %[[VAL_31]]{{\[}}%[[VAL_36]]] = %[[VAL_35]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_37:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_38:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_32]], %[[VAL_37]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_31]], %[[VAL_38]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_39:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_40:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_25]], %[[VAL_39]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[VAL_41:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_42:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_43:[0-9a-zA-Z_\.]+]] = %[[VAL_27]]#0, %[[VAL_44:[0-9a-zA-Z_\.]+]] = %[[VAL_41]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[VAL_45:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_44]], %[[VAL_40]])
+// CHECK-NEXT:          scf.condition(%[[VAL_45]]) %[[VAL_43]], %[[VAL_44]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        } do {
+// CHECK-NEXT:        ^bb0(%[[VAL_46:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_47:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[VAL_48:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_40]], %[[VAL_47]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[VAL_49:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_48]]
+// CHECK-NEXT:          %[[VAL_50:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_0]]{{\[}}%[[VAL_49]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_51:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_40]]
+// CHECK-NEXT:          array.write %[[VAL_46]]{{\[}}%[[VAL_51]]] = %[[VAL_50]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_52:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_53:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_47]], %[[VAL_52]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_46]], %[[VAL_53]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_54:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_55:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_40]], %[[VAL_54]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[VAL_56:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_57:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_58:[0-9a-zA-Z_\.]+]] = %[[VAL_42]]#0, %[[VAL_59:[0-9a-zA-Z_\.]+]] = %[[VAL_56]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[VAL_60:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_59]], %[[VAL_55]])
+// CHECK-NEXT:          scf.condition(%[[VAL_60]]) %[[VAL_58]], %[[VAL_59]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        } do {
+// CHECK-NEXT:        ^bb0(%[[VAL_61:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_62:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[VAL_63:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_55]], %[[VAL_62]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[VAL_64:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_63]]
+// CHECK-NEXT:          %[[VAL_65:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_0]]{{\[}}%[[VAL_64]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_66:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_55]]
+// CHECK-NEXT:          array.write %[[VAL_61]]{{\[}}%[[VAL_66]]] = %[[VAL_65]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_67:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_68:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_62]], %[[VAL_67]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_61]], %[[VAL_68]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_69:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_70:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_55]], %[[VAL_69]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[VAL_71:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_72:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_73:[0-9a-zA-Z_\.]+]] = %[[VAL_57]]#0, %[[VAL_74:[0-9a-zA-Z_\.]+]] = %[[VAL_71]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[VAL_75:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_74]], %[[VAL_70]])
+// CHECK-NEXT:          scf.condition(%[[VAL_75]]) %[[VAL_73]], %[[VAL_74]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        } do {
+// CHECK-NEXT:        ^bb0(%[[VAL_76:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_77:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[VAL_78:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_70]], %[[VAL_77]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[VAL_79:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_78]]
+// CHECK-NEXT:          %[[VAL_80:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_0]]{{\[}}%[[VAL_79]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_81:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_70]]
+// CHECK-NEXT:          array.write %[[VAL_76]]{{\[}}%[[VAL_81]]] = %[[VAL_80]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_82:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_83:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_77]], %[[VAL_82]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_76]], %[[VAL_83]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_84:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_85:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_70]], %[[VAL_84]] : !felt.type, !felt.type
+// CHECK-NEXT:        function.return %[[VAL_1]] : !struct.type<@InnerLoops<[@n]>>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[VAL_86:[0-9a-zA-Z_\.]+]]: !struct.type<@InnerLoops<[@n]>>, %[[VAL_87:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[VAL_88:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_89:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_90:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !felt.type>
+// CHECK-NEXT:        %[[VAL_91:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_92:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_90]], %[[VAL_91]] : <@n x !felt.type>
+// CHECK-NEXT:        %[[VAL_93:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_94:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[VAL_95:[0-9a-zA-Z_\.]+]] = %[[VAL_93]] to %[[VAL_92]] step %[[VAL_94]] {
+// CHECK-NEXT:          array.write %[[VAL_90]]{{\[}}%[[VAL_95]]] = %[[VAL_89]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_96:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_97:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_98:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_99:[0-9a-zA-Z_\.]+]] = %[[VAL_90]], %[[VAL_100:[0-9a-zA-Z_\.]+]] = %[[VAL_97]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[VAL_101:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_100]], %[[VAL_96]])
+// CHECK-NEXT:          scf.condition(%[[VAL_101]]) %[[VAL_99]], %[[VAL_100]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        } do {
+// CHECK-NEXT:        ^bb0(%[[VAL_102:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_103:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[VAL_104:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_96]], %[[VAL_103]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[VAL_105:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_104]]
+// CHECK-NEXT:          %[[VAL_106:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_87]]{{\[}}%[[VAL_105]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_107:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_96]]
+// CHECK-NEXT:          array.write %[[VAL_102]]{{\[}}%[[VAL_107]]] = %[[VAL_106]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_108:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_109:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_103]], %[[VAL_108]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_102]], %[[VAL_109]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_110:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_111:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_96]], %[[VAL_110]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[VAL_112:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_113:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_114:[0-9a-zA-Z_\.]+]] = %[[VAL_98]]#0, %[[VAL_115:[0-9a-zA-Z_\.]+]] = %[[VAL_112]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[VAL_116:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_115]], %[[VAL_111]])
+// CHECK-NEXT:          scf.condition(%[[VAL_116]]) %[[VAL_114]], %[[VAL_115]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        } do {
+// CHECK-NEXT:        ^bb0(%[[VAL_117:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_118:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[VAL_119:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_111]], %[[VAL_118]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[VAL_120:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_119]]
+// CHECK-NEXT:          %[[VAL_121:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_87]]{{\[}}%[[VAL_120]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_122:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_111]]
+// CHECK-NEXT:          array.write %[[VAL_117]]{{\[}}%[[VAL_122]]] = %[[VAL_121]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_123:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_124:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_118]], %[[VAL_123]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_117]], %[[VAL_124]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_125:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_126:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_111]], %[[VAL_125]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[VAL_127:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_128:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_129:[0-9a-zA-Z_\.]+]] = %[[VAL_113]]#0, %[[VAL_130:[0-9a-zA-Z_\.]+]] = %[[VAL_127]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[VAL_131:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_130]], %[[VAL_126]])
+// CHECK-NEXT:          scf.condition(%[[VAL_131]]) %[[VAL_129]], %[[VAL_130]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        } do {
+// CHECK-NEXT:        ^bb0(%[[VAL_132:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_133:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[VAL_134:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_126]], %[[VAL_133]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[VAL_135:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_134]]
+// CHECK-NEXT:          %[[VAL_136:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_87]]{{\[}}%[[VAL_135]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_137:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_126]]
+// CHECK-NEXT:          array.write %[[VAL_132]]{{\[}}%[[VAL_137]]] = %[[VAL_136]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_138:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_139:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_133]], %[[VAL_138]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_132]], %[[VAL_139]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_140:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_141:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_126]], %[[VAL_140]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[VAL_142:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_143:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_144:[0-9a-zA-Z_\.]+]] = %[[VAL_128]]#0, %[[VAL_145:[0-9a-zA-Z_\.]+]] = %[[VAL_142]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[VAL_146:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_145]], %[[VAL_141]])
+// CHECK-NEXT:          scf.condition(%[[VAL_146]]) %[[VAL_144]], %[[VAL_145]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        } do {
+// CHECK-NEXT:        ^bb0(%[[VAL_147:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_148:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[VAL_149:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_141]], %[[VAL_148]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[VAL_150:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_149]]
+// CHECK-NEXT:          %[[VAL_151:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_87]]{{\[}}%[[VAL_150]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_152:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_141]]
+// CHECK-NEXT:          array.write %[[VAL_147]]{{\[}}%[[VAL_152]]] = %[[VAL_151]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_153:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_154:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_148]], %[[VAL_153]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_147]], %[[VAL_154]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_155:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_156:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_141]], %[[VAL_155]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[VAL_157:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_158:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_159:[0-9a-zA-Z_\.]+]] = %[[VAL_143]]#0, %[[VAL_160:[0-9a-zA-Z_\.]+]] = %[[VAL_157]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[VAL_161:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_160]], %[[VAL_156]])
+// CHECK-NEXT:          scf.condition(%[[VAL_161]]) %[[VAL_159]], %[[VAL_160]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        } do {
+// CHECK-NEXT:        ^bb0(%[[VAL_162:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_163:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[VAL_164:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_156]], %[[VAL_163]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[VAL_165:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_164]]
+// CHECK-NEXT:          %[[VAL_166:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_87]]{{\[}}%[[VAL_165]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_167:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_156]]
+// CHECK-NEXT:          array.write %[[VAL_162]]{{\[}}%[[VAL_167]]] = %[[VAL_166]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_168:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_169:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_163]], %[[VAL_168]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_162]], %[[VAL_169]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_170:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_171:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_156]], %[[VAL_170]] : !felt.type, !felt.type
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/loops/inner_loop_02.circom
+++ b/circom/tests/loops/inner_loop_02.circom
@@ -38,203 +38,205 @@ component main = InnerLoops(5);
 
 // CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
 // CHECK-NEXT:    struct.def @InnerLoops<[@n]> {
-// CHECK-NEXT:      function.def @compute(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) -> !struct.type<@InnerLoops<[@n]>> attributes {function.allow_witness} {
-// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = struct.new : <@InnerLoops<[@n]>>
-// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
-// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !felt.type>
-// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_4]], %[[VAL_5]] : <@n x !felt.type>
-// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:        scf.for %[[VAL_9:[0-9a-zA-Z_\.]+]] = %[[VAL_7]] to %[[VAL_6]] step %[[VAL_8]] {
-// CHECK-NEXT:          array.write %[[VAL_4]]{{\[}}%[[VAL_9]]] = %[[VAL_3]] : <@n x !felt.type>, !felt.type
+// CHECK-LABEL:     function.def @compute
+// CHECK-SAME:      (%[[V_A:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) -> !struct.type<@InnerLoops<[@n]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[V_1:[0-9a-zA-Z_\.]+]] = struct.new : <@InnerLoops<[@n]>>
+// CHECK-NEXT:        %[[V_N:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[V_3:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_B:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !felt.type>
+// CHECK-NEXT:        %[[V_5:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[V_6:[0-9a-zA-Z_\.]+]] = array.len %[[V_B]], %[[V_5]] : <@n x !felt.type>
+// CHECK-NEXT:        %[[V_7:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[V_8:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[V_9:[0-9a-zA-Z_\.]+]] = %[[V_7]] to %[[V_6]] step %[[V_8]] {
+// CHECK-NEXT:          array.write %[[V_B]]{{\[}}%[[V_9]]] = %[[V_3]] : <@n x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_12:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_13:[0-9a-zA-Z_\.]+]] = %[[VAL_4]], %[[VAL_14:[0-9a-zA-Z_\.]+]] = %[[VAL_11]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
-// CHECK-NEXT:          %[[VAL_15:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_14]], %[[VAL_10]])
-// CHECK-NEXT:          scf.condition(%[[VAL_15]]) %[[VAL_13]], %[[VAL_14]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[V_10:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_11:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_12:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_B1:[0-9a-zA-Z_\.]+]] = %[[V_B]], %[[V_14:[0-9a-zA-Z_\.]+]] = %[[V_11]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[V_15:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[V_14]], %[[V_10]])
+// CHECK-NEXT:          scf.condition(%[[V_15]]) %[[V_B1]], %[[V_14]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        } do {
-// CHECK-NEXT:        ^bb0(%[[VAL_16:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_17:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:          %[[VAL_18:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_10]], %[[VAL_17]] : !felt.type, !felt.type
-// CHECK-NEXT:          %[[VAL_19:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_18]]
-// CHECK-NEXT:          %[[VAL_20:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_0]]{{\[}}%[[VAL_19]]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_21:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_10]]
-// CHECK-NEXT:          array.write %[[VAL_16]]{{\[}}%[[VAL_21]]] = %[[VAL_20]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_22:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:          %[[VAL_23:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_17]], %[[VAL_22]] : !felt.type, !felt.type
-// CHECK-NEXT:          scf.yield %[[VAL_16]], %[[VAL_23]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        ^bb0(%[[V_B2:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[V_17:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[V_18:[0-9a-zA-Z_\.]+]] = felt.sub %[[V_10]], %[[V_17]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[V_19:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_18]]
+// CHECK-NEXT:          %[[V_20:[0-9a-zA-Z_\.]+]] = array.read %[[V_A]]{{\[}}%[[V_19]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_21:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_10]]
+// CHECK-NEXT:          array.write %[[V_B2]]{{\[}}%[[V_21]]] = %[[V_20]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_22:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[V_23:[0-9a-zA-Z_\.]+]] = felt.add %[[V_17]], %[[V_22]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[V_B2]], %[[V_23]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_24:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:        %[[VAL_25:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_10]], %[[VAL_24]] : !felt.type, !felt.type
-// CHECK-NEXT:        %[[VAL_26:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_27:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_28:[0-9a-zA-Z_\.]+]] = %[[VAL_12]]#0, %[[VAL_29:[0-9a-zA-Z_\.]+]] = %[[VAL_26]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
-// CHECK-NEXT:          %[[VAL_30:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_29]], %[[VAL_25]])
-// CHECK-NEXT:          scf.condition(%[[VAL_30]]) %[[VAL_28]], %[[VAL_29]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[V_24:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[V_25:[0-9a-zA-Z_\.]+]] = felt.add %[[V_10]], %[[V_24]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[V_26:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_27:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_B3:[0-9a-zA-Z_\.]+]] = %[[V_12]]#0, %[[V_29:[0-9a-zA-Z_\.]+]] = %[[V_26]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[V_30:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[V_29]], %[[V_25]])
+// CHECK-NEXT:          scf.condition(%[[V_30]]) %[[V_B3]], %[[V_29]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        } do {
-// CHECK-NEXT:        ^bb0(%[[VAL_31:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_32:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:          %[[VAL_33:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_25]], %[[VAL_32]] : !felt.type, !felt.type
-// CHECK-NEXT:          %[[VAL_34:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_33]]
-// CHECK-NEXT:          %[[VAL_35:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_0]]{{\[}}%[[VAL_34]]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_36:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_25]]
-// CHECK-NEXT:          array.write %[[VAL_31]]{{\[}}%[[VAL_36]]] = %[[VAL_35]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_37:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:          %[[VAL_38:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_32]], %[[VAL_37]] : !felt.type, !felt.type
-// CHECK-NEXT:          scf.yield %[[VAL_31]], %[[VAL_38]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        ^bb0(%[[V_B4:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[V_32:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[V_33:[0-9a-zA-Z_\.]+]] = felt.sub %[[V_25]], %[[V_32]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[V_34:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_33]]
+// CHECK-NEXT:          %[[V_35:[0-9a-zA-Z_\.]+]] = array.read %[[V_A]]{{\[}}%[[V_34]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_36:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_25]]
+// CHECK-NEXT:          array.write %[[V_B4]]{{\[}}%[[V_36]]] = %[[V_35]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_37:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[V_38:[0-9a-zA-Z_\.]+]] = felt.add %[[V_32]], %[[V_37]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[V_B4]], %[[V_38]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_39:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:        %[[VAL_40:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_25]], %[[VAL_39]] : !felt.type, !felt.type
-// CHECK-NEXT:        %[[VAL_41:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_42:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_43:[0-9a-zA-Z_\.]+]] = %[[VAL_27]]#0, %[[VAL_44:[0-9a-zA-Z_\.]+]] = %[[VAL_41]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
-// CHECK-NEXT:          %[[VAL_45:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_44]], %[[VAL_40]])
-// CHECK-NEXT:          scf.condition(%[[VAL_45]]) %[[VAL_43]], %[[VAL_44]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[V_39:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[V_40:[0-9a-zA-Z_\.]+]] = felt.add %[[V_25]], %[[V_39]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[V_41:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_42:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_B5:[0-9a-zA-Z_\.]+]] = %[[V_27]]#0, %[[V_44:[0-9a-zA-Z_\.]+]] = %[[V_41]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[V_45:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[V_44]], %[[V_40]])
+// CHECK-NEXT:          scf.condition(%[[V_45]]) %[[V_B5]], %[[V_44]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        } do {
-// CHECK-NEXT:        ^bb0(%[[VAL_46:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_47:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:          %[[VAL_48:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_40]], %[[VAL_47]] : !felt.type, !felt.type
-// CHECK-NEXT:          %[[VAL_49:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_48]]
-// CHECK-NEXT:          %[[VAL_50:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_0]]{{\[}}%[[VAL_49]]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_51:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_40]]
-// CHECK-NEXT:          array.write %[[VAL_46]]{{\[}}%[[VAL_51]]] = %[[VAL_50]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_52:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:          %[[VAL_53:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_47]], %[[VAL_52]] : !felt.type, !felt.type
-// CHECK-NEXT:          scf.yield %[[VAL_46]], %[[VAL_53]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        ^bb0(%[[V_B6:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[V_47:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[V_48:[0-9a-zA-Z_\.]+]] = felt.sub %[[V_40]], %[[V_47]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[V_49:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_48]]
+// CHECK-NEXT:          %[[V_50:[0-9a-zA-Z_\.]+]] = array.read %[[V_A]]{{\[}}%[[V_49]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_51:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_40]]
+// CHECK-NEXT:          array.write %[[V_B6]]{{\[}}%[[V_51]]] = %[[V_50]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_52:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[V_53:[0-9a-zA-Z_\.]+]] = felt.add %[[V_47]], %[[V_52]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[V_B6]], %[[V_53]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_54:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:        %[[VAL_55:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_40]], %[[VAL_54]] : !felt.type, !felt.type
-// CHECK-NEXT:        %[[VAL_56:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_57:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_58:[0-9a-zA-Z_\.]+]] = %[[VAL_42]]#0, %[[VAL_59:[0-9a-zA-Z_\.]+]] = %[[VAL_56]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
-// CHECK-NEXT:          %[[VAL_60:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_59]], %[[VAL_55]])
-// CHECK-NEXT:          scf.condition(%[[VAL_60]]) %[[VAL_58]], %[[VAL_59]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[V_54:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[V_55:[0-9a-zA-Z_\.]+]] = felt.add %[[V_40]], %[[V_54]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[V_56:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_57:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_B7:[0-9a-zA-Z_\.]+]] = %[[V_42]]#0, %[[V_59:[0-9a-zA-Z_\.]+]] = %[[V_56]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[V_60:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[V_59]], %[[V_55]])
+// CHECK-NEXT:          scf.condition(%[[V_60]]) %[[V_B7]], %[[V_59]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        } do {
-// CHECK-NEXT:        ^bb0(%[[VAL_61:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_62:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:          %[[VAL_63:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_55]], %[[VAL_62]] : !felt.type, !felt.type
-// CHECK-NEXT:          %[[VAL_64:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_63]]
-// CHECK-NEXT:          %[[VAL_65:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_0]]{{\[}}%[[VAL_64]]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_66:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_55]]
-// CHECK-NEXT:          array.write %[[VAL_61]]{{\[}}%[[VAL_66]]] = %[[VAL_65]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_67:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:          %[[VAL_68:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_62]], %[[VAL_67]] : !felt.type, !felt.type
-// CHECK-NEXT:          scf.yield %[[VAL_61]], %[[VAL_68]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        ^bb0(%[[V_B8:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[V_62:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[V_63:[0-9a-zA-Z_\.]+]] = felt.sub %[[V_55]], %[[V_62]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[V_64:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_63]]
+// CHECK-NEXT:          %[[V_65:[0-9a-zA-Z_\.]+]] = array.read %[[V_A]]{{\[}}%[[V_64]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_66:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_55]]
+// CHECK-NEXT:          array.write %[[V_B8]]{{\[}}%[[V_66]]] = %[[V_65]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_67:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[V_68:[0-9a-zA-Z_\.]+]] = felt.add %[[V_62]], %[[V_67]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[V_B8]], %[[V_68]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_69:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:        %[[VAL_70:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_55]], %[[VAL_69]] : !felt.type, !felt.type
-// CHECK-NEXT:        %[[VAL_71:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_72:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_73:[0-9a-zA-Z_\.]+]] = %[[VAL_57]]#0, %[[VAL_74:[0-9a-zA-Z_\.]+]] = %[[VAL_71]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
-// CHECK-NEXT:          %[[VAL_75:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_74]], %[[VAL_70]])
-// CHECK-NEXT:          scf.condition(%[[VAL_75]]) %[[VAL_73]], %[[VAL_74]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[V_69:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[V_70:[0-9a-zA-Z_\.]+]] = felt.add %[[V_55]], %[[V_69]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[V_71:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_72:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_B9:[0-9a-zA-Z_\.]+]] = %[[V_57]]#0, %[[V_74:[0-9a-zA-Z_\.]+]] = %[[V_71]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[V_75:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[V_74]], %[[V_70]])
+// CHECK-NEXT:          scf.condition(%[[V_75]]) %[[V_B9]], %[[V_74]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        } do {
-// CHECK-NEXT:        ^bb0(%[[VAL_76:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_77:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:          %[[VAL_78:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_70]], %[[VAL_77]] : !felt.type, !felt.type
-// CHECK-NEXT:          %[[VAL_79:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_78]]
-// CHECK-NEXT:          %[[VAL_80:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_0]]{{\[}}%[[VAL_79]]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_81:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_70]]
-// CHECK-NEXT:          array.write %[[VAL_76]]{{\[}}%[[VAL_81]]] = %[[VAL_80]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_82:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:          %[[VAL_83:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_77]], %[[VAL_82]] : !felt.type, !felt.type
-// CHECK-NEXT:          scf.yield %[[VAL_76]], %[[VAL_83]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        ^bb0(%[[V_76:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[V_77:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[V_78:[0-9a-zA-Z_\.]+]] = felt.sub %[[V_70]], %[[V_77]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[V_79:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_78]]
+// CHECK-NEXT:          %[[V_80:[0-9a-zA-Z_\.]+]] = array.read %[[V_A]]{{\[}}%[[V_79]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_81:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_70]]
+// CHECK-NEXT:          array.write %[[V_76]]{{\[}}%[[V_81]]] = %[[V_80]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_82:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[V_83:[0-9a-zA-Z_\.]+]] = felt.add %[[V_77]], %[[V_82]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[V_76]], %[[V_83]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_84:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:        %[[VAL_85:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_70]], %[[VAL_84]] : !felt.type, !felt.type
-// CHECK-NEXT:        function.return %[[VAL_1]] : !struct.type<@InnerLoops<[@n]>>
+// CHECK-NEXT:        %[[V_84:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[V_85:[0-9a-zA-Z_\.]+]] = felt.add %[[V_70]], %[[V_84]] : !felt.type, !felt.type
+// CHECK-NEXT:        function.return %[[V_1]] : !struct.type<@InnerLoops<[@n]>>
 // CHECK-NEXT:      }
-// CHECK-NEXT:      function.def @constrain(%[[VAL_86:[0-9a-zA-Z_\.]+]]: !struct.type<@InnerLoops<[@n]>>, %[[VAL_87:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) attributes {function.allow_constraint} {
-// CHECK-NEXT:        %[[VAL_88:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
-// CHECK-NEXT:        %[[VAL_89:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_90:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !felt.type>
-// CHECK-NEXT:        %[[VAL_91:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_92:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_90]], %[[VAL_91]] : <@n x !felt.type>
-// CHECK-NEXT:        %[[VAL_93:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_94:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:        scf.for %[[VAL_95:[0-9a-zA-Z_\.]+]] = %[[VAL_93]] to %[[VAL_92]] step %[[VAL_94]] {
-// CHECK-NEXT:          array.write %[[VAL_90]]{{\[}}%[[VAL_95]]] = %[[VAL_89]] : <@n x !felt.type>, !felt.type
+// CHECK-LABEL:     function.def @constrain
+// CHECK-SAME:      (%[[V_A:[0-9a-zA-Z_\.]+]]: !struct.type<@InnerLoops<[@n]>>, %[[V_87:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[V_N:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[V_89:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_B:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !felt.type>
+// CHECK-NEXT:        %[[V_91:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[V_92:[0-9a-zA-Z_\.]+]] = array.len %[[V_B]], %[[V_91]] : <@n x !felt.type>
+// CHECK-NEXT:        %[[V_93:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[V_94:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[V_95:[0-9a-zA-Z_\.]+]] = %[[V_93]] to %[[V_92]] step %[[V_94]] {
+// CHECK-NEXT:          array.write %[[V_B]]{{\[}}%[[V_95]]] = %[[V_89]] : <@n x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_96:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_97:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_98:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_99:[0-9a-zA-Z_\.]+]] = %[[VAL_90]], %[[VAL_100:[0-9a-zA-Z_\.]+]] = %[[VAL_97]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
-// CHECK-NEXT:          %[[VAL_101:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_100]], %[[VAL_96]])
-// CHECK-NEXT:          scf.condition(%[[VAL_101]]) %[[VAL_99]], %[[VAL_100]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[V_96:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_97:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_98:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_99:[0-9a-zA-Z_\.]+]] = %[[V_B]], %[[V_100:[0-9a-zA-Z_\.]+]] = %[[V_97]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[V_101:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[V_100]], %[[V_96]])
+// CHECK-NEXT:          scf.condition(%[[V_101]]) %[[V_99]], %[[V_100]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        } do {
-// CHECK-NEXT:        ^bb0(%[[VAL_102:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_103:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:          %[[VAL_104:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_96]], %[[VAL_103]] : !felt.type, !felt.type
-// CHECK-NEXT:          %[[VAL_105:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_104]]
-// CHECK-NEXT:          %[[VAL_106:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_87]]{{\[}}%[[VAL_105]]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_107:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_96]]
-// CHECK-NEXT:          array.write %[[VAL_102]]{{\[}}%[[VAL_107]]] = %[[VAL_106]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_108:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:          %[[VAL_109:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_103]], %[[VAL_108]] : !felt.type, !felt.type
-// CHECK-NEXT:          scf.yield %[[VAL_102]], %[[VAL_109]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        ^bb0(%[[V_102:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[V_103:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[V_104:[0-9a-zA-Z_\.]+]] = felt.sub %[[V_96]], %[[V_103]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[V_105:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_104]]
+// CHECK-NEXT:          %[[V_106:[0-9a-zA-Z_\.]+]] = array.read %[[V_87]]{{\[}}%[[V_105]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_107:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_96]]
+// CHECK-NEXT:          array.write %[[V_102]]{{\[}}%[[V_107]]] = %[[V_106]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_108:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[V_109:[0-9a-zA-Z_\.]+]] = felt.add %[[V_103]], %[[V_108]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[V_102]], %[[V_109]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_110:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:        %[[VAL_111:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_96]], %[[VAL_110]] : !felt.type, !felt.type
-// CHECK-NEXT:        %[[VAL_112:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_113:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_114:[0-9a-zA-Z_\.]+]] = %[[VAL_98]]#0, %[[VAL_115:[0-9a-zA-Z_\.]+]] = %[[VAL_112]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
-// CHECK-NEXT:          %[[VAL_116:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_115]], %[[VAL_111]])
-// CHECK-NEXT:          scf.condition(%[[VAL_116]]) %[[VAL_114]], %[[VAL_115]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[V_110:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[V_111:[0-9a-zA-Z_\.]+]] = felt.add %[[V_96]], %[[V_110]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[V_112:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_113:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_114:[0-9a-zA-Z_\.]+]] = %[[V_98]]#0, %[[V_115:[0-9a-zA-Z_\.]+]] = %[[V_112]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[V_116:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[V_115]], %[[V_111]])
+// CHECK-NEXT:          scf.condition(%[[V_116]]) %[[V_114]], %[[V_115]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        } do {
-// CHECK-NEXT:        ^bb0(%[[VAL_117:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_118:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:          %[[VAL_119:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_111]], %[[VAL_118]] : !felt.type, !felt.type
-// CHECK-NEXT:          %[[VAL_120:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_119]]
-// CHECK-NEXT:          %[[VAL_121:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_87]]{{\[}}%[[VAL_120]]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_122:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_111]]
-// CHECK-NEXT:          array.write %[[VAL_117]]{{\[}}%[[VAL_122]]] = %[[VAL_121]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_123:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:          %[[VAL_124:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_118]], %[[VAL_123]] : !felt.type, !felt.type
-// CHECK-NEXT:          scf.yield %[[VAL_117]], %[[VAL_124]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        ^bb0(%[[V_117:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[V_118:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[V_119:[0-9a-zA-Z_\.]+]] = felt.sub %[[V_111]], %[[V_118]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[V_120:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_119]]
+// CHECK-NEXT:          %[[V_121:[0-9a-zA-Z_\.]+]] = array.read %[[V_87]]{{\[}}%[[V_120]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_122:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_111]]
+// CHECK-NEXT:          array.write %[[V_117]]{{\[}}%[[V_122]]] = %[[V_121]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_123:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[V_124:[0-9a-zA-Z_\.]+]] = felt.add %[[V_118]], %[[V_123]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[V_117]], %[[V_124]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_125:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:        %[[VAL_126:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_111]], %[[VAL_125]] : !felt.type, !felt.type
-// CHECK-NEXT:        %[[VAL_127:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_128:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_129:[0-9a-zA-Z_\.]+]] = %[[VAL_113]]#0, %[[VAL_130:[0-9a-zA-Z_\.]+]] = %[[VAL_127]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
-// CHECK-NEXT:          %[[VAL_131:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_130]], %[[VAL_126]])
-// CHECK-NEXT:          scf.condition(%[[VAL_131]]) %[[VAL_129]], %[[VAL_130]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[V_125:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[V_126:[0-9a-zA-Z_\.]+]] = felt.add %[[V_111]], %[[V_125]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[V_127:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_128:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_129:[0-9a-zA-Z_\.]+]] = %[[V_113]]#0, %[[V_130:[0-9a-zA-Z_\.]+]] = %[[V_127]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[V_131:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[V_130]], %[[V_126]])
+// CHECK-NEXT:          scf.condition(%[[V_131]]) %[[V_129]], %[[V_130]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        } do {
-// CHECK-NEXT:        ^bb0(%[[VAL_132:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_133:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:          %[[VAL_134:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_126]], %[[VAL_133]] : !felt.type, !felt.type
-// CHECK-NEXT:          %[[VAL_135:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_134]]
-// CHECK-NEXT:          %[[VAL_136:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_87]]{{\[}}%[[VAL_135]]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_137:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_126]]
-// CHECK-NEXT:          array.write %[[VAL_132]]{{\[}}%[[VAL_137]]] = %[[VAL_136]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_138:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:          %[[VAL_139:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_133]], %[[VAL_138]] : !felt.type, !felt.type
-// CHECK-NEXT:          scf.yield %[[VAL_132]], %[[VAL_139]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        ^bb0(%[[V_132:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[V_133:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[V_134:[0-9a-zA-Z_\.]+]] = felt.sub %[[V_126]], %[[V_133]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[V_135:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_134]]
+// CHECK-NEXT:          %[[V_136:[0-9a-zA-Z_\.]+]] = array.read %[[V_87]]{{\[}}%[[V_135]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_137:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_126]]
+// CHECK-NEXT:          array.write %[[V_132]]{{\[}}%[[V_137]]] = %[[V_136]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_138:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[V_139:[0-9a-zA-Z_\.]+]] = felt.add %[[V_133]], %[[V_138]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[V_132]], %[[V_139]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_140:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:        %[[VAL_141:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_126]], %[[VAL_140]] : !felt.type, !felt.type
-// CHECK-NEXT:        %[[VAL_142:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_143:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_144:[0-9a-zA-Z_\.]+]] = %[[VAL_128]]#0, %[[VAL_145:[0-9a-zA-Z_\.]+]] = %[[VAL_142]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
-// CHECK-NEXT:          %[[VAL_146:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_145]], %[[VAL_141]])
-// CHECK-NEXT:          scf.condition(%[[VAL_146]]) %[[VAL_144]], %[[VAL_145]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[V_140:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[V_141:[0-9a-zA-Z_\.]+]] = felt.add %[[V_126]], %[[V_140]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[V_142:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_143:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_144:[0-9a-zA-Z_\.]+]] = %[[V_128]]#0, %[[V_145:[0-9a-zA-Z_\.]+]] = %[[V_142]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[V_146:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[V_145]], %[[V_141]])
+// CHECK-NEXT:          scf.condition(%[[V_146]]) %[[V_144]], %[[V_145]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        } do {
-// CHECK-NEXT:        ^bb0(%[[VAL_147:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_148:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:          %[[VAL_149:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_141]], %[[VAL_148]] : !felt.type, !felt.type
-// CHECK-NEXT:          %[[VAL_150:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_149]]
-// CHECK-NEXT:          %[[VAL_151:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_87]]{{\[}}%[[VAL_150]]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_152:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_141]]
-// CHECK-NEXT:          array.write %[[VAL_147]]{{\[}}%[[VAL_152]]] = %[[VAL_151]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_153:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:          %[[VAL_154:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_148]], %[[VAL_153]] : !felt.type, !felt.type
-// CHECK-NEXT:          scf.yield %[[VAL_147]], %[[VAL_154]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        ^bb0(%[[V_147:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[V_148:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[V_149:[0-9a-zA-Z_\.]+]] = felt.sub %[[V_141]], %[[V_148]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[V_150:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_149]]
+// CHECK-NEXT:          %[[V_151:[0-9a-zA-Z_\.]+]] = array.read %[[V_87]]{{\[}}%[[V_150]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_152:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_141]]
+// CHECK-NEXT:          array.write %[[V_147]]{{\[}}%[[V_152]]] = %[[V_151]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_153:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[V_154:[0-9a-zA-Z_\.]+]] = felt.add %[[V_148]], %[[V_153]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[V_147]], %[[V_154]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_155:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:        %[[VAL_156:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_141]], %[[VAL_155]] : !felt.type, !felt.type
-// CHECK-NEXT:        %[[VAL_157:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_158:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_159:[0-9a-zA-Z_\.]+]] = %[[VAL_143]]#0, %[[VAL_160:[0-9a-zA-Z_\.]+]] = %[[VAL_157]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
-// CHECK-NEXT:          %[[VAL_161:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_160]], %[[VAL_156]])
-// CHECK-NEXT:          scf.condition(%[[VAL_161]]) %[[VAL_159]], %[[VAL_160]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[V_155:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[V_156:[0-9a-zA-Z_\.]+]] = felt.add %[[V_141]], %[[V_155]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[V_157:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_158:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_159:[0-9a-zA-Z_\.]+]] = %[[V_143]]#0, %[[V_160:[0-9a-zA-Z_\.]+]] = %[[V_157]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[V_161:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[V_160]], %[[V_156]])
+// CHECK-NEXT:          scf.condition(%[[V_161]]) %[[V_159]], %[[V_160]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        } do {
-// CHECK-NEXT:        ^bb0(%[[VAL_162:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_163:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:          %[[VAL_164:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_156]], %[[VAL_163]] : !felt.type, !felt.type
-// CHECK-NEXT:          %[[VAL_165:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_164]]
-// CHECK-NEXT:          %[[VAL_166:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_87]]{{\[}}%[[VAL_165]]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_167:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_156]]
-// CHECK-NEXT:          array.write %[[VAL_162]]{{\[}}%[[VAL_167]]] = %[[VAL_166]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_168:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:          %[[VAL_169:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_163]], %[[VAL_168]] : !felt.type, !felt.type
-// CHECK-NEXT:          scf.yield %[[VAL_162]], %[[VAL_169]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        ^bb0(%[[V_162:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[V_163:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[V_164:[0-9a-zA-Z_\.]+]] = felt.sub %[[V_156]], %[[V_163]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[V_165:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_164]]
+// CHECK-NEXT:          %[[V_166:[0-9a-zA-Z_\.]+]] = array.read %[[V_87]]{{\[}}%[[V_165]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_167:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_156]]
+// CHECK-NEXT:          array.write %[[V_162]]{{\[}}%[[V_167]]] = %[[V_166]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_168:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[V_169:[0-9a-zA-Z_\.]+]] = felt.add %[[V_163]], %[[V_168]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[V_162]], %[[V_169]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_170:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:        %[[VAL_171:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_156]], %[[VAL_170]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[V_170:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[V_171:[0-9a-zA-Z_\.]+]] = felt.add %[[V_156]], %[[V_170]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }

--- a/circom/tests/loops/inner_loop_03.circom
+++ b/circom/tests/loops/inner_loop_03.circom
@@ -1,7 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL:.*
 
 pragma circom 2.0.0;
 
@@ -29,3 +28,213 @@ template InnerLoops(n) {
 component main = InnerLoops(5);
 
 // CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-NEXT:    struct.def @InnerLoops<[@n]> {
+// CHECK-NEXT:      function.def @compute(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) -> !struct.type<@InnerLoops<[@n]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = struct.new : <@InnerLoops<[@n]>>
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !felt.type>
+// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_4]], %[[VAL_5]] : <@n x !felt.type>
+// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[VAL_9:[0-9a-zA-Z_\.]+]] = %[[VAL_7]] to %[[VAL_6]] step %[[VAL_8]] {
+// CHECK-NEXT:          array.write %[[VAL_4]]{{\[}}%[[VAL_9]]] = %[[VAL_3]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_12:[0-9a-zA-Z_\.]+]] = %[[VAL_4]], %[[VAL_13:[0-9a-zA-Z_\.]+]] = %[[VAL_10]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[VAL_14:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:          %[[VAL_15:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_13]], %[[VAL_14]])
+// CHECK-NEXT:          scf.condition(%[[VAL_15]]) %[[VAL_12]], %[[VAL_13]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        } do {
+// CHECK-NEXT:        ^bb0(%[[VAL_16:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_17:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[VAL_18:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:          %[[VAL_19:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_18]], %[[VAL_17]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[VAL_20:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_19]]
+// CHECK-NEXT:          %[[VAL_21:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_0]]{{\[}}%[[VAL_20]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_22:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:          %[[VAL_23:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_22]]
+// CHECK-NEXT:          array.write %[[VAL_16]]{{\[}}%[[VAL_23]]] = %[[VAL_21]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_24:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_25:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_17]], %[[VAL_24]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_16]], %[[VAL_25]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_26:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_27:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_28:[0-9a-zA-Z_\.]+]] = %[[VAL_11]]#0, %[[VAL_29:[0-9a-zA-Z_\.]+]] = %[[VAL_26]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[VAL_30:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_31:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_29]], %[[VAL_30]])
+// CHECK-NEXT:          scf.condition(%[[VAL_31]]) %[[VAL_28]], %[[VAL_29]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        } do {
+// CHECK-NEXT:        ^bb0(%[[VAL_32:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_33:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[VAL_34:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_35:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_34]], %[[VAL_33]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[VAL_36:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_35]]
+// CHECK-NEXT:          %[[VAL_37:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_0]]{{\[}}%[[VAL_36]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_38:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_39:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_38]]
+// CHECK-NEXT:          array.write %[[VAL_32]]{{\[}}%[[VAL_39]]] = %[[VAL_37]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_40:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_41:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_33]], %[[VAL_40]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_32]], %[[VAL_41]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_42:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_43:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_44:[0-9a-zA-Z_\.]+]] = %[[VAL_27]]#0, %[[VAL_45:[0-9a-zA-Z_\.]+]] = %[[VAL_42]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[VAL_46:[0-9a-zA-Z_\.]+]] = felt.const  2
+// CHECK-NEXT:          %[[VAL_47:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_45]], %[[VAL_46]])
+// CHECK-NEXT:          scf.condition(%[[VAL_47]]) %[[VAL_44]], %[[VAL_45]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        } do {
+// CHECK-NEXT:        ^bb0(%[[VAL_48:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_49:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[VAL_50:[0-9a-zA-Z_\.]+]] = felt.const  2
+// CHECK-NEXT:          %[[VAL_51:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_50]], %[[VAL_49]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[VAL_52:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_51]]
+// CHECK-NEXT:          %[[VAL_53:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_0]]{{\[}}%[[VAL_52]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_54:[0-9a-zA-Z_\.]+]] = felt.const  2
+// CHECK-NEXT:          %[[VAL_55:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_54]]
+// CHECK-NEXT:          array.write %[[VAL_48]]{{\[}}%[[VAL_55]]] = %[[VAL_53]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_56:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_57:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_49]], %[[VAL_56]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_48]], %[[VAL_57]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_58:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_59:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_60:[0-9a-zA-Z_\.]+]] = %[[VAL_43]]#0, %[[VAL_61:[0-9a-zA-Z_\.]+]] = %[[VAL_58]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[VAL_62:[0-9a-zA-Z_\.]+]] = felt.const  3
+// CHECK-NEXT:          %[[VAL_63:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_61]], %[[VAL_62]])
+// CHECK-NEXT:          scf.condition(%[[VAL_63]]) %[[VAL_60]], %[[VAL_61]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        } do {
+// CHECK-NEXT:        ^bb0(%[[VAL_64:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_65:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[VAL_66:[0-9a-zA-Z_\.]+]] = felt.const  3
+// CHECK-NEXT:          %[[VAL_67:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_66]], %[[VAL_65]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[VAL_68:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_67]]
+// CHECK-NEXT:          %[[VAL_69:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_0]]{{\[}}%[[VAL_68]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_70:[0-9a-zA-Z_\.]+]] = felt.const  3
+// CHECK-NEXT:          %[[VAL_71:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_70]]
+// CHECK-NEXT:          array.write %[[VAL_64]]{{\[}}%[[VAL_71]]] = %[[VAL_69]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_72:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_73:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_65]], %[[VAL_72]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_64]], %[[VAL_73]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_74:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_75:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_76:[0-9a-zA-Z_\.]+]] = %[[VAL_59]]#0, %[[VAL_77:[0-9a-zA-Z_\.]+]] = %[[VAL_74]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[VAL_78:[0-9a-zA-Z_\.]+]] = felt.const  4
+// CHECK-NEXT:          %[[VAL_79:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_77]], %[[VAL_78]])
+// CHECK-NEXT:          scf.condition(%[[VAL_79]]) %[[VAL_76]], %[[VAL_77]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        } do {
+// CHECK-NEXT:        ^bb0(%[[VAL_80:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_81:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[VAL_82:[0-9a-zA-Z_\.]+]] = felt.const  4
+// CHECK-NEXT:          %[[VAL_83:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_82]], %[[VAL_81]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[VAL_84:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_83]]
+// CHECK-NEXT:          %[[VAL_85:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_0]]{{\[}}%[[VAL_84]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_86:[0-9a-zA-Z_\.]+]] = felt.const  4
+// CHECK-NEXT:          %[[VAL_87:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_86]]
+// CHECK-NEXT:          array.write %[[VAL_80]]{{\[}}%[[VAL_87]]] = %[[VAL_85]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_88:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_89:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_81]], %[[VAL_88]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_80]], %[[VAL_89]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.return %[[VAL_1]] : !struct.type<@InnerLoops<[@n]>>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[VAL_90:[0-9a-zA-Z_\.]+]]: !struct.type<@InnerLoops<[@n]>>, %[[VAL_91:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[VAL_92:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_93:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_94:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !felt.type>
+// CHECK-NEXT:        %[[VAL_95:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_96:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_94]], %[[VAL_95]] : <@n x !felt.type>
+// CHECK-NEXT:        %[[VAL_97:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_98:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[VAL_99:[0-9a-zA-Z_\.]+]] = %[[VAL_97]] to %[[VAL_96]] step %[[VAL_98]] {
+// CHECK-NEXT:          array.write %[[VAL_94]]{{\[}}%[[VAL_99]]] = %[[VAL_93]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_100:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_101:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_102:[0-9a-zA-Z_\.]+]] = %[[VAL_94]], %[[VAL_103:[0-9a-zA-Z_\.]+]] = %[[VAL_100]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[VAL_104:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:          %[[VAL_105:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_103]], %[[VAL_104]])
+// CHECK-NEXT:          scf.condition(%[[VAL_105]]) %[[VAL_102]], %[[VAL_103]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        } do {
+// CHECK-NEXT:        ^bb0(%[[VAL_106:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_107:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[VAL_108:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:          %[[VAL_109:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_108]], %[[VAL_107]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[VAL_110:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_109]]
+// CHECK-NEXT:          %[[VAL_111:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_91]]{{\[}}%[[VAL_110]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_112:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:          %[[VAL_113:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_112]]
+// CHECK-NEXT:          array.write %[[VAL_106]]{{\[}}%[[VAL_113]]] = %[[VAL_111]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_114:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_115:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_107]], %[[VAL_114]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_106]], %[[VAL_115]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_116:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_117:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_118:[0-9a-zA-Z_\.]+]] = %[[VAL_101]]#0, %[[VAL_119:[0-9a-zA-Z_\.]+]] = %[[VAL_116]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[VAL_120:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_121:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_119]], %[[VAL_120]])
+// CHECK-NEXT:          scf.condition(%[[VAL_121]]) %[[VAL_118]], %[[VAL_119]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        } do {
+// CHECK-NEXT:        ^bb0(%[[VAL_122:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_123:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[VAL_124:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_125:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_124]], %[[VAL_123]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[VAL_126:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_125]]
+// CHECK-NEXT:          %[[VAL_127:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_91]]{{\[}}%[[VAL_126]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_128:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_129:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_128]]
+// CHECK-NEXT:          array.write %[[VAL_122]]{{\[}}%[[VAL_129]]] = %[[VAL_127]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_130:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_131:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_123]], %[[VAL_130]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_122]], %[[VAL_131]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_132:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_133:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_134:[0-9a-zA-Z_\.]+]] = %[[VAL_117]]#0, %[[VAL_135:[0-9a-zA-Z_\.]+]] = %[[VAL_132]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[VAL_136:[0-9a-zA-Z_\.]+]] = felt.const  2
+// CHECK-NEXT:          %[[VAL_137:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_135]], %[[VAL_136]])
+// CHECK-NEXT:          scf.condition(%[[VAL_137]]) %[[VAL_134]], %[[VAL_135]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        } do {
+// CHECK-NEXT:        ^bb0(%[[VAL_138:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_139:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[VAL_140:[0-9a-zA-Z_\.]+]] = felt.const  2
+// CHECK-NEXT:          %[[VAL_141:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_140]], %[[VAL_139]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[VAL_142:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_141]]
+// CHECK-NEXT:          %[[VAL_143:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_91]]{{\[}}%[[VAL_142]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_144:[0-9a-zA-Z_\.]+]] = felt.const  2
+// CHECK-NEXT:          %[[VAL_145:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_144]]
+// CHECK-NEXT:          array.write %[[VAL_138]]{{\[}}%[[VAL_145]]] = %[[VAL_143]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_146:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_147:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_139]], %[[VAL_146]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_138]], %[[VAL_147]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_148:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_149:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_150:[0-9a-zA-Z_\.]+]] = %[[VAL_133]]#0, %[[VAL_151:[0-9a-zA-Z_\.]+]] = %[[VAL_148]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[VAL_152:[0-9a-zA-Z_\.]+]] = felt.const  3
+// CHECK-NEXT:          %[[VAL_153:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_151]], %[[VAL_152]])
+// CHECK-NEXT:          scf.condition(%[[VAL_153]]) %[[VAL_150]], %[[VAL_151]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        } do {
+// CHECK-NEXT:        ^bb0(%[[VAL_154:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_155:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[VAL_156:[0-9a-zA-Z_\.]+]] = felt.const  3
+// CHECK-NEXT:          %[[VAL_157:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_156]], %[[VAL_155]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[VAL_158:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_157]]
+// CHECK-NEXT:          %[[VAL_159:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_91]]{{\[}}%[[VAL_158]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_160:[0-9a-zA-Z_\.]+]] = felt.const  3
+// CHECK-NEXT:          %[[VAL_161:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_160]]
+// CHECK-NEXT:          array.write %[[VAL_154]]{{\[}}%[[VAL_161]]] = %[[VAL_159]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_162:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_163:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_155]], %[[VAL_162]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_154]], %[[VAL_163]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_164:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_165:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_166:[0-9a-zA-Z_\.]+]] = %[[VAL_149]]#0, %[[VAL_167:[0-9a-zA-Z_\.]+]] = %[[VAL_164]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[VAL_168:[0-9a-zA-Z_\.]+]] = felt.const  4
+// CHECK-NEXT:          %[[VAL_169:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_167]], %[[VAL_168]])
+// CHECK-NEXT:          scf.condition(%[[VAL_169]]) %[[VAL_166]], %[[VAL_167]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        } do {
+// CHECK-NEXT:        ^bb0(%[[VAL_170:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_171:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[VAL_172:[0-9a-zA-Z_\.]+]] = felt.const  4
+// CHECK-NEXT:          %[[VAL_173:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_172]], %[[VAL_171]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[VAL_174:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_173]]
+// CHECK-NEXT:          %[[VAL_175:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_91]]{{\[}}%[[VAL_174]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_176:[0-9a-zA-Z_\.]+]] = felt.const  4
+// CHECK-NEXT:          %[[VAL_177:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_176]]
+// CHECK-NEXT:          array.write %[[VAL_170]]{{\[}}%[[VAL_177]]] = %[[VAL_175]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_178:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_179:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_171]], %[[VAL_178]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_170]], %[[VAL_179]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/loops/inner_loop_03.circom
+++ b/circom/tests/loops/inner_loop_03.circom
@@ -29,210 +29,212 @@ component main = InnerLoops(5);
 
 // CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
 // CHECK-NEXT:    struct.def @InnerLoops<[@n]> {
-// CHECK-NEXT:      function.def @compute(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) -> !struct.type<@InnerLoops<[@n]>> attributes {function.allow_witness} {
-// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = struct.new : <@InnerLoops<[@n]>>
-// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
-// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !felt.type>
-// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_4]], %[[VAL_5]] : <@n x !felt.type>
-// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:        scf.for %[[VAL_9:[0-9a-zA-Z_\.]+]] = %[[VAL_7]] to %[[VAL_6]] step %[[VAL_8]] {
-// CHECK-NEXT:          array.write %[[VAL_4]]{{\[}}%[[VAL_9]]] = %[[VAL_3]] : <@n x !felt.type>, !felt.type
+// CHECK-LABEL:     function.def @compute
+// CHECK-SAME:      (%[[V_A:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) -> !struct.type<@InnerLoops<[@n]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[V_1:[0-9a-zA-Z_\.]+]] = struct.new : <@InnerLoops<[@n]>>
+// CHECK-NEXT:        %[[V_N:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[V_3:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_B:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !felt.type>
+// CHECK-NEXT:        %[[V_5:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[V_6:[0-9a-zA-Z_\.]+]] = array.len %[[V_B]], %[[V_5]] : <@n x !felt.type>
+// CHECK-NEXT:        %[[V_7:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[V_8:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[V_9:[0-9a-zA-Z_\.]+]] = %[[V_7]] to %[[V_6]] step %[[V_8]] {
+// CHECK-NEXT:          array.write %[[V_B]]{{\[}}%[[V_9]]] = %[[V_3]] : <@n x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_12:[0-9a-zA-Z_\.]+]] = %[[VAL_4]], %[[VAL_13:[0-9a-zA-Z_\.]+]] = %[[VAL_10]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
-// CHECK-NEXT:          %[[VAL_14:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:          %[[VAL_15:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_13]], %[[VAL_14]])
-// CHECK-NEXT:          scf.condition(%[[VAL_15]]) %[[VAL_12]], %[[VAL_13]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[V_10:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_11:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_12:[0-9a-zA-Z_\.]+]] = %[[V_B]], %[[V_13:[0-9a-zA-Z_\.]+]] = %[[V_10]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[V_14:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:          %[[V_15:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[V_13]], %[[V_14]])
+// CHECK-NEXT:          scf.condition(%[[V_15]]) %[[V_12]], %[[V_13]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        } do {
-// CHECK-NEXT:        ^bb0(%[[VAL_16:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_17:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:          %[[VAL_18:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:          %[[VAL_19:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_18]], %[[VAL_17]] : !felt.type, !felt.type
-// CHECK-NEXT:          %[[VAL_20:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_19]]
-// CHECK-NEXT:          %[[VAL_21:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_0]]{{\[}}%[[VAL_20]]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_22:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:          %[[VAL_23:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_22]]
-// CHECK-NEXT:          array.write %[[VAL_16]]{{\[}}%[[VAL_23]]] = %[[VAL_21]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_24:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:          %[[VAL_25:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_17]], %[[VAL_24]] : !felt.type, !felt.type
-// CHECK-NEXT:          scf.yield %[[VAL_16]], %[[VAL_25]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        ^bb0(%[[V_16:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[V_17:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[V_18:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:          %[[V_19:[0-9a-zA-Z_\.]+]] = felt.sub %[[V_18]], %[[V_17]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[V_20:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_19]]
+// CHECK-NEXT:          %[[V_21:[0-9a-zA-Z_\.]+]] = array.read %[[V_A]]{{\[}}%[[V_20]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_22:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:          %[[V_23:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_22]]
+// CHECK-NEXT:          array.write %[[V_16]]{{\[}}%[[V_23]]] = %[[V_21]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_24:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[V_25:[0-9a-zA-Z_\.]+]] = felt.add %[[V_17]], %[[V_24]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[V_16]], %[[V_25]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_26:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_27:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_28:[0-9a-zA-Z_\.]+]] = %[[VAL_11]]#0, %[[VAL_29:[0-9a-zA-Z_\.]+]] = %[[VAL_26]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
-// CHECK-NEXT:          %[[VAL_30:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:          %[[VAL_31:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_29]], %[[VAL_30]])
-// CHECK-NEXT:          scf.condition(%[[VAL_31]]) %[[VAL_28]], %[[VAL_29]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[V_26:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_27:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_28:[0-9a-zA-Z_\.]+]] = %[[V_11]]#0, %[[V_29:[0-9a-zA-Z_\.]+]] = %[[V_26]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[V_30:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[V_31:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[V_29]], %[[V_30]])
+// CHECK-NEXT:          scf.condition(%[[V_31]]) %[[V_28]], %[[V_29]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        } do {
-// CHECK-NEXT:        ^bb0(%[[VAL_32:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_33:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:          %[[VAL_34:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:          %[[VAL_35:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_34]], %[[VAL_33]] : !felt.type, !felt.type
-// CHECK-NEXT:          %[[VAL_36:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_35]]
-// CHECK-NEXT:          %[[VAL_37:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_0]]{{\[}}%[[VAL_36]]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_38:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:          %[[VAL_39:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_38]]
-// CHECK-NEXT:          array.write %[[VAL_32]]{{\[}}%[[VAL_39]]] = %[[VAL_37]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_40:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:          %[[VAL_41:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_33]], %[[VAL_40]] : !felt.type, !felt.type
-// CHECK-NEXT:          scf.yield %[[VAL_32]], %[[VAL_41]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        ^bb0(%[[V_32:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[V_33:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[V_34:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[V_35:[0-9a-zA-Z_\.]+]] = felt.sub %[[V_34]], %[[V_33]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[V_36:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_35]]
+// CHECK-NEXT:          %[[V_37:[0-9a-zA-Z_\.]+]] = array.read %[[V_A]]{{\[}}%[[V_36]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_38:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[V_39:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_38]]
+// CHECK-NEXT:          array.write %[[V_32]]{{\[}}%[[V_39]]] = %[[V_37]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_40:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[V_41:[0-9a-zA-Z_\.]+]] = felt.add %[[V_33]], %[[V_40]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[V_32]], %[[V_41]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_42:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_43:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_44:[0-9a-zA-Z_\.]+]] = %[[VAL_27]]#0, %[[VAL_45:[0-9a-zA-Z_\.]+]] = %[[VAL_42]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
-// CHECK-NEXT:          %[[VAL_46:[0-9a-zA-Z_\.]+]] = felt.const  2
-// CHECK-NEXT:          %[[VAL_47:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_45]], %[[VAL_46]])
-// CHECK-NEXT:          scf.condition(%[[VAL_47]]) %[[VAL_44]], %[[VAL_45]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[V_42:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_43:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_44:[0-9a-zA-Z_\.]+]] = %[[V_27]]#0, %[[V_45:[0-9a-zA-Z_\.]+]] = %[[V_42]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[V_46:[0-9a-zA-Z_\.]+]] = felt.const  2
+// CHECK-NEXT:          %[[V_47:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[V_45]], %[[V_46]])
+// CHECK-NEXT:          scf.condition(%[[V_47]]) %[[V_44]], %[[V_45]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        } do {
-// CHECK-NEXT:        ^bb0(%[[VAL_48:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_49:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:          %[[VAL_50:[0-9a-zA-Z_\.]+]] = felt.const  2
-// CHECK-NEXT:          %[[VAL_51:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_50]], %[[VAL_49]] : !felt.type, !felt.type
-// CHECK-NEXT:          %[[VAL_52:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_51]]
-// CHECK-NEXT:          %[[VAL_53:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_0]]{{\[}}%[[VAL_52]]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_54:[0-9a-zA-Z_\.]+]] = felt.const  2
-// CHECK-NEXT:          %[[VAL_55:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_54]]
-// CHECK-NEXT:          array.write %[[VAL_48]]{{\[}}%[[VAL_55]]] = %[[VAL_53]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_56:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:          %[[VAL_57:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_49]], %[[VAL_56]] : !felt.type, !felt.type
-// CHECK-NEXT:          scf.yield %[[VAL_48]], %[[VAL_57]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        ^bb0(%[[V_48:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[V_49:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[V_50:[0-9a-zA-Z_\.]+]] = felt.const  2
+// CHECK-NEXT:          %[[V_51:[0-9a-zA-Z_\.]+]] = felt.sub %[[V_50]], %[[V_49]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[V_52:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_51]]
+// CHECK-NEXT:          %[[V_53:[0-9a-zA-Z_\.]+]] = array.read %[[V_A]]{{\[}}%[[V_52]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_54:[0-9a-zA-Z_\.]+]] = felt.const  2
+// CHECK-NEXT:          %[[V_55:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_54]]
+// CHECK-NEXT:          array.write %[[V_48]]{{\[}}%[[V_55]]] = %[[V_53]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_56:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[V_57:[0-9a-zA-Z_\.]+]] = felt.add %[[V_49]], %[[V_56]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[V_48]], %[[V_57]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_58:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_59:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_60:[0-9a-zA-Z_\.]+]] = %[[VAL_43]]#0, %[[VAL_61:[0-9a-zA-Z_\.]+]] = %[[VAL_58]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
-// CHECK-NEXT:          %[[VAL_62:[0-9a-zA-Z_\.]+]] = felt.const  3
-// CHECK-NEXT:          %[[VAL_63:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_61]], %[[VAL_62]])
-// CHECK-NEXT:          scf.condition(%[[VAL_63]]) %[[VAL_60]], %[[VAL_61]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[V_58:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_59:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_60:[0-9a-zA-Z_\.]+]] = %[[V_43]]#0, %[[V_61:[0-9a-zA-Z_\.]+]] = %[[V_58]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[V_62:[0-9a-zA-Z_\.]+]] = felt.const  3
+// CHECK-NEXT:          %[[V_63:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[V_61]], %[[V_62]])
+// CHECK-NEXT:          scf.condition(%[[V_63]]) %[[V_60]], %[[V_61]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        } do {
-// CHECK-NEXT:        ^bb0(%[[VAL_64:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_65:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:          %[[VAL_66:[0-9a-zA-Z_\.]+]] = felt.const  3
-// CHECK-NEXT:          %[[VAL_67:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_66]], %[[VAL_65]] : !felt.type, !felt.type
-// CHECK-NEXT:          %[[VAL_68:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_67]]
-// CHECK-NEXT:          %[[VAL_69:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_0]]{{\[}}%[[VAL_68]]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_70:[0-9a-zA-Z_\.]+]] = felt.const  3
-// CHECK-NEXT:          %[[VAL_71:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_70]]
-// CHECK-NEXT:          array.write %[[VAL_64]]{{\[}}%[[VAL_71]]] = %[[VAL_69]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_72:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:          %[[VAL_73:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_65]], %[[VAL_72]] : !felt.type, !felt.type
-// CHECK-NEXT:          scf.yield %[[VAL_64]], %[[VAL_73]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        ^bb0(%[[V_64:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[V_65:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[V_66:[0-9a-zA-Z_\.]+]] = felt.const  3
+// CHECK-NEXT:          %[[V_67:[0-9a-zA-Z_\.]+]] = felt.sub %[[V_66]], %[[V_65]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[V_68:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_67]]
+// CHECK-NEXT:          %[[V_69:[0-9a-zA-Z_\.]+]] = array.read %[[V_A]]{{\[}}%[[V_68]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_70:[0-9a-zA-Z_\.]+]] = felt.const  3
+// CHECK-NEXT:          %[[V_71:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_70]]
+// CHECK-NEXT:          array.write %[[V_64]]{{\[}}%[[V_71]]] = %[[V_69]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_72:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[V_73:[0-9a-zA-Z_\.]+]] = felt.add %[[V_65]], %[[V_72]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[V_64]], %[[V_73]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_74:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_75:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_76:[0-9a-zA-Z_\.]+]] = %[[VAL_59]]#0, %[[VAL_77:[0-9a-zA-Z_\.]+]] = %[[VAL_74]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
-// CHECK-NEXT:          %[[VAL_78:[0-9a-zA-Z_\.]+]] = felt.const  4
-// CHECK-NEXT:          %[[VAL_79:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_77]], %[[VAL_78]])
-// CHECK-NEXT:          scf.condition(%[[VAL_79]]) %[[VAL_76]], %[[VAL_77]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[V_74:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_75:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_76:[0-9a-zA-Z_\.]+]] = %[[V_59]]#0, %[[V_77:[0-9a-zA-Z_\.]+]] = %[[V_74]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[V_78:[0-9a-zA-Z_\.]+]] = felt.const  4
+// CHECK-NEXT:          %[[V_79:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[V_77]], %[[V_78]])
+// CHECK-NEXT:          scf.condition(%[[V_79]]) %[[V_76]], %[[V_77]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        } do {
-// CHECK-NEXT:        ^bb0(%[[VAL_80:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_81:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:          %[[VAL_82:[0-9a-zA-Z_\.]+]] = felt.const  4
-// CHECK-NEXT:          %[[VAL_83:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_82]], %[[VAL_81]] : !felt.type, !felt.type
-// CHECK-NEXT:          %[[VAL_84:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_83]]
-// CHECK-NEXT:          %[[VAL_85:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_0]]{{\[}}%[[VAL_84]]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_86:[0-9a-zA-Z_\.]+]] = felt.const  4
-// CHECK-NEXT:          %[[VAL_87:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_86]]
-// CHECK-NEXT:          array.write %[[VAL_80]]{{\[}}%[[VAL_87]]] = %[[VAL_85]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_88:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:          %[[VAL_89:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_81]], %[[VAL_88]] : !felt.type, !felt.type
-// CHECK-NEXT:          scf.yield %[[VAL_80]], %[[VAL_89]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        ^bb0(%[[V_80:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[V_81:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[V_82:[0-9a-zA-Z_\.]+]] = felt.const  4
+// CHECK-NEXT:          %[[V_83:[0-9a-zA-Z_\.]+]] = felt.sub %[[V_82]], %[[V_81]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[V_84:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_83]]
+// CHECK-NEXT:          %[[V_85:[0-9a-zA-Z_\.]+]] = array.read %[[V_A]]{{\[}}%[[V_84]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_86:[0-9a-zA-Z_\.]+]] = felt.const  4
+// CHECK-NEXT:          %[[V_87:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_86]]
+// CHECK-NEXT:          array.write %[[V_80]]{{\[}}%[[V_87]]] = %[[V_85]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_88:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[V_89:[0-9a-zA-Z_\.]+]] = felt.add %[[V_81]], %[[V_88]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[V_80]], %[[V_89]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        function.return %[[VAL_1]] : !struct.type<@InnerLoops<[@n]>>
+// CHECK-NEXT:        function.return %[[V_1]] : !struct.type<@InnerLoops<[@n]>>
 // CHECK-NEXT:      }
-// CHECK-NEXT:      function.def @constrain(%[[VAL_90:[0-9a-zA-Z_\.]+]]: !struct.type<@InnerLoops<[@n]>>, %[[VAL_91:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) attributes {function.allow_constraint} {
-// CHECK-NEXT:        %[[VAL_92:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
-// CHECK-NEXT:        %[[VAL_93:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_94:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !felt.type>
-// CHECK-NEXT:        %[[VAL_95:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_96:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_94]], %[[VAL_95]] : <@n x !felt.type>
-// CHECK-NEXT:        %[[VAL_97:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_98:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:        scf.for %[[VAL_99:[0-9a-zA-Z_\.]+]] = %[[VAL_97]] to %[[VAL_96]] step %[[VAL_98]] {
-// CHECK-NEXT:          array.write %[[VAL_94]]{{\[}}%[[VAL_99]]] = %[[VAL_93]] : <@n x !felt.type>, !felt.type
+// CHECK-LABEL:     function.def @constrain
+// CHECK-SAME:      (%[[V_A:[0-9a-zA-Z_\.]+]]: !struct.type<@InnerLoops<[@n]>>, %[[V_91:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[V_N:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[V_93:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_B:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !felt.type>
+// CHECK-NEXT:        %[[V_95:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[V_96:[0-9a-zA-Z_\.]+]] = array.len %[[V_B]], %[[V_95]] : <@n x !felt.type>
+// CHECK-NEXT:        %[[V_97:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[V_98:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[V_99:[0-9a-zA-Z_\.]+]] = %[[V_97]] to %[[V_96]] step %[[V_98]] {
+// CHECK-NEXT:          array.write %[[V_B]]{{\[}}%[[V_99]]] = %[[V_93]] : <@n x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_100:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_101:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_102:[0-9a-zA-Z_\.]+]] = %[[VAL_94]], %[[VAL_103:[0-9a-zA-Z_\.]+]] = %[[VAL_100]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
-// CHECK-NEXT:          %[[VAL_104:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:          %[[VAL_105:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_103]], %[[VAL_104]])
-// CHECK-NEXT:          scf.condition(%[[VAL_105]]) %[[VAL_102]], %[[VAL_103]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[V_100:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_101:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_102:[0-9a-zA-Z_\.]+]] = %[[V_B]], %[[V_103:[0-9a-zA-Z_\.]+]] = %[[V_100]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[V_104:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:          %[[V_105:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[V_103]], %[[V_104]])
+// CHECK-NEXT:          scf.condition(%[[V_105]]) %[[V_102]], %[[V_103]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        } do {
-// CHECK-NEXT:        ^bb0(%[[VAL_106:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_107:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:          %[[VAL_108:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:          %[[VAL_109:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_108]], %[[VAL_107]] : !felt.type, !felt.type
-// CHECK-NEXT:          %[[VAL_110:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_109]]
-// CHECK-NEXT:          %[[VAL_111:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_91]]{{\[}}%[[VAL_110]]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_112:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:          %[[VAL_113:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_112]]
-// CHECK-NEXT:          array.write %[[VAL_106]]{{\[}}%[[VAL_113]]] = %[[VAL_111]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_114:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:          %[[VAL_115:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_107]], %[[VAL_114]] : !felt.type, !felt.type
-// CHECK-NEXT:          scf.yield %[[VAL_106]], %[[VAL_115]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        ^bb0(%[[V_106:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[V_107:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[V_108:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:          %[[V_109:[0-9a-zA-Z_\.]+]] = felt.sub %[[V_108]], %[[V_107]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[V_110:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_109]]
+// CHECK-NEXT:          %[[V_111:[0-9a-zA-Z_\.]+]] = array.read %[[V_91]]{{\[}}%[[V_110]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_112:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:          %[[V_113:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_112]]
+// CHECK-NEXT:          array.write %[[V_106]]{{\[}}%[[V_113]]] = %[[V_111]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_114:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[V_115:[0-9a-zA-Z_\.]+]] = felt.add %[[V_107]], %[[V_114]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[V_106]], %[[V_115]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_116:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_117:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_118:[0-9a-zA-Z_\.]+]] = %[[VAL_101]]#0, %[[VAL_119:[0-9a-zA-Z_\.]+]] = %[[VAL_116]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
-// CHECK-NEXT:          %[[VAL_120:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:          %[[VAL_121:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_119]], %[[VAL_120]])
-// CHECK-NEXT:          scf.condition(%[[VAL_121]]) %[[VAL_118]], %[[VAL_119]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[V_116:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_117:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_118:[0-9a-zA-Z_\.]+]] = %[[V_101]]#0, %[[V_119:[0-9a-zA-Z_\.]+]] = %[[V_116]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[V_120:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[V_121:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[V_119]], %[[V_120]])
+// CHECK-NEXT:          scf.condition(%[[V_121]]) %[[V_118]], %[[V_119]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        } do {
-// CHECK-NEXT:        ^bb0(%[[VAL_122:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_123:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:          %[[VAL_124:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:          %[[VAL_125:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_124]], %[[VAL_123]] : !felt.type, !felt.type
-// CHECK-NEXT:          %[[VAL_126:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_125]]
-// CHECK-NEXT:          %[[VAL_127:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_91]]{{\[}}%[[VAL_126]]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_128:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:          %[[VAL_129:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_128]]
-// CHECK-NEXT:          array.write %[[VAL_122]]{{\[}}%[[VAL_129]]] = %[[VAL_127]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_130:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:          %[[VAL_131:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_123]], %[[VAL_130]] : !felt.type, !felt.type
-// CHECK-NEXT:          scf.yield %[[VAL_122]], %[[VAL_131]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        ^bb0(%[[V_122:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[V_123:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[V_124:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[V_125:[0-9a-zA-Z_\.]+]] = felt.sub %[[V_124]], %[[V_123]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[V_126:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_125]]
+// CHECK-NEXT:          %[[V_127:[0-9a-zA-Z_\.]+]] = array.read %[[V_91]]{{\[}}%[[V_126]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_128:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[V_129:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_128]]
+// CHECK-NEXT:          array.write %[[V_122]]{{\[}}%[[V_129]]] = %[[V_127]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_130:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[V_131:[0-9a-zA-Z_\.]+]] = felt.add %[[V_123]], %[[V_130]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[V_122]], %[[V_131]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_132:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_133:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_134:[0-9a-zA-Z_\.]+]] = %[[VAL_117]]#0, %[[VAL_135:[0-9a-zA-Z_\.]+]] = %[[VAL_132]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
-// CHECK-NEXT:          %[[VAL_136:[0-9a-zA-Z_\.]+]] = felt.const  2
-// CHECK-NEXT:          %[[VAL_137:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_135]], %[[VAL_136]])
-// CHECK-NEXT:          scf.condition(%[[VAL_137]]) %[[VAL_134]], %[[VAL_135]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[V_132:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_133:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_134:[0-9a-zA-Z_\.]+]] = %[[V_117]]#0, %[[V_135:[0-9a-zA-Z_\.]+]] = %[[V_132]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[V_136:[0-9a-zA-Z_\.]+]] = felt.const  2
+// CHECK-NEXT:          %[[V_137:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[V_135]], %[[V_136]])
+// CHECK-NEXT:          scf.condition(%[[V_137]]) %[[V_134]], %[[V_135]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        } do {
-// CHECK-NEXT:        ^bb0(%[[VAL_138:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_139:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:          %[[VAL_140:[0-9a-zA-Z_\.]+]] = felt.const  2
-// CHECK-NEXT:          %[[VAL_141:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_140]], %[[VAL_139]] : !felt.type, !felt.type
-// CHECK-NEXT:          %[[VAL_142:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_141]]
-// CHECK-NEXT:          %[[VAL_143:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_91]]{{\[}}%[[VAL_142]]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_144:[0-9a-zA-Z_\.]+]] = felt.const  2
-// CHECK-NEXT:          %[[VAL_145:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_144]]
-// CHECK-NEXT:          array.write %[[VAL_138]]{{\[}}%[[VAL_145]]] = %[[VAL_143]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_146:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:          %[[VAL_147:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_139]], %[[VAL_146]] : !felt.type, !felt.type
-// CHECK-NEXT:          scf.yield %[[VAL_138]], %[[VAL_147]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        ^bb0(%[[V_138:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[V_139:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[V_140:[0-9a-zA-Z_\.]+]] = felt.const  2
+// CHECK-NEXT:          %[[V_141:[0-9a-zA-Z_\.]+]] = felt.sub %[[V_140]], %[[V_139]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[V_142:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_141]]
+// CHECK-NEXT:          %[[V_143:[0-9a-zA-Z_\.]+]] = array.read %[[V_91]]{{\[}}%[[V_142]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_144:[0-9a-zA-Z_\.]+]] = felt.const  2
+// CHECK-NEXT:          %[[V_145:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_144]]
+// CHECK-NEXT:          array.write %[[V_138]]{{\[}}%[[V_145]]] = %[[V_143]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_146:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[V_147:[0-9a-zA-Z_\.]+]] = felt.add %[[V_139]], %[[V_146]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[V_138]], %[[V_147]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_148:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_149:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_150:[0-9a-zA-Z_\.]+]] = %[[VAL_133]]#0, %[[VAL_151:[0-9a-zA-Z_\.]+]] = %[[VAL_148]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
-// CHECK-NEXT:          %[[VAL_152:[0-9a-zA-Z_\.]+]] = felt.const  3
-// CHECK-NEXT:          %[[VAL_153:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_151]], %[[VAL_152]])
-// CHECK-NEXT:          scf.condition(%[[VAL_153]]) %[[VAL_150]], %[[VAL_151]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[V_148:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_149:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_150:[0-9a-zA-Z_\.]+]] = %[[V_133]]#0, %[[V_151:[0-9a-zA-Z_\.]+]] = %[[V_148]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[V_152:[0-9a-zA-Z_\.]+]] = felt.const  3
+// CHECK-NEXT:          %[[V_153:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[V_151]], %[[V_152]])
+// CHECK-NEXT:          scf.condition(%[[V_153]]) %[[V_150]], %[[V_151]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        } do {
-// CHECK-NEXT:        ^bb0(%[[VAL_154:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_155:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:          %[[VAL_156:[0-9a-zA-Z_\.]+]] = felt.const  3
-// CHECK-NEXT:          %[[VAL_157:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_156]], %[[VAL_155]] : !felt.type, !felt.type
-// CHECK-NEXT:          %[[VAL_158:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_157]]
-// CHECK-NEXT:          %[[VAL_159:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_91]]{{\[}}%[[VAL_158]]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_160:[0-9a-zA-Z_\.]+]] = felt.const  3
-// CHECK-NEXT:          %[[VAL_161:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_160]]
-// CHECK-NEXT:          array.write %[[VAL_154]]{{\[}}%[[VAL_161]]] = %[[VAL_159]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_162:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:          %[[VAL_163:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_155]], %[[VAL_162]] : !felt.type, !felt.type
-// CHECK-NEXT:          scf.yield %[[VAL_154]], %[[VAL_163]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        ^bb0(%[[V_154:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[V_155:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[V_156:[0-9a-zA-Z_\.]+]] = felt.const  3
+// CHECK-NEXT:          %[[V_157:[0-9a-zA-Z_\.]+]] = felt.sub %[[V_156]], %[[V_155]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[V_158:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_157]]
+// CHECK-NEXT:          %[[V_159:[0-9a-zA-Z_\.]+]] = array.read %[[V_91]]{{\[}}%[[V_158]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_160:[0-9a-zA-Z_\.]+]] = felt.const  3
+// CHECK-NEXT:          %[[V_161:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_160]]
+// CHECK-NEXT:          array.write %[[V_154]]{{\[}}%[[V_161]]] = %[[V_159]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_162:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[V_163:[0-9a-zA-Z_\.]+]] = felt.add %[[V_155]], %[[V_162]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[V_154]], %[[V_163]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_164:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_165:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_166:[0-9a-zA-Z_\.]+]] = %[[VAL_149]]#0, %[[VAL_167:[0-9a-zA-Z_\.]+]] = %[[VAL_164]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
-// CHECK-NEXT:          %[[VAL_168:[0-9a-zA-Z_\.]+]] = felt.const  4
-// CHECK-NEXT:          %[[VAL_169:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_167]], %[[VAL_168]])
-// CHECK-NEXT:          scf.condition(%[[VAL_169]]) %[[VAL_166]], %[[VAL_167]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[V_164:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_165:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_166:[0-9a-zA-Z_\.]+]] = %[[V_149]]#0, %[[V_167:[0-9a-zA-Z_\.]+]] = %[[V_164]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[V_168:[0-9a-zA-Z_\.]+]] = felt.const  4
+// CHECK-NEXT:          %[[V_169:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[V_167]], %[[V_168]])
+// CHECK-NEXT:          scf.condition(%[[V_169]]) %[[V_166]], %[[V_167]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        } do {
-// CHECK-NEXT:        ^bb0(%[[VAL_170:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_171:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:          %[[VAL_172:[0-9a-zA-Z_\.]+]] = felt.const  4
-// CHECK-NEXT:          %[[VAL_173:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_172]], %[[VAL_171]] : !felt.type, !felt.type
-// CHECK-NEXT:          %[[VAL_174:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_173]]
-// CHECK-NEXT:          %[[VAL_175:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_91]]{{\[}}%[[VAL_174]]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_176:[0-9a-zA-Z_\.]+]] = felt.const  4
-// CHECK-NEXT:          %[[VAL_177:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_176]]
-// CHECK-NEXT:          array.write %[[VAL_170]]{{\[}}%[[VAL_177]]] = %[[VAL_175]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_178:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:          %[[VAL_179:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_171]], %[[VAL_178]] : !felt.type, !felt.type
-// CHECK-NEXT:          scf.yield %[[VAL_170]], %[[VAL_179]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        ^bb0(%[[V_170:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[V_171:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[V_172:[0-9a-zA-Z_\.]+]] = felt.const  4
+// CHECK-NEXT:          %[[V_173:[0-9a-zA-Z_\.]+]] = felt.sub %[[V_172]], %[[V_171]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[V_174:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_173]]
+// CHECK-NEXT:          %[[V_175:[0-9a-zA-Z_\.]+]] = array.read %[[V_91]]{{\[}}%[[V_174]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_176:[0-9a-zA-Z_\.]+]] = felt.const  4
+// CHECK-NEXT:          %[[V_177:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_176]]
+// CHECK-NEXT:          array.write %[[V_170]]{{\[}}%[[V_177]]] = %[[V_175]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_178:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[V_179:[0-9a-zA-Z_\.]+]] = felt.add %[[V_171]], %[[V_178]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[V_170]], %[[V_179]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        }
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/loops/inner_loop_04.circom
+++ b/circom/tests/loops/inner_loop_04.circom
@@ -19,82 +19,84 @@ component main = InnerLoops(2);
 
 // CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
 // CHECK-NEXT:    struct.def @InnerLoops<[@n]> {
-// CHECK-NEXT:      function.def @compute(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) -> !struct.type<@InnerLoops<[@n]>> attributes {function.allow_witness} {
-// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = struct.new : <@InnerLoops<[@n]>>
-// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
-// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !felt.type>
-// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_4]], %[[VAL_5]] : <@n x !felt.type>
-// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:        scf.for %[[VAL_9:[0-9a-zA-Z_\.]+]] = %[[VAL_7]] to %[[VAL_6]] step %[[VAL_8]] {
-// CHECK-NEXT:          array.write %[[VAL_4]]{{\[}}%[[VAL_9]]] = %[[VAL_3]] : <@n x !felt.type>, !felt.type
+// CHECK-LABEL:     function.def @compute
+// CHECK-SAME:      (%[[V_A:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) -> !struct.type<@InnerLoops<[@n]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[V_1:[0-9a-zA-Z_\.]+]] = struct.new : <@InnerLoops<[@n]>>
+// CHECK-NEXT:        %[[V_N:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[V_3:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_B:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !felt.type>
+// CHECK-NEXT:        %[[V_5:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[V_6:[0-9a-zA-Z_\.]+]] = array.len %[[V_B]], %[[V_5]] : <@n x !felt.type>
+// CHECK-NEXT:        %[[V_7:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[V_8:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[V_9:[0-9a-zA-Z_\.]+]] = %[[V_7]] to %[[V_6]] step %[[V_8]] {
+// CHECK-NEXT:          array.write %[[V_B]]{{\[}}%[[V_9]]] = %[[V_3]] : <@n x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_12:[0-9a-zA-Z_\.]+]]:3 = scf.while (%[[VAL_13:[0-9a-zA-Z_\.]+]] = %[[VAL_4]], %[[VAL_14:[0-9a-zA-Z_\.]+]] = %[[VAL_11]], %[[VAL_15:[0-9a-zA-Z_\.]+]] = %[[VAL_10]]) : (!array.type<@n x !felt.type>, !felt.type, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type, !felt.type) {
-// CHECK-NEXT:          %[[VAL_16:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_14]], %[[VAL_2]])
-// CHECK-NEXT:          scf.condition(%[[VAL_16]]) %[[VAL_13]], %[[VAL_14]], %[[VAL_15]] : !array.type<@n x !felt.type>, !felt.type, !felt.type
+// CHECK-NEXT:        %[[V_J0:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_I0:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_12:[0-9a-zA-Z_\.]+]]:3 = scf.while (%[[V_B1:[0-9a-zA-Z_\.]+]] = %[[V_B]], %[[V_I1:[0-9a-zA-Z_\.]+]] = %[[V_I0]], %[[V_J1:[0-9a-zA-Z_\.]+]] = %[[V_J0]]) : (!array.type<@n x !felt.type>, !felt.type, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type, !felt.type) {
+// CHECK-NEXT:          %[[V_16:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[V_I1]], %[[V_N]])
+// CHECK-NEXT:          scf.condition(%[[V_16]]) %[[V_B1]], %[[V_I1]], %[[V_J1]] : !array.type<@n x !felt.type>, !felt.type, !felt.type
 // CHECK-NEXT:        } do {
-// CHECK-NEXT:        ^bb0(%[[VAL_17:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_18:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_19:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:          %[[VAL_20:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:          %[[VAL_21:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_22:[0-9a-zA-Z_\.]+]] = %[[VAL_17]], %[[VAL_23:[0-9a-zA-Z_\.]+]] = %[[VAL_20]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
-// CHECK-NEXT:            %[[VAL_24:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_23]], %[[VAL_18]])
-// CHECK-NEXT:            scf.condition(%[[VAL_24]]) %[[VAL_22]], %[[VAL_23]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        ^bb0(%[[V_B2:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[V_I2:[0-9a-zA-Z_\.]+]]: !felt.type, %[[V_J2:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[V_20:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:          %[[V_21:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_B3:[0-9a-zA-Z_\.]+]] = %[[V_B2]], %[[V_J3:[0-9a-zA-Z_\.]+]] = %[[V_20]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:            %[[V_24:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[V_J3]], %[[V_I2]])
+// CHECK-NEXT:            scf.condition(%[[V_24]]) %[[V_B3]], %[[V_J3]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:          } do {
-// CHECK-NEXT:          ^bb0(%[[VAL_25:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_26:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:            %[[VAL_27:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_18]], %[[VAL_26]] : !felt.type, !felt.type
-// CHECK-NEXT:            %[[VAL_28:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_27]]
-// CHECK-NEXT:            %[[VAL_29:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_0]]{{\[}}%[[VAL_28]]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:            %[[VAL_30:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_18]]
-// CHECK-NEXT:            array.write %[[VAL_25]]{{\[}}%[[VAL_30]]] = %[[VAL_29]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:            %[[VAL_31:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:            %[[VAL_32:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_26]], %[[VAL_31]] : !felt.type, !felt.type
-// CHECK-NEXT:            scf.yield %[[VAL_25]], %[[VAL_32]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:          ^bb0(%[[V_B4:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[V_J4:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:            %[[V_27:[0-9a-zA-Z_\.]+]] = felt.sub %[[V_I2]], %[[V_J4]] : !felt.type, !felt.type
+// CHECK-NEXT:            %[[V_28:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_27]]
+// CHECK-NEXT:            %[[V_29:[0-9a-zA-Z_\.]+]] = array.read %[[V_A]]{{\[}}%[[V_28]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:            %[[V_30:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_I2]]
+// CHECK-NEXT:            array.write %[[V_B4]]{{\[}}%[[V_30]]] = %[[V_29]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:            %[[V_31:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:            %[[V_J5:[0-9a-zA-Z_\.]+]] = felt.add %[[V_J4]], %[[V_31]] : !felt.type, !felt.type
+// CHECK-NEXT:            scf.yield %[[V_B4]], %[[V_J5]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[VAL_33:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:          %[[VAL_34:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_18]], %[[VAL_33]] : !felt.type, !felt.type
-// CHECK-NEXT:          scf.yield %[[VAL_21]]#0, %[[VAL_34]], %[[VAL_21]]#1 : !array.type<@n x !felt.type>, !felt.type, !felt.type
+// CHECK-NEXT:          %[[V_33:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[V_I3:[0-9a-zA-Z_\.]+]] = felt.add %[[V_I2]], %[[V_33]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[V_21]]#0, %[[V_I3]], %[[V_21]]#1 : !array.type<@n x !felt.type>, !felt.type, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        function.return %[[VAL_1]] : !struct.type<@InnerLoops<[@n]>>
+// CHECK-NEXT:        function.return %[[V_1]] : !struct.type<@InnerLoops<[@n]>>
 // CHECK-NEXT:      }
-// CHECK-NEXT:      function.def @constrain(%[[VAL_35:[0-9a-zA-Z_\.]+]]: !struct.type<@InnerLoops<[@n]>>, %[[VAL_36:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) attributes {function.allow_constraint} {
-// CHECK-NEXT:        %[[VAL_37:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
-// CHECK-NEXT:        %[[VAL_38:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_39:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !felt.type>
-// CHECK-NEXT:        %[[VAL_40:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_41:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_39]], %[[VAL_40]] : <@n x !felt.type>
-// CHECK-NEXT:        %[[VAL_42:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_43:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:        scf.for %[[VAL_44:[0-9a-zA-Z_\.]+]] = %[[VAL_42]] to %[[VAL_41]] step %[[VAL_43]] {
-// CHECK-NEXT:          array.write %[[VAL_39]]{{\[}}%[[VAL_44]]] = %[[VAL_38]] : <@n x !felt.type>, !felt.type
+// CHECK-LABEL:     function.def @constrain
+// CHECK-SAME:      (%[[V_A:[0-9a-zA-Z_\.]+]]: !struct.type<@InnerLoops<[@n]>>, %[[V_36:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[V_N:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[V_38:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_B:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !felt.type>
+// CHECK-NEXT:        %[[V_40:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[V_41:[0-9a-zA-Z_\.]+]] = array.len %[[V_B]], %[[V_40]] : <@n x !felt.type>
+// CHECK-NEXT:        %[[V_42:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[V_43:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[V_44:[0-9a-zA-Z_\.]+]] = %[[V_42]] to %[[V_41]] step %[[V_43]] {
+// CHECK-NEXT:          array.write %[[V_B]]{{\[}}%[[V_44]]] = %[[V_38]] : <@n x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_45:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_46:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_47:[0-9a-zA-Z_\.]+]]:3 = scf.while (%[[VAL_48:[0-9a-zA-Z_\.]+]] = %[[VAL_39]], %[[VAL_49:[0-9a-zA-Z_\.]+]] = %[[VAL_46]], %[[VAL_50:[0-9a-zA-Z_\.]+]] = %[[VAL_45]]) : (!array.type<@n x !felt.type>, !felt.type, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type, !felt.type) {
-// CHECK-NEXT:          %[[VAL_51:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_49]], %[[VAL_37]])
-// CHECK-NEXT:          scf.condition(%[[VAL_51]]) %[[VAL_48]], %[[VAL_49]], %[[VAL_50]] : !array.type<@n x !felt.type>, !felt.type, !felt.type
+// CHECK-NEXT:        %[[V_45:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_46:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_47:[0-9a-zA-Z_\.]+]]:3 = scf.while (%[[V_48:[0-9a-zA-Z_\.]+]] = %[[V_B]], %[[V_49:[0-9a-zA-Z_\.]+]] = %[[V_46]], %[[V_50:[0-9a-zA-Z_\.]+]] = %[[V_45]]) : (!array.type<@n x !felt.type>, !felt.type, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type, !felt.type) {
+// CHECK-NEXT:          %[[V_51:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[V_49]], %[[V_N]])
+// CHECK-NEXT:          scf.condition(%[[V_51]]) %[[V_48]], %[[V_49]], %[[V_50]] : !array.type<@n x !felt.type>, !felt.type, !felt.type
 // CHECK-NEXT:        } do {
-// CHECK-NEXT:        ^bb0(%[[VAL_52:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_53:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_54:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:          %[[VAL_55:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:          %[[VAL_56:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_57:[0-9a-zA-Z_\.]+]] = %[[VAL_52]], %[[VAL_58:[0-9a-zA-Z_\.]+]] = %[[VAL_55]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
-// CHECK-NEXT:            %[[VAL_59:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_58]], %[[VAL_53]])
-// CHECK-NEXT:            scf.condition(%[[VAL_59]]) %[[VAL_57]], %[[VAL_58]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        ^bb0(%[[V_52:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[V_53:[0-9a-zA-Z_\.]+]]: !felt.type, %[[V_54:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[V_55:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:          %[[V_56:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_57:[0-9a-zA-Z_\.]+]] = %[[V_52]], %[[V_58:[0-9a-zA-Z_\.]+]] = %[[V_55]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:            %[[V_59:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[V_58]], %[[V_53]])
+// CHECK-NEXT:            scf.condition(%[[V_59]]) %[[V_57]], %[[V_58]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:          } do {
-// CHECK-NEXT:          ^bb0(%[[VAL_60:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_61:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:            %[[VAL_62:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_53]], %[[VAL_61]] : !felt.type, !felt.type
-// CHECK-NEXT:            %[[VAL_63:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_62]]
-// CHECK-NEXT:            %[[VAL_64:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_36]]{{\[}}%[[VAL_63]]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:            %[[VAL_65:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_53]]
-// CHECK-NEXT:            array.write %[[VAL_60]]{{\[}}%[[VAL_65]]] = %[[VAL_64]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:            %[[VAL_66:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:            %[[VAL_67:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_61]], %[[VAL_66]] : !felt.type, !felt.type
-// CHECK-NEXT:            scf.yield %[[VAL_60]], %[[VAL_67]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:          ^bb0(%[[V_60:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[V_61:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:            %[[V_62:[0-9a-zA-Z_\.]+]] = felt.sub %[[V_53]], %[[V_61]] : !felt.type, !felt.type
+// CHECK-NEXT:            %[[V_63:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_62]]
+// CHECK-NEXT:            %[[V_64:[0-9a-zA-Z_\.]+]] = array.read %[[V_36]]{{\[}}%[[V_63]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:            %[[V_65:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_53]]
+// CHECK-NEXT:            array.write %[[V_60]]{{\[}}%[[V_65]]] = %[[V_64]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:            %[[V_66:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:            %[[V_67:[0-9a-zA-Z_\.]+]] = felt.add %[[V_61]], %[[V_66]] : !felt.type, !felt.type
+// CHECK-NEXT:            scf.yield %[[V_60]], %[[V_67]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[VAL_68:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:          %[[VAL_69:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_53]], %[[VAL_68]] : !felt.type, !felt.type
-// CHECK-NEXT:          scf.yield %[[VAL_56]]#0, %[[VAL_69]], %[[VAL_56]]#1 : !array.type<@n x !felt.type>, !felt.type, !felt.type
+// CHECK-NEXT:          %[[V_68:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[V_69:[0-9a-zA-Z_\.]+]] = felt.add %[[V_53]], %[[V_68]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[V_56]]#0, %[[V_69]], %[[V_56]]#1 : !array.type<@n x !felt.type>, !felt.type, !felt.type
 // CHECK-NEXT:        }
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/loops/inner_loop_04.circom
+++ b/circom/tests/loops/inner_loop_04.circom
@@ -1,7 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL:.*
 
 pragma circom 2.0.0;
 
@@ -19,3 +18,85 @@ template InnerLoops(n) {
 component main = InnerLoops(2);
 
 // CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-NEXT:    struct.def @InnerLoops<[@n]> {
+// CHECK-NEXT:      function.def @compute(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) -> !struct.type<@InnerLoops<[@n]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = struct.new : <@InnerLoops<[@n]>>
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !felt.type>
+// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_4]], %[[VAL_5]] : <@n x !felt.type>
+// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[VAL_9:[0-9a-zA-Z_\.]+]] = %[[VAL_7]] to %[[VAL_6]] step %[[VAL_8]] {
+// CHECK-NEXT:          array.write %[[VAL_4]]{{\[}}%[[VAL_9]]] = %[[VAL_3]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_12:[0-9a-zA-Z_\.]+]]:3 = scf.while (%[[VAL_13:[0-9a-zA-Z_\.]+]] = %[[VAL_4]], %[[VAL_14:[0-9a-zA-Z_\.]+]] = %[[VAL_11]], %[[VAL_15:[0-9a-zA-Z_\.]+]] = %[[VAL_10]]) : (!array.type<@n x !felt.type>, !felt.type, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type, !felt.type) {
+// CHECK-NEXT:          %[[VAL_16:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_14]], %[[VAL_2]])
+// CHECK-NEXT:          scf.condition(%[[VAL_16]]) %[[VAL_13]], %[[VAL_14]], %[[VAL_15]] : !array.type<@n x !felt.type>, !felt.type, !felt.type
+// CHECK-NEXT:        } do {
+// CHECK-NEXT:        ^bb0(%[[VAL_17:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_18:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_19:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[VAL_20:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:          %[[VAL_21:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_22:[0-9a-zA-Z_\.]+]] = %[[VAL_17]], %[[VAL_23:[0-9a-zA-Z_\.]+]] = %[[VAL_20]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:            %[[VAL_24:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_23]], %[[VAL_18]])
+// CHECK-NEXT:            scf.condition(%[[VAL_24]]) %[[VAL_22]], %[[VAL_23]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:          } do {
+// CHECK-NEXT:          ^bb0(%[[VAL_25:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_26:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:            %[[VAL_27:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_18]], %[[VAL_26]] : !felt.type, !felt.type
+// CHECK-NEXT:            %[[VAL_28:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_27]]
+// CHECK-NEXT:            %[[VAL_29:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_0]]{{\[}}%[[VAL_28]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:            %[[VAL_30:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_18]]
+// CHECK-NEXT:            array.write %[[VAL_25]]{{\[}}%[[VAL_30]]] = %[[VAL_29]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:            %[[VAL_31:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:            %[[VAL_32:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_26]], %[[VAL_31]] : !felt.type, !felt.type
+// CHECK-NEXT:            scf.yield %[[VAL_25]], %[[VAL_32]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:          }
+// CHECK-NEXT:          %[[VAL_33:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_34:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_18]], %[[VAL_33]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_21]]#0, %[[VAL_34]], %[[VAL_21]]#1 : !array.type<@n x !felt.type>, !felt.type, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.return %[[VAL_1]] : !struct.type<@InnerLoops<[@n]>>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[VAL_35:[0-9a-zA-Z_\.]+]]: !struct.type<@InnerLoops<[@n]>>, %[[VAL_36:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[VAL_37:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_38:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_39:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !felt.type>
+// CHECK-NEXT:        %[[VAL_40:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_41:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_39]], %[[VAL_40]] : <@n x !felt.type>
+// CHECK-NEXT:        %[[VAL_42:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_43:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[VAL_44:[0-9a-zA-Z_\.]+]] = %[[VAL_42]] to %[[VAL_41]] step %[[VAL_43]] {
+// CHECK-NEXT:          array.write %[[VAL_39]]{{\[}}%[[VAL_44]]] = %[[VAL_38]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_45:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_46:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_47:[0-9a-zA-Z_\.]+]]:3 = scf.while (%[[VAL_48:[0-9a-zA-Z_\.]+]] = %[[VAL_39]], %[[VAL_49:[0-9a-zA-Z_\.]+]] = %[[VAL_46]], %[[VAL_50:[0-9a-zA-Z_\.]+]] = %[[VAL_45]]) : (!array.type<@n x !felt.type>, !felt.type, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type, !felt.type) {
+// CHECK-NEXT:          %[[VAL_51:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_49]], %[[VAL_37]])
+// CHECK-NEXT:          scf.condition(%[[VAL_51]]) %[[VAL_48]], %[[VAL_49]], %[[VAL_50]] : !array.type<@n x !felt.type>, !felt.type, !felt.type
+// CHECK-NEXT:        } do {
+// CHECK-NEXT:        ^bb0(%[[VAL_52:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_53:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_54:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[VAL_55:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:          %[[VAL_56:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_57:[0-9a-zA-Z_\.]+]] = %[[VAL_52]], %[[VAL_58:[0-9a-zA-Z_\.]+]] = %[[VAL_55]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:            %[[VAL_59:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_58]], %[[VAL_53]])
+// CHECK-NEXT:            scf.condition(%[[VAL_59]]) %[[VAL_57]], %[[VAL_58]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:          } do {
+// CHECK-NEXT:          ^bb0(%[[VAL_60:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_61:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:            %[[VAL_62:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_53]], %[[VAL_61]] : !felt.type, !felt.type
+// CHECK-NEXT:            %[[VAL_63:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_62]]
+// CHECK-NEXT:            %[[VAL_64:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_36]]{{\[}}%[[VAL_63]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:            %[[VAL_65:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_53]]
+// CHECK-NEXT:            array.write %[[VAL_60]]{{\[}}%[[VAL_65]]] = %[[VAL_64]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:            %[[VAL_66:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:            %[[VAL_67:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_61]], %[[VAL_66]] : !felt.type, !felt.type
+// CHECK-NEXT:            scf.yield %[[VAL_60]], %[[VAL_67]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:          }
+// CHECK-NEXT:          %[[VAL_68:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_69:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_53]], %[[VAL_68]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_56]]#0, %[[VAL_69]], %[[VAL_56]]#1 : !array.type<@n x !felt.type>, !felt.type, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/loops/inner_loop_06.circom
+++ b/circom/tests/loops/inner_loop_06.circom
@@ -1,7 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL:.*
 
 pragma circom 2.0.0;
 
@@ -19,3 +18,87 @@ template InnerLoops(n) {
 component main = InnerLoops(2);
 
 // CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-NEXT:    struct.def @InnerLoops<[@n]> {
+// CHECK-NEXT:      function.def @compute(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) -> !struct.type<@InnerLoops<[@n]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = struct.new : <@InnerLoops<[@n]>>
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !felt.type>
+// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_4]], %[[VAL_5]] : <@n x !felt.type>
+// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[VAL_9:[0-9a-zA-Z_\.]+]] = %[[VAL_7]] to %[[VAL_6]] step %[[VAL_8]] {
+// CHECK-NEXT:          array.write %[[VAL_4]]{{\[}}%[[VAL_9]]] = %[[VAL_3]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_12:[0-9a-zA-Z_\.]+]] = %[[VAL_4]], %[[VAL_13:[0-9a-zA-Z_\.]+]] = %[[VAL_10]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[VAL_14:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_13]], %[[VAL_2]])
+// CHECK-NEXT:          scf.condition(%[[VAL_14]]) %[[VAL_12]], %[[VAL_13]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        } do {
+// CHECK-NEXT:        ^bb0(%[[VAL_15:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_16:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[VAL_17:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:          %[[VAL_18:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_19:[0-9a-zA-Z_\.]+]] = %[[VAL_15]], %[[VAL_20:[0-9a-zA-Z_\.]+]] = %[[VAL_17]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:            %[[VAL_21:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_20]], %[[VAL_16]])
+// CHECK-NEXT:            scf.condition(%[[VAL_21]]) %[[VAL_19]], %[[VAL_20]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:          } do {
+// CHECK-NEXT:          ^bb0(%[[VAL_22:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_23:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:            %[[VAL_24:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_16]]
+// CHECK-NEXT:            %[[VAL_25:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_22]]{{\[}}%[[VAL_24]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:            %[[VAL_26:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_16]]
+// CHECK-NEXT:            %[[VAL_27:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_0]]{{\[}}%[[VAL_26]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:            %[[VAL_28:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_25]], %[[VAL_27]] : !felt.type, !felt.type
+// CHECK-NEXT:            %[[VAL_29:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_16]]
+// CHECK-NEXT:            array.write %[[VAL_22]]{{\[}}%[[VAL_29]]] = %[[VAL_28]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:            %[[VAL_30:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:            %[[VAL_31:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_23]], %[[VAL_30]] : !felt.type, !felt.type
+// CHECK-NEXT:            scf.yield %[[VAL_22]], %[[VAL_31]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:          }
+// CHECK-NEXT:          %[[VAL_32:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_33:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_16]], %[[VAL_32]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_18]]#0, %[[VAL_33]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.return %[[VAL_1]] : !struct.type<@InnerLoops<[@n]>>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[VAL_34:[0-9a-zA-Z_\.]+]]: !struct.type<@InnerLoops<[@n]>>, %[[VAL_35:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[VAL_36:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_37:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_38:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !felt.type>
+// CHECK-NEXT:        %[[VAL_39:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_40:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_38]], %[[VAL_39]] : <@n x !felt.type>
+// CHECK-NEXT:        %[[VAL_41:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_42:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[VAL_43:[0-9a-zA-Z_\.]+]] = %[[VAL_41]] to %[[VAL_40]] step %[[VAL_42]] {
+// CHECK-NEXT:          array.write %[[VAL_38]]{{\[}}%[[VAL_43]]] = %[[VAL_37]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_44:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_45:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_46:[0-9a-zA-Z_\.]+]] = %[[VAL_38]], %[[VAL_47:[0-9a-zA-Z_\.]+]] = %[[VAL_44]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[VAL_48:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_47]], %[[VAL_36]])
+// CHECK-NEXT:          scf.condition(%[[VAL_48]]) %[[VAL_46]], %[[VAL_47]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        } do {
+// CHECK-NEXT:        ^bb0(%[[VAL_49:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_50:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[VAL_51:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:          %[[VAL_52:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_53:[0-9a-zA-Z_\.]+]] = %[[VAL_49]], %[[VAL_54:[0-9a-zA-Z_\.]+]] = %[[VAL_51]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:            %[[VAL_55:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_54]], %[[VAL_50]])
+// CHECK-NEXT:            scf.condition(%[[VAL_55]]) %[[VAL_53]], %[[VAL_54]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:          } do {
+// CHECK-NEXT:          ^bb0(%[[VAL_56:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_57:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:            %[[VAL_58:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_50]]
+// CHECK-NEXT:            %[[VAL_59:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_56]]{{\[}}%[[VAL_58]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:            %[[VAL_60:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_50]]
+// CHECK-NEXT:            %[[VAL_61:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_35]]{{\[}}%[[VAL_60]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:            %[[VAL_62:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_59]], %[[VAL_61]] : !felt.type, !felt.type
+// CHECK-NEXT:            %[[VAL_63:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_50]]
+// CHECK-NEXT:            array.write %[[VAL_56]]{{\[}}%[[VAL_63]]] = %[[VAL_62]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:            %[[VAL_64:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:            %[[VAL_65:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_57]], %[[VAL_64]] : !felt.type, !felt.type
+// CHECK-NEXT:            scf.yield %[[VAL_56]], %[[VAL_65]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:          }
+// CHECK-NEXT:          %[[VAL_66:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_67:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_50]], %[[VAL_66]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_52]]#0, %[[VAL_67]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/loops/inner_loop_06.circom
+++ b/circom/tests/loops/inner_loop_06.circom
@@ -19,84 +19,86 @@ component main = InnerLoops(2);
 
 // CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
 // CHECK-NEXT:    struct.def @InnerLoops<[@n]> {
-// CHECK-NEXT:      function.def @compute(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) -> !struct.type<@InnerLoops<[@n]>> attributes {function.allow_witness} {
-// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = struct.new : <@InnerLoops<[@n]>>
-// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
-// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !felt.type>
-// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_4]], %[[VAL_5]] : <@n x !felt.type>
-// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:        scf.for %[[VAL_9:[0-9a-zA-Z_\.]+]] = %[[VAL_7]] to %[[VAL_6]] step %[[VAL_8]] {
-// CHECK-NEXT:          array.write %[[VAL_4]]{{\[}}%[[VAL_9]]] = %[[VAL_3]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:      function.def @compute
+// CHECK-SAME:      (%[[V_0:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) -> !struct.type<@InnerLoops<[@n]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[V_1:[0-9a-zA-Z_\.]+]] = struct.new : <@InnerLoops<[@n]>>
+// CHECK-NEXT:        %[[V_N:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[V_3:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_4:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !felt.type>
+// CHECK-NEXT:        %[[V_5:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[V_6:[0-9a-zA-Z_\.]+]] = array.len %[[V_4]], %[[V_5]] : <@n x !felt.type>
+// CHECK-NEXT:        %[[V_7:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[V_8:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[V_9:[0-9a-zA-Z_\.]+]] = %[[V_7]] to %[[V_6]] step %[[V_8]] {
+// CHECK-NEXT:          array.write %[[V_4]]{{\[}}%[[V_9]]] = %[[V_3]] : <@n x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_12:[0-9a-zA-Z_\.]+]] = %[[VAL_4]], %[[VAL_13:[0-9a-zA-Z_\.]+]] = %[[VAL_10]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
-// CHECK-NEXT:          %[[VAL_14:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_13]], %[[VAL_2]])
-// CHECK-NEXT:          scf.condition(%[[VAL_14]]) %[[VAL_12]], %[[VAL_13]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[V_10:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_11:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_12:[0-9a-zA-Z_\.]+]] = %[[V_4]], %[[V_13:[0-9a-zA-Z_\.]+]] = %[[V_10]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[V_14:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[V_13]], %[[V_N]])
+// CHECK-NEXT:          scf.condition(%[[V_14]]) %[[V_12]], %[[V_13]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        } do {
-// CHECK-NEXT:        ^bb0(%[[VAL_15:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_16:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:          %[[VAL_17:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:          %[[VAL_18:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_19:[0-9a-zA-Z_\.]+]] = %[[VAL_15]], %[[VAL_20:[0-9a-zA-Z_\.]+]] = %[[VAL_17]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
-// CHECK-NEXT:            %[[VAL_21:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_20]], %[[VAL_16]])
-// CHECK-NEXT:            scf.condition(%[[VAL_21]]) %[[VAL_19]], %[[VAL_20]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        ^bb0(%[[V_15:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[V_16:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[V_17:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:          %[[V_18:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_19:[0-9a-zA-Z_\.]+]] = %[[V_15]], %[[V_20:[0-9a-zA-Z_\.]+]] = %[[V_17]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:            %[[V_21:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[V_20]], %[[V_16]])
+// CHECK-NEXT:            scf.condition(%[[V_21]]) %[[V_19]], %[[V_20]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:          } do {
-// CHECK-NEXT:          ^bb0(%[[VAL_22:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_23:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:            %[[VAL_24:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_16]]
-// CHECK-NEXT:            %[[VAL_25:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_22]]{{\[}}%[[VAL_24]]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:            %[[VAL_26:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_16]]
-// CHECK-NEXT:            %[[VAL_27:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_0]]{{\[}}%[[VAL_26]]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:            %[[VAL_28:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_25]], %[[VAL_27]] : !felt.type, !felt.type
-// CHECK-NEXT:            %[[VAL_29:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_16]]
-// CHECK-NEXT:            array.write %[[VAL_22]]{{\[}}%[[VAL_29]]] = %[[VAL_28]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:            %[[VAL_30:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:            %[[VAL_31:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_23]], %[[VAL_30]] : !felt.type, !felt.type
-// CHECK-NEXT:            scf.yield %[[VAL_22]], %[[VAL_31]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:          ^bb0(%[[V_22:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[V_23:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:            %[[V_24:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_16]]
+// CHECK-NEXT:            %[[V_25:[0-9a-zA-Z_\.]+]] = array.read %[[V_22]]{{\[}}%[[V_24]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:            %[[V_26:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_16]]
+// CHECK-NEXT:            %[[V_27:[0-9a-zA-Z_\.]+]] = array.read %[[V_0]]{{\[}}%[[V_26]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:            %[[V_28:[0-9a-zA-Z_\.]+]] = felt.add %[[V_25]], %[[V_27]] : !felt.type, !felt.type
+// CHECK-NEXT:            %[[V_29:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_16]]
+// CHECK-NEXT:            array.write %[[V_22]]{{\[}}%[[V_29]]] = %[[V_28]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:            %[[V_30:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:            %[[V_31:[0-9a-zA-Z_\.]+]] = felt.add %[[V_23]], %[[V_30]] : !felt.type, !felt.type
+// CHECK-NEXT:            scf.yield %[[V_22]], %[[V_31]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[VAL_32:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:          %[[VAL_33:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_16]], %[[VAL_32]] : !felt.type, !felt.type
-// CHECK-NEXT:          scf.yield %[[VAL_18]]#0, %[[VAL_33]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_32:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[V_33:[0-9a-zA-Z_\.]+]] = felt.add %[[V_16]], %[[V_32]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[V_18]]#0, %[[V_33]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        function.return %[[VAL_1]] : !struct.type<@InnerLoops<[@n]>>
+// CHECK-NEXT:        function.return %[[V_1]] : !struct.type<@InnerLoops<[@n]>>
 // CHECK-NEXT:      }
-// CHECK-NEXT:      function.def @constrain(%[[VAL_34:[0-9a-zA-Z_\.]+]]: !struct.type<@InnerLoops<[@n]>>, %[[VAL_35:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) attributes {function.allow_constraint} {
-// CHECK-NEXT:        %[[VAL_36:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
-// CHECK-NEXT:        %[[VAL_37:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_38:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !felt.type>
-// CHECK-NEXT:        %[[VAL_39:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_40:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_38]], %[[VAL_39]] : <@n x !felt.type>
-// CHECK-NEXT:        %[[VAL_41:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_42:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:        scf.for %[[VAL_43:[0-9a-zA-Z_\.]+]] = %[[VAL_41]] to %[[VAL_40]] step %[[VAL_42]] {
-// CHECK-NEXT:          array.write %[[VAL_38]]{{\[}}%[[VAL_43]]] = %[[VAL_37]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:      function.def @constrain
+// CHECK-SAME:      (%[[V_34:[0-9a-zA-Z_\.]+]]: !struct.type<@InnerLoops<[@n]>>, %[[V_35:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[V_N:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[V_37:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_38:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !felt.type>
+// CHECK-NEXT:        %[[V_39:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[V_40:[0-9a-zA-Z_\.]+]] = array.len %[[V_38]], %[[V_39]] : <@n x !felt.type>
+// CHECK-NEXT:        %[[V_41:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[V_42:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[V_43:[0-9a-zA-Z_\.]+]] = %[[V_41]] to %[[V_40]] step %[[V_42]] {
+// CHECK-NEXT:          array.write %[[V_38]]{{\[}}%[[V_43]]] = %[[V_37]] : <@n x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_44:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_45:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_46:[0-9a-zA-Z_\.]+]] = %[[VAL_38]], %[[VAL_47:[0-9a-zA-Z_\.]+]] = %[[VAL_44]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
-// CHECK-NEXT:          %[[VAL_48:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_47]], %[[VAL_36]])
-// CHECK-NEXT:          scf.condition(%[[VAL_48]]) %[[VAL_46]], %[[VAL_47]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[V_44:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[V_45:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_46:[0-9a-zA-Z_\.]+]] = %[[V_38]], %[[V_47:[0-9a-zA-Z_\.]+]] = %[[V_44]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:          %[[V_48:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[V_47]], %[[V_N]])
+// CHECK-NEXT:          scf.condition(%[[V_48]]) %[[V_46]], %[[V_47]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        } do {
-// CHECK-NEXT:        ^bb0(%[[VAL_49:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_50:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:          %[[VAL_51:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:          %[[VAL_52:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_53:[0-9a-zA-Z_\.]+]] = %[[VAL_49]], %[[VAL_54:[0-9a-zA-Z_\.]+]] = %[[VAL_51]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
-// CHECK-NEXT:            %[[VAL_55:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_54]], %[[VAL_50]])
-// CHECK-NEXT:            scf.condition(%[[VAL_55]]) %[[VAL_53]], %[[VAL_54]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:        ^bb0(%[[V_49:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[V_50:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[V_51:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:          %[[V_52:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_53:[0-9a-zA-Z_\.]+]] = %[[V_49]], %[[V_54:[0-9a-zA-Z_\.]+]] = %[[V_51]]) : (!array.type<@n x !felt.type>, !felt.type) -> (!array.type<@n x !felt.type>, !felt.type) {
+// CHECK-NEXT:            %[[V_55:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[V_54]], %[[V_50]])
+// CHECK-NEXT:            scf.condition(%[[V_55]]) %[[V_53]], %[[V_54]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:          } do {
-// CHECK-NEXT:          ^bb0(%[[VAL_56:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_57:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:            %[[VAL_58:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_50]]
-// CHECK-NEXT:            %[[VAL_59:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_56]]{{\[}}%[[VAL_58]]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:            %[[VAL_60:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_50]]
-// CHECK-NEXT:            %[[VAL_61:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_35]]{{\[}}%[[VAL_60]]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:            %[[VAL_62:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_59]], %[[VAL_61]] : !felt.type, !felt.type
-// CHECK-NEXT:            %[[VAL_63:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_50]]
-// CHECK-NEXT:            array.write %[[VAL_56]]{{\[}}%[[VAL_63]]] = %[[VAL_62]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:            %[[VAL_64:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:            %[[VAL_65:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_57]], %[[VAL_64]] : !felt.type, !felt.type
-// CHECK-NEXT:            scf.yield %[[VAL_56]], %[[VAL_65]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:          ^bb0(%[[V_56:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[V_57:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:            %[[V_58:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_50]]
+// CHECK-NEXT:            %[[V_59:[0-9a-zA-Z_\.]+]] = array.read %[[V_56]]{{\[}}%[[V_58]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:            %[[V_60:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_50]]
+// CHECK-NEXT:            %[[V_61:[0-9a-zA-Z_\.]+]] = array.read %[[V_35]]{{\[}}%[[V_60]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:            %[[V_62:[0-9a-zA-Z_\.]+]] = felt.add %[[V_59]], %[[V_61]] : !felt.type, !felt.type
+// CHECK-NEXT:            %[[V_63:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_50]]
+// CHECK-NEXT:            array.write %[[V_56]]{{\[}}%[[V_63]]] = %[[V_62]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:            %[[V_64:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:            %[[V_65:[0-9a-zA-Z_\.]+]] = felt.add %[[V_57]], %[[V_64]] : !felt.type, !felt.type
+// CHECK-NEXT:            scf.yield %[[V_56]], %[[V_65]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[VAL_66:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:          %[[VAL_67:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_50]], %[[VAL_66]] : !felt.type, !felt.type
-// CHECK-NEXT:          scf.yield %[[VAL_52]]#0, %[[VAL_67]] : !array.type<@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[V_66:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[V_67:[0-9a-zA-Z_\.]+]] = felt.add %[[V_50]], %[[V_66]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[V_52]]#0, %[[V_67]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        }
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/subcmps/array_copy_constraints.circom
+++ b/circom/tests/subcmps/array_copy_constraints.circom
@@ -1,7 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL:.*
 
 pragma circom 2.0.0;
 
@@ -30,3 +29,69 @@ template Caller(n) {
 component main = Caller(5);
 
 // CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-NEXT:    struct.def @Caller<[@n]> {
+// CHECK-NEXT:      struct.field @outp : !felt.type
+// CHECK-NEXT:      struct.field @op : !struct.type<@Sum<[@n]>>
+// CHECK-NEXT:      function.def @compute(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) -> !struct.type<@Caller<[@n]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = struct.new : <@Caller<[@n]>>
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = function.call @Sum::@compute(%[[VAL_0]]) : (!array.type<@n x !felt.type>) -> !struct.type<@Sum<[@n]>>
+// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_3]][@outp] : <@Sum<[@n]>>, !felt.type
+// CHECK-NEXT:        struct.writef %[[VAL_1]][@outp] = %[[VAL_4]] : <@Caller<[@n]>>, !felt.type
+// CHECK-NEXT:        struct.writef %[[VAL_1]][@op] = %[[VAL_3]] : <@Caller<[@n]>>, !struct.type<@Sum<[@n]>>
+// CHECK-NEXT:        function.return %[[VAL_1]] : !struct.type<@Caller<[@n]>>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[VAL_5:[0-9a-zA-Z_\.]+]]: !struct.type<@Caller<[@n]>>, %[[VAL_6:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_5]][@op] : <@Caller<[@n]>>, !struct.type<@Sum<[@n]>>
+// CHECK-NEXT:        function.call @Sum::@constrain(%[[VAL_8]], %[[VAL_6]]) : (!struct.type<@Sum<[@n]>>, !array.type<@n x !felt.type>) -> ()
+// CHECK-NEXT:        %[[VAL_9:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_8]][@outp] : <@Sum<[@n]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_5]][@outp] : <@Caller<[@n]>>, !felt.type
+// CHECK-NEXT:        constrain.eq %[[VAL_10]], %[[VAL_9]] : !felt.type, !felt.type
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    struct.def @Sum<[@n]> {
+// CHECK-NEXT:      struct.field @outp : !felt.type {llzk.pub}
+// CHECK-NEXT:      function.def @compute(%[[VAL_11:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) -> !struct.type<@Sum<[@n]>> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_12:[0-9a-zA-Z_\.]+]] = struct.new : <@Sum<[@n]>>
+// CHECK-NEXT:        %[[VAL_13:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_14:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_15:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_16:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_17:[0-9a-zA-Z_\.]+]] = %[[VAL_14]], %[[VAL_18:[0-9a-zA-Z_\.]+]] = %[[VAL_15]]) : (!felt.type, !felt.type) -> (!felt.type, !felt.type) {
+// CHECK-NEXT:          %[[VAL_19:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_18]], %[[VAL_13]])
+// CHECK-NEXT:          scf.condition(%[[VAL_19]]) %[[VAL_17]], %[[VAL_18]] : !felt.type, !felt.type
+// CHECK-NEXT:        } do {
+// CHECK-NEXT:        ^bb0(%[[VAL_20:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_21:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[VAL_22:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_21]]
+// CHECK-NEXT:          %[[VAL_23:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_11]]{{\[}}%[[VAL_22]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_24:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_20]], %[[VAL_23]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[VAL_25:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_26:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_21]], %[[VAL_25]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_24]], %[[VAL_26]] : !felt.type, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        struct.writef %[[VAL_12]][@outp] = %[[VAL_16]]#0 : <@Sum<[@n]>>, !felt.type
+// CHECK-NEXT:        function.return %[[VAL_12]] : !struct.type<@Sum<[@n]>>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[VAL_27:[0-9a-zA-Z_\.]+]]: !struct.type<@Sum<[@n]>>, %[[VAL_28:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[VAL_29:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_30:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_31:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_32:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_33:[0-9a-zA-Z_\.]+]] = %[[VAL_30]], %[[VAL_34:[0-9a-zA-Z_\.]+]] = %[[VAL_31]]) : (!felt.type, !felt.type) -> (!felt.type, !felt.type) {
+// CHECK-NEXT:          %[[VAL_35:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_34]], %[[VAL_29]])
+// CHECK-NEXT:          scf.condition(%[[VAL_35]]) %[[VAL_33]], %[[VAL_34]] : !felt.type, !felt.type
+// CHECK-NEXT:        } do {
+// CHECK-NEXT:        ^bb0(%[[VAL_36:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_37:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[VAL_38:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_37]]
+// CHECK-NEXT:          %[[VAL_39:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_28]]{{\[}}%[[VAL_38]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_40:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_36]], %[[VAL_39]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[VAL_41:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_42:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_37]], %[[VAL_41]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_40]], %[[VAL_42]] : !felt.type, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_43:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_27]][@outp] : <@Sum<[@n]>>, !felt.type
+// CHECK-NEXT:        constrain.eq %[[VAL_43]], %[[VAL_32]]#0 : !felt.type, !felt.type
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/flake.lock
+++ b/flake.lock
@@ -88,11 +88,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769018304,
-        "narHash": "sha256-M2Qsw9z2lH80GsbRW4dr1DUqxAU4lvLbFIdaxt2ll0E=",
+        "lastModified": 1769047368,
+        "narHash": "sha256-ldSkrUgMzFwAYFgOgOF1F9TIwmBlKX+ML6VnUNARTz4=",
         "ref": "refs/heads/main",
-        "rev": "30be0c62b12188ebf11f59677bb16de21b492307",
-        "revCount": 317,
+        "rev": "1fab594b7c7c451d86f8c0bd038adf0fe621f17e",
+        "revCount": 318,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/project-llzk/llzk-rs"

--- a/llzk_backend/src/function.rs
+++ b/llzk_backend/src/function.rs
@@ -789,9 +789,9 @@ where
         codegen: &LlzkCodegen<'ast, 'ctx, impl ProgramLike>,
         location: Location<'ctx>,
         value: Value<'ctx, 'val>,
-        dimension: ArrayDimension<'ctx, 'val>
+        dimension: &ArrayDimension<'ctx, 'val>
     ) -> Result<Value<'ctx, 'val>> {
-        let const_dim = IntegerAttribute::try_from(&dimension);
+        let const_dim = IntegerAttribute::try_from(dimension);
         if let Ok(subarr_ty) = ArrayType::try_from(value.r#type()) {
             let arr_ty = dimension.new_array_type(&subarr_ty.into());
             // The array.new constructor doesn't accept arrays as initializer values,
@@ -1854,7 +1854,7 @@ where
                 // Multi-dimensional arrays are made up of array values as their elements
                 let value = value.gen_llzk_in_function(codegen, function)?;
                 let dimension = function.convert_dim_expr(codegen, dimension)?;
-                function.generate_uniform_array(codegen, location, value, dimension)
+                function.generate_uniform_array(codegen, location, value, &dimension)
             }
             Expression::Call { meta, id, args } => {
                 let builder = OpBuilder::new(codegen.context.deref());

--- a/llzk_backend/src/function.rs
+++ b/llzk_backend/src/function.rs
@@ -23,6 +23,8 @@ use crate::shared::replace_uses_with_new_block_argument;
 use crate::shared::set_operand_if_undef;
 use crate::shared::single_result_as_value;
 use crate::shared::ArrayDimension;
+use crate::shared::ArrayDimensionResult;
+use crate::shared::ArrayDimensions;
 use crate::shared::DimExprConverter;
 use crate::shared::LlzkCodegen;
 use crate::subcmp::SubcmpCallsMap;
@@ -791,6 +793,8 @@ where
         value: Value<'ctx, 'val>,
         dimension: &ArrayDimension<'ctx, 'val>,
     ) -> Result<Value<'ctx, 'val>> {
+        // Ensure all symbols are of index type
+        let dimension = &self.transform_symbols_to_index(location, dimension)?;
         let const_dim = IntegerAttribute::try_from(dimension);
         if let Ok(subarr_ty) = ArrayType::try_from(value.r#type()) {
             let arr_ty = dimension.new_array_type(&subarr_ty.into());
@@ -1140,6 +1144,17 @@ where
 
         Ok(())
     }
+
+    /// Cast all symbols passed to affine_maps into index types, which is required
+    /// for affine_map usage.
+    #[inline]
+    fn transform_symbols_to_index(
+        &mut self,
+        location: Location<'ctx>,
+        dimension: &ArrayDimension<'ctx, 'val>,
+    ) -> Result<ArrayDimension<'ctx, 'val>> {
+        dimension.transform(|val| self.cast_to_index_if_needed(location, val))
+    }
 }
 
 impl<'ast, 'ctx, 'func, 'blk, 'val> DimExprConverter<'ctx, 'ast, 'val>
@@ -1154,7 +1169,7 @@ where
         &self,
         codegen: &LlzkCodegen<'ast, 'ctx, impl ProgramLike>,
         expr: &Expression,
-    ) -> Result<ArrayDimension<'ctx, 'val>> {
+    ) -> Result<ArrayDimensionResult<'ctx, 'val>> {
         // First try to compute statically, falling back to literal computation
         // if all values are not compile-time constants or if the final result
         // does not properly convert to i64.
@@ -1162,7 +1177,7 @@ where
             codegen.try_compute_dim_expr(expr)?.as_ref().and_then(BigUint::to_i64)
         {
             let int_attr = codegen.index_attr(integer);
-            ArrayDimension::new(int_attr.into(), &[])
+            ArrayDimensionResult::new(int_attr.into(), &[])
         } else {
             match expr {
                 Expression::Number(_, _) => {
@@ -1172,7 +1187,7 @@ where
                     [] => {
                         if let Ok(v) = self.block_ctx.get_named_value(name) {
                             let id_map = codegen.affine_map_attr("affine_map<()[i] -> (i)>")?;
-                            ArrayDimension::new(id_map, &[*v])
+                            ArrayDimensionResult::new(id_map, &[*v])
                         } else {
                             todo!("Handle Variable expression in dimension for non-integer, non-template parameter attributes in FunctionContext")
                         }
@@ -1200,7 +1215,7 @@ where
                 // Give the same error that the circom type checker gives. The type checker ran
                 // earlier so this should technically be unreachable.
                 _ => {
-                    Err(anyhow!("Array indexes and lengths must be single arithmetic expressions"))
+                    unreachable!("Array indexes and lengths must be single arithmetic expressions")
                 }
             }
         }
@@ -1341,13 +1356,16 @@ where
     nonreturning_block_overwrites.insert(
         VAR_NAME_RETURN_VAL.to_string(),
         function.block_ctx.get_named_value(VAR_NAME_RETURN_VAL).cloned().or_else(|_| {
-            single_result_as_value(nonreturning_block.append_operation(
-                // TODO: just like `gen_function_llzk()`, this must use an array type
-                // if applicable but is currently implemented for scalar `felt.type` only.
-                // In this case, the correct solution (once nondet op is supported for any type)
-                // is to just create the nondet op using `return_val.getType()`
-                function.new_nondet_felt_of_dimensions_at_location(codegen, location, &[])?,
-            ))
+            single_result_as_value(
+                nonreturning_block.append_operation(
+                    // TODO: just like `gen_function_llzk()`, this must use an array type
+                    // if applicable but is currently implemented for scalar `felt.type` only.
+                    // In this case, the correct solution (once nondet op is supported for any type)
+                    // is to just create the nondet op using `return_val.getType()`
+                    ArrayDimensions::new_empty()
+                        .new_nondet_felt_of_dimensions_at_location(codegen, location)?,
+                ),
+            )
         })?,
     );
     Ok(())
@@ -1537,7 +1555,8 @@ where
                 // In this case, the correct solution (once nondet op is supported for any
                 // type) is to just create the nondet op using
                 // `return_val.getType()`
-                function.new_nondet_felt_of_dimensions_at_location(codegen, location, &[])?,
+                ArrayDimensions::new_empty()
+                    .new_nondet_felt_of_dimensions_at_location(codegen, location)?,
                 VAR_NAME_RETURN_VAL.to_string(),
             )?;
         }
@@ -1605,7 +1624,8 @@ where
                     unreachable!("Template elements declared inside the function")
                 }
                 if !function.block_ctx.is_name_present(name) {
-                    let op = function.new_nondet_felt_of_dimensions(codegen, meta, dimensions)?;
+                    let dims = function.get_dimensions(codegen, dimensions)?;
+                    let op = dims.new_nondet_felt_of_dimensions(codegen, meta)?;
                     function.block_ctx.declare_name_ensure_not_present(name, op)?;
                 }
                 Ok(false)
@@ -1849,8 +1869,10 @@ where
                 let location = codegen.location_from_meta(meta);
                 // Multi-dimensional arrays are made up of array values as their elements
                 let value = value.gen_llzk_in_function(codegen, function)?;
-                let dimension = function.convert_dim_expr(codegen, dimension)?;
-                function.generate_uniform_array(codegen, location, value, &dimension)
+                let dim_result = function.convert_dim_expr(codegen, dimension)?;
+                let dim = Option::from(dim_result)
+                    .ok_or_else(|| anyhow!("unable to convert dimension in function context"))?;
+                function.generate_uniform_array(codegen, location, value, &dim)
             }
             Expression::Call { meta, id, args } => {
                 let builder = OpBuilder::new(codegen.context.deref());

--- a/llzk_backend/src/function.rs
+++ b/llzk_backend/src/function.rs
@@ -744,6 +744,130 @@ where
         Ok(scf::r#if(condition, &[then_value.r#type()], then_region, else_region, location))
     }
 
+    /// Generate a simple `scf.for` op that doesn't need to override variables
+    /// in the block context.
+    /// The body function (`body_fn`) accepts a `Block` with a single argument representing
+    /// the for-loop induction variable and is used to fill in the `scf.for` op.
+    pub fn gen_simple_scf_for<'ast>(
+        &mut self,
+        codegen: &LlzkCodegen<'ast, 'ctx, impl ProgramLike>,
+        location: Location<'ctx>,
+        start: Value<'ctx, 'val>,
+        step: Value<'ctx, 'val>,
+        end: Value<'ctx, 'val>,
+        body_fn: impl FnOnce(&mut Block<'ctx>) -> Result<()>
+    ) -> Result<()> {
+        let block_arg = (codegen.index_type(), location);
+        let mut block = Block::new(&[block_arg]);
+        body_fn(&mut block)?;
+        let region = Region::new();
+        region.append_block(block);
+        let scf_op = scf::r#for(start, end, step, region, location);
+        self.append_op_no_result(scf_op)
+    }
+
+    /// Generate a simple `scf.for` op with normalized start=0 and step=1.
+    #[inline]
+    pub fn gen_normalized_scf_for<'ast>(
+        &mut self,
+        codegen: &LlzkCodegen<'ast, 'ctx, impl ProgramLike>,
+        location: Location<'ctx>,
+        end: Value<'ctx, 'val>,
+        body_fn: impl FnOnce(&mut Block<'ctx>) -> Result<()>
+    ) -> Result<()> {
+        let start = self.append_op_unnamed_result(codegen.new_index_const_op(0, location))?;
+        let step = self.append_op_unnamed_result(codegen.new_index_const_op(1, location))?;
+        self.gen_simple_scf_for(codegen, location, start, step, end, body_fn)
+    }
+
+    /// Implementation for [Expression::UniformArray] after conversion of dimension
+    /// expression. Useful because dimension generation differs between function
+    /// and template contexts due to template parameters, but other implementation
+    /// is otherwise the same.
+    pub fn generate_uniform_array<'ast>(
+        &mut self,
+        codegen: &LlzkCodegen<'ast, 'ctx, impl ProgramLike>,
+        location: Location<'ctx>,
+        value: Value<'ctx, 'val>,
+        dimension: ArrayDimension<'ctx, 'val>
+    ) -> Result<Value<'ctx, 'val>> {
+        let const_dim = IntegerAttribute::try_from(&dimension);
+        if let Ok(subarr_ty) = ArrayType::try_from(value.r#type()) {
+            let arr_ty = dimension.new_array_type(&subarr_ty.into());
+            // The array.new constructor doesn't accept arrays as initializer values,
+            // so we instead create the array empty and use array.insert to insert values.
+            let ctor = if let Some(symbols) = dimension.value_range()? {
+                ArrayCtor::MapDimSlice(&[symbols], &[0])
+            } else {
+                ArrayCtor::Values(&[])
+            };
+            let new_arr = self.append_op_unnamed_result(array::new(
+                &OpBuilder::new(codegen.context),
+                location,
+                arr_ty,
+                ctor,
+            ))?;
+            if let Ok(const_dim) = const_dim {
+                for idx in 0..const_dim.value() {
+                    let idx_val = self.append_op_unnamed_result(
+                        codegen.new_index_const_op(idx, location),
+                    )?;
+                    self.append_op_no_result(array::insert(
+                        location,
+                        new_arr,
+                        &[idx_val],
+                        value,
+                    ))?;
+                }
+            } else {
+                let dim = self.append_op_unnamed_result(codegen.new_index_const_op(0, location))?;
+                let array_len = self.append_op_unnamed_result(array::len(
+                    location, new_arr, dim
+                ))?;
+                self.gen_normalized_scf_for(codegen, location, array_len, |b| {
+                    let induction_var = b.argument(0)?;
+                    b.append_operation(array::insert(location, new_arr, &[induction_var.into()], value));
+                    b.append_operation(scf::r#yield(&[], location));
+                    Ok(())
+                })?;
+            };
+            // Output value is still the newly created array
+            Ok(new_arr)
+        } else {
+            let arr_ty = dimension.new_array_type(&value.r#type());
+            let builder = &OpBuilder::new(codegen.context);
+            if let Ok(const_dim) = const_dim {
+                let ctor =
+                    ArrayCtor::Values(&vec![value; usize::try_from(const_dim.value())?]);
+                self.append_op_unnamed_result(array::new(
+                    builder,
+                    location,
+                    arr_ty,
+                    ctor,
+                ))
+            } else {
+                let ctor = if let Ok(Some(v)) = dimension.value_range() {
+                    ArrayCtor::MapDimSlice(&[v], &[0])
+                } else {
+                    ArrayCtor::Values(&[])
+                };
+                let array_ref = self.append_op_unnamed_result(array::new(
+                    builder, location, arr_ty, ctor))?;
+                let dim = self.append_op_unnamed_result(codegen.new_index_const_op(0, location))?;
+                let array_len = self.append_op_unnamed_result(array::len(
+                    location, array_ref, dim
+                ))?;
+                self.gen_normalized_scf_for(codegen, location, array_len, |b| {
+                    let induction_var = b.argument(0)?;
+                    b.append_operation(array::write(location, array_ref, &[induction_var.into()], value));
+                    b.append_operation(scf::r#yield(&[], location));
+                    Ok(())
+                })?;
+                Ok(array_ref)
+            }
+        }
+    }
+
     /// Generate an `scf.while` op based on the given [NestedBlockInfo] and update the
     /// block context with the results of the `scf.while` op mapped to the given names.
     pub fn gen_scf_while<'ast>(
@@ -1728,60 +1852,9 @@ where
             Expression::UniformArray { meta, value, dimension } => {
                 let location = codegen.location_from_meta(meta);
                 // Multi-dimensional arrays are made up of array values as their elements
-                let val = value.gen_llzk_in_function(codegen, function)?;
-                let dim = function.convert_dim_expr(codegen, dimension)?;
-                let const_dim = IntegerAttribute::try_from(&dim);
-                if let Ok(subarr_ty) = ArrayType::try_from(val.r#type()) {
-                    let arr_ty = dim.new_array_type(&subarr_ty.into());
-                    // The array.new constructor doesn't accept arrays as initializer values,
-                    // so we instead create the array empty and use array.insert to insert values.
-                    let ctor = if let Some(symbols) = dim.value_range()? {
-                        ArrayCtor::MapDimSlice(&[symbols], &[0])
-                    } else {
-                        ArrayCtor::Values(&[])
-                    };
-                    let new_arr = function.append_op_unnamed_result(array::new(
-                        &OpBuilder::new(codegen.context),
-                        codegen.location_from_meta(meta),
-                        arr_ty,
-                        ctor,
-                    ))?;
-                    if let Ok(const_dim) = const_dim {
-                        for idx in 0..const_dim.value() {
-                            let idx_val = function.append_op_unnamed_result(
-                                codegen.new_index_const_op(idx, location),
-                            )?;
-                            function.append_op_no_result(array::insert(
-                                location,
-                                new_arr,
-                                &[idx_val],
-                                val,
-                            ))?;
-                        }
-                    } else {
-                        todo!(
-                            "Handle template parameter array lengths for multi-dimensional arrays"
-                        )
-                    };
-                    // Output value is still the newly created array
-                    Ok(new_arr)
-                } else {
-                    let arr_ty = dim.new_array_type(&val.r#type());
-                    if let Ok(const_dim) = const_dim {
-                        let ctor =
-                            ArrayCtor::Values(&vec![val; usize::try_from(const_dim.value())?]);
-                        function.append_op_unnamed_result(array::new(
-                            &OpBuilder::new(codegen.context),
-                            location,
-                            arr_ty,
-                            ctor,
-                        ))
-                    } else {
-                        todo!(
-                            "Handle template parameter array lengths for single-dimensional arrays"
-                        )
-                    }
-                }
+                let value = value.gen_llzk_in_function(codegen, function)?;
+                let dimension = function.convert_dim_expr(codegen, dimension)?;
+                function.generate_uniform_array(codegen, location, value, dimension)
             }
             Expression::Call { meta, id, args } => {
                 let builder = OpBuilder::new(codegen.context.deref());

--- a/llzk_backend/src/function.rs
+++ b/llzk_backend/src/function.rs
@@ -755,7 +755,7 @@ where
         start: Value<'ctx, 'val>,
         step: Value<'ctx, 'val>,
         end: Value<'ctx, 'val>,
-        body_fn: impl FnOnce(&mut Block<'ctx>) -> Result<()>
+        body_fn: impl FnOnce(&mut Block<'ctx>) -> Result<()>,
     ) -> Result<()> {
         let block_arg = (codegen.index_type(), location);
         let mut block = Block::new(&[block_arg]);
@@ -773,7 +773,7 @@ where
         codegen: &LlzkCodegen<'ast, 'ctx, impl ProgramLike>,
         location: Location<'ctx>,
         end: Value<'ctx, 'val>,
-        body_fn: impl FnOnce(&mut Block<'ctx>) -> Result<()>
+        body_fn: impl FnOnce(&mut Block<'ctx>) -> Result<()>,
     ) -> Result<()> {
         let start = self.append_op_unnamed_result(codegen.new_index_const_op(0, location))?;
         let step = self.append_op_unnamed_result(codegen.new_index_const_op(1, location))?;
@@ -782,14 +782,14 @@ where
 
     /// Implementation for [Expression::UniformArray] after conversion of dimension
     /// expression. Useful because dimension generation differs between function
-    /// and template contexts due to template parameters, but other implementation
+    /// and template contexts due to template parameters, but the actual array generation
     /// is otherwise the same.
     pub fn generate_uniform_array<'ast>(
         &mut self,
         codegen: &LlzkCodegen<'ast, 'ctx, impl ProgramLike>,
         location: Location<'ctx>,
         value: Value<'ctx, 'val>,
-        dimension: &ArrayDimension<'ctx, 'val>
+        dimension: &ArrayDimension<'ctx, 'val>,
     ) -> Result<Value<'ctx, 'val>> {
         let const_dim = IntegerAttribute::try_from(dimension);
         if let Ok(subarr_ty) = ArrayType::try_from(value.r#type()) {
@@ -809,24 +809,22 @@ where
             ))?;
             if let Ok(const_dim) = const_dim {
                 for idx in 0..const_dim.value() {
-                    let idx_val = self.append_op_unnamed_result(
-                        codegen.new_index_const_op(idx, location),
-                    )?;
-                    self.append_op_no_result(array::insert(
-                        location,
-                        new_arr,
-                        &[idx_val],
-                        value,
-                    ))?;
+                    let idx_val =
+                        self.append_op_unnamed_result(codegen.new_index_const_op(idx, location))?;
+                    self.append_op_no_result(array::insert(location, new_arr, &[idx_val], value))?;
                 }
             } else {
                 let dim = self.append_op_unnamed_result(codegen.new_index_const_op(0, location))?;
-                let array_len = self.append_op_unnamed_result(array::len(
-                    location, new_arr, dim
-                ))?;
+                let array_len =
+                    self.append_op_unnamed_result(array::len(location, new_arr, dim))?;
                 self.gen_normalized_scf_for(codegen, location, array_len, |b| {
                     let induction_var = b.argument(0)?;
-                    b.append_operation(array::insert(location, new_arr, &[induction_var.into()], value));
+                    b.append_operation(array::insert(
+                        location,
+                        new_arr,
+                        &[induction_var.into()],
+                        value,
+                    ));
                     b.append_operation(scf::r#yield(&[], location));
                     Ok(())
                 })?;
@@ -837,29 +835,27 @@ where
             let arr_ty = dimension.new_array_type(&value.r#type());
             let builder = &OpBuilder::new(codegen.context);
             if let Ok(const_dim) = const_dim {
-                let ctor =
-                    ArrayCtor::Values(&vec![value; usize::try_from(const_dim.value())?]);
-                self.append_op_unnamed_result(array::new(
-                    builder,
-                    location,
-                    arr_ty,
-                    ctor,
-                ))
+                let ctor = ArrayCtor::Values(&vec![value; usize::try_from(const_dim.value())?]);
+                self.append_op_unnamed_result(array::new(builder, location, arr_ty, ctor))
             } else {
                 let ctor = if let Ok(Some(v)) = dimension.value_range() {
                     ArrayCtor::MapDimSlice(&[v], &[0])
                 } else {
                     ArrayCtor::Values(&[])
                 };
-                let array_ref = self.append_op_unnamed_result(array::new(
-                    builder, location, arr_ty, ctor))?;
+                let array_ref =
+                    self.append_op_unnamed_result(array::new(builder, location, arr_ty, ctor))?;
                 let dim = self.append_op_unnamed_result(codegen.new_index_const_op(0, location))?;
-                let array_len = self.append_op_unnamed_result(array::len(
-                    location, array_ref, dim
-                ))?;
+                let array_len =
+                    self.append_op_unnamed_result(array::len(location, array_ref, dim))?;
                 self.gen_normalized_scf_for(codegen, location, array_len, |b| {
                     let induction_var = b.argument(0)?;
-                    b.append_operation(array::write(location, array_ref, &[induction_var.into()], value));
+                    b.append_operation(array::write(
+                        location,
+                        array_ref,
+                        &[induction_var.into()],
+                        value,
+                    ));
                     b.append_operation(scf::r#yield(&[], location));
                     Ok(())
                 })?;

--- a/llzk_backend/src/module.rs
+++ b/llzk_backend/src/module.rs
@@ -6,7 +6,7 @@ use crate::function::GenerateLLZKInFunction as _;
 use crate::function_ext::FunctionLike;
 use crate::program_ext::ProgramLike;
 use crate::shared::map_name_to_arg_value;
-use crate::shared::ArrayDimension;
+use crate::shared::ArrayDimensionResult;
 use crate::shared::DimExprConverter;
 use crate::shared::LlzkCodegen;
 use crate::subcmp::unique_instance_types;
@@ -14,7 +14,6 @@ use crate::subcmp::SubcmpDeclInfo;
 use crate::template::GenerateLLZKInTemplate as _;
 use crate::template::TemplateContext;
 use crate::template_ext::TemplateLike;
-use anyhow::anyhow;
 use anyhow::bail;
 use anyhow::Result;
 use llzk::attributes::NamedAttribute;
@@ -171,9 +170,10 @@ impl<'ctx> DeclarationInfo<'ctx> {
                     VariableType::Var => {
                         // Create an `undef` of the appropriate type. When the actual assignment is
                         // processed later, this is replaced with the appropriate value.
+                        let dimensions = self.get_dimensions(codegen, dimensions)?;
                         self.decl_inits.insert(
                             name.clone(),
-                            self.new_nondet_felt_of_dimensions(codegen, meta, dimensions)?,
+                            dimensions.new_nondet_felt_of_dimensions(codegen, meta)?,
                         );
                         Ok(())
                     }
@@ -199,7 +199,8 @@ impl<'ctx> DeclarationInfo<'ctx> {
     ) -> Result<StructType<'ctx>> {
         match expression {
             Expression::Call { meta, id, args, .. } if meta.get_type_knowledge().is_component() => {
-                self.struct_type_with_concrete_dimensions(codegen, id, args)
+                let dims = self.get_dimensions(codegen, args)?;
+                Ok(dims.struct_type_with_concrete_dimensions(codegen, id))
             }
             Expression::ParallelOp { rhe, .. } => {
                 // `parallel` is a tag used to generate parallelized code for the C++
@@ -220,13 +221,10 @@ impl<'ctx> DeclarationInfo<'ctx> {
         dimensions: &[Expression],
     ) -> Result<()> {
         let location = codegen.location_from_meta(meta);
-
+        let dims = self.get_dimensions(codegen, dimensions)?;
         if self
             .subcmp_decls
-            .insert(
-                name.to_owned(),
-                SubcmpDeclInfo::new(self.try_dimensions_to_attrs(codegen, dimensions)?, location),
-            )
+            .insert(name.to_owned(), SubcmpDeclInfo::new(dims.attrs(), location))
             .is_some()
         {
             bail!("Subcomponent {name} declared twice");
@@ -246,7 +244,8 @@ impl<'ctx> DeclarationInfo<'ctx> {
         base_type: Type<'ctx>,
     ) -> Result<()> {
         let location = codegen.location_from_meta(meta);
-        let decl_type = self.type_from_dimension_exprs(codegen, base_type, dimensions)?;
+        let dims = self.get_dimensions(codegen, dimensions)?;
+        let decl_type = dims.type_from_dimension_exprs(base_type);
         self.visit_signal_or_bus_impl(codegen, signal_type, name, location, decl_type)
     }
 
@@ -335,7 +334,7 @@ where
         &self,
         codegen: &LlzkCodegen<'ast, 'ctx, impl ProgramLike>,
         expr: &Expression,
-    ) -> Result<ArrayDimension<'ctx, 'val>> {
+    ) -> Result<ArrayDimensionResult<'ctx, 'val>> {
         // First try to compute statically, falling back to literal computation
         // if all values are not compile-time constants or if the final result
         // does not properly convert to i64.
@@ -343,7 +342,7 @@ where
             codegen.try_compute_dim_expr(expr)?.as_ref().and_then(BigUint::to_i64)
         {
             let int_attr = codegen.index_attr(integer);
-            ArrayDimension::new(int_attr.into(), &[])
+            ArrayDimensionResult::new(int_attr.into(), &[])
         } else {
             match expr {
                 Expression::Number(_, _) => {
@@ -354,14 +353,14 @@ where
                         if self.template_params.contains(name) {
                             let template_param_attr =
                                 FlatSymbolRefAttribute::new(codegen.context, name);
-                            ArrayDimension::new(template_param_attr.into(), &[])
+                            ArrayDimensionResult::new(template_param_attr.into(), &[])
                         } else if let Some(op) = self.decl_inits.get(name) {
                             let id_map = codegen.affine_map_attr("affine_map<()[i] -> (i)>")?;
                             let value_range = op
                                 .results()
                                 .map(Into::<Value<'ctx, 'val>>::into)
                                 .collect::<Vec<_>>();
-                            ArrayDimension::new(id_map, &value_range)
+                            ArrayDimensionResult::new(id_map, &value_range)
                         } else {
                             todo!("Handle Variable expression in dimension for non-integer, non-template parameter attributes in DeclarationInfo")
                         }
@@ -389,7 +388,7 @@ where
                 // Give the same error that the circom type checker gives. The type checker ran
                 // earlier so this should technically be unreachable.
                 _ => {
-                    Err(anyhow!("Array indexes and lengths must be single arithmetic expressions"))
+                    unreachable!("Array indexes and lengths must be single arithmetic expressions")
                 }
             }
         }

--- a/llzk_backend/src/shared.rs
+++ b/llzk_backend/src/shared.rs
@@ -788,16 +788,23 @@ impl<'ctx, 'val> ArrayDimension<'ctx, 'val> {
     }
     /// Transform the array dimension using the given function that converts
     /// values into new values (e.g., casting operations to index).
-    pub fn transform(&self, map_fn: impl Fn(Value<'ctx, 'val>) -> Result<Value<'ctx, 'val>>) -> Result<Self> {
+    pub fn transform(
+        &self,
+        map_fn: impl Fn(Value<'ctx, 'val>) -> Result<Value<'ctx, 'val>>,
+    ) -> Result<Self> {
         Ok(Self {
             attr: self.attr,
             symbols: match &self.symbols {
                 None => None,
                 Some(ovr) => {
-                    let translated_vals = ovr.values().iter().map(|v| map_fn( unsafe { Value::from_raw(*v) })).collect::<Result<Vec<_>>>()?;
+                    let translated_vals = ovr
+                        .values()
+                        .iter()
+                        .map(|v| map_fn(unsafe { Value::from_raw(*v) }))
+                        .collect::<Result<Vec<_>>>()?;
                     Some(OwningValueRange::from(translated_vals.as_slice()))
                 }
-            }
+            },
         })
     }
     /// Access the inner attribute.

--- a/llzk_backend/src/shared.rs
+++ b/llzk_backend/src/shared.rs
@@ -829,7 +829,7 @@ impl<'ctx, 'val> ArrayDimension<'ctx, 'val> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 /// Conveys information about array dimension computation.
 pub enum ArrayDimensionResult<'ctx, 'val> {
     /// Indicates that the computing context had

--- a/llzk_backend/src/shared.rs
+++ b/llzk_backend/src/shared.rs
@@ -786,6 +786,20 @@ impl<'ctx, 'val> ArrayDimension<'ctx, 'val> {
             symbols: (!symbol_vals.is_empty()).then(|| OwningValueRange::from(symbol_vals)),
         })
     }
+    /// Transform the array dimension using the given function that converts
+    /// values into new values (e.g., casting operations to index).
+    pub fn transform(&self, map_fn: impl Fn(Value<'ctx, 'val>) -> Result<Value<'ctx, 'val>>) -> Result<Self> {
+        Ok(Self {
+            attr: self.attr,
+            symbols: match &self.symbols {
+                None => None,
+                Some(ovr) => {
+                    let translated_vals = ovr.values().iter().map(|v| map_fn( unsafe { Value::from_raw(*v) })).collect::<Result<Vec<_>>>()?;
+                    Some(OwningValueRange::from(translated_vals.as_slice()))
+                }
+            }
+        })
+    }
     /// Access the inner attribute.
     pub fn attr(&self) -> &Attribute<'ctx> {
         &self.attr

--- a/llzk_backend/src/shared.rs
+++ b/llzk_backend/src/shared.rs
@@ -765,7 +765,7 @@ pub fn remove_from_parent<'c: 'a, 'a>(
 /// Information needed to create a new LLZK array type with the given dimension
 /// and to instantiate that array if the dimension attribute is an affine_map
 /// with symbols.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ArrayDimension<'ctx, 'val> {
     /// The attribute to use as the dimension; could be a constant, a symbol, or an affine map.
     attr: Attribute<'ctx>,

--- a/llzk_backend/src/shared.rs
+++ b/llzk_backend/src/shared.rs
@@ -885,19 +885,12 @@ impl<'ast, 'ctx, 'val> ArrayDimensions<'ctx, 'val> {
     pub fn from_results(dim_results: &[ArrayDimensionResult<'ctx, 'val>]) -> Option<Self> {
         let dims = dim_results
             .iter()
-            .map(|d| match d {
-                ArrayDimensionResult::Computed(array_dimension) => Some(array_dimension),
-                ArrayDimensionResult::InsufficientData => None,
-            })
-            .filter_map(|mut x| Option::take(&mut x))
             .cloned()
+            .map(Option::from)
+            .filter_map(|mut x| Option::take(&mut x))
             .collect::<Vec<_>>();
 
-        if dims.len() != dim_results.len() {
-            None
-        } else {
-            Some(ArrayDimensions(dims))
-        }
+        (dims.len() == dim_results.len()).then(|| ArrayDimensions(dims))
     }
     /// Constructs a new empty list of dimensions.
     pub fn new_empty() -> Self {

--- a/llzk_backend/src/shared.rs
+++ b/llzk_backend/src/shared.rs
@@ -970,8 +970,9 @@ pub trait DimExprConverter<'ctx, 'ast, 'val> {
     /// Convert a circom [Expression] used as an array dimension to an LLZK Attribute.
     /// Returns an error if there was an error converting a dimension that should
     /// be convertible.
-    /// Returns [ArrayDimensionResult::InsufficientData] if a dimension is not convertible due to lack of information
-    /// in the implementer. Users can then attempt to resolve the dimension in a different
+    /// Returns [ArrayDimensionResult::InsufficientData] if a dimension is not
+    /// convertible due to lack of information in the implementer.
+    /// Users can then attempt to resolve the dimension in a different
     /// context, or throw an error if all available contexts are unable to convert
     /// the dimension.
     ///

--- a/llzk_backend/src/shared.rs
+++ b/llzk_backend/src/shared.rs
@@ -786,27 +786,6 @@ impl<'ctx, 'val> ArrayDimension<'ctx, 'val> {
             symbols: (!symbol_vals.is_empty()).then(|| OwningValueRange::from(symbol_vals)),
         })
     }
-    /// Transform the array dimension using the given function that converts
-    /// values into new values (e.g., casting operations to index).
-    pub fn transform(
-        &self,
-        map_fn: impl Fn(Value<'ctx, 'val>) -> Result<Value<'ctx, 'val>>,
-    ) -> Result<Self> {
-        Ok(Self {
-            attr: self.attr,
-            symbols: match &self.symbols {
-                None => None,
-                Some(ovr) => {
-                    let translated_vals = ovr
-                        .values()
-                        .iter()
-                        .map(|v| map_fn(unsafe { Value::from_raw(*v) }))
-                        .collect::<Result<Vec<_>>>()?;
-                    Some(OwningValueRange::from(translated_vals.as_slice()))
-                }
-            },
-        })
-    }
     /// Access the inner attribute.
     pub fn attr(&self) -> &Attribute<'ctx> {
         &self.attr
@@ -825,6 +804,60 @@ impl<'ctx, 'val> ArrayDimension<'ctx, 'val> {
             new_array_type(self.attr, &subarr_ty)
         } else {
             ArrayType::new(*element_type, &[self.attr])
+        }
+    }
+    /// Transform the array dimension using the given function that converts
+    /// values into new values (e.g., casting operations to index).
+    pub fn transform(
+        &self,
+        mut map_fn: impl FnMut(Value<'ctx, 'val>) -> Result<Value<'ctx, 'val>>,
+    ) -> Result<Self> {
+        Ok(Self {
+            attr: self.attr,
+            symbols: match &self.symbols {
+                None => None,
+                Some(ovr) => {
+                    let translated_vals = ovr
+                        .values()
+                        .iter()
+                        .map(|v| map_fn(unsafe { Value::from_raw(*v) }))
+                        .collect::<Result<Vec<_>>>()?;
+                    Some(OwningValueRange::from(translated_vals.as_slice()))
+                }
+            },
+        })
+    }
+}
+
+#[derive(Debug)]
+/// Conveys information about array dimension computation.
+pub enum ArrayDimensionResult<'ctx, 'val> {
+    /// Indicates that the computing context had
+    /// sufficient information to compute the array and computed it successfully.
+    Computed(ArrayDimension<'ctx, 'val>),
+    /// Indicates that the computing context
+    /// was missing information (e.g., variables defined within the function not accessible
+    /// at template level).
+    InsufficientData,
+}
+
+impl<'ctx, 'val> ArrayDimensionResult<'ctx, 'val> {
+    /// Construct a new [ArrayDimensionResult::Computed].
+    pub fn new(attr: Attribute<'ctx>, symbol_vals: &[Value<'ctx, 'val>]) -> Result<Self> {
+        Ok(Self::Computed(ArrayDimension::new(attr, symbol_vals)?))
+    }
+    /// Construct a [ArrayDimensionResult::InsufficientData].
+    /// A convenience method for cases needing a return value of [Result<ArrayDimensionResult>]
+    pub fn insufficient_data_result() -> Result<Self> {
+        Ok(Self::InsufficientData)
+    }
+}
+
+impl<'ctx, 'val> From<ArrayDimensionResult<'ctx, 'val>> for Option<ArrayDimension<'ctx, 'val>> {
+    fn from(value: ArrayDimensionResult<'ctx, 'val>) -> Self {
+        match value {
+            ArrayDimensionResult::Computed(array_dimension) => Some(array_dimension),
+            ArrayDimensionResult::InsufficientData => None,
         }
     }
 }
@@ -846,7 +879,34 @@ impl<'ctx, 'val> TryFrom<&ArrayDimension<'ctx, 'val>> for IntegerAttribute<'ctx>
 #[derive(Debug)]
 pub struct ArrayDimensions<'ctx, 'val>(Vec<ArrayDimension<'ctx, 'val>>);
 
-impl<'ctx, 'val> ArrayDimensions<'ctx, 'val> {
+impl<'ast, 'ctx, 'val> ArrayDimensions<'ctx, 'val> {
+    /// Constructs a new [ArrayDimensions] if all `dim_results` are [ArrayDimensionResult::Computed],
+    /// [None] otherwise.
+    pub fn from_results(dim_results: &[ArrayDimensionResult<'ctx, 'val>]) -> Option<Self> {
+        let dims = dim_results
+            .iter()
+            .map(|d| match d {
+                ArrayDimensionResult::Computed(array_dimension) => Some(array_dimension),
+                ArrayDimensionResult::InsufficientData => None,
+            })
+            .filter_map(|mut x| Option::take(&mut x))
+            .cloned()
+            .collect::<Vec<_>>();
+
+        if dims.len() != dim_results.len() {
+            None
+        } else {
+            Some(ArrayDimensions(dims))
+        }
+    }
+    /// Constructs a new empty list of dimensions.
+    pub fn new_empty() -> Self {
+        ArrayDimensions(vec![])
+    }
+    /// Check if the number of dimensions is non-zero.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
     /// Get all contained attributes.
     pub fn attrs(&self) -> Vec<Attribute<'ctx>> {
         self.0.iter().map(|d| *d.attr()).collect()
@@ -861,11 +921,66 @@ impl<'ctx, 'val> ArrayDimensions<'ctx, 'val> {
         let optional_vec = self.0.iter().map(|d| d.value_range()).collect::<Result<Vec<_>>>()?;
         Ok(optional_vec.into_iter().flatten().collect())
     }
+
+    /// If `self` is empty, return `base_type`. Otherwise, create [ArrayType] by
+    /// converting the dimension circom [Expressions](Expression) to LLZK Attributes.
+    pub fn type_from_dimension_exprs(&self, base_type: Type<'ctx>) -> Type<'ctx> {
+        if self.is_empty() {
+            base_type
+        } else {
+            self.new_array_type(&base_type).into()
+        }
+    }
+
+    /// Create an LLZK operation that produces a nondeterministic `felt.type` value of the given
+    /// `dimensions` (non-array scalar if empty).
+    pub fn new_nondet_felt_of_dimensions_at_location(
+        &self,
+        codegen: &LlzkCodegen<'ast, 'ctx, impl ProgramLike>,
+        location: Location<'ctx>,
+    ) -> Result<Operation<'ctx>> {
+        codegen.new_nondet_at_location(
+            location,
+            self.type_from_dimension_exprs(codegen.felt_type().into()),
+        )
+    }
+
+    /// Create an LLZK operation that produces a nondeterministic `felt.type` value of the given
+    /// `dimensions` (non-array scalar if empty).
+    #[inline]
+    pub fn new_nondet_felt_of_dimensions(
+        &self,
+        codegen: &LlzkCodegen<'ast, 'ctx, impl ProgramLike>,
+        meta: &Meta,
+    ) -> Result<Operation<'ctx>> {
+        self.new_nondet_felt_of_dimensions_at_location(codegen, codegen.location_from_meta(meta))
+    }
+
+    /// If `dimensions` is empty, returns a [`StructType`] with just the name. Otherwise,
+    /// returns a [`StructType`] with parameters by converting the
+    /// dimension circom Expressions to LLZK Attributes.
+    pub fn struct_type_with_concrete_dimensions(
+        &self,
+        codegen: &LlzkCodegen<'ast, 'ctx, impl ProgramLike>,
+        name: &str,
+    ) -> StructType<'ctx> {
+        if self.is_empty() {
+            StructType::from_str(codegen.context, name)
+        } else {
+            StructType::new(FlatSymbolRefAttribute::new(codegen.context, name), &self.attrs())
+        }
+    }
 }
 
 /// A trait to generate array dimensions from the given dimension expressions.
 pub trait DimExprConverter<'ctx, 'ast, 'val> {
     /// Convert a circom [Expression] used as an array dimension to an LLZK Attribute.
+    /// Returns an error if there was an error converting a dimension that should
+    /// be convertible.
+    /// Returns [ArrayDimensionResult::InsufficientData] if a dimension is not convertible due to lack of information
+    /// in the implementer. Users can then attempt to resolve the dimension in a different
+    /// context, or throw an error if all available contexts are unable to convert
+    /// the dimension.
     ///
     /// Note: The LLZK ArrayType can only use the following Attribute types for dimensions:
     /// IntegerAttr (`index` or `i1`) or AffineMapAttr (with single result).
@@ -876,88 +991,34 @@ pub trait DimExprConverter<'ctx, 'ast, 'val> {
         &self,
         codegen: &LlzkCodegen<'ast, 'ctx, impl ProgramLike>,
         expr: &Expression,
-    ) -> Result<ArrayDimension<'ctx, 'val>>;
+    ) -> Result<ArrayDimensionResult<'ctx, 'val>>;
 
-    /// If `dimensions` is empty, return `base_type`. Otherwise, create [ArrayType] by
-    /// converting the dimension circom [Expressions](Expression) to LLZK Attributes.
-    fn type_from_dimension_exprs(
+    /// Computes the [ArrayDimensions] from the given `dimension_exprs`, returning:
+    /// - An error if one of the underlying [Expression]s generated an error,
+    /// - [None] if one of the underling [Expression]s generated a [ArrayDimensionResult::InsufficientData]
+    /// - [Some] otherwise
+    fn get_dimensions_if_able(
         &self,
         codegen: &LlzkCodegen<'ast, 'ctx, impl ProgramLike>,
-        base_type: Type<'ctx>,
-        dimensions: &[Expression],
-    ) -> Result<Type<'ctx>> {
-        if dimensions.is_empty() {
-            Ok(base_type)
-        } else {
-            let array_dims = ArrayDimensions(
-                dimensions
-                    .iter()
-                    .map(|e| self.convert_dim_expr(codegen, e))
-                    .collect::<Result<Vec<_>>>()?,
-            );
-            Ok(array_dims.new_array_type(&base_type).into())
-        }
+        dimension_exprs: &[Expression],
+    ) -> Result<Option<ArrayDimensions<'ctx, 'val>>> {
+        let dim_result_vec = dimension_exprs
+            .iter()
+            .map(|e| self.convert_dim_expr(codegen, e))
+            .collect::<Result<Vec<_>>>()?;
+        Ok(ArrayDimensions::from_results(dim_result_vec.as_slice()))
     }
 
-    /// Tries to convert a list of [`Expression`] to a list of [`Attribute`].
-    #[inline]
-    fn try_dimensions_to_attrs(
+    /// Same as [DimExprConverter::get_dimensions_if_able], but converts [None]
+    /// into an error. For cases where [ArrayDimensions] are expected to be generated
+    /// and there are no fallback contexts to try.
+    fn get_dimensions(
         &self,
         codegen: &LlzkCodegen<'ast, 'ctx, impl ProgramLike>,
-        dimensions: &[Expression],
-    ) -> Result<Vec<Attribute<'ctx>>> {
-        dimensions.iter().map(|e| self.convert_dim_expr(codegen, e).map(|d| *d.attr())).collect()
-    }
-
-    /// Create an LLZK operation that produces a nondeterministic `felt.type` value of the given
-    /// `dimensions` (non-array scalar if empty).
-    fn new_nondet_felt_of_dimensions_at_location(
-        &self,
-        codegen: &LlzkCodegen<'ast, 'ctx, impl ProgramLike>,
-        location: Location<'ctx>,
-        dimensions: &[Expression],
-    ) -> Result<Operation<'ctx>> {
-        codegen.new_nondet_at_location(
-            location,
-            self.type_from_dimension_exprs(codegen, codegen.felt_type().into(), dimensions)?,
-        )
-    }
-
-    /// Create an LLZK operation that produces a nondeterministic `felt.type` value of the given
-    /// `dimensions` (non-array scalar if empty).
-    #[inline]
-    fn new_nondet_felt_of_dimensions(
-        &self,
-        codegen: &LlzkCodegen<'ast, 'ctx, impl ProgramLike>,
-        meta: &Meta,
-        dimensions: &[Expression],
-    ) -> Result<Operation<'ctx>> {
-        self.new_nondet_felt_of_dimensions_at_location(
-            codegen,
-            codegen.location_from_meta(meta),
-            dimensions,
-        )
-    }
-
-    /// If `dimensions` is empty, returns a [`StructType`] with just the name. Otherwise,
-    /// returns a [`StructType`] with parameters by converting the
-    /// dimension circom Expressions to LLZK Attributes.
-    fn struct_type_with_concrete_dimensions(
-        &self,
-        codegen: &LlzkCodegen<'ast, 'ctx, impl ProgramLike>,
-        name: &str,
-        dimensions: &[Expression],
-    ) -> Result<StructType<'ctx>> {
-        if dimensions.is_empty() {
-            Ok(StructType::from_str(codegen.context, name))
-        } else {
-            let dims = ArrayDimensions(
-                dimensions
-                    .iter()
-                    .map(|e| self.convert_dim_expr(codegen, e))
-                    .collect::<Result<Vec<_>, _>>()?,
-            );
-            Ok(StructType::new(FlatSymbolRefAttribute::new(codegen.context, name), &dims.attrs()))
-        }
+        dimension_exprs: &[Expression],
+    ) -> Result<ArrayDimensions<'ctx, 'val>> {
+        self.get_dimensions_if_able(codegen, dimension_exprs)?.ok_or_else(|| {
+            anyhow!("unexpected lack of data needed to convert dimension expressions")
+        })
     }
 }

--- a/llzk_backend/src/template.rs
+++ b/llzk_backend/src/template.rs
@@ -1409,11 +1409,16 @@ where
             }
             Expression::UniformArray { meta, value, dimension } => {
                 let location = codegen.location_from_meta(meta);
+                let template_dim_res = template.convert_dim_expr(codegen, dimension);
                 let value = value.gen_llzk_in_template(codegen, template)?;
                 value.and_then_same(|fc, value| {
                     // Try to convert in template first, or defer to function context if unsuccessful.
-                    let dimension = template.convert_dim_expr(codegen, dimension).or_else(|_| fc.convert_dim_expr(codegen, dimension))?;
-                    fc.generate_uniform_array(codegen, location, value, dimension)
+                    let final_dim = if let Ok(d) = &template_dim_res {
+                        d
+                    } else {
+                        &fc.convert_dim_expr(codegen, dimension)?
+                    };
+                    fc.generate_uniform_array(codegen, location, value, &final_dim)
                 })
             }
             // Delegate any other kind of expression to the implementation in `function.rs`.

--- a/llzk_backend/src/template.rs
+++ b/llzk_backend/src/template.rs
@@ -12,7 +12,7 @@ use crate::gen_context::NestedBlockInfo;
 use crate::program_ext::ProgramLike;
 use crate::shared::get_constrain_call;
 use crate::shared::op_result_owner;
-use crate::shared::ArrayDimension;
+use crate::shared::ArrayDimensionResult;
 use crate::shared::DimExprConverter;
 use crate::shared::LlzkCodegen;
 use crate::template_ext::TemplateLike as _;
@@ -579,7 +579,7 @@ where
         &self,
         codegen: &LlzkCodegen<'ast, 'ctx, impl ProgramLike>,
         expr: &Expression,
-    ) -> Result<ArrayDimension<'ctx, 'val>> {
+    ) -> Result<ArrayDimensionResult<'ctx, 'val>> {
         // First try to compute statically, falling back to literal computation
         // if all values are not compile-time constants or if the final result
         // does not properly convert to i64.
@@ -587,7 +587,7 @@ where
             codegen.try_compute_dim_expr(expr)?.as_ref().and_then(BigUint::to_i64)
         {
             let int_attr = codegen.index_attr(integer);
-            ArrayDimension::new(int_attr.into(), &[])
+            ArrayDimensionResult::new(int_attr.into(), &[])
         } else {
             match expr {
                 Expression::Number(_, _) => {
@@ -597,14 +597,13 @@ where
                     [] => {
                         // Grab the parameter name if it exists, else, defer to function generation.
                         if self.struct_def.has_param_name(name) {
-                            ArrayDimension::new(
+                            ArrayDimensionResult::new(
                                 FlatSymbolRefAttribute::new(codegen.context, name).into(),
                                 &[],
                             )
                         } else {
-                            Err(anyhow!(
-                                "other variables are unsupported, defer to function context"
-                            ))
+                            // Other variables are unsupported, defer to function context
+                            ArrayDimensionResult::insufficient_data_result()
                         }
                     }
                     a => {
@@ -630,7 +629,7 @@ where
                 // Give the same error that the circom type checker gives. The type checker ran
                 // earlier so this should technically be unreachable.
                 _ => {
-                    Err(anyhow!("Array indexes and lengths must be single arithmetic expressions"))
+                    unreachable!("Array indexes and lengths must be single arithmetic expressions")
                 }
             }
         }
@@ -895,7 +894,8 @@ where
             Statement::Declaration { meta, name, dimensions, .. } => {
                 template.and_then_same(|fc, _| {
                     if !fc.block_ctx.is_name_present(name) {
-                        let op = fc.new_nondet_felt_of_dimensions(codegen, meta, dimensions)?;
+                        let dimensions = fc.get_dimensions(codegen, dimensions)?;
+                        let op = dimensions.new_nondet_felt_of_dimensions(codegen, meta)?;
                         fc.block_ctx.declare_name_ensure_not_present(name, op)
                     } else {
                         Ok(())
@@ -1361,8 +1361,8 @@ where
                     && codegen.program.contains_template(id) =>
             {
                 let location = codegen.location_from_meta(meta);
-                let subcmp_type =
-                    template.struct_type_with_concrete_dimensions(codegen, id, args)?;
+                let dimensions = template.get_dimensions(codegen, args)?;
+                let subcmp_type = dimensions.struct_type_with_concrete_dimensions(codegen, id);
                 let arg_types = std::iter::once(Type::from(subcmp_type))
                     .chain(codegen.get_template_input_types(id)?)
                     .collect::<Vec<_>>();
@@ -1414,14 +1414,15 @@ where
             }
             Expression::UniformArray { meta, value, dimension } => {
                 let location = codegen.location_from_meta(meta);
-                let template_dim_res = template.convert_dim_expr(codegen, dimension);
+                let template_dim_res = template.convert_dim_expr(codegen, dimension)?;
                 let value = value.gen_llzk_in_template(codegen, template)?;
                 value.and_then_same(|fc, value| {
                     // Try to convert in template first, or defer to function context if unsuccessful.
-                    let final_dim = if let Ok(d) = &template_dim_res {
-                        d
-                    } else {
-                        &fc.convert_dim_expr(codegen, dimension)?
+                    let final_dim = match &template_dim_res {
+                        ArrayDimensionResult::Computed(array_dimension) => array_dimension,
+                        ArrayDimensionResult::InsufficientData => {
+                            &Option::from(fc.convert_dim_expr(codegen, dimension)?).ok_or_else(|| anyhow!("missing data required to compute uniform array dimensions in template"))?
+                        },
                     };
                     fc.generate_uniform_array(codegen, location, value, final_dim)
                 })

--- a/llzk_backend/src/template.rs
+++ b/llzk_backend/src/template.rs
@@ -597,9 +597,14 @@ where
                     [] => {
                         // Grab the parameter name if it exists, else, defer to function generation.
                         if self.struct_def.has_param_name(name) {
-                            ArrayDimension::new(FlatSymbolRefAttribute::new(&codegen.context, &name).into(), &[])
+                            ArrayDimension::new(
+                                FlatSymbolRefAttribute::new(codegen.context, name).into(),
+                                &[],
+                            )
                         } else {
-                            Err(anyhow!("other variables are unsupported, defer to function context"))
+                            Err(anyhow!(
+                                "other variables are unsupported, defer to function context"
+                            ))
                         }
                     }
                     a => {
@@ -1418,7 +1423,7 @@ where
                     } else {
                         &fc.convert_dim_expr(codegen, dimension)?
                     };
-                    fc.generate_uniform_array(codegen, location, value, &final_dim)
+                    fc.generate_uniform_array(codegen, location, value, final_dim)
                 })
             }
             // Delegate any other kind of expression to the implementation in `function.rs`.

--- a/llzk_backend/src/template.rs
+++ b/llzk_backend/src/template.rs
@@ -1421,7 +1421,9 @@ where
                     let final_dim = match &template_dim_res {
                         ArrayDimensionResult::Computed(array_dimension) => array_dimension,
                         ArrayDimensionResult::InsufficientData => {
-                            &Option::from(fc.convert_dim_expr(codegen, dimension)?).ok_or_else(|| anyhow!("missing data required to compute uniform array dimensions in template"))?
+                            &Option::from(fc.convert_dim_expr(codegen, dimension)?)
+                                .ok_or_else(||
+                                    anyhow!("missing data required to compute uniform array dimensions in template"))?
                         },
                     };
                     fc.generate_uniform_array(codegen, location, value, final_dim)

--- a/llzk_backend/src/template.rs
+++ b/llzk_backend/src/template.rs
@@ -32,10 +32,12 @@ use llzk::prelude::BlockRef;
 use llzk::prelude::CallOpLike as _;
 use llzk::prelude::CallOpRef;
 use llzk::prelude::FeltType;
+use llzk::prelude::FlatSymbolRefAttribute;
 use llzk::prelude::FuncDefOpLike as _;
 use llzk::prelude::Location;
 use llzk::prelude::LoopBoundsAttribute;
 use llzk::prelude::OperationLike;
+use llzk::prelude::StructDefOpLike;
 use llzk::prelude::StructDefOpRefMut;
 use llzk::prelude::SymbolRefAttribute;
 use llzk::prelude::Type;
@@ -593,11 +595,15 @@ where
                 }
                 Expression::Variable { meta, name, access } => match access.as_slice() {
                     [] => {
-                        println!("got {name} for var dim");
-                        todo!("complete me")
+                        // Grab the parameter name if it exists, else, defer to function generation.
+                        if self.struct_def.has_param_name(name) {
+                            ArrayDimension::new(FlatSymbolRefAttribute::new(&codegen.context, &name).into(), &[])
+                        } else {
+                            Err(anyhow!("other variables are unsupported, defer to function context"))
+                        }
                     }
                     a => {
-                        todo!("resolve")
+                        todo!("Handle Variable expression in dimension for non-integer attributes")
                     }
                 },
                 Expression::InfixOp { meta, lhe, infix_op, rhe } => {
@@ -1400,6 +1406,15 @@ where
                         Ok(undefs[0])
                     },
                 )
+            }
+            Expression::UniformArray { meta, value, dimension } => {
+                let location = codegen.location_from_meta(meta);
+                let value = value.gen_llzk_in_template(codegen, template)?;
+                value.and_then_same(|fc, value| {
+                    // Try to convert in template first, or defer to function context if unsuccessful.
+                    let dimension = template.convert_dim_expr(codegen, dimension).or_else(|_| fc.convert_dim_expr(codegen, dimension))?;
+                    fc.generate_uniform_array(codegen, location, value, dimension)
+                })
             }
             // Delegate any other kind of expression to the implementation in `function.rs`.
             expr => {


### PR DESCRIPTION
- Implement uniform arrays for non-constant integer dimensions
- Add special handing for both functions and templates, allowing arrays in templates to query template parameters

Resolves #324.