### PR TITLE
Make template parameter constants accessible in concrete mode

### DIFF
--- a/circom/tests/from_concrete/inner_conditional_03.circom
+++ b/circom/tests/from_concrete/inner_conditional_03.circom
@@ -27,6 +27,7 @@ component main = InnerConditional3(3);
 // CHECK-NEXT:      struct.field @out : !felt.type {llzk.pub}
 // CHECK-NEXT:      function.def @compute(%[[V_0:[0-9a-zA-Z_\.]+]]: !felt.type) -> !struct.type<@InnerConditional3<[]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
 // CHECK-NEXT:        %[[SELF:[0-9a-zA-Z_\.]+]] = struct.new : <@InnerConditional3<[]>>
+// CHECK-NEXT:        %[[V_N:[0-9a-zA-Z_\.]+]] = felt.const  3
 // CHECK-NEXT:        %[[V_A0:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[V_I0:[0-9a-zA-Z_\.]+]] = felt.const  1
 // CHECK-NEXT:        %[[V_4:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_A1:[0-9a-zA-Z_\.]+]] = %[[V_A0]], %[[V_I1:[0-9a-zA-Z_\.]+]] = %[[V_I0]]) : (!felt.type, !felt.type) -> (!felt.type, !felt.type) {
@@ -52,6 +53,7 @@ component main = InnerConditional3(3);
 // CHECK-NEXT:        function.return %[[SELF]] : !struct.type<@InnerConditional3<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[SELF:[0-9a-zA-Z_\.]+]]: !struct.type<@InnerConditional3<[]>>, %[[V_19:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %[[V_N:[0-9a-zA-Z_\.]+]] = felt.const  3
 // CHECK-NEXT:        %[[V_A0:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[V_I0:[0-9a-zA-Z_\.]+]] = felt.const  1
 // CHECK-NEXT:        %[[V_22:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_A1:[0-9a-zA-Z_\.]+]] = %[[V_A0]], %[[V_I1:[0-9a-zA-Z_\.]+]] = %[[V_I0]]) : (!felt.type, !felt.type) -> (!felt.type, !felt.type) {

--- a/circom/tests/from_concrete/template_param_uses.circom
+++ b/circom/tests/from_concrete/template_param_uses.circom
@@ -1,0 +1,146 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk concrete -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
+
+pragma circom 2.0.0;
+
+function f(a) {
+    return a;
+}
+
+template Template(m, n, c) {
+    var v[2][2] = m;
+    var x[c] = n;
+    var ret[2][2] = f(v);
+}
+
+component main = Template([[0, 1], [2, 3]], [1, 0], 2);
+
+// CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-NEXT:    function.def @f_0(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !array.type<2,2 x !felt.type>) -> !array.type<2,2 x !felt.type> attributes {function.allow_non_native_field_ops} {
+// CHECK-NEXT:      function.return %[[VAL_0]] : !array.type<2,2 x !felt.type>
+// CHECK-NEXT:    }
+// CHECK-NEXT:    struct.def @Template<[]> {
+// CHECK-NEXT:      function.def @compute() -> !struct.type<@Template<[]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = struct.new : <@Template<[]>>
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = felt.const  2
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_3]], %[[VAL_4]] : <2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = felt.const  2
+// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = felt.const  3
+// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_6]], %[[VAL_7]] : <2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_9:[0-9a-zA-Z_\.]+]] = array.new  : <2,2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        array.insert %[[VAL_9]]{{\[}}%[[VAL_10]]] = %[[VAL_5]] : <2,2 x !felt.type>, <2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        array.insert %[[VAL_9]]{{\[}}%[[VAL_11]]] = %[[VAL_8]] : <2,2 x !felt.type>, <2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_12:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_13:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_14:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_12]], %[[VAL_13]] : <2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_15:[0-9a-zA-Z_\.]+]] = undef.undef : !array.type<2,2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_16:[0-9a-zA-Z_\.]+]] = undef.undef : !array.type<2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_17:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_18:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_19:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_18]]
+// CHECK-NEXT:        array.write %[[VAL_16]]{{\[}}%[[VAL_19]]] = %[[VAL_17]] : <2 x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[VAL_20:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_21:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_22:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_21]]
+// CHECK-NEXT:        array.write %[[VAL_16]]{{\[}}%[[VAL_22]]] = %[[VAL_20]] : <2 x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[VAL_23:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_24:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_23]]
+// CHECK-NEXT:        array.insert %[[VAL_15]]{{\[}}%[[VAL_24]]] = %[[VAL_16]] : <2,2 x !felt.type>, <2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_25:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_26:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_25]]
+// CHECK-NEXT:        array.insert %[[VAL_15]]{{\[}}%[[VAL_26]]] = %[[VAL_16]] : <2,2 x !felt.type>, <2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_27:[0-9a-zA-Z_\.]+]] = undef.undef : !array.type<2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_28:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_29:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_30:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_29]]
+// CHECK-NEXT:        array.write %[[VAL_27]]{{\[}}%[[VAL_30]]] = %[[VAL_28]] : <2 x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[VAL_31:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_32:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_33:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_32]]
+// CHECK-NEXT:        array.write %[[VAL_27]]{{\[}}%[[VAL_33]]] = %[[VAL_31]] : <2 x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[VAL_34:[0-9a-zA-Z_\.]+]] = undef.undef : !array.type<2,2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_35:[0-9a-zA-Z_\.]+]] = undef.undef : !array.type<2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_36:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_37:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_38:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_37]]
+// CHECK-NEXT:        array.write %[[VAL_35]]{{\[}}%[[VAL_38]]] = %[[VAL_36]] : <2 x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[VAL_39:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_40:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_41:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_40]]
+// CHECK-NEXT:        array.write %[[VAL_35]]{{\[}}%[[VAL_41]]] = %[[VAL_39]] : <2 x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[VAL_42:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_43:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_42]]
+// CHECK-NEXT:        array.insert %[[VAL_34]]{{\[}}%[[VAL_43]]] = %[[VAL_35]] : <2,2 x !felt.type>, <2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_44:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_45:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_44]]
+// CHECK-NEXT:        array.insert %[[VAL_34]]{{\[}}%[[VAL_45]]] = %[[VAL_35]] : <2,2 x !felt.type>, <2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_46:[0-9a-zA-Z_\.]+]] = function.call @f_0(%[[VAL_9]]) : (!array.type<2,2 x !felt.type>) -> !array.type<2,2 x !felt.type>
+// CHECK-NEXT:        function.return %[[VAL_1]] : !struct.type<@Template<[]>>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[VAL_47:[0-9a-zA-Z_\.]+]]: !struct.type<@Template<[]>>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %[[VAL_48:[0-9a-zA-Z_\.]+]] = felt.const  2
+// CHECK-NEXT:        %[[VAL_49:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_50:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_51:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_49]], %[[VAL_50]] : <2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_52:[0-9a-zA-Z_\.]+]] = felt.const  2
+// CHECK-NEXT:        %[[VAL_53:[0-9a-zA-Z_\.]+]] = felt.const  3
+// CHECK-NEXT:        %[[VAL_54:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_52]], %[[VAL_53]] : <2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_55:[0-9a-zA-Z_\.]+]] = array.new  : <2,2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_56:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        array.insert %[[VAL_55]]{{\[}}%[[VAL_56]]] = %[[VAL_51]] : <2,2 x !felt.type>, <2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_57:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        array.insert %[[VAL_55]]{{\[}}%[[VAL_57]]] = %[[VAL_54]] : <2,2 x !felt.type>, <2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_58:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_59:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_60:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_58]], %[[VAL_59]] : <2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_61:[0-9a-zA-Z_\.]+]] = undef.undef : !array.type<2,2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_62:[0-9a-zA-Z_\.]+]] = undef.undef : !array.type<2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_63:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_64:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_65:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_64]]
+// CHECK-NEXT:        array.write %[[VAL_62]]{{\[}}%[[VAL_65]]] = %[[VAL_63]] : <2 x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[VAL_66:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_67:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_68:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_67]]
+// CHECK-NEXT:        array.write %[[VAL_62]]{{\[}}%[[VAL_68]]] = %[[VAL_66]] : <2 x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[VAL_69:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_70:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_69]]
+// CHECK-NEXT:        array.insert %[[VAL_61]]{{\[}}%[[VAL_70]]] = %[[VAL_62]] : <2,2 x !felt.type>, <2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_71:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_72:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_71]]
+// CHECK-NEXT:        array.insert %[[VAL_61]]{{\[}}%[[VAL_72]]] = %[[VAL_62]] : <2,2 x !felt.type>, <2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_73:[0-9a-zA-Z_\.]+]] = undef.undef : !array.type<2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_74:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_75:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_76:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_75]]
+// CHECK-NEXT:        array.write %[[VAL_73]]{{\[}}%[[VAL_76]]] = %[[VAL_74]] : <2 x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[VAL_77:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_78:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_79:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_78]]
+// CHECK-NEXT:        array.write %[[VAL_73]]{{\[}}%[[VAL_79]]] = %[[VAL_77]] : <2 x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[VAL_80:[0-9a-zA-Z_\.]+]] = undef.undef : !array.type<2,2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_81:[0-9a-zA-Z_\.]+]] = undef.undef : !array.type<2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_82:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_83:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_84:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_83]]
+// CHECK-NEXT:        array.write %[[VAL_81]]{{\[}}%[[VAL_84]]] = %[[VAL_82]] : <2 x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[VAL_85:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_86:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_87:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_86]]
+// CHECK-NEXT:        array.write %[[VAL_81]]{{\[}}%[[VAL_87]]] = %[[VAL_85]] : <2 x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[VAL_88:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_89:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_88]]
+// CHECK-NEXT:        array.insert %[[VAL_80]]{{\[}}%[[VAL_89]]] = %[[VAL_81]] : <2,2 x !felt.type>, <2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_90:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_91:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_90]]
+// CHECK-NEXT:        array.insert %[[VAL_80]]{{\[}}%[[VAL_91]]] = %[[VAL_81]] : <2,2 x !felt.type>, <2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_92:[0-9a-zA-Z_\.]+]] = function.call @f_0(%[[VAL_55]]) : (!array.type<2,2 x !felt.type>) -> !array.type<2,2 x !felt.type>
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/operators/assert.circom
+++ b/circom/tests/operators/assert.circom
@@ -15,6 +15,7 @@ component main = A(32);
 // CHECK-NEXT:    struct.def @A<[]> {
 // CHECK-NEXT:      function.def @compute() -> !struct.type<@A<[]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
 // CHECK-NEXT:        %[[VAL_0:[0-9a-zA-Z_\.]+]] = struct.new : <@A<[]>>
+// CHECK-NEXT:        %[[V_nBits:[0-9a-zA-Z_\.]+]] = felt.const  32
 // CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = felt.const  1
 // CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = bool.cmp ne(%[[VAL_1]], %[[VAL_2]])
@@ -22,6 +23,7 @@ component main = A(32);
 // CHECK-NEXT:        function.return %[[VAL_0]] : !struct.type<@A<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_4:[0-9a-zA-Z_\.]+]]: !struct.type<@A<[]>>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %[[V_nBits:[0-9a-zA-Z_\.]+]] = felt.const  32
 // CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = felt.const  1
 // CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = bool.cmp ne(%[[VAL_5]], %[[VAL_6]])

--- a/llzk_backend/src/module.rs
+++ b/llzk_backend/src/module.rs
@@ -544,6 +544,7 @@ fn gen_template_llzk<'ast, 'ctx, T: TemplateLike>(
     // Visit the body of the template and generate LLZK IR for it within the struct functions.
     let template_context =
         TemplateContext::new(new_struct, compute_ctx, constrain_ctx, &subcmp_names);
+    template_like.gen_preamble(codegen, &template_context)?;
     template_like.get_body().gen_llzk_in_template(codegen, &template_context)?;
     template_context.finalize(codegen)
 }

--- a/llzk_backend/src/template_ext.rs
+++ b/llzk_backend/src/template_ext.rs
@@ -277,7 +277,7 @@ impl TemplateLike for TemplateInstance {
             match dims {
                 [] => {
                     if offset >= flat_vals.len() {
-                        Err(anyhow!("offset {} ouf of bounds (len {})", offset, flat_vals.len()))
+                        Err(anyhow!("offset {} out of bounds (len {})", offset, flat_vals.len()))
                     } else {
                         Ok((
                             Expression::Number(meta.clone(), flat_vals[offset].clone()),
@@ -302,7 +302,7 @@ impl TemplateLike for TemplateInstance {
 
         // Insert Argument values (static versions of template parameters) in
         // case an assignment references these (happens when assigning an array
-        // variable to equal an array Argument.
+        // variable to equal an array Argument).
         for arg in &self.header {
             let meta = Meta::new(0, 0);
             let declaration = Statement::Declaration {

--- a/llzk_backend/src/template_ext.rs
+++ b/llzk_backend/src/template_ext.rs
@@ -12,9 +12,9 @@ use anyhow::Result;
 use compiler::hir::very_concrete_program::ClusterType;
 use compiler::hir::very_concrete_program::TemplateInstance;
 use compiler::hir::very_concrete_program::Wire;
+use llzk::prelude::Attribute;
 use llzk::prelude::FlatSymbolRefAttribute;
 use llzk::prelude::Location;
-use llzk::prelude::Attribute;
 use llzk::prelude::StructType;
 use num_bigint_dig::BigInt;
 use num_traits::FromPrimitive;
@@ -29,8 +29,8 @@ use program_structure::wire_data::WireData;
 use program_structure::wire_data::WireType;
 use std::borrow::Cow;
 use std::collections::HashMap;
-use std::slice;
 use std::convert::TryFrom;
+use std::slice;
 
 /// A trait that allows common handling of structs/enums that represent template
 /// inputs or outputs.
@@ -58,7 +58,7 @@ pub trait TemplateLike: std::fmt::Debug {
     /// if any.
     fn get_init_subcmp_decls<'ctx>(
         &self,
-        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
     ) -> Result<HashMap<String, SubcmpDeclInfo<'ctx>>>;
     /// Get the body statements of the template.
     fn get_body(&self) -> &[Statement];
@@ -85,7 +85,7 @@ pub trait TemplateLike: std::fmt::Debug {
     fn gen_preamble<'ctx>(
         &self,
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        template: &TemplateContext<'ctx, '_, '_, '_, '_>
+        template: &TemplateContext<'ctx, '_, '_, '_, '_>,
     ) -> Result<()>;
 }
 
@@ -107,7 +107,10 @@ impl TemplateLike for TemplateData {
     fn get_body(&self) -> &[Statement] {
         self.get_body_as_vec()
     }
-    fn get_init_subcmp_decls<'ctx>(&self, _codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>) -> Result<HashMap<String, SubcmpDeclInfo<'ctx>>> {
+    fn get_init_subcmp_decls<'ctx>(
+        &self,
+        _codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+    ) -> Result<HashMap<String, SubcmpDeclInfo<'ctx>>> {
         Ok(HashMap::new())
     }
     fn get_declarations<'ctx>(
@@ -131,7 +134,7 @@ impl TemplateLike for TemplateData {
     fn gen_preamble<'ctx>(
         &self,
         _codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        _template: &TemplateContext<'ctx, '_, '_, '_, '_>
+        _template: &TemplateContext<'ctx, '_, '_, '_, '_>,
     ) -> Result<()> {
         Ok(())
     }
@@ -161,7 +164,10 @@ impl TemplateLike for TemplateInstance {
     fn get_body(&self) -> &[Statement] {
         slice::from_ref(&self.code)
     }
-    fn get_init_subcmp_decls<'ctx>(&self, codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>) -> Result<HashMap<String, SubcmpDeclInfo<'ctx>>> {
+    fn get_init_subcmp_decls<'ctx>(
+        &self,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+    ) -> Result<HashMap<String, SubcmpDeclInfo<'ctx>>> {
         let mut subcmp_decls = HashMap::new();
         let location = codegen.location_unknown();
         // Create the declarations, but they currently have no types
@@ -177,10 +183,7 @@ impl TemplateLike for TemplateInstance {
                 .collect::<Result<Vec<Attribute>>>()?;
             let subcmp_decl = SubcmpDeclInfo::new(dimensions, location);
 
-            if subcmp_decls
-                .insert(name.clone(), subcmp_decl)
-                .is_some()
-            {
+            if subcmp_decls.insert(name.clone(), subcmp_decl).is_some() {
                 bail!("Subcomponent {name} declared twice");
             }
         }
@@ -189,14 +192,21 @@ impl TemplateLike for TemplateInstance {
             if let Some(subcmp_decl) = subcmp_decls.get_mut(&cluster.cmp_name) {
                 match &cluster.xtype {
                     // Mixed instantiation is also not supported in [DeclarationInfo::complete]
-                    ClusterType::Mixed { .. } => todo!("Support mixed type subcomponent instantiations"),
+                    ClusterType::Mixed { .. } => {
+                        todo!("Support mixed type subcomponent instantiations")
+                    }
                     ClusterType::Uniform { header, .. } => {
                         // See ExecutedTemplate::export_to_circuit for header construction
-                        let last_underscore = header.rfind("_").ok_or_else(|| anyhow!("unexpected header string format"))?;
+                        let last_underscore = header
+                            .rfind("_")
+                            .ok_or_else(|| anyhow!("unexpected header string format"))?;
                         let (template_name, _) = header.split_at(last_underscore);
-                        let struct_type = StructType::new(FlatSymbolRefAttribute::new(codegen.context, template_name), &[]);
+                        let struct_type = StructType::new(
+                            FlatSymbolRefAttribute::new(codegen.context, template_name),
+                            &[],
+                        );
                         subcmp_decl.instances_mut().push(struct_type);
-                    },
+                    }
                 }
             }
         }
@@ -256,23 +266,31 @@ impl TemplateLike for TemplateInstance {
     fn gen_preamble<'ctx>(
         &self,
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        template: &TemplateContext<'ctx, '_, '_, '_, '_>
+        template: &TemplateContext<'ctx, '_, '_, '_, '_>,
     ) -> Result<()> {
-
-        fn build_nested(meta: &Meta, flat_vals: &[BigInt], offset: usize, dims: &[usize]) -> Result<(Expression, usize)> {
+        fn build_nested(
+            meta: &Meta,
+            flat_vals: &[BigInt],
+            offset: usize,
+            dims: &[usize],
+        ) -> Result<(Expression, usize)> {
             match dims {
                 [] => {
                     if offset >= flat_vals.len() {
                         Err(anyhow!("offset {} ouf of bounds (len {})", offset, flat_vals.len()))
                     } else {
-                        Ok((Expression::Number(meta.clone(), flat_vals[offset].clone()), offset + 1))
+                        Ok((
+                            Expression::Number(meta.clone(), flat_vals[offset].clone()),
+                            offset + 1,
+                        ))
                     }
                 }
                 [next, remaining @ ..] => {
                     let mut values = vec![];
                     let mut curr_offset = offset;
                     for _ in 0..*next {
-                        let (expr, new_offset) = build_nested(meta, flat_vals, curr_offset, remaining)?;
+                        let (expr, new_offset) =
+                            build_nested(meta, flat_vals, curr_offset, remaining)?;
                         curr_offset = new_offset;
                         values.push(expr);
                     }
@@ -291,9 +309,12 @@ impl TemplateLike for TemplateInstance {
                 meta: meta.clone(),
                 xtype: VariableType::Var,
                 name: arg.name.clone(),
-                dimensions: arg.lengths.iter()
+                dimensions: arg
+                    .lengths
+                    .iter()
                     .map(|d| {
-                        let bigint = BigInt::from_usize(*d).ok_or_else(|| anyhow!("could not convert usize to bigint"))?;
+                        let bigint = BigInt::from_usize(*d)
+                            .ok_or_else(|| anyhow!("could not convert usize to bigint"))?;
                         Ok(Expression::Number(meta.clone(), bigint))
                     })
                     .collect::<Result<Vec<_>>>()?,

--- a/llzk_backend/src/template_ext.rs
+++ b/llzk_backend/src/template_ext.rs
@@ -4,6 +4,8 @@ use crate::module::DeclarationInfo;
 use crate::program_ext::ProgramLike;
 use crate::shared::LlzkCodegen;
 use crate::subcmp::SubcmpDeclInfo;
+use crate::template::GenerateLLZKInTemplate;
+use crate::template::TemplateContext;
 use anyhow::anyhow;
 use anyhow::bail;
 use anyhow::Result;
@@ -14,8 +16,14 @@ use llzk::prelude::FlatSymbolRefAttribute;
 use llzk::prelude::Location;
 use llzk::prelude::Attribute;
 use llzk::prelude::StructType;
+use num_bigint_dig::BigInt;
+use num_traits::FromPrimitive;
+use program_structure::ast::AssignOp::AssignVar;
+use program_structure::ast::Expression;
+use program_structure::ast::Meta;
 use program_structure::ast::SignalType;
 use program_structure::ast::Statement;
+use program_structure::ast::VariableType;
 use program_structure::template_data::TemplateData;
 use program_structure::wire_data::WireData;
 use program_structure::wire_data::WireType;
@@ -73,6 +81,12 @@ pub trait TemplateLike: std::fmt::Debug {
             Cow::Owned(i) => i.get(name).cloned().map(Cow::Owned),
         }
     }
+    /// Generate any LLZK code needed in the beginning of the template.
+    fn gen_preamble<'ctx>(
+        &self,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+        template: &TemplateContext<'ctx, '_, '_, '_, '_>
+    ) -> Result<()>;
 }
 
 impl TemplateLike for TemplateData {
@@ -113,6 +127,13 @@ impl TemplateLike for TemplateData {
     }
     fn get_input_info(&'_ self, name: &str) -> Option<Cow<'_, WireData>> {
         self.get_input_info(name).map(Cow::Borrowed)
+    }
+    fn gen_preamble<'ctx>(
+        &self,
+        _codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+        _template: &TemplateContext<'ctx, '_, '_, '_, '_>
+    ) -> Result<()> {
+        Ok(())
     }
 }
 
@@ -231,6 +252,65 @@ impl TemplateLike for TemplateInstance {
     }
     fn get_outputs(&'_ self) -> Cow<'_, HashMap<String, Wire>> {
         Cow::Owned(wires_of_type(&self.wires, SignalType::Output))
+    }
+    fn gen_preamble<'ctx>(
+        &self,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+        template: &TemplateContext<'ctx, '_, '_, '_, '_>
+    ) -> Result<()> {
+
+        fn build_nested(meta: &Meta, flat_vals: &[BigInt], offset: usize, dims: &[usize]) -> Result<(Expression, usize)> {
+            match dims {
+                [] => {
+                    if offset >= flat_vals.len() {
+                        Err(anyhow!("offset {} ouf of bounds (len {})", offset, flat_vals.len()))
+                    } else {
+                        Ok((Expression::Number(meta.clone(), flat_vals[offset].clone()), offset + 1))
+                    }
+                }
+                [next, remaining @ ..] => {
+                    let mut values = vec![];
+                    let mut curr_offset = offset;
+                    for _ in 0..*next {
+                        let (expr, new_offset) = build_nested(meta, flat_vals, curr_offset, remaining)?;
+                        curr_offset = new_offset;
+                        values.push(expr);
+                    }
+                    let expr = Expression::ArrayInLine { meta: meta.clone(), values };
+                    Ok((expr, curr_offset))
+                }
+            }
+        }
+
+        // Insert Argument values (static versions of template parameters) in
+        // case an assignment references these (happens when assigning an array
+        // variable to equal an array Argument.
+        for arg in &self.header {
+            let meta = Meta::new(0, 0);
+            let declaration = Statement::Declaration {
+                meta: meta.clone(),
+                xtype: VariableType::Var,
+                name: arg.name.clone(),
+                dimensions: arg.lengths.iter()
+                    .map(|d| {
+                        let bigint = BigInt::from_usize(*d).ok_or_else(|| anyhow!("could not convert usize to bigint"))?;
+                        Ok(Expression::Number(meta.clone(), bigint))
+                    })
+                    .collect::<Result<Vec<_>>>()?,
+                is_constant: true,
+                is_anonymous: false,
+            };
+            let assignment = Statement::Substitution {
+                meta: meta.clone(),
+                var: arg.name.clone(),
+                access: vec![],
+                op: AssignVar,
+                rhe: build_nested(&meta, &arg.values, 0, &arg.lengths)?.0,
+            };
+            declaration.gen_llzk_in_template(codegen, template)?;
+            assignment.gen_llzk_in_template(codegen, template)?;
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Some operations still need access to template parameters by name, but in VCP mode, they are no longer declared within the template body and instead exist as constants in the `TemplateInstance::header` field. I make these accessible by creating synthetic Declaration and Substitution statements and generating them at the beginning of the template.