### PR TITLE
Relax signal assignment/constraint type restrictions

### DIFF
--- a/circom/tests/arrays/array_copy2_vec.circom
+++ b/circom/tests/arrays/array_copy2_vec.circom
@@ -1,7 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL:.*
 
 pragma circom 2.0.0;
 
@@ -16,3 +15,19 @@ template Array2(n) {
 component main = Array2(5);
 
 // CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-NEXT:    struct.def @Array2<[@n]> {
+// CHECK-NEXT:      struct.field @out : !array.type<@n x !felt.type> {llzk.pub}
+// CHECK-NEXT:      function.def @compute(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) -> !struct.type<@Array2<[@n]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = struct.new : <@Array2<[@n]>>
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        struct.writef %[[VAL_1]][@out] = %[[VAL_0]] : <@Array2<[@n]>>, !array.type<@n x !felt.type>
+// CHECK-NEXT:        function.return %[[VAL_1]] : !struct.type<@Array2<[@n]>>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[VAL_3:[0-9a-zA-Z_\.]+]]: !struct.type<@Array2<[@n]>>, %[[VAL_4:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_3]][@out] : <@Array2<[@n]>>, !array.type<@n x !felt.type>
+// CHECK-NEXT:        constrain.eq %[[VAL_6]], %[[VAL_4]] : !array.type<@n x !felt.type>, !array.type<@n x !felt.type>
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/arrays/array_copy3_vec.circom
+++ b/circom/tests/arrays/array_copy3_vec.circom
@@ -1,14 +1,10 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL:.*
 
 pragma circom 2.0.0;
 
-// Vector copy version of `array_copy3_loop.circom` test. Output is very similar except the
-//  vector version comes through the circom front-end as a flattened array which mean lvar
-//  indexing is slightly different here. There is only one loop iteration variable instead
-//  of two and the additional statements for updating index variables are not necessary.
+// Vector copy version of `array_copy3_loop.circom` test.
 template Array3(n) {
     signal input inp[n][n];
     signal output out[n][n];
@@ -19,3 +15,19 @@ template Array3(n) {
 component main = Array3(5);
 
 // CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-NEXT:    struct.def @Array3<[@n]> {
+// CHECK-NEXT:      struct.field @out : !array.type<@n,@n x !felt.type> {llzk.pub}
+// CHECK-NEXT:      function.def @compute(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !array.type<@n,@n x !felt.type>) -> !struct.type<@Array3<[@n]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = struct.new : <@Array3<[@n]>>
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        struct.writef %[[VAL_1]][@out] = %[[VAL_0]] : <@Array3<[@n]>>, !array.type<@n,@n x !felt.type>
+// CHECK-NEXT:        function.return %[[VAL_1]] : !struct.type<@Array3<[@n]>>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[VAL_3:[0-9a-zA-Z_\.]+]]: !struct.type<@Array3<[@n]>>, %[[VAL_4:[0-9a-zA-Z_\.]+]]: !array.type<@n,@n x !felt.type>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_3]][@out] : <@Array3<[@n]>>, !array.type<@n,@n x !felt.type>
+// CHECK-NEXT:        constrain.eq %[[VAL_6]], %[[VAL_4]] : !array.type<@n,@n x !felt.type>, !array.type<@n,@n x !felt.type>
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/declaration_in_template/array_dim_expr_param_B.circom
+++ b/circom/tests/declaration_in_template/array_dim_expr_param_B.circom
@@ -1,7 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL:.*
 
 pragma circom 2.0.0;
 
@@ -14,3 +13,37 @@ template A(s) {
 component main = A(12);
 
 // CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-NEXT:    struct.def @A<[@s]> {
+// CHECK-NEXT:      struct.field @out : !array.type<@s x !felt.type> {llzk.pub}
+// CHECK-NEXT:      function.def @compute(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !array.type<@s x !felt.type>) -> !struct.type<@A<[@s]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = struct.new : <@A<[@s]>>
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = poly.read_const @s : !felt.type
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = array.new  : <@s x !felt.type>
+// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_4]], %[[VAL_5]] : <@s x !felt.type>
+// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[VAL_9:[0-9a-zA-Z_\.]+]] = %[[VAL_7]] to %[[VAL_6]] step %[[VAL_8]] {
+// CHECK-NEXT:          array.write %[[VAL_4]]{{\[}}%[[VAL_9]]] = %[[VAL_3]] : <@s x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        struct.writef %[[VAL_1]][@out] = %[[VAL_0]] : <@A<[@s]>>, !array.type<@s x !felt.type>
+// CHECK-NEXT:        function.return %[[VAL_1]] : !struct.type<@A<[@s]>>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[VAL_10:[0-9a-zA-Z_\.]+]]: !struct.type<@A<[@s]>>, %[[VAL_11:[0-9a-zA-Z_\.]+]]: !array.type<@s x !felt.type>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %[[VAL_12:[0-9a-zA-Z_\.]+]] = poly.read_const @s : !felt.type
+// CHECK-NEXT:        %[[VAL_13:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_14:[0-9a-zA-Z_\.]+]] = array.new  : <@s x !felt.type>
+// CHECK-NEXT:        %[[VAL_15:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_16:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_14]], %[[VAL_15]] : <@s x !felt.type>
+// CHECK-NEXT:        %[[VAL_17:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_18:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        scf.for %[[VAL_19:[0-9a-zA-Z_\.]+]] = %[[VAL_17]] to %[[VAL_16]] step %[[VAL_18]] {
+// CHECK-NEXT:          array.write %[[VAL_14]]{{\[}}%[[VAL_19]]] = %[[VAL_13]] : <@s x !felt.type>, !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_20:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_10]][@out] : <@A<[@s]>>, !array.type<@s x !felt.type>
+// CHECK-NEXT:        constrain.eq %[[VAL_20]], %[[VAL_11]] : !array.type<@s x !felt.type>, !array.type<@s x !felt.type>
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/from_concrete/assign_array_from_param.circom
+++ b/circom/tests/from_concrete/assign_array_from_param.circom
@@ -1,0 +1,49 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk concrete -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
+
+pragma circom 2.0.0;
+
+template Template(m) {
+    signal output ret[2][2] <== m;
+}
+
+component main = Template([[0, 1], [2, 3]]);
+
+// CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-NEXT:    struct.def @Template<[]> {
+// CHECK-NEXT:      struct.field @ret : !array.type<2,2 x !felt.type> {llzk.pub}
+// CHECK-NEXT:      function.def @compute() -> !struct.type<@Template<[]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_0:[0-9a-zA-Z_\.]+]] = struct.new : <@Template<[]>>
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_1]], %[[VAL_2]] : <2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = felt.const  2
+// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = felt.const  3
+// CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_4]], %[[VAL_5]] : <2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = array.new  : <2,2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        array.insert %[[VAL_7]]{{\[}}%[[VAL_8]]] = %[[VAL_3]] : <2,2 x !felt.type>, <2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_9:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        array.insert %[[VAL_7]]{{\[}}%[[VAL_9]]] = %[[VAL_6]] : <2,2 x !felt.type>, <2 x !felt.type>
+// CHECK-NEXT:        struct.writef %[[VAL_0]][@ret] = %[[VAL_7]] : <@Template<[]>>, !array.type<2,2 x !felt.type>
+// CHECK-NEXT:        function.return %[[VAL_0]] : !struct.type<@Template<[]>>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[VAL_10:[0-9a-zA-Z_\.]+]]: !struct.type<@Template<[]>>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_12:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_13:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_11]], %[[VAL_12]] : <2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_14:[0-9a-zA-Z_\.]+]] = felt.const  2
+// CHECK-NEXT:        %[[VAL_15:[0-9a-zA-Z_\.]+]] = felt.const  3
+// CHECK-NEXT:        %[[VAL_16:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_14]], %[[VAL_15]] : <2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_17:[0-9a-zA-Z_\.]+]] = array.new  : <2,2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_18:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        array.insert %[[VAL_17]]{{\[}}%[[VAL_18]]] = %[[VAL_13]] : <2,2 x !felt.type>, <2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_19:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        array.insert %[[VAL_17]]{{\[}}%[[VAL_19]]] = %[[VAL_16]] : <2,2 x !felt.type>, <2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_20:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_10]][@ret] : <@Template<[]>>, !array.type<2,2 x !felt.type>
+// CHECK-NEXT:        constrain.eq %[[VAL_20]], %[[VAL_17]] : !array.type<2,2 x !felt.type>, !array.type<2,2 x !felt.type>
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/from_concrete/assign_array_from_var.circom
+++ b/circom/tests/from_concrete/assign_array_from_var.circom
@@ -1,0 +1,108 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk concrete -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
+
+pragma circom 2.0.0;
+
+template Template() {
+    var m[2][2] = [[0, 1], [2, 3]];
+    signal output ret[2][2] <== m;
+}
+
+component main = Template();
+
+// CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-NEXT:    struct.def @Template<[]> {
+// CHECK-NEXT:      struct.field @ret : !array.type<2,2 x !felt.type> {llzk.pub}
+// CHECK-NEXT:      function.def @compute() -> !struct.type<@Template<[]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_0:[0-9a-zA-Z_\.]+]] = struct.new : <@Template<[]>>
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = undef.undef : !array.type<2,2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = undef.undef : !array.type<2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_4]]
+// CHECK-NEXT:        array.write %[[VAL_2]]{{\[}}%[[VAL_5]]] = %[[VAL_3]] : <2 x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_7]]
+// CHECK-NEXT:        array.write %[[VAL_2]]{{\[}}%[[VAL_8]]] = %[[VAL_6]] : <2 x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[VAL_9:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_9]]
+// CHECK-NEXT:        array.insert %[[VAL_1]]{{\[}}%[[VAL_10]]] = %[[VAL_2]] : <2,2 x !felt.type>, <2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_12:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_11]]
+// CHECK-NEXT:        array.insert %[[VAL_1]]{{\[}}%[[VAL_12]]] = %[[VAL_2]] : <2,2 x !felt.type>, <2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_13:[0-9a-zA-Z_\.]+]] = undef.undef : !array.type<2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_14:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_15:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_16:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_15]]
+// CHECK-NEXT:        array.write %[[VAL_13]]{{\[}}%[[VAL_16]]] = %[[VAL_14]] : <2 x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[VAL_17:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_18:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_19:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_18]]
+// CHECK-NEXT:        array.write %[[VAL_13]]{{\[}}%[[VAL_19]]] = %[[VAL_17]] : <2 x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[VAL_20:[0-9a-zA-Z_\.]+]] = undef.undef : !array.type<2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_21:[0-9a-zA-Z_\.]+]] = felt.const  2
+// CHECK-NEXT:        %[[VAL_22:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_23:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_22]]
+// CHECK-NEXT:        array.write %[[VAL_20]]{{\[}}%[[VAL_23]]] = %[[VAL_21]] : <2 x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[VAL_24:[0-9a-zA-Z_\.]+]] = felt.const  3
+// CHECK-NEXT:        %[[VAL_25:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_26:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_25]]
+// CHECK-NEXT:        array.write %[[VAL_20]]{{\[}}%[[VAL_26]]] = %[[VAL_24]] : <2 x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[VAL_27:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_28:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_27]]
+// CHECK-NEXT:        array.insert %[[VAL_1]]{{\[}}%[[VAL_28]]] = %[[VAL_13]] : <2,2 x !felt.type>, <2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_29:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_30:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_29]]
+// CHECK-NEXT:        array.insert %[[VAL_1]]{{\[}}%[[VAL_30]]] = %[[VAL_20]] : <2,2 x !felt.type>, <2 x !felt.type>
+// CHECK-NEXT:        struct.writef %[[VAL_0]][@ret] = %[[VAL_1]] : <@Template<[]>>, !array.type<2,2 x !felt.type>
+// CHECK-NEXT:        function.return %[[VAL_0]] : !struct.type<@Template<[]>>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[VAL_31:[0-9a-zA-Z_\.]+]]: !struct.type<@Template<[]>>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %[[VAL_32:[0-9a-zA-Z_\.]+]] = undef.undef : !array.type<2,2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_33:[0-9a-zA-Z_\.]+]] = undef.undef : !array.type<2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_34:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_35:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_36:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_35]]
+// CHECK-NEXT:        array.write %[[VAL_33]]{{\[}}%[[VAL_36]]] = %[[VAL_34]] : <2 x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[VAL_37:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_38:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_39:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_38]]
+// CHECK-NEXT:        array.write %[[VAL_33]]{{\[}}%[[VAL_39]]] = %[[VAL_37]] : <2 x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[VAL_40:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_41:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_40]]
+// CHECK-NEXT:        array.insert %[[VAL_32]]{{\[}}%[[VAL_41]]] = %[[VAL_33]] : <2,2 x !felt.type>, <2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_42:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_43:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_42]]
+// CHECK-NEXT:        array.insert %[[VAL_32]]{{\[}}%[[VAL_43]]] = %[[VAL_33]] : <2,2 x !felt.type>, <2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_44:[0-9a-zA-Z_\.]+]] = undef.undef : !array.type<2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_45:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_46:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_47:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_46]]
+// CHECK-NEXT:        array.write %[[VAL_44]]{{\[}}%[[VAL_47]]] = %[[VAL_45]] : <2 x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[VAL_48:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_49:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_50:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_49]]
+// CHECK-NEXT:        array.write %[[VAL_44]]{{\[}}%[[VAL_50]]] = %[[VAL_48]] : <2 x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[VAL_51:[0-9a-zA-Z_\.]+]] = undef.undef : !array.type<2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_52:[0-9a-zA-Z_\.]+]] = felt.const  2
+// CHECK-NEXT:        %[[VAL_53:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_54:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_53]]
+// CHECK-NEXT:        array.write %[[VAL_51]]{{\[}}%[[VAL_54]]] = %[[VAL_52]] : <2 x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[VAL_55:[0-9a-zA-Z_\.]+]] = felt.const  3
+// CHECK-NEXT:        %[[VAL_56:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_57:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_56]]
+// CHECK-NEXT:        array.write %[[VAL_51]]{{\[}}%[[VAL_57]]] = %[[VAL_55]] : <2 x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[VAL_58:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_59:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_58]]
+// CHECK-NEXT:        array.insert %[[VAL_32]]{{\[}}%[[VAL_59]]] = %[[VAL_44]] : <2,2 x !felt.type>, <2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_60:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_61:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_60]]
+// CHECK-NEXT:        array.insert %[[VAL_32]]{{\[}}%[[VAL_61]]] = %[[VAL_51]] : <2,2 x !felt.type>, <2 x !felt.type>
+// CHECK-NEXT:        %[[VAL_62:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_31]][@ret] : <@Template<[]>>, !array.type<2,2 x !felt.type>
+// CHECK-NEXT:        constrain.eq %[[VAL_62]], %[[VAL_32]] : !array.type<2,2 x !felt.type>, !array.type<2,2 x !felt.type>
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/llzk_backend/src/template.rs
+++ b/llzk_backend/src/template.rs
@@ -32,6 +32,7 @@ use llzk::prelude::BlockRef;
 use llzk::prelude::CallOpLike as _;
 use llzk::prelude::CallOpRef;
 use llzk::prelude::FeltType;
+use llzk::prelude::FieldDefOpLike;
 use llzk::prelude::FlatSymbolRefAttribute;
 use llzk::prelude::FuncDefOpLike as _;
 use llzk::prelude::Location;
@@ -174,6 +175,16 @@ impl<'ctx, 'str, 'func, 'blk, 'val> TemplateContext<'ctx, 'str, 'func, 'blk, 'va
     /// Marks the given signal as written.
     pub fn mark_signal_as_written(&self, name: String) {
         self.written_signals.borrow_mut().insert(name);
+    }
+
+    /// Get the type of the struct field with the given name.
+    /// Errors if the field does not exist within the struct.
+    pub fn get_signal_type(&self, name: &str) -> Result<Type<'ctx>> {
+        Ok(self
+            .struct_def
+            .get_field_def(name)
+            .ok_or_else(|| anyhow!("no field '{}' in struct", name))?
+            .field_type())
     }
 
     /// Finalizes the context by emitting the final write operations that write subcomponent
@@ -977,12 +988,18 @@ where
                                 // The `<--` operator is witness generation only so code for the RHS
                                 // expression should only be generated in the compute function.
                                 let compute_only = template.compute_only();
+                                let signal_type = template.get_signal_type(var)?;
                                 let _: () = rhe
                                     .gen_llzk_in_template(codegen, &compute_only)?
                                     .and_then_same(|fc, val| {
                                         let location = codegen.location_from_meta(meta);
-                                        // Cast value to field type if needed.
-                                        let value = fc.cast_to_felt_if_needed(location, val)?;
+                                        // Cast value to signal type if needed.
+                                        let value = fc.cast_to_expected_type_if_needed(
+                                            codegen,
+                                            location,
+                                            val,
+                                            signal_type,
+                                        )?;
                                         // Write value to field of "self" struct.
                                         fc.append_op_no_result(
                                             r#struct::writef(
@@ -1002,7 +1019,7 @@ where
                                         r#struct::readf(
                                             &OpBuilder::new(codegen.context.deref()),
                                             codegen.location_from_meta(meta),
-                                            FeltType::new(codegen.context).into(),
+                                            signal_type,
                                             fc.func.self_value_of_constrain()?,
                                             var,
                                         )?
@@ -1056,11 +1073,12 @@ where
                     AssignOp::AssignConstraintSignal => {
                         match &access[..] {
                             [] => {
+                                let signal_type = template.get_signal_type(var)?;
                                 rhe.gen_llzk_in_template(codegen, template)?.and_then(
                                     |fc, val| {
                                         let location = codegen.location_from_meta(meta);
                                         // Cast value to field type if needed.
-                                        let value = fc.cast_to_felt_if_needed(location, val)?;
+                                        let value = fc.cast_to_expected_type_if_needed(codegen, location, val, signal_type)?;
                                         // Write value to field of "self" struct.
                                         fc.append_op_no_result(
                                             r#struct::writef(
@@ -1076,13 +1094,13 @@ where
                                     |fc, val| {
                                         // Read value of field from "self" struct and generate
                                         // equality constraint with 'val'.
+                                        let location = codegen.location_from_meta(meta);
                                         let builder = OpBuilder::new(codegen.context.deref());
-                                        let felt_type = FeltType::new(codegen.context).into();
                                         let val_from_read = fc.append_op_unnamed_result(
                                             r#struct::readf(
                                                 &builder,
-                                                codegen.location_from_meta(meta),
-                                                felt_type,
+                                                location,
+                                                signal_type,
                                                 fc.func.self_value_of_constrain()?,
                                                 var,
                                             )?
@@ -1090,13 +1108,13 @@ where
                                         )?;
                                         let (lhs, rhs) = unify_constrain_eq_types(
                                             fc,
-                                            codegen.location_from_meta(meta),
+                                            location,
                                             val_from_read,
                                             val,
                                         )?;
                                         fc.append_op_no_result(
                                             constrain::eq(
-                                                codegen.location_from_meta(meta),
+                                                location,
                                                 lhs,
                                                 rhs,
                                             )


### PR DESCRIPTION
Rather than casting to `felt.type`, get the field's type and use that as the expected type.