### PR TITLE
Fix array write type error

### DIFF
--- a/circom/tests/arrays/dimension_handling.circom
+++ b/circom/tests/arrays/dimension_handling.circom
@@ -1,6 +1,7 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk=concrete -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
+// XFAIL:.*
 
 pragma circom 2.0.0;
 

--- a/circom/tests/arrays/dimension_handling.circom
+++ b/circom/tests/arrays/dimension_handling.circom
@@ -1,0 +1,28 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk=concrete -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
+
+pragma circom 2.0.0;
+
+function myAdd(x1,y1,x2,y2) {
+    var res[2] = [0x1 + y1, x2 + y2];
+    return res;
+}
+
+function myFun() {
+    var out[1][1];
+    var dbl[2] = [18446744073709551557,18446744073709551557];
+    for (var i=0; i < 4; i++) {
+        dbl = myAdd(dbl[0], dbl[1], dbl[0], dbl[1]);
+    }
+    return out;
+}
+
+template A() {
+    var table[1][1];
+    table = myFun();
+}
+
+component main = A();
+
+// CHECK-LABEL: module attributes {veridise.lang = "llzk"} {

--- a/llzk_backend/src/codegen.rs
+++ b/llzk_backend/src/codegen.rs
@@ -44,11 +44,7 @@ pub fn generate_llzk(
     // Verify the module
     if let Err(err) = codegen.verify() {
         eprintln!("{}", Color::Red.paint("Generated LLZK IR is invalid"));
-        if verbose {
-            eprintln!("{err:?}");
-        } else {
-            eprintln!("{err}");
-        }
+        eprintln!("{err}");
         eprintln!("{}", codegen.module.as_operation());
         std::process::exit(2); // force exit to avoid hang if MLIR state is inconsistent
     }

--- a/llzk_backend/src/function.rs
+++ b/llzk_backend/src/function.rs
@@ -1360,8 +1360,8 @@ where
                 nonreturning_block.append_operation(
                     // TODO: just like `gen_function_llzk()`, this must use an array type
                     // if applicable but is currently implemented for scalar `felt.type` only.
-                    // In this case, the correct solution (once nondet op is supported for any type)
-                    // is to just create the nondet op using `return_val.getType()`
+                    // In this case, the correct solution (once nondet op is supported for any
+                    // type) is to just create the nondet op using `return_val.getType()`
                     ArrayDimensions::new_empty()
                         .new_nondet_felt_of_dimensions_at_location(codegen, location)?,
                 ),
@@ -1670,13 +1670,22 @@ where
                             })
                             .collect::<Result<Vec<Value<'_, '_>>>>()?;
                         let arr_ref = function.block_ctx.get_named_value(var)?;
-                        let arr_ty = ArrayType::try_from(arr_ref.r#type())?;
-                        let arr_dims = arr_ty.num_dims() as usize;
-                        assert!(arr_dims >= indices.len());
-                        let write_op = if arr_dims > indices.len() {
-                            array::insert(location, *arr_ref, indices, rvalue)
-                        } else {
-                            array::write(location, *arr_ref, indices, rvalue)
+                        let arr_ty = ArrayType::try_from(arr_ref.r#type()).with_context(|| {
+                            format!("Conflicting types to write '{var}' at {location}")
+                        })?;
+                        let arr_ty_dims = arr_ty.dims();
+                        let write_op = match indices.len().cmp(&arr_ty_dims.len()) {
+                            std::cmp::Ordering::Equal => {
+                                // Indexing all dimensions requires an `array.write`
+                                array::write(location, *arr_ref, indices, rvalue)
+                            }
+                            std::cmp::Ordering::Less => {
+                                // Indexing a subset of dimensions requires an `array.insert`
+                                array::insert(location, *arr_ref, indices, rvalue)
+                            }
+                            std::cmp::Ordering::Greater => {
+                                anyhow::bail!("Too many indices to write array '{}'", var);
+                            }
                         };
                         no_results(function.append_op(write_op))?;
                     }
@@ -1786,8 +1795,9 @@ where
                         })
                         .collect::<Result<Vec<Value<'_, '_>>>>()?;
                     let v = function.block_ctx.get_named_value(name)?;
-                    let arr_ty = ArrayType::try_from(v.r#type())
-                        .with_context(|| format!("Conflicting types for '{name}' at {location}"))?;
+                    let arr_ty = ArrayType::try_from(v.r#type()).with_context(|| {
+                        format!("Conflicting types to read '{name}' at {location}")
+                    })?;
                     let arr_ty_dims = arr_ty.dims();
                     let array_get_op = match indices.len().cmp(&arr_ty_dims.len()) {
                         std::cmp::Ordering::Equal => {
@@ -1803,7 +1813,7 @@ where
                             array::extract(location, reduced_type.into(), *v, &indices)
                         }
                         std::cmp::Ordering::Greater => {
-                            anyhow::bail!("Too many indices to access array '{}'", name);
+                            anyhow::bail!("Too many indices to read array '{}'", name);
                         }
                     };
                     function.append_op_unnamed_result(array_get_op)
@@ -1847,8 +1857,7 @@ where
                     values.iter().all(|&v| v.r#type() == value_ty),
                     "All array elements must have the same type"
                 );
-                let subarr_ty = ArrayType::try_from(value_ty);
-                if let Ok(subarr_ty) = subarr_ty {
+                if let Ok(subarr_ty) = ArrayType::try_from(value_ty) {
                     // For subarrays, we need to create a new array then insert the values
                     let dim = codegen.index_attr(i64::try_from(values.len())?);
                     let arr_ty = new_array_type(dim.into(), &subarr_ty);

--- a/llzk_backend/src/function.rs
+++ b/llzk_backend/src/function.rs
@@ -1155,6 +1155,35 @@ where
     ) -> Result<ArrayDimension<'ctx, 'val>> {
         dimension.transform(|val| self.cast_to_index_if_needed(location, val))
     }
+
+    /// Handle a [Statement::Declaration] by generating a nondet felt value with the given
+    /// dimensions and declaring it in the current block context.
+    pub fn gen_declaration(
+        &mut self,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+        meta: &Meta,
+        name: &str,
+        dimensions: &[Expression],
+    ) -> Result<()> {
+        if self.block_ctx.is_name_present(name) {
+            return Ok(());
+        }
+        // If generating from VCP, there are cases where the `sugar_cleaner` added new
+        // declarations that only have `MemoryKnowledge` but not `dimensions` in the AST. So
+        // check `MemoryKnowledge` first (if not generating from VCP, this will always be
+        // empty so `dimensions` will be used).
+        let mk = meta.get_memory_knowledge();
+        let dims = if mk.has_concrete_dimensions() {
+            (mk.get_concrete_dimensions(), codegen).try_into()?
+        } else {
+            self.get_dimensions(codegen, dimensions)?
+        };
+        if codegen.verbose {
+            println!("Declaring variable '{name}' with dimensions {dims:?}");
+        }
+        let op = dims.new_nondet_felt_of_dimensions(codegen, meta)?;
+        self.block_ctx.declare_name_ensure_not_present(name, op)
+    }
 }
 
 impl<'ast, 'ctx, 'func, 'blk, 'val> DimExprConverter<'ctx, 'ast, 'val>
@@ -1362,7 +1391,7 @@ where
                     // if applicable but is currently implemented for scalar `felt.type` only.
                     // In this case, the correct solution (once nondet op is supported for any
                     // type) is to just create the nondet op using `return_val.getType()`
-                    ArrayDimensions::new_empty()
+                    ArrayDimensions::default()
                         .new_nondet_felt_of_dimensions_at_location(codegen, location)?,
                 ),
             )
@@ -1555,7 +1584,7 @@ where
                 // In this case, the correct solution (once nondet op is supported for any
                 // type) is to just create the nondet op using
                 // `return_val.getType()`
-                ArrayDimensions::new_empty()
+                ArrayDimensions::default()
                     .new_nondet_felt_of_dimensions_at_location(codegen, location)?,
                 VAR_NAME_RETURN_VAL.to_string(),
             )?;
@@ -1623,11 +1652,7 @@ where
                     // per `type_analysis/src/analyzers/functions_free_of_template_elements.rs`
                     unreachable!("Template elements declared inside the function")
                 }
-                if !function.block_ctx.is_name_present(name) {
-                    let dims = function.get_dimensions(codegen, dimensions)?;
-                    let op = dims.new_nondet_felt_of_dimensions(codegen, meta)?;
-                    function.block_ctx.declare_name_ensure_not_present(name, op)?;
-                }
+                function.gen_declaration(codegen, meta, name, dimensions)?;
                 Ok(false)
             }
             Statement::Block { meta, stmts } => {

--- a/llzk_backend/src/shared.rs
+++ b/llzk_backend/src/shared.rs
@@ -876,26 +876,10 @@ impl<'ctx, 'val> TryFrom<&ArrayDimension<'ctx, 'val>> for IntegerAttribute<'ctx>
 }
 
 /// Information needed to create a new LLZK array type with the given dimensions.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct ArrayDimensions<'ctx, 'val>(Vec<ArrayDimension<'ctx, 'val>>);
 
 impl<'ast, 'ctx, 'val> ArrayDimensions<'ctx, 'val> {
-    /// Constructs a new [ArrayDimensions] if all `dim_results` are [ArrayDimensionResult::Computed],
-    /// [None] otherwise.
-    pub fn from_results(dim_results: &[ArrayDimensionResult<'ctx, 'val>]) -> Option<Self> {
-        let dims = dim_results
-            .iter()
-            .cloned()
-            .map(Option::from)
-            .filter_map(|mut x| Option::take(&mut x))
-            .collect::<Vec<_>>();
-
-        (dims.len() == dim_results.len()).then(|| ArrayDimensions(dims))
-    }
-    /// Constructs a new empty list of dimensions.
-    pub fn new_empty() -> Self {
-        ArrayDimensions(vec![])
-    }
     /// Check if the number of dimensions is non-zero.
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
@@ -927,6 +911,7 @@ impl<'ast, 'ctx, 'val> ArrayDimensions<'ctx, 'val> {
 
     /// Create an LLZK operation that produces a nondeterministic `felt.type` value of the given
     /// `dimensions` (non-array scalar if empty).
+    #[inline]
     pub fn new_nondet_felt_of_dimensions_at_location(
         &self,
         codegen: &LlzkCodegen<'ast, 'ctx, impl ProgramLike>,
@@ -965,6 +950,42 @@ impl<'ast, 'ctx, 'val> ArrayDimensions<'ctx, 'val> {
     }
 }
 
+/// Constructs a new [ArrayDimensions] if all input [ArrayDimensionResult] are
+/// [ArrayDimensionResult::Computed], returns [Err] otherwise.
+impl<'ctx, 'val> TryFrom<&[ArrayDimensionResult<'ctx, 'val>]> for ArrayDimensions<'ctx, 'val> {
+    type Error = ();
+
+    fn try_from(dim_results: &[ArrayDimensionResult<'ctx, 'val>]) -> Result<Self, Self::Error> {
+        let dims = dim_results
+            .iter()
+            .cloned()
+            .map(Option::from)
+            .filter_map(|mut x| Option::take(&mut x))
+            .collect::<Vec<_>>();
+        if dims.len() == dim_results.len() {
+            Ok(ArrayDimensions(dims))
+        } else {
+            Err(())
+        }
+    }
+}
+
+impl<'ctx, 'val, P: ProgramLike> TryFrom<(&[usize], &LlzkCodegen<'_, 'ctx, P>)>
+    for ArrayDimensions<'ctx, 'val>
+{
+    type Error = anyhow::Error;
+
+    fn try_from(
+        (dim_sizes, codegen): (&[usize], &LlzkCodegen<'_, 'ctx, P>),
+    ) -> Result<Self, Self::Error> {
+        dim_sizes
+            .iter()
+            .map(|size| ArrayDimension::new(codegen.index_attr(i64::try_from(*size)?).into(), &[]))
+            .collect::<Result<Vec<_>>>()
+            .map(ArrayDimensions)
+    }
+}
+
 /// A trait to generate array dimensions from the given dimension expressions.
 pub trait DimExprConverter<'ctx, 'ast, 'val> {
     /// Convert a circom [Expression] used as an array dimension to an LLZK Attribute.
@@ -989,7 +1010,8 @@ pub trait DimExprConverter<'ctx, 'ast, 'val> {
 
     /// Computes the [ArrayDimensions] from the given `dimension_exprs`, returning:
     /// - An error if one of the underlying [Expression]s generated an error,
-    /// - [None] if one of the underling [Expression]s generated a [ArrayDimensionResult::InsufficientData]
+    /// - [None] if one of the underling [Expression]s generated a
+    ///   [ArrayDimensionResult::InsufficientData]
     /// - [Some] otherwise
     fn get_dimensions_if_able(
         &self,
@@ -1000,7 +1022,7 @@ pub trait DimExprConverter<'ctx, 'ast, 'val> {
             .iter()
             .map(|e| self.convert_dim_expr(codegen, e))
             .collect::<Result<Vec<_>>>()?;
-        Ok(ArrayDimensions::from_results(dim_result_vec.as_slice()))
+        Ok(ArrayDimensions::try_from(dim_result_vec.as_slice()).ok())
     }
 
     /// Same as [DimExprConverter::get_dimensions_if_able], but converts [None]

--- a/llzk_backend/src/template.rs
+++ b/llzk_backend/src/template.rs
@@ -892,15 +892,7 @@ where
                 gen_init_block(codegen, template, initializations)
             }
             Statement::Declaration { meta, name, dimensions, .. } => {
-                template.and_then_same(|fc, _| {
-                    if !fc.block_ctx.is_name_present(name) {
-                        let dimensions = fc.get_dimensions(codegen, dimensions)?;
-                        let op = dimensions.new_nondet_felt_of_dimensions(codegen, meta)?;
-                        fc.block_ctx.declare_name_ensure_not_present(name, op)
-                    } else {
-                        Ok(())
-                    }
-                })
+                template.and_then_same(|fc, _| fc.gen_declaration(codegen, meta, name, dimensions))
             }
             Statement::Block { meta, stmts } => {
                 let mut template = template; // satisfy the &mut in `GenWithCircomScopeHandling`


### PR DESCRIPTION
This PR fixes a bug with array declaration handing when generating from VCP. Also makes errors more clear in some places and refactors a few things to be more "rusty".

The attached test still fails but it's due to a different known issue with array type returns.