### PR TITLE
fix: several locations used `numdims` not signal `idx`

### DIFF
--- a/llzk_backend/src/function.rs
+++ b/llzk_backend/src/function.rs
@@ -442,17 +442,7 @@ where
         let template_data = codegen.find_template_data(name).ok_or_else(|| {
             anyhow::anyhow!("template with name {name:?} constructed by {subcmp_value} not found")
         })?;
-        template_data
-            .get_declaration_inputs()
-            .iter()
-            .enumerate()
-            .find_map(|(idx, (signal, _))| (subcmp_signal == signal).then_some(idx))
-            .ok_or_else(|| {
-                anyhow::anyhow!(
-                    "template '{}' has no input signal '{subcmp_signal}'",
-                    template_data.get_name()
-                )
-            })
+        template_data.get_declaration_input_idx(subcmp_signal)
     }
 
     /// Assigns the `rhe` value to the given subcomponent signal.

--- a/llzk_backend/src/template.rs
+++ b/llzk_backend/src/template.rs
@@ -1268,10 +1268,8 @@ where
                                 )?)
                             } else if template_data.get_inputs().contains_key(signal_name) {
                                 let idx = template_data
-                                    .get_declaration_inputs()
-                                    .iter()
-                                    .find_map(|(s, idx)| (signal_name == s).then_some(*idx))
-                                    .expect("signal in mapping but not in declaration list");
+                                    .get_declaration_input_idx(signal_name)
+                                    .expect("signal from mapping");
                                 let call = CallOpRef::try_from(op_result_owner(*subcmp_value)?)?;
                                 assert!(call.callee_is_struct_compute());
                                 Ok(call.operand(idx)?)
@@ -1306,10 +1304,8 @@ where
                                 )?)
                             } else if template_data.get_inputs().contains_key(signal_name) {
                                 let idx = template_data
-                                    .get_declaration_inputs()
-                                    .iter()
-                                    .find_map(|(s, idx)| (signal_name == s).then_some(*idx))
-                                    .expect("signal in mapping but not in declaration list");
+                                    .get_declaration_input_idx(signal_name)
+                                    .expect("signal from mapping");
                                 let call = get_constrain_call(*subcmp_value)?;
                                 Ok(call.operand(idx + 1)?)
                             } else {

--- a/llzk_backend/src/template_ext.rs
+++ b/llzk_backend/src/template_ext.rs
@@ -68,8 +68,18 @@ pub trait TemplateLike: std::fmt::Debug {
         &self,
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
     ) -> Result<DeclarationInfo<'ctx>>;
-    /// Returns the inputs in declaration order.
+    /// Returns the inputs in declaration order, containing name and number of dimensions.
     fn get_declaration_inputs(&'_ self) -> Cow<'_, [(String, usize)]>;
+    /// Gets the index of the input signal with the given name from `get_declaration_inputs()`.
+    fn get_declaration_input_idx(&self, signal_name: &str) -> Result<usize> {
+        self.get_declaration_inputs()
+            .iter()
+            .enumerate()
+            .find_map(|(idx, (s, _))| (signal_name == s).then_some(idx))
+            .ok_or_else(|| {
+                anyhow::anyhow!("no input signal '{signal_name}' in template '{}'", self.get_name())
+            })
+    }
     /// Returns the inputs of the template.
     fn get_inputs(&'_ self) -> Cow<'_, HashMap<String, Self::WireData>>;
     /// Returns the outputs of the template.

--- a/llzk_backend/src/write_chain.rs
+++ b/llzk_backend/src/write_chain.rs
@@ -321,11 +321,8 @@ impl<'ast> WriteChain<'ast> {
                 signal_name,
             )?)
         } else if template_data.get_inputs().contains_key(signal_name) {
-            let idx = template_data
-                .get_declaration_inputs()
-                .iter()
-                .find_map(|(s, idx)| (signal_name == s).then_some(*idx))
-                .expect("signal in mapping but not in declaration list");
+            let idx =
+                template_data.get_declaration_input_idx(signal_name).expect("signal from mapping");
             let call = CallOpRef::try_from(op_result_owner(subcmp_value)?)?;
             assert!(call.callee_is_struct_compute());
             Ok(call.operand(idx)?)
@@ -361,12 +358,8 @@ impl<'ast> WriteChain<'ast> {
                 signal_name,
             )?)
         } else if template_data.get_inputs().contains_key(signal_name) {
-            let idx = template_data
-                .get_declaration_inputs()
-                .iter()
-                .enumerate()
-                .find_map(|(idx, (s, _))| (signal_name == s).then_some(idx))
-                .expect("signal in mapping but not in declaration list");
+            let idx =
+                template_data.get_declaration_input_idx(signal_name).expect("signal from mapping");
             let call = get_constrain_call(subcmp_value)?;
             Ok(call.operand(idx + 1)?)
         } else {


### PR DESCRIPTION
Adds `get_declaration_input_idx()` to correctly get declaration index from signal name. This is done in several places but in 3 out of 5, the number of dimensions of the signal was returned instead of the index!

Unfortunately, this was not the only remaining error affecting any lit tests or benchmarks.