### PR TITLE
Fix field reads in constrain functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -807,7 +807,7 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 [[package]]
 name = "llzk"
 version = "0.1.0"
-source = "git+https://github.com/project-llzk/llzk-rs#dcfd4069d3898a957e78b6d3fa235d6bd8afc292"
+source = "git+https://github.com/project-llzk/llzk-rs#48dca086579da61b18a9ce1cb9113405480da85b"
 dependencies = [
  "llzk-macro",
  "llzk-sys",
@@ -821,7 +821,7 @@ dependencies = [
 [[package]]
 name = "llzk-macro"
 version = "0.1.0"
-source = "git+https://github.com/project-llzk/llzk-rs#dcfd4069d3898a957e78b6d3fa235d6bd8afc292"
+source = "git+https://github.com/project-llzk/llzk-rs#48dca086579da61b18a9ce1cb9113405480da85b"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -833,7 +833,7 @@ dependencies = [
 [[package]]
 name = "llzk-sys"
 version = "0.1.0"
-source = "git+https://github.com/project-llzk/llzk-rs#dcfd4069d3898a957e78b6d3fa235d6bd8afc292"
+source = "git+https://github.com/project-llzk/llzk-rs#48dca086579da61b18a9ce1cb9113405480da85b"
 dependencies = [
  "anyhow",
  "llzk-sys-build-support",
@@ -843,7 +843,7 @@ dependencies = [
 [[package]]
 name = "llzk-sys-build-support"
 version = "0.1.0"
-source = "git+https://github.com/project-llzk/llzk-rs#dcfd4069d3898a957e78b6d3fa235d6bd8afc292"
+source = "git+https://github.com/project-llzk/llzk-rs#48dca086579da61b18a9ce1cb9113405480da85b"
 dependencies = [
  "anyhow",
  "bindgen 0.71.1",

--- a/circom/tests/arrays/array_copy2_loop.circom
+++ b/circom/tests/arrays/array_copy2_loop.circom
@@ -42,20 +42,20 @@ component main = Array2(5);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_14:[0-9a-zA-Z_\.]+]]: !struct.type<@Array2<[@n]>>, %[[VAL_15:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[VAL_16:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
-// CHECK-NEXT:        %[[VAL_17:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_18:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_19:[0-9a-zA-Z_\.]+]] = %[[VAL_17]]) : (!felt.type) -> !felt.type {
-// CHECK-NEXT:          %[[VAL_20:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_19]], %[[VAL_16]])
-// CHECK-NEXT:          scf.condition(%[[VAL_20]]) %[[VAL_19]] : !felt.type
+// CHECK-NEXT:        %[[VAL_17:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_14]][@b] : <@Array2<[@n]>>, !array.type<@n x !felt.type>
+// CHECK-NEXT:        %[[VAL_18:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_19:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_20:[0-9a-zA-Z_\.]+]] = %[[VAL_18]]) : (!felt.type) -> !felt.type {
+// CHECK-NEXT:          %[[VAL_21:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_20]], %[[VAL_16]])
+// CHECK-NEXT:          scf.condition(%[[VAL_21]]) %[[VAL_20]] : !felt.type
 // CHECK-NEXT:        } do {
-// CHECK-NEXT:        ^bb0(%[[VAL_21:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:          %[[VAL_22:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_21]]
-// CHECK-NEXT:          %[[VAL_23:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_15]]{{\[}}%[[VAL_22]]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_24:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_14]][@b] : <@Array2<[@n]>>, !array.type<@n x !felt.type>
-// CHECK-NEXT:          %[[VAL_25:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_21]]
-// CHECK-NEXT:          %[[VAL_26:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_24]]{{\[}}%[[VAL_25]]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:          constrain.eq %[[VAL_26]], %[[VAL_23]] : !felt.type, !felt.type
+// CHECK-NEXT:        ^bb0(%[[VAL_22:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[VAL_23:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_22]]
+// CHECK-NEXT:          %[[VAL_24:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_15]]{{\[}}%[[VAL_23]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_25:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_22]]
+// CHECK-NEXT:          %[[VAL_26:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_17]]{{\[}}%[[VAL_25]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          constrain.eq %[[VAL_26]], %[[VAL_24]] : !felt.type, !felt.type
 // CHECK-NEXT:          %[[VAL_27:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:          %[[VAL_28:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_21]], %[[VAL_27]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[VAL_28:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_22]], %[[VAL_27]] : !felt.type, !felt.type
 // CHECK-NEXT:          scf.yield %[[VAL_28]] : !felt.type
 // CHECK-NEXT:        }
 // CHECK-NEXT:        function.return

--- a/circom/tests/arrays/array_copy3_loop.circom
+++ b/circom/tests/arrays/array_copy3_loop.circom
@@ -56,32 +56,32 @@ component main = Array3(5);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_23:[0-9a-zA-Z_\.]+]]: !struct.type<@Array3<[@n]>>, %[[VAL_24:[0-9a-zA-Z_\.]+]]: !array.type<@n,@n x !felt.type>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[VAL_25:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
-// CHECK-NEXT:        %[[VAL_26:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_27:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_28:[0-9a-zA-Z_\.]+]] = %[[VAL_26]]) : (!felt.type) -> !felt.type {
-// CHECK-NEXT:          %[[VAL_29:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_28]], %[[VAL_25]])
-// CHECK-NEXT:          scf.condition(%[[VAL_29]]) %[[VAL_28]] : !felt.type
+// CHECK-NEXT:        %[[VAL_26:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_23]][@out] : <@Array3<[@n]>>, !array.type<@n,@n x !felt.type>
+// CHECK-NEXT:        %[[VAL_27:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_28:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_29:[0-9a-zA-Z_\.]+]] = %[[VAL_27]]) : (!felt.type) -> !felt.type {
+// CHECK-NEXT:          %[[VAL_30:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_29]], %[[VAL_25]])
+// CHECK-NEXT:          scf.condition(%[[VAL_30]]) %[[VAL_29]] : !felt.type
 // CHECK-NEXT:        } do {
-// CHECK-NEXT:        ^bb0(%[[VAL_30:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:          %[[VAL_31:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:          %[[VAL_32:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_33:[0-9a-zA-Z_\.]+]] = %[[VAL_31]]) : (!felt.type) -> !felt.type {
-// CHECK-NEXT:            %[[VAL_34:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_33]], %[[VAL_25]])
-// CHECK-NEXT:            scf.condition(%[[VAL_34]]) %[[VAL_33]] : !felt.type
+// CHECK-NEXT:        ^bb0(%[[VAL_31:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[VAL_32:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:          %[[VAL_33:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_34:[0-9a-zA-Z_\.]+]] = %[[VAL_32]]) : (!felt.type) -> !felt.type {
+// CHECK-NEXT:            %[[VAL_35:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_34]], %[[VAL_25]])
+// CHECK-NEXT:            scf.condition(%[[VAL_35]]) %[[VAL_34]] : !felt.type
 // CHECK-NEXT:          } do {
-// CHECK-NEXT:          ^bb0(%[[VAL_35:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:            %[[VAL_36:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_30]]
-// CHECK-NEXT:            %[[VAL_37:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_35]]
-// CHECK-NEXT:            %[[VAL_38:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_24]]{{\[}}%[[VAL_36]], %[[VAL_37]]] : <@n,@n x !felt.type>, !felt.type
-// CHECK-NEXT:            %[[VAL_39:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_23]][@out] : <@Array3<[@n]>>, !array.type<@n,@n x !felt.type>
-// CHECK-NEXT:            %[[VAL_40:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_30]]
-// CHECK-NEXT:            %[[VAL_41:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_35]]
-// CHECK-NEXT:            %[[VAL_42:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_39]]{{\[}}%[[VAL_40]], %[[VAL_41]]] : <@n,@n x !felt.type>, !felt.type
-// CHECK-NEXT:            constrain.eq %[[VAL_42]], %[[VAL_38]] : !felt.type, !felt.type
+// CHECK-NEXT:          ^bb0(%[[VAL_36:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:            %[[VAL_37:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_31]]
+// CHECK-NEXT:            %[[VAL_38:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_36]]
+// CHECK-NEXT:            %[[VAL_39:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_24]]{{\[}}%[[VAL_37]], %[[VAL_38]]] : <@n,@n x !felt.type>, !felt.type
+// CHECK-NEXT:            %[[VAL_40:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_31]]
+// CHECK-NEXT:            %[[VAL_41:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_36]]
+// CHECK-NEXT:            %[[VAL_42:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_26]]{{\[}}%[[VAL_40]], %[[VAL_41]]] : <@n,@n x !felt.type>, !felt.type
+// CHECK-NEXT:            constrain.eq %[[VAL_42]], %[[VAL_39]] : !felt.type, !felt.type
 // CHECK-NEXT:            %[[VAL_43:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:            %[[VAL_44:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_35]], %[[VAL_43]] : !felt.type, !felt.type
+// CHECK-NEXT:            %[[VAL_44:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_36]], %[[VAL_43]] : !felt.type, !felt.type
 // CHECK-NEXT:            scf.yield %[[VAL_44]] : !felt.type
 // CHECK-NEXT:          }
 // CHECK-NEXT:          %[[VAL_45:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:          %[[VAL_46:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_30]], %[[VAL_45]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[VAL_46:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_31]], %[[VAL_45]] : !felt.type, !felt.type
 // CHECK-NEXT:          scf.yield %[[VAL_46]] : !felt.type
 // CHECK-NEXT:        }
 // CHECK-NEXT:        function.return

--- a/circom/tests/arrays/array_copy3_partial.circom
+++ b/circom/tests/arrays/array_copy3_partial.circom
@@ -43,20 +43,20 @@ component main = Array3(5);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_14:[0-9a-zA-Z_\.]+]]: !struct.type<@Array3<[@n]>>, %[[VAL_15:[0-9a-zA-Z_\.]+]]: !array.type<@n,@n x !felt.type>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[VAL_16:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
-// CHECK-NEXT:        %[[VAL_17:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_18:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_19:[0-9a-zA-Z_\.]+]] = %[[VAL_17]]) : (!felt.type) -> !felt.type {
-// CHECK-NEXT:          %[[VAL_20:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_19]], %[[VAL_16]])
-// CHECK-NEXT:          scf.condition(%[[VAL_20]]) %[[VAL_19]] : !felt.type
+// CHECK-NEXT:        %[[VAL_17:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_14]][@out] : <@Array3<[@n]>>, !array.type<@n,@n x !felt.type>
+// CHECK-NEXT:        %[[VAL_18:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_19:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_20:[0-9a-zA-Z_\.]+]] = %[[VAL_18]]) : (!felt.type) -> !felt.type {
+// CHECK-NEXT:          %[[VAL_21:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_20]], %[[VAL_16]])
+// CHECK-NEXT:          scf.condition(%[[VAL_21]]) %[[VAL_20]] : !felt.type
 // CHECK-NEXT:        } do {
-// CHECK-NEXT:        ^bb0(%[[VAL_21:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:          %[[VAL_22:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_21]]
-// CHECK-NEXT:          %[[VAL_23:[0-9a-zA-Z_\.]+]] = array.extract %[[VAL_15]]{{\[}}%[[VAL_22]]] : <@n,@n x !felt.type>
-// CHECK-NEXT:          %[[VAL_24:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_14]][@out] : <@Array3<[@n]>>, !array.type<@n,@n x !felt.type>
-// CHECK-NEXT:          %[[VAL_25:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_21]]
-// CHECK-NEXT:          %[[VAL_26:[0-9a-zA-Z_\.]+]] = array.extract %[[VAL_24]]{{\[}}%[[VAL_25]]] : <@n,@n x !felt.type>
-// CHECK-NEXT:          constrain.eq %[[VAL_26]], %[[VAL_23]] : !array.type<@n x !felt.type>, !array.type<@n x !felt.type>
+// CHECK-NEXT:        ^bb0(%[[VAL_22:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[VAL_23:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_22]]
+// CHECK-NEXT:          %[[VAL_24:[0-9a-zA-Z_\.]+]] = array.extract %[[VAL_15]]{{\[}}%[[VAL_23]]] : <@n,@n x !felt.type>
+// CHECK-NEXT:          %[[VAL_25:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_22]]
+// CHECK-NEXT:          %[[VAL_26:[0-9a-zA-Z_\.]+]] = array.extract %[[VAL_17]]{{\[}}%[[VAL_25]]] : <@n,@n x !felt.type>
+// CHECK-NEXT:          constrain.eq %[[VAL_26]], %[[VAL_24]] : !array.type<@n x !felt.type>, !array.type<@n x !felt.type>
 // CHECK-NEXT:          %[[VAL_27:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:          %[[VAL_28:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_21]], %[[VAL_27]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[VAL_28:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_22]], %[[VAL_27]] : !felt.type, !felt.type
 // CHECK-NEXT:          scf.yield %[[VAL_28]] : !felt.type
 // CHECK-NEXT:        }
 // CHECK-NEXT:        function.return

--- a/circom/tests/arrays/array_dimensions_05.circom
+++ b/circom/tests/arrays/array_dimensions_05.circom
@@ -27,10 +27,10 @@ component main = ArrayDims(7);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_4:[0-9a-zA-Z_\.]+]]: !struct.type<@ArrayDims<[@N]>>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type
-// CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_5]], %[[VAL_6]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_4]][@outp] : <@ArrayDims<[@N]>>, !array.type<#[[$ATTR_0]] x !felt.type>
+// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_5]], %[[VAL_7]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
-

--- a/circom/tests/arrays/array_extract_01.circom
+++ b/circom/tests/arrays/array_extract_01.circom
@@ -50,6 +50,7 @@ component main = A();
 // CHECK-NEXT:      }
 // CHECK-LABEL:     function.def @constrain
 // CHECK-SAME:      (%[[V_22:[0-9a-zA-Z_\.]+]]: !struct.type<@A<[]>>, %[[V_23:[0-9a-zA-Z_\.]+]]: !array.type<17,13 x !felt.type>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %{{[0-9a-zA-Z_\.]+}} = struct.readf %[[V_22]][@out] : <@A<[]>>, !felt.type
 // CHECK-NEXT:        %[[V_S0:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[V_I0:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[V_26:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_I1:[0-9a-zA-Z_\.]+]] = %[[V_I0]], %[[V_S1:[0-9a-zA-Z_\.]+]] = %[[V_S0]]) : (!felt.type, !felt.type) -> (!felt.type, !felt.type) {

--- a/circom/tests/arrays/array_insert_in_function.circom
+++ b/circom/tests/arrays/array_insert_in_function.circom
@@ -55,8 +55,8 @@ component main = Caller();
 // CHECK-NEXT:        function.return %[[VAL_21]] : !struct.type<@Caller<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_23:[0-9a-zA-Z_\.]+]]: !struct.type<@Caller<[]>>, %[[VAL_24:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:        %[[VAL_25:[0-9a-zA-Z_\.]+]] = function.call @lookup() : () -> !felt.type
-// CHECK-NEXT:        %[[VAL_26:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_23]][@out] : <@Caller<[]>>, !felt.type
+// CHECK-DAG:         %[[VAL_25:[0-9a-zA-Z_\.]+]] = function.call @lookup() : () -> !felt.type
+// CHECK-DAG:         %[[VAL_26:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_23]][@out] : <@Caller<[]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_26]], %[[VAL_25]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/arrays/array_size_mismatch_store.circom
+++ b/circom/tests/arrays/array_size_mismatch_store.circom
@@ -60,6 +60,7 @@ component main = ImplicitExtension();
 // CHECK-NEXT:        function.return %[[VAL_0]] : !struct.type<@ImplicitExtension<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_30:[0-9a-zA-Z_\.]+]]: !struct.type<@ImplicitExtension<[]>>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %{{[0-9a-zA-Z_\.]+}} = struct.readf %[[VAL_30]][@out] : <@ImplicitExtension<[]>>, !array.type<10 x !felt.type>
 // CHECK-NEXT:        %[[VAL_31:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_32:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_31]], %[[VAL_31]], %[[VAL_31]], %[[VAL_31]], %[[VAL_31]], %[[VAL_31]], %[[VAL_31]], %[[VAL_31]], %[[VAL_31]], %[[VAL_31]] : <10 x !felt.type>
 // CHECK-NEXT:        %[[VAL_33:[0-9a-zA-Z_\.]+]] = felt.const  99

--- a/circom/tests/arrays/array_write1_loop.circom
+++ b/circom/tests/arrays/array_write1_loop.circom
@@ -39,6 +39,7 @@ component main = Array1();
 // CHECK-NEXT:        function.return %[[VAL_0]] : !struct.type<@Array1<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_13:[0-9a-zA-Z_\.]+]]: !struct.type<@Array1<[]>>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %[[VAL_20:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_13]][@out] : <@Array1<[]>>, !array.type<5,1 x !felt.type>
 // CHECK-NEXT:        %[[VAL_14:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_15:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_16:[0-9a-zA-Z_\.]+]] = %[[VAL_14]]) : (!felt.type) -> !felt.type {
 // CHECK-NEXT:          %[[VAL_17:[0-9a-zA-Z_\.]+]] = felt.const  5
@@ -46,7 +47,6 @@ component main = Array1();
 // CHECK-NEXT:          scf.condition(%[[VAL_18]]) %[[VAL_16]] : !felt.type
 // CHECK-NEXT:        } do {
 // CHECK-NEXT:        ^bb0(%[[VAL_19:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:          %[[VAL_20:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_13]][@out] : <@Array1<[]>>, !array.type<5,1 x !felt.type>
 // CHECK-NEXT:          %[[VAL_21:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_19]]
 // CHECK-NEXT:          %[[VAL_22:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:          %[[VAL_23:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_22]]

--- a/circom/tests/arrays/array_write2_loop.circom
+++ b/circom/tests/arrays/array_write2_loop.circom
@@ -58,6 +58,7 @@ component main = Array1();
 // CHECK-NEXT:        function.return %[[VAL_0]] : !struct.type<@Array1<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_24:[0-9a-zA-Z_\.]+]]: !struct.type<@Array1<[]>>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %[[VAL_31:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_24]][@out] : <@Array1<[]>>, !array.type<5,2 x !felt.type>
 // CHECK-NEXT:        %[[VAL_25:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_26:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_27:[0-9a-zA-Z_\.]+]] = %[[VAL_25]]) : (!felt.type) -> !felt.type {
 // CHECK-NEXT:          %[[VAL_28:[0-9a-zA-Z_\.]+]] = felt.const  5
@@ -65,7 +66,6 @@ component main = Array1();
 // CHECK-NEXT:          scf.condition(%[[VAL_29]]) %[[VAL_27]] : !felt.type
 // CHECK-NEXT:        } do {
 // CHECK-NEXT:        ^bb0(%[[VAL_30:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:          %[[VAL_31:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_24]][@out] : <@Array1<[]>>, !array.type<5,2 x !felt.type>
 // CHECK-NEXT:          %[[VAL_32:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_30]]
 // CHECK-NEXT:          %[[VAL_33:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:          %[[VAL_34:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_33]]
@@ -82,11 +82,10 @@ component main = Array1();
 // CHECK-NEXT:          scf.condition(%[[VAL_42]]) %[[VAL_40]] : !felt.type
 // CHECK-NEXT:        } do {
 // CHECK-NEXT:        ^bb0(%[[VAL_43:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:          %[[VAL_44:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_24]][@out] : <@Array1<[]>>, !array.type<5,2 x !felt.type>
 // CHECK-NEXT:          %[[VAL_45:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_43]]
 // CHECK-NEXT:          %[[VAL_46:[0-9a-zA-Z_\.]+]] = felt.const  1
 // CHECK-NEXT:          %[[VAL_47:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_46]]
-// CHECK-NEXT:          %[[VAL_48:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_44]]{{\[}}%[[VAL_45]], %[[VAL_47]]] : <5,2 x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_48:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_31]]{{\[}}%[[VAL_45]], %[[VAL_47]]] : <5,2 x !felt.type>, !felt.type
 // CHECK-NEXT:          constrain.eq %[[VAL_48]], %[[VAL_43]] : !felt.type, !felt.type
 // CHECK-NEXT:          %[[VAL_49:[0-9a-zA-Z_\.]+]] = felt.const  1
 // CHECK-NEXT:          %[[VAL_50:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_43]], %[[VAL_49]] : !felt.type, !felt.type

--- a/circom/tests/arrays/array_write_in_function.circom
+++ b/circom/tests/arrays/array_write_in_function.circom
@@ -60,8 +60,8 @@ component main = Caller();
 // CHECK-NEXT:        function.return %[[VAL_27]] : !struct.type<@Caller<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_29:[0-9a-zA-Z_\.]+]]: !struct.type<@Caller<[]>>, %[[VAL_30:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:        %[[VAL_31:[0-9a-zA-Z_\.]+]] = function.call @compute(%[[VAL_30]]) : (!felt.type) -> !felt.type
-// CHECK-NEXT:        %[[VAL_32:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_29]][@out] : <@Caller<[]>>, !felt.type
+// CHECK-DAG:         %[[VAL_31:[0-9a-zA-Z_\.]+]] = function.call @compute(%[[VAL_30]]) : (!felt.type) -> !felt.type
+// CHECK-DAG:         %[[VAL_32:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_29]][@out] : <@Caller<[]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_32]], %[[VAL_31]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/arrays/basic_array_00.circom
+++ b/circom/tests/arrays/basic_array_00.circom
@@ -29,10 +29,10 @@ component main = Array00();
 // CHECK-NEXT:        function.return %[[VAL_1]] : !struct.type<@Array00<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_8:[0-9a-zA-Z_\.]+]]: !struct.type<@Array00<[]>>, %[[VAL_9:[0-9a-zA-Z_\.]+]]: !array.type<1 x !felt.type>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %[[VAL_13:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_8]][@b] : <@Array00<[]>>, !array.type<1 x !felt.type>
 // CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_10]]
 // CHECK-NEXT:        %[[VAL_12:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_9]]{{\[}}%[[VAL_11]]] : <1 x !felt.type>, !felt.type
-// CHECK-NEXT:        %[[VAL_13:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_8]][@b] : <@Array00<[]>>, !array.type<1 x !felt.type>
 // CHECK-NEXT:        %[[VAL_14:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_15:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_14]]
 // CHECK-NEXT:        %[[VAL_16:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_13]]{{\[}}%[[VAL_15]]] : <1 x !felt.type>, !felt.type

--- a/circom/tests/arrays/pass_and_constrain_arrays.circom
+++ b/circom/tests/arrays/pass_and_constrain_arrays.circom
@@ -370,6 +370,7 @@ component main = Main();
 // CHECK-NEXT:        function.return %[[VAL_173]] : !struct.type<@Main<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_252:[0-9a-zA-Z_\.]+]]: !struct.type<@Main<[]>>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %[[VAL_318:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_252]][@out] : <@Main<[]>>, !array.type<16,2 x !felt.type>
 // CHECK-NEXT:        %[[VAL_253:[0-9a-zA-Z_\.]+]] = undef.undef : !array.type<2 x !felt.type>
 // CHECK-NEXT:        %[[VAL_254:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_255:[0-9a-zA-Z_\.]+]] = felt.const  0
@@ -458,7 +459,6 @@ component main = Main();
 // CHECK-NEXT:          %[[VAL_315:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:          %[[VAL_316:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_315]]
 // CHECK-NEXT:          %[[VAL_317:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_307]]{{\[}}%[[VAL_314]], %[[VAL_316]]] : <16,2 x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_318:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_252]][@out] : <@Main<[]>>, !array.type<16,2 x !felt.type>
 // CHECK-NEXT:          %[[VAL_319:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_313]]
 // CHECK-NEXT:          %[[VAL_320:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:          %[[VAL_321:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_320]]
@@ -468,11 +468,10 @@ component main = Main();
 // CHECK-NEXT:          %[[VAL_324:[0-9a-zA-Z_\.]+]] = felt.const  1
 // CHECK-NEXT:          %[[VAL_325:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_324]]
 // CHECK-NEXT:          %[[VAL_326:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_307]]{{\[}}%[[VAL_323]], %[[VAL_325]]] : <16,2 x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_327:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_252]][@out] : <@Main<[]>>, !array.type<16,2 x !felt.type>
 // CHECK-NEXT:          %[[VAL_328:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_313]]
 // CHECK-NEXT:          %[[VAL_329:[0-9a-zA-Z_\.]+]] = felt.const  1
 // CHECK-NEXT:          %[[VAL_330:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_329]]
-// CHECK-NEXT:          %[[VAL_331:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_327]]{{\[}}%[[VAL_328]], %[[VAL_330]]] : <16,2 x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_331:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_318]]{{\[}}%[[VAL_328]], %[[VAL_330]]] : <16,2 x !felt.type>, !felt.type
 // CHECK-NEXT:          constrain.eq %[[VAL_331]], %[[VAL_326]] : !felt.type, !felt.type
 // CHECK-NEXT:          %[[VAL_332:[0-9a-zA-Z_\.]+]] = felt.const  1
 // CHECK-NEXT:          %[[VAL_333:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_313]], %[[VAL_332]] : !felt.type, !felt.type

--- a/circom/tests/arrays/unknown_index_load_store.circom
+++ b/circom/tests/arrays/unknown_index_load_store.circom
@@ -70,6 +70,7 @@ component main = UnknownIndexLoadStore();
 // CHECK-NEXT:        function.return %[[VAL_1]] : !struct.type<@UnknownIndexLoadStore<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_45:[0-9a-zA-Z_\.]+]]: !struct.type<@UnknownIndexLoadStore<[]>>, %[[VAL_46:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %{{[0-9a-zA-Z_\.]+}} = struct.readf %[[VAL_45]][@out] : <@UnknownIndexLoadStore<[]>>, !array.type<8 x !felt.type>
 // CHECK-NEXT:        %[[VAL_47:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_48:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_47]], %[[VAL_47]], %[[VAL_47]], %[[VAL_47]], %[[VAL_47]], %[[VAL_47]], %[[VAL_47]], %[[VAL_47]], %[[VAL_47]] : <9 x !felt.type>
 // CHECK-NEXT:        %[[VAL_49:[0-9a-zA-Z_\.]+]] = felt.const  0

--- a/circom/tests/arrays/unknown_index_overwrites_known_A.circom
+++ b/circom/tests/arrays/unknown_index_overwrites_known_A.circom
@@ -62,6 +62,7 @@ component main = UnknownIndexOverwriteKnown();
 // CHECK-NEXT:        function.return %[[VAL_1]] : !struct.type<@UnknownIndexOverwriteKnown<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_27:[0-9a-zA-Z_\.]+]]: !struct.type<@UnknownIndexOverwriteKnown<[]>>, %[[VAL_28:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %{{[0-9a-zA-Z_\.]+}} = struct.readf %[[VAL_27]][@out] : <@UnknownIndexOverwriteKnown<[]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_29:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_30:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_29]], %[[VAL_29]], %[[VAL_29]], %[[VAL_29]], %[[VAL_29]], %[[VAL_29]], %[[VAL_29]], %[[VAL_29]], %[[VAL_29]], %[[VAL_29]] : <10 x !felt.type>
 // CHECK-NEXT:        %[[VAL_31:[0-9a-zA-Z_\.]+]] = felt.const  0

--- a/circom/tests/arrays/unknown_index_overwrites_known_B.circom
+++ b/circom/tests/arrays/unknown_index_overwrites_known_B.circom
@@ -120,6 +120,7 @@ component main = UnknownIndexOverwriteKnown();
 // CHECK-NEXT:        function.return %[[VAL_1]] : !struct.type<@UnknownIndexOverwriteKnown<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_77:[0-9a-zA-Z_\.]+]]: !struct.type<@UnknownIndexOverwriteKnown<[]>>, %[[VAL_78:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %{{[0-9a-zA-Z_\.]+}} = struct.readf %[[VAL_77]][@out] : <@UnknownIndexOverwriteKnown<[]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_79:[0-9a-zA-Z_\.]+]] = felt.const  45
 // CHECK-NEXT:        %[[VAL_80:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_81:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_80]], %[[VAL_80]], %[[VAL_80]], %[[VAL_80]], %[[VAL_80]], %[[VAL_80]], %[[VAL_80]], %[[VAL_80]], %[[VAL_80]], %[[VAL_80]] : <10 x !felt.type>

--- a/circom/tests/arrays/unknown_index_store.circom
+++ b/circom/tests/arrays/unknown_index_store.circom
@@ -26,6 +26,7 @@ component main = UnknownIndexStore();
 // CHECK-NEXT:        function.return %[[VAL_1]] : !struct.type<@UnknownIndexStore<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_5:[0-9a-zA-Z_\.]+]]: !struct.type<@UnknownIndexStore<[]>>, %[[VAL_6:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %{{[0-9a-zA-Z_\.]+}} = struct.readf %[[VAL_5]][@out] : <@UnknownIndexStore<[]>>, !array.type<8 x !felt.type>
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }

--- a/circom/tests/arrays/unknown_index_unconstrained.circom
+++ b/circom/tests/arrays/unknown_index_unconstrained.circom
@@ -41,6 +41,7 @@ component main = UnknownIndex();
 // CHECK-NEXT:        function.return %[[VAL_1]] : !struct.type<@UnknownIndex<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_17:[0-9a-zA-Z_\.]+]]: !struct.type<@UnknownIndex<[]>>, %[[VAL_18:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %[[VAL_32:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_17]][@out] : <@UnknownIndex<[]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_19:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_20:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_19]], %[[VAL_19]], %[[VAL_19]], %[[VAL_19]], %[[VAL_19]], %[[VAL_19]], %[[VAL_19]], %[[VAL_19]], %[[VAL_19]], %[[VAL_19]] : <10 x !felt.type>
 // CHECK-NEXT:        %[[VAL_21:[0-9a-zA-Z_\.]+]] = felt.const  0
@@ -54,7 +55,6 @@ component main = UnknownIndex();
 // CHECK-NEXT:        %[[VAL_29:[0-9a-zA-Z_\.]+]] = felt.const  8
 // CHECK-NEXT:        %[[VAL_30:[0-9a-zA-Z_\.]+]] = felt.const  9
 // CHECK-NEXT:        %[[VAL_31:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_21]], %[[VAL_22]], %[[VAL_23]], %[[VAL_24]], %[[VAL_25]], %[[VAL_26]], %[[VAL_27]], %[[VAL_28]], %[[VAL_29]], %[[VAL_30]] : <10 x !felt.type>
-// CHECK-NEXT:        %[[VAL_32:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_17]][@out] : <@UnknownIndex<[]>>, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }

--- a/circom/tests/calls/basic_call_01.circom
+++ b/circom/tests/calls/basic_call_01.circom
@@ -38,8 +38,8 @@ component main = Call1();
 // CHECK-NEXT:      }
 // CHECK-LABEL:     function.def @constrain
 // CHECK-SAME:      (%[[V_4:[0-9a-zA-Z_\.]+]]: !struct.type<@B<[]>>, %[[V_5:[0-9a-zA-Z_\.]+]]: !felt.type, %[[V_6:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:        %[[V_7:[0-9a-zA-Z_\.]+]] = felt.mul %[[V_5]], %[[V_6]] : !felt.type, !felt.type
-// CHECK-NEXT:        %[[V_8:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_4]][@x] : <@B<[]>>, !felt.type
+// CHECK-DAG:         %[[V_7:[0-9a-zA-Z_\.]+]] = felt.mul %[[V_5]], %[[V_6]] : !felt.type, !felt.type
+// CHECK-DAG:         %[[V_8:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_4]][@x] : <@B<[]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[V_8]], %[[V_7]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
@@ -58,10 +58,10 @@ component main = Call1();
 // CHECK-NEXT:      }
 // CHECK-LABEL:     function.def @constrain
 // CHECK-SAME:      (%[[V_15:[0-9a-zA-Z_\.]+]]: !struct.type<@Call1<[]>>, %[[V_16:[0-9a-zA-Z_\.]+]]: !felt.type, %[[V_17:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %[[V_21:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_15]][@y] : <@Call1<[]>>, !felt.type
 // CHECK-NEXT:        %[[V_18:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_15]][@a] : <@Call1<[]>>, !struct.type<@B<[]>>
 // CHECK-NEXT:        function.call @B::@constrain(%[[V_18]], %[[V_16]], %[[V_17]]) : (!struct.type<@B<[]>>, !felt.type, !felt.type) -> ()
 // CHECK-NEXT:        %[[V_20:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_18]][@x] : <@B<[]>>, !felt.type
-// CHECK-NEXT:        %[[V_21:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_15]][@y] : <@Call1<[]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[V_21]], %[[V_20]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/calls/call_diff_type_per_call.circom
+++ b/circom/tests/calls/call_diff_type_per_call.circom
@@ -48,12 +48,12 @@ component main = CallDiffTypeTest();
 // CHECK-NEXT:      }
 // CHECK-LABEL:     function.def @constrain
 // CHECK-SAME:      (%[[VAL_6:[0-9a-zA-Z_\.]+]]: !struct.type<@CallDiffTypeTest<[]>>, %[[VAL_7:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_8:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:        %[[VAL_9:[0-9a-zA-Z_\.]+]] = function.call @f(%[[VAL_7]], %[[VAL_8]]) : (!felt.type, !felt.type) -> !felt.type
 // CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_6]][@out1] : <@CallDiffTypeTest<[]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_13:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_6]][@out2] : <@CallDiffTypeTest<[]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_9:[0-9a-zA-Z_\.]+]] = function.call @f(%[[VAL_7]], %[[VAL_8]]) : (!felt.type, !felt.type) -> !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_10]], %[[VAL_9]] : !felt.type, !felt.type
 // CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]] = felt.const  1
 // CHECK-NEXT:        %[[VAL_12:[0-9a-zA-Z_\.]+]] = function.call @f(%[[VAL_11]], %[[VAL_8]]) : (!felt.type, !felt.type) -> !felt.type
-// CHECK-NEXT:        %[[VAL_13:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_6]][@out2] : <@CallDiffTypeTest<[]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_13]], %[[VAL_12]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/calls/recurse_known.circom
+++ b/circom/tests/calls/recurse_known.circom
@@ -56,9 +56,9 @@ component main = FnAssign();
 // CHECK-NEXT:      }
 // CHECK-LABEL:     function.def @constrain
 // CHECK-SAME:      (%[[VAL_4:[0-9a-zA-Z_\.]+]]: !struct.type<@FnAssign<[]>>, %[[VAL_5:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_4]][@outp] : <@FnAssign<[]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = felt.const  20
 // CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = function.call @Recurse(%[[VAL_5]], %[[VAL_6]]) : (!felt.type, !felt.type) -> !felt.type
-// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_4]][@outp] : <@FnAssign<[]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_8]], %[[VAL_7]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/calls/return_intermediate.circom
+++ b/circom/tests/calls/return_intermediate.circom
@@ -42,7 +42,7 @@ component main = Foo();
 // CHECK-NEXT:        function.return %[[VAL_4]] : !struct.type<@Foo<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_15:[0-9a-zA-Z_\.]+]]: !struct.type<@Foo<[]>>, %[[VAL_16:[0-9a-zA-Z_\.]+]]: !array.type<2 x !felt.type>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:        %[[VAL_17:[0-9a-zA-Z_\.]+]] = undef.undef : !array.type<1 x !felt.type>
+// CHECK-NEXT:        %[[VAL_17:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_15]][@outp] : <@Foo<[]>>, !array.type<1 x !felt.type>
 // CHECK-NEXT:        %[[VAL_18:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_19:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_18]]
 // CHECK-NEXT:        %[[VAL_20:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_17]]{{\[}}%[[VAL_19]]] : <1 x !felt.type>, !felt.type

--- a/circom/tests/circom_doc_examples/01.circom
+++ b/circom/tests/circom_doc_examples/01.circom
@@ -26,8 +26,8 @@ component main {public [in1,in2]} = Multiplier2();
 // CHECK-NEXT:      }
 // CHECK-LABEL:     function.def @constrain
 // CHECK-SAME:      (%[[VAL_4:[0-9a-zA-Z_\.]+]]: !struct.type<@Multiplier2<[]>>, %[[VAL_5:[0-9a-zA-Z_\.]+]]: !felt.type {llzk.pub}, %[[VAL_6:[0-9a-zA-Z_\.]+]]: !felt.type {llzk.pub}) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_5]], %[[VAL_6]] : !felt.type, !felt.type
-// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_4]][@out] : <@Multiplier2<[]>>, !felt.type
+// CHECK-DAG:         %[[VAL_7:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_5]], %[[VAL_6]] : !felt.type, !felt.type
+// CHECK-DAG:         %[[VAL_8:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_4]][@out] : <@Multiplier2<[]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_8]], %[[VAL_7]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/circom_doc_examples/02.circom
+++ b/circom/tests/circom_doc_examples/02.circom
@@ -25,8 +25,8 @@ component main {public [in1,in2]} = Multiplier2();
 // CHECK-NEXT:      }
 // CHECK-LABEL:     function.def @constrain
 // CHECK-SAME:      (%[[VAL_4:[0-9a-zA-Z_\.]+]]: !struct.type<@Multiplier2<[]>>, %[[VAL_5:[0-9a-zA-Z_\.]+]]: !felt.type {llzk.pub}, %[[VAL_6:[0-9a-zA-Z_\.]+]]: !felt.type {llzk.pub}) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_5]], %[[VAL_6]] : !felt.type, !felt.type
-// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_4]][@out] : <@Multiplier2<[]>>, !felt.type
+// CHECK-DAG:         %[[VAL_7:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_5]], %[[VAL_6]] : !felt.type, !felt.type
+// CHECK-DAG:         %[[VAL_8:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_4]][@out] : <@Multiplier2<[]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_8]], %[[VAL_7]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/circom_doc_examples/06.circom
+++ b/circom/tests/circom_doc_examples/06.circom
@@ -4,7 +4,7 @@
 
 pragma circom 2.0.0;
 
-// This function calculates the number of extra bits 
+// This function calculates the number of extra bits
 // in the output to do the full sum.
 function nbits(a) {
     var n = 1;
@@ -71,9 +71,9 @@ component main = Caller();
 // CHECK-NEXT:        function.return %[[V_22]] : !struct.type<@Caller<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[V_25:[0-9a-zA-Z_\.]+]]: !struct.type<@Caller<[]>>, %[[V_26:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %[[V_29:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_25]][@out] : <@Caller<[]>>, !felt.type
 // CHECK-NEXT:        %[[V_27:[0-9a-zA-Z_\.]+]] = function.call @nbits(%[[V_26]]) : (!felt.type) -> !felt.type
 // CHECK-NEXT:        %[[V_28:[0-9a-zA-Z_\.]+]] = function.call @example(%[[V_27]]) : (!felt.type) -> !felt.type
-// CHECK-NEXT:        %[[V_29:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_25]][@out] : <@Caller<[]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[V_29]], %[[V_28]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/circom_doc_examples/07.circom
+++ b/circom/tests/circom_doc_examples/07.circom
@@ -25,8 +25,8 @@ component main {public [in1]}= A();
 // CHECK-NEXT:      }
 // CHECK-LABEL:     function.def @constrain
 // CHECK-SAME:      (%[[VAL_4:[0-9a-zA-Z_\.]+]]: !struct.type<@A<[]>>, %[[VAL_5:[0-9a-zA-Z_\.]+]]: !felt.type {llzk.pub}, %[[VAL_6:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_5]], %[[VAL_6]] : !felt.type, !felt.type
-// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_4]][@out] : <@A<[]>>, !felt.type
+// CHECK-DAG:         %[[VAL_7:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_5]], %[[VAL_6]] : !felt.type, !felt.type
+// CHECK-DAG:         %[[VAL_8:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_4]][@out] : <@A<[]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_8]], %[[VAL_7]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/circom_doc_examples/08.circom
+++ b/circom/tests/circom_doc_examples/08.circom
@@ -40,18 +40,17 @@ component main {public [in]}= IsZero();
 // CHECK-NEXT:        function.return %[[VAL_1]] : !struct.type<@IsZero<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_12:[0-9a-zA-Z_\.]+]]: !struct.type<@IsZero<[]>>, %[[VAL_13:[0-9a-zA-Z_\.]+]]: !felt.type {llzk.pub}) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %[[VAL_19:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_12]][@out] : <@IsZero<[]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_14:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_12]][@inv] : <@IsZero<[]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_15:[0-9a-zA-Z_\.]+]] = felt.neg %[[VAL_13]] : !felt.type
 // CHECK-NEXT:        %[[VAL_16:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_15]], %[[VAL_14]] : !felt.type, !felt.type
 // CHECK-NEXT:        %[[VAL_17:[0-9a-zA-Z_\.]+]] = felt.const  1
 // CHECK-NEXT:        %[[VAL_18:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_16]], %[[VAL_17]] : !felt.type, !felt.type
-// CHECK-NEXT:        %[[VAL_19:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_12]][@out] : <@IsZero<[]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_19]], %[[VAL_18]] : !felt.type, !felt.type
-// CHECK-NEXT:        %[[VAL_20:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_13]], %[[VAL_18]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[VAL_20:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_13]], %[[VAL_19]] : !felt.type, !felt.type
 // CHECK-NEXT:        %[[VAL_21:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        constrain.eq %[[VAL_20]], %[[VAL_21]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
-

--- a/circom/tests/circom_doc_examples/09.circom
+++ b/circom/tests/circom_doc_examples/09.circom
@@ -54,7 +54,7 @@ component main {public [in]}= Num2Bits(3);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_26:[0-9a-zA-Z_\.]+]]: !struct.type<@Num2Bits<[@n]>>, %[[VAL_27:[0-9a-zA-Z_\.]+]]: !felt.type {llzk.pub}) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[VAL_28:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
-// CHECK-NEXT:        %[[VAL_29:[0-9a-zA-Z_\.]+]] = undef.undef : !array.type<@n x !felt.type>
+// CHECK-NEXT:        %[[VAL_29:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_26]][@out] : <@Num2Bits<[@n]>>, !array.type<@n x !felt.type>
 // CHECK-NEXT:        %[[VAL_30:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_31:[0-9a-zA-Z_\.]+]] = felt.const  1
 // CHECK-NEXT:        %[[VAL_32:[0-9a-zA-Z_\.]+]] = felt.const  0

--- a/circom/tests/circom_doc_examples/10.circom
+++ b/circom/tests/circom_doc_examples/10.circom
@@ -42,6 +42,7 @@ component main = T14();
 // CHECK-NEXT:        function.return %[[VAL_0]] : !struct.type<@T14<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_12:[0-9a-zA-Z_\.]+]]: !struct.type<@T14<[]>>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %[[VAL_24:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_12]][@out] : <@T14<[]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_13:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_14:[0-9a-zA-Z_\.]+]] = felt.const  1
 // CHECK-NEXT:        %[[VAL_15:[0-9a-zA-Z_\.]+]] = felt.const  0
@@ -56,7 +57,6 @@ component main = T14();
 // CHECK-NEXT:          scf.yield %[[VAL_13]], %[[VAL_13]] : !felt.type, !felt.type
 // CHECK-NEXT:        }
 // CHECK-NEXT:        %[[VAL_22:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_17]]#0, %[[VAL_17]]#1 : !felt.type, !felt.type
-// CHECK-NEXT:        %[[VAL_24:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_12]][@out] : <@T14<[]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_24]], %[[VAL_22]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/circom_doc_examples/11.circom
+++ b/circom/tests/circom_doc_examples/11.circom
@@ -41,6 +41,7 @@ component main = T15();
 // CHECK-NEXT:      }
 // CHECK-LABEL:     function.def @constrain
 // CHECK-SAME:      (%[[VAL_15:[0-9a-zA-Z_\.]+]]: !struct.type<@T15<[]>>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %[[VAL_29:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_15]][@out] : <@T15<[]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_y_1:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_i_1:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_20:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_i_2:[0-9a-zA-Z_\.]+]] = %[[VAL_i_1]], %[[VAL_y_2:[0-9a-zA-Z_\.]+]] = %[[VAL_y_1]])
@@ -56,7 +57,6 @@ component main = T15();
 // CHECK-NEXT:          %[[VAL_28:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_i_3]], %[[VAL_27]] : !felt.type, !felt.type
 // CHECK-NEXT:          scf.yield %[[VAL_28]], %[[VAL_26]] : !felt.type, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_29:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_15]][@out] : <@T15<[]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_29]], %[[VAL_20]]#1 : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/circom_doc_examples/12.circom
+++ b/circom/tests/circom_doc_examples/12.circom
@@ -42,6 +42,7 @@ component main = T16();
 // CHECK-NEXT:      }
 // CHECK-LABEL:     function.def @constrain
 // CHECK-SAME:      (%[[VAL_14:[0-9a-zA-Z_\.]+]]: !struct.type<@T16<[]>>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %[[VAL_27:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_14]][@out] : <@T16<[]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_15:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_16:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_19:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_20:[0-9a-zA-Z_\.]+]] = %[[VAL_16]], %[[VAL_21:[0-9a-zA-Z_\.]+]] = %[[VAL_15]])
@@ -56,7 +57,6 @@ component main = T16();
 // CHECK-NEXT:          %[[VAL_26:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_23]], %[[VAL_23]] : !felt.type, !felt.type
 // CHECK-NEXT:          scf.yield %[[VAL_25]], %[[VAL_26]] : !felt.type, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_27:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_14]][@out] : <@T16<[]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_27]], %[[VAL_19]]#1 : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/circom_doc_examples/18.circom
+++ b/circom/tests/circom_doc_examples/18.circom
@@ -31,8 +31,8 @@ component main = B(2);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_5:[0-9a-zA-Z_\.]+]]: !struct.type<@A<[@n]>>, %[[VAL_6:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_7:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
-// CHECK-NEXT:        %[[VAL_9:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_6]], %[[VAL_7]] : !felt.type, !felt.type
 // CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_5]][@c] : <@A<[@n]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_9:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_6]], %[[VAL_7]] : !felt.type, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_10]], %[[VAL_9]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
@@ -57,6 +57,7 @@ component main = B(2);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_22:[0-9a-zA-Z_\.]+]]: !struct.type<@B<[@n]>>, %[[VAL_23:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[VAL_24:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_33:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_22]][@out] : <@B<[@n]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_25:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_22]][@temp_a] : <@B<[@n]>>, !struct.type<@A<[@n]>>
 // CHECK-NEXT:        %[[VAL_26:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_27:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_26]]
@@ -66,7 +67,6 @@ component main = B(2);
 // CHECK-NEXT:        %[[VAL_31:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_23]]{{\[}}%[[VAL_30]]] : <@n x !felt.type>, !felt.type
 // CHECK-NEXT:        function.call @A::@constrain(%[[VAL_25]], %[[VAL_28]], %[[VAL_31]]) : (!struct.type<@A<[@n]>>, !felt.type, !felt.type) -> ()
 // CHECK-NEXT:        %[[VAL_32:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_25]][@c] : <@A<[@n]>>, !felt.type
-// CHECK-NEXT:        %[[VAL_33:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_22]][@out] : <@B<[@n]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_33]], %[[VAL_32]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/circom_doc_examples/19.circom
+++ b/circom/tests/circom_doc_examples/19.circom
@@ -27,8 +27,8 @@ component main = B(2);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_5:[0-9a-zA-Z_\.]+]]: !struct.type<@A<[@n]>>, %[[VAL_6:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_7:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
-// CHECK-NEXT:        %[[VAL_9:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_6]], %[[VAL_7]] : !felt.type, !felt.type
 // CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_5]][@c] : <@A<[@n]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_9:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_6]], %[[VAL_7]] : !felt.type, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_10]], %[[VAL_9]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
@@ -53,6 +53,7 @@ component main = B(2);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_22:[0-9a-zA-Z_\.]+]]: !struct.type<@B<[@n]>>, %[[VAL_23:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[VAL_24:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_33:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_22]][@out] : <@B<[@n]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_25:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_22]][@[[TEMP]]] : <@B<[@n]>>, !struct.type<@A<[@n]>>
 // CHECK-NEXT:        %[[VAL_26:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_27:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_26]]
@@ -62,7 +63,6 @@ component main = B(2);
 // CHECK-NEXT:        %[[VAL_31:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_23]]{{\[}}%[[VAL_30]]] : <@n x !felt.type>, !felt.type
 // CHECK-NEXT:        function.call @A::@constrain(%[[VAL_25]], %[[VAL_28]], %[[VAL_31]]) : (!struct.type<@A<[@n]>>, !felt.type, !felt.type) -> ()
 // CHECK-NEXT:        %[[VAL_32:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_25]][@c] : <@A<[@n]>>, !felt.type
-// CHECK-NEXT:        %[[VAL_33:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_22]][@out] : <@B<[@n]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_33]], %[[VAL_32]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/circom_doc_examples/20.circom
+++ b/circom/tests/circom_doc_examples/20.circom
@@ -27,8 +27,8 @@ component main = B(2);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_5:[0-9a-zA-Z_\.]+]]: !struct.type<@A<[@n]>>, %[[VAL_6:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_7:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
-// CHECK-NEXT:        %[[VAL_9:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_6]], %[[VAL_7]] : !felt.type, !felt.type
 // CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_5]][@c] : <@A<[@n]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_9:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_6]], %[[VAL_7]] : !felt.type, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_10]], %[[VAL_9]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
@@ -53,6 +53,7 @@ component main = B(2);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_22:[0-9a-zA-Z_\.]+]]: !struct.type<@B<[@n]>>, %[[VAL_23:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[VAL_24:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_33:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_22]][@out] : <@B<[@n]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_25:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_22]][@[[TEMP]]] : <@B<[@n]>>, !struct.type<@A<[@n]>>
 // CHECK-NEXT:        %[[VAL_26:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_27:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_26]]
@@ -62,7 +63,6 @@ component main = B(2);
 // CHECK-NEXT:        %[[VAL_31:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_23]]{{\[}}%[[VAL_30]]] : <@n x !felt.type>, !felt.type
 // CHECK-NEXT:        function.call @A::@constrain(%[[VAL_25]], %[[VAL_28]], %[[VAL_31]]) : (!struct.type<@A<[@n]>>, !felt.type, !felt.type) -> ()
 // CHECK-NEXT:        %[[VAL_32:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_25]][@c] : <@A<[@n]>>, !felt.type
-// CHECK-NEXT:        %[[VAL_33:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_22]][@out] : <@B<[@n]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_33]], %[[VAL_32]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/circom_doc_examples/22.circom
+++ b/circom/tests/circom_doc_examples/22.circom
@@ -4,11 +4,11 @@
 
 pragma circom 2.1.0;
 
-template Ex(n, m){ 
+template Ex(n, m){
    signal input in[n];
    signal output out[m];
    var i = 0;
-   while(i < n) { 
+   while(i < n) {
       out[i] <== in[i];
       i += 1;
    }
@@ -44,6 +44,7 @@ component main = Ex(3, 3);
 // CHECK-NEXT:      function.def @constrain(%[[VAL_15:[0-9a-zA-Z_\.]+]]: !struct.type<@Ex<[@n, @m]>>, %[[VAL_16:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[VAL_17:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
 // CHECK-NEXT:        %[[VAL_18:[0-9a-zA-Z_\.]+]] = poly.read_const @m : !felt.type
+// CHECK-NEXT:          %[[VAL_26:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_15]][@out] : <@Ex<[@n, @m]>>, !array.type<@m x !felt.type>
 // CHECK-NEXT:        %[[VAL_19:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_20:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_21:[0-9a-zA-Z_\.]+]] = %[[VAL_19]]) : (!felt.type) -> !felt.type {
 // CHECK-NEXT:          %[[VAL_22:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_21]], %[[VAL_17]])
@@ -52,7 +53,6 @@ component main = Ex(3, 3);
 // CHECK-NEXT:        ^bb0(%[[VAL_23:[0-9a-zA-Z_\.]+]]: !felt.type):
 // CHECK-NEXT:          %[[VAL_24:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_23]]
 // CHECK-NEXT:          %[[VAL_25:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_16]]{{\[}}%[[VAL_24]]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_26:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_15]][@out] : <@Ex<[@n, @m]>>, !array.type<@m x !felt.type>
 // CHECK-NEXT:          %[[VAL_27:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_23]]
 // CHECK-NEXT:          %[[VAL_28:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_26]]{{\[}}%[[VAL_27]]] : <@m x !felt.type>, !felt.type
 // CHECK-NEXT:          constrain.eq %[[VAL_28]], %[[VAL_25]] : !felt.type, !felt.type

--- a/circom/tests/circom_doc_examples/25.circom
+++ b/circom/tests/circom_doc_examples/25.circom
@@ -29,9 +29,9 @@ component main = B(3);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_7:[0-9a-zA-Z_\.]+]]: !struct.type<@A<[@n]>>, %[[VAL_8:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_9:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_10:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_14:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_7]][@d] : <@A<[@n]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_12:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_8]], %[[VAL_9]] : !felt.type, !felt.type
 // CHECK-NEXT:        %[[VAL_13:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_12]], %[[VAL_10]] : !felt.type, !felt.type
-// CHECK-NEXT:        %[[VAL_14:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_7]][@d] : <@A<[@n]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_14]], %[[VAL_13]] : !felt.type, !felt.type
 // CHECK-NEXT:        %[[VAL_15:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_8]], %[[VAL_9]] : !felt.type, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_15]], %[[VAL_10]] : !felt.type, !felt.type

--- a/circom/tests/circom_doc_examples/26.circom
+++ b/circom/tests/circom_doc_examples/26.circom
@@ -39,17 +39,17 @@ component main = B(3);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_9:[0-9a-zA-Z_\.]+]]: !struct.type<@A<[@n]>>, %[[VAL_10:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
-// CHECK-NEXT:        %[[VAL_12:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_10]], %[[VAL_10]] : !felt.type, !felt.type
 // CHECK-NEXT:        %[[VAL_13:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_9]][@b] : <@A<[@n]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_16:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_9]][@c] : <@A<[@n]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_20:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_9]][@d] : <@A<[@n]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_12:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_10]], %[[VAL_10]] : !felt.type, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_13]], %[[VAL_12]] : !felt.type, !felt.type
 // CHECK-NEXT:        %[[VAL_14:[0-9a-zA-Z_\.]+]] = felt.const  2
 // CHECK-NEXT:        %[[VAL_15:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_10]], %[[VAL_14]] : !felt.type, !felt.type
-// CHECK-NEXT:        %[[VAL_16:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_9]][@c] : <@A<[@n]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_16]], %[[VAL_15]] : !felt.type, !felt.type
 // CHECK-NEXT:        %[[VAL_17:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_10]], %[[VAL_10]] : !felt.type, !felt.type
 // CHECK-NEXT:        %[[VAL_18:[0-9a-zA-Z_\.]+]] = felt.const  2
 // CHECK-NEXT:        %[[VAL_19:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_17]], %[[VAL_18]] : !felt.type, !felt.type
-// CHECK-NEXT:        %[[VAL_20:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_9]][@d] : <@A<[@n]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_20]], %[[VAL_19]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
@@ -70,11 +70,11 @@ component main = B(3);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_28:[0-9a-zA-Z_\.]+]]: !struct.type<@B<[@n]>>, %[[VAL_29:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[VAL_30:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_34:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_28]][@out1] : <@B<[@n]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_31:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_28]][@[[TEMP]]] : <@B<[@n]>>, !struct.type<@A<[@n]>>
 // CHECK-NEXT:        function.call @A::@constrain(%[[VAL_31]], %[[VAL_29]]) : (!struct.type<@A<[@n]>>, !felt.type) -> ()
 // CHECK-NEXT:        %[[VAL_32:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_31]][@b] : <@A<[@n]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_33:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_31]][@c] : <@A<[@n]>>, !felt.type
-// CHECK-NEXT:        %[[VAL_34:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_28]][@out1] : <@B<[@n]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_34]], %[[VAL_33]] : !felt.type, !felt.type
 // CHECK-NEXT:        %[[VAL_35:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_31]][@d] : <@A<[@n]>>, !felt.type
 // CHECK-NEXT:        function.return

--- a/circom/tests/circom_doc_examples/27.circom
+++ b/circom/tests/circom_doc_examples/27.circom
@@ -41,10 +41,10 @@ component main = A();
 // CHECK-NEXT:        function.return %[[VAL_1]] : !struct.type<@A<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_4:[0-9a-zA-Z_\.]+]]: !struct.type<@A<[]>>, %[[VAL_5:[0-9a-zA-Z_\.]+]]: !array.type<10 x !felt.type>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_4]][@out] : <@A<[]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_4]][@b] : <@A<[]>>, !struct.type<@Bits2Num<[10]>>
 // CHECK-NEXT:        function.call @Bits2Num::@constrain(%[[VAL_6]], %[[VAL_5]]) : (!struct.type<@Bits2Num<[10]>>, !array.type<10 x !felt.type>) -> ()
 // CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_6]][@out] : <@Bits2Num<[10]>>, !felt.type
-// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_4]][@out] : <@A<[]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_8]], %[[VAL_7]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
@@ -76,6 +76,7 @@ component main = A();
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_30:[0-9a-zA-Z_\.]+]]: !struct.type<@Bits2Num<[@n]>>, %[[VAL_31:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[VAL_32:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_51:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_30]][@out] : <@Bits2Num<[@n]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_33:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_34:[0-9a-zA-Z_\.]+]] = felt.const  1
 // CHECK-NEXT:        %[[VAL_35:[0-9a-zA-Z_\.]+]] = felt.const  0
@@ -93,7 +94,6 @@ component main = A();
 // CHECK-NEXT:          %[[VAL_50:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_42]], %[[VAL_49]] : !felt.type, !felt.type
 // CHECK-NEXT:          scf.yield %[[VAL_48]], %[[VAL_50]], %[[VAL_47]] : !felt.type, !felt.type, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_51:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_30]][@out] : <@Bits2Num<[@n]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_51]], %[[VAL_36]]#2 : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/circom_doc_examples/28.circom
+++ b/circom/tests/circom_doc_examples/28.circom
@@ -34,9 +34,9 @@ component main = Caller();
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_2:[0-9a-zA-Z_\.]+]]: !struct.type<@A<[]>>, %[[VAL_3:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_2]][@intermediate] : <@A<[]>>, !felt.type
-// CHECK-NEXT:        constrain.eq %[[VAL_4]], %[[VAL_3]] : !felt.type, !felt.type
 // CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_2]][@out] : <@A<[]>>, !felt.type
-// CHECK-NEXT:        constrain.eq %[[VAL_5]], %[[VAL_3]] : !felt.type, !felt.type
+// CHECK-NEXT:        constrain.eq %[[VAL_4]], %[[VAL_3]] : !felt.type, !felt.type
+// CHECK-NEXT:        constrain.eq %[[VAL_5]], %[[VAL_4]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }
@@ -52,10 +52,10 @@ component main = Caller();
 // CHECK-NEXT:        function.return %[[VAL_7]] : !struct.type<@Caller<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_10:[0-9a-zA-Z_\.]+]]: !struct.type<@Caller<[]>>, %[[VAL_11:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %[[VAL_14:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_10]][@out] : <@Caller<[]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_12:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_10]][@a] : <@Caller<[]>>, !struct.type<@A<[]>>
 // CHECK-NEXT:        function.call @A::@constrain(%[[VAL_12]], %[[VAL_11]]) : (!struct.type<@A<[]>>, !felt.type) -> ()
 // CHECK-NEXT:        %[[VAL_13:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_12]][@out] : <@A<[]>>, !felt.type
-// CHECK-NEXT:        %[[VAL_14:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_10]][@out] : <@Caller<[]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_14]], %[[VAL_13]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/circom_doc_examples/29.circom
+++ b/circom/tests/circom_doc_examples/29.circom
@@ -40,14 +40,14 @@ component main = IsZero();
 // CHECK-NEXT:        function.return %[[VAL_1]] : !struct.type<@IsZero<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_12:[0-9a-zA-Z_\.]+]]: !struct.type<@IsZero<[]>>, %[[VAL_13:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %[[VAL_19:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_12]][@out] : <@IsZero<[]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_14:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_12]][@inv] : <@IsZero<[]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_15:[0-9a-zA-Z_\.]+]] = felt.neg %[[VAL_13]] : !felt.type
 // CHECK-NEXT:        %[[VAL_16:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_15]], %[[VAL_14]] : !felt.type, !felt.type
 // CHECK-NEXT:        %[[VAL_17:[0-9a-zA-Z_\.]+]] = felt.const  1
 // CHECK-NEXT:        %[[VAL_18:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_16]], %[[VAL_17]] : !felt.type, !felt.type
-// CHECK-NEXT:        %[[VAL_19:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_12]][@out] : <@IsZero<[]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_19]], %[[VAL_18]] : !felt.type, !felt.type
-// CHECK-NEXT:        %[[VAL_20:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_13]], %[[VAL_18]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[VAL_20:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_13]], %[[VAL_19]] : !felt.type, !felt.type
 // CHECK-NEXT:        %[[VAL_21:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        constrain.eq %[[VAL_20]], %[[VAL_21]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return

--- a/circom/tests/circom_doc_examples/37.circom
+++ b/circom/tests/circom_doc_examples/37.circom
@@ -42,8 +42,8 @@ component main = Multiplier3();
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain
 // CHECK-SAME:      (%[[VAL_4:[0-9a-zA-Z_\.]+]]: !struct.type<@Multiplier2<[]>>, %[[VAL_5:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_6:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_5]], %[[VAL_6]] : !felt.type, !felt.type
-// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_4]][@out] : <@Multiplier2<[]>>, !felt.type
+// CHECK-DAG:         %[[VAL_7:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_5]], %[[VAL_6]] : !felt.type, !felt.type
+// CHECK-DAG:         %[[VAL_8:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_4]][@out] : <@Multiplier2<[]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_8]], %[[VAL_7]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
@@ -68,11 +68,11 @@ component main = Multiplier3();
 // CHECK-SAME:      (%[[VAL_17:[0-9a-zA-Z_\.]+]]: !struct.type<@Multiplier3<[]>>, %[[VAL_18:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_19:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_20:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-DAG:         %[[VAL_21:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_17]][@mult2] : <@Multiplier3<[]>>, !struct.type<@Multiplier2<[]>>
 // CHECK-DAG:         %[[VAL_22:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_17]][@mult1] : <@Multiplier3<[]>>, !struct.type<@Multiplier2<[]>>
+// CHECK-DAG:         %[[VAL_25:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_17]][@out] : <@Multiplier3<[]>>, !felt.type
 // CHECK-NEXT:        function.call @Multiplier2::@constrain(%[[VAL_22]], %[[VAL_18]], %[[VAL_19]]) : (!struct.type<@Multiplier2<[]>>, !felt.type, !felt.type) -> ()
 // CHECK-NEXT:        %[[VAL_23:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_22]][@out] : <@Multiplier2<[]>>, !felt.type
 // CHECK-NEXT:        function.call @Multiplier2::@constrain(%[[VAL_21]], %[[VAL_23]], %[[VAL_20]]) : (!struct.type<@Multiplier2<[]>>, !felt.type, !felt.type) -> ()
 // CHECK-NEXT:        %[[VAL_24:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_21]][@out] : <@Multiplier2<[]>>, !felt.type
-// CHECK-NEXT:        %[[VAL_25:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_17]][@out] : <@Multiplier3<[]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_25]], %[[VAL_24]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/circom_doc_examples/39A.circom
+++ b/circom/tests/circom_doc_examples/39A.circom
@@ -52,24 +52,20 @@ component main = A(3);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_11:[0-9a-zA-Z_\.]+]]: !struct.type<@A<[@n]>>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[VAL_12:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
-// CHECK-NEXT:        %[[VAL_13:[0-9a-zA-Z_\.]+]] = undef.undef : !felt.type
+// CHECK-NEXT:        %[[VAL_19:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_11]][@aux] : <@A<[@n]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_21:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_11]][@out] : <@A<[@n]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_14:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_11]][@[[B]]] : <@A<[@n]>>, !struct.type<@B<[]>>
 // CHECK-NEXT:        %[[VAL_15:[0-9a-zA-Z_\.]+]] = felt.const  2
 // CHECK-NEXT:        %[[VAL_16:[0-9a-zA-Z_\.]+]] = bool.cmp eq(%[[VAL_12]], %[[VAL_15]])
-// CHECK-NEXT:        %[[VAL_17:[0-9a-zA-Z_\.]+]]:2 = scf.if %[[VAL_16]] -> (!felt.type, !felt.type) {
+// CHECK-NEXT:        scf.if %[[VAL_16]] {
 // CHECK-NEXT:          %[[VAL_18:[0-9a-zA-Z_\.]+]] = felt.const  2
-// CHECK-NEXT:          function.call @B::@constrain(%[[VAL_14]], %[[VAL_18]]) : (!struct.type<@B<[]>>, !felt.type) -> ()
-// CHECK-NEXT:          %[[VAL_19:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_11]][@aux] : <@A<[@n]>>, !felt.type
 // CHECK-NEXT:          constrain.eq %[[VAL_19]], %[[VAL_18]] : !felt.type, !felt.type
+// CHECK-NEXT:          function.call @B::@constrain(%[[VAL_14]], %[[VAL_19]]) : (!struct.type<@B<[]>>, !felt.type) -> ()
 // CHECK-NEXT:          %[[VAL_20:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_14]][@out] : <@B<[]>>, !felt.type
-// CHECK-NEXT:          %[[VAL_21:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_11]][@out] : <@A<[@n]>>, !felt.type
 // CHECK-NEXT:          constrain.eq %[[VAL_21]], %[[VAL_20]] : !felt.type, !felt.type
-// CHECK-NEXT:          scf.yield %[[VAL_18]], %[[VAL_20]] : !felt.type, !felt.type
 // CHECK-NEXT:        } else {
 // CHECK-NEXT:          %[[VAL_22:[0-9a-zA-Z_\.]+]] = felt.const  5
-// CHECK-NEXT:          %[[VAL_23:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_11]][@out] : <@A<[@n]>>, !felt.type
-// CHECK-NEXT:          constrain.eq %[[VAL_23]], %[[VAL_22]] : !felt.type, !felt.type
-// CHECK-NEXT:          scf.yield %[[VAL_13]], %[[VAL_22]] : !felt.type, !felt.type
+// CHECK-NEXT:          constrain.eq %[[VAL_21]], %[[VAL_22]] : !felt.type, !felt.type
 // CHECK-NEXT:        }
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
@@ -84,9 +80,9 @@ component main = A(3);
 // CHECK-NEXT:        function.return %[[VAL_25]] : !struct.type<@B<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_28:[0-9a-zA-Z_\.]+]]: !struct.type<@B<[]>>, %[[VAL_29:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %[[VAL_32:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_28]][@out] : <@B<[]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_30:[0-9a-zA-Z_\.]+]] = felt.const  1
 // CHECK-NEXT:        %[[VAL_31:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_29]], %[[VAL_30]] : !felt.type, !felt.type
-// CHECK-NEXT:        %[[VAL_32:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_28]][@out] : <@B<[]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_32]], %[[VAL_31]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/circom_doc_examples/39B.circom
+++ b/circom/tests/circom_doc_examples/39B.circom
@@ -55,26 +55,22 @@ component main = A(3);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_11:[0-9a-zA-Z_\.]+]]: !struct.type<@A<[@n]>>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[VAL_12:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_18:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_11]][@aux] : <@A<[@n]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_20:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_11]][@out] : <@A<[@n]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_13:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_11]][@[[B]]] : <@A<[@n]>>, !struct.type<@B<[]>>
 // CHECK-NEXT:        %[[VAL_14:[0-9a-zA-Z_\.]+]] = felt.const  2
 // CHECK-NEXT:        %[[VAL_15:[0-9a-zA-Z_\.]+]] = bool.cmp eq(%[[VAL_12]], %[[VAL_14]])
-// CHECK-NEXT:        %[[VAL_16:[0-9a-zA-Z_\.]+]]:2 = scf.if %[[VAL_15]] -> (!felt.type, !felt.type) {
+// CHECK-NEXT:        scf.if %[[VAL_15]] {
 // CHECK-NEXT:          %[[VAL_17:[0-9a-zA-Z_\.]+]] = felt.const  2
-// CHECK-NEXT:          function.call @B::@constrain(%[[VAL_13]], %[[VAL_17]]) : (!struct.type<@B<[]>>, !felt.type) -> ()
-// CHECK-NEXT:          %[[VAL_18:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_11]][@aux] : <@A<[@n]>>, !felt.type
 // CHECK-NEXT:          constrain.eq %[[VAL_18]], %[[VAL_17]] : !felt.type, !felt.type
+// CHECK-NEXT:          function.call @B::@constrain(%[[VAL_13]], %[[VAL_18]]) : (!struct.type<@B<[]>>, !felt.type) -> ()
 // CHECK-NEXT:          %[[VAL_19:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_13]][@out] : <@B<[]>>, !felt.type
-// CHECK-NEXT:          %[[VAL_20:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_11]][@out] : <@A<[@n]>>, !felt.type
 // CHECK-NEXT:          constrain.eq %[[VAL_20]], %[[VAL_19]] : !felt.type, !felt.type
-// CHECK-NEXT:          scf.yield %[[VAL_17]], %[[VAL_19]] : !felt.type, !felt.type
 // CHECK-NEXT:        } else {
 // CHECK-NEXT:          %[[VAL_21:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:          %[[VAL_22:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_11]][@aux] : <@A<[@n]>>, !felt.type
-// CHECK-NEXT:          constrain.eq %[[VAL_22]], %[[VAL_21]] : !felt.type, !felt.type
+// CHECK-NEXT:          constrain.eq %[[VAL_18]], %[[VAL_21]] : !felt.type, !felt.type
 // CHECK-NEXT:          %[[VAL_23:[0-9a-zA-Z_\.]+]] = felt.const  5
-// CHECK-NEXT:          %[[VAL_24:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_11]][@out] : <@A<[@n]>>, !felt.type
-// CHECK-NEXT:          constrain.eq %[[VAL_24]], %[[VAL_23]] : !felt.type, !felt.type
-// CHECK-NEXT:          scf.yield %[[VAL_21]], %[[VAL_23]] : !felt.type, !felt.type
+// CHECK-NEXT:          constrain.eq %[[VAL_20]], %[[VAL_23]] : !felt.type, !felt.type
 // CHECK-NEXT:        }
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
@@ -89,9 +85,9 @@ component main = A(3);
 // CHECK-NEXT:        function.return %[[VAL_26]] : !struct.type<@B<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_29:[0-9a-zA-Z_\.]+]]: !struct.type<@B<[]>>, %[[VAL_30:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %[[VAL_33:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_29]][@out] : <@B<[]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_31:[0-9a-zA-Z_\.]+]] = felt.const  1
 // CHECK-NEXT:        %[[VAL_32:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_30]], %[[VAL_31]] : !felt.type, !felt.type
-// CHECK-NEXT:        %[[VAL_33:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_29]][@out] : <@B<[]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_33]], %[[VAL_32]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/circom_doc_examples/40A.circom
+++ b/circom/tests/circom_doc_examples/40A.circom
@@ -62,7 +62,7 @@ component main = check_bits(10);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_26:[0-9a-zA-Z_\.]+]]: !struct.type<@Num2Bits<[@n]>>, %[[VAL_27:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[VAL_28:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
-// CHECK-NEXT:        %[[VAL_29:[0-9a-zA-Z_\.]+]] = undef.undef : !array.type<@n x !felt.type>
+// CHECK-NEXT:        %[[VAL_29:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_26]][@out] : <@Num2Bits<[@n]>>, !array.type<@n x !felt.type>
 // CHECK-NEXT:        %[[VAL_30:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_31:[0-9a-zA-Z_\.]+]] = felt.const  1
 // CHECK-NEXT:        %[[VAL_32:[0-9a-zA-Z_\.]+]] = felt.const  0

--- a/circom/tests/constraints/known5.circom
+++ b/circom/tests/constraints/known5.circom
@@ -31,9 +31,9 @@ component main = A();
 // CHECK-LABEL:     function.def @constrain
 // CHECK-SAME:      (%[[VAL_4:[0-9a-zA-Z_\.]+]]: !struct.type<@A<[]>>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_4]][@valA] : <@A<[]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_4]][@valB] : <@A<[]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = felt.const  1
 // CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_5]], %[[VAL_6]] : !felt.type, !felt.type
-// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_4]][@valB] : <@A<[]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_8]], %[[VAL_7]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/constraints/with_call_scalars.circom
+++ b/circom/tests/constraints/with_call_scalars.circom
@@ -53,6 +53,7 @@ component main = ComputeFee();
 // CHECK-NEXT:        function.return %[[VAL_8]] : !struct.type<@ComputeFee<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_20:[0-9a-zA-Z_\.]+]]: !struct.type<@ComputeFee<[]>>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %[[VAL_28:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_20]][@feeOut] : <@ComputeFee<[]>>, !array.type<2 x !felt.type>
 // CHECK-NEXT:        %[[VAL_21:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_22:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_23:[0-9a-zA-Z_\.]+]] = %[[VAL_21]]) : (!felt.type) -> !felt.type {
 // CHECK-NEXT:          %[[VAL_24:[0-9a-zA-Z_\.]+]] = felt.const  2
@@ -61,7 +62,6 @@ component main = ComputeFee();
 // CHECK-NEXT:        } do {
 // CHECK-NEXT:        ^bb0(%[[VAL_26:[0-9a-zA-Z_\.]+]]: !felt.type):
 // CHECK-NEXT:          %[[VAL_27:[0-9a-zA-Z_\.]+]] = function.call @feeShiftTable(%[[VAL_26]]) : (!felt.type) -> !felt.type
-// CHECK-NEXT:          %[[VAL_28:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_20]][@feeOut] : <@ComputeFee<[]>>, !array.type<2 x !felt.type>
 // CHECK-NEXT:          %[[VAL_29:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_26]]
 // CHECK-NEXT:          %[[VAL_30:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_28]]{{\[}}%[[VAL_29]]] : <2 x !felt.type>, !felt.type
 // CHECK-NEXT:          constrain.eq %[[VAL_30]], %[[VAL_27]] : !felt.type, !felt.type

--- a/circom/tests/controlflow/branch_in_template_02.circom
+++ b/circom/tests/controlflow/branch_in_template_02.circom
@@ -39,6 +39,7 @@ component main = B();
 // CHECK-NEXT:      }
 // CHECK-LABEL:     function.def @constrain
 // CHECK-SAME:      (%[[VAL_7:[0-9a-zA-Z_\.]+]]: !struct.type<@B<[]>>, %[[VAL_8:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_9:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %{{[0-9a-zA-Z_\.]+}} = struct.readf %[[VAL_7]][@out] : <@B<[]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_12:[0-9a-zA-Z_\.]+]] = bool.cmp gt(%[[VAL_8]], %[[VAL_11]])
@@ -47,7 +48,6 @@ component main = B();
 // CHECK-NEXT:        } else {
 // CHECK-NEXT:          scf.yield %[[VAL_9]] : !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_14:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_7]][@out] : <@B<[]>>, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }

--- a/circom/tests/controlflow/early_return_if_1.circom
+++ b/circom/tests/controlflow/early_return_if_1.circom
@@ -56,9 +56,9 @@ component main = EarlyReturn();
 // CHECK-NEXT:      }
 // CHECK-LABEL:     function.def @constrain
 // CHECK-SAME:      (%[[VAL_4:[0-9a-zA-Z_\.]+]]: !struct.type<@EarlyReturn<[]>>, %[[VAL_5:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_4]][@outp] : <@EarlyReturn<[]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = function.call @earlyReturnFn(%[[VAL_5]], %[[VAL_6]]) : (!felt.type, !felt.type) -> !felt.type
-// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_4]][@outp] : <@EarlyReturn<[]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_8]], %[[VAL_7]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/controlflow/early_return_if_3.circom
+++ b/circom/tests/controlflow/early_return_if_3.circom
@@ -59,8 +59,8 @@ component main = EarlyReturn();
 // CHECK-NEXT:        function.return %[[VAL_14]] : !struct.type<@EarlyReturn<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_16:[0-9a-zA-Z_\.]+]]: !struct.type<@EarlyReturn<[]>>, %[[VAL_17:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:        %[[VAL_18:[0-9a-zA-Z_\.]+]] = function.call @earlyReturnFn(%[[VAL_17]]) : (!felt.type) -> !felt.type
-// CHECK-NEXT:        %[[VAL_19:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_16]][@outp] : <@EarlyReturn<[]>>, !felt.type
+// CHECK-DAG:         %[[VAL_18:[0-9a-zA-Z_\.]+]] = function.call @earlyReturnFn(%[[VAL_17]]) : (!felt.type) -> !felt.type
+// CHECK-DAG:         %[[VAL_19:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_16]][@outp] : <@EarlyReturn<[]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_19]], %[[VAL_18]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/controlflow/early_return_if_4.circom
+++ b/circom/tests/controlflow/early_return_if_4.circom
@@ -55,8 +55,8 @@ component main = EarlyReturn();
 // CHECK-NEXT:        function.return %[[V_13]] : !struct.type<@EarlyReturn<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[V_15:[0-9a-zA-Z_\.]+]]: !struct.type<@EarlyReturn<[]>>, %[[V_16:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:        %[[V_17:[0-9a-zA-Z_\.]+]] = function.call @earlyReturnFn(%[[V_16]]) : (!felt.type) -> !felt.type
-// CHECK-NEXT:        %[[V_18:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_15]][@outp] : <@EarlyReturn<[]>>, !felt.type
+// CHECK-DAG:         %[[V_17:[0-9a-zA-Z_\.]+]] = function.call @earlyReturnFn(%[[V_16]]) : (!felt.type) -> !felt.type
+// CHECK-DAG:         %[[V_18:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_15]][@outp] : <@EarlyReturn<[]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[V_18]], %[[V_17]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/controlflow/early_return_if_5.circom
+++ b/circom/tests/controlflow/early_return_if_5.circom
@@ -77,8 +77,8 @@ component main = EarlyReturn();
 // CHECK-NEXT:        function.return %[[VAL_23]] : !struct.type<@EarlyReturn<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_25:[0-9a-zA-Z_\.]+]]: !struct.type<@EarlyReturn<[]>>, %[[VAL_26:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:        %[[VAL_27:[0-9a-zA-Z_\.]+]] = function.call @earlyReturnFn(%[[VAL_26]]) : (!felt.type) -> !felt.type
-// CHECK-NEXT:        %[[VAL_28:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_25]][@outp] : <@EarlyReturn<[]>>, !felt.type
+// CHECK-DAG:         %[[VAL_27:[0-9a-zA-Z_\.]+]] = function.call @earlyReturnFn(%[[VAL_26]]) : (!felt.type) -> !felt.type
+// CHECK-DAG:         %[[VAL_28:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_25]][@outp] : <@EarlyReturn<[]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_28]], %[[VAL_27]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/controlflow/early_return_if_6.circom
+++ b/circom/tests/controlflow/early_return_if_6.circom
@@ -69,9 +69,9 @@ component main = EarlyReturn();
 // CHECK-NEXT:        function.return %[[V_19]] : !struct.type<@EarlyReturn<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[V_22:[0-9a-zA-Z_\.]+]]: !struct.type<@EarlyReturn<[]>>, %[[V_23:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %[[V_26:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_22]][@outp] : <@EarlyReturn<[]>>, !felt.type
 // CHECK-NEXT:        %[[V_24:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[V_25:[0-9a-zA-Z_\.]+]] = function.call @earlyReturnFn(%[[V_23]], %[[V_24]]) : (!felt.type, !felt.type) -> !felt.type
-// CHECK-NEXT:        %[[V_26:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_22]][@outp] : <@EarlyReturn<[]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[V_26]], %[[V_25]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/controlflow/early_return_loop_1.circom
+++ b/circom/tests/controlflow/early_return_loop_1.circom
@@ -142,17 +142,16 @@ component main = EarlyReturn();
 // CHECK-NEXT:        function.return %[[VAL_62]] : !struct.type<@EarlyReturn<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_70:[0-9a-zA-Z_\.]+]]: !struct.type<@EarlyReturn<[]>>, %[[VAL_71:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:        %[[VAL_72:[0-9a-zA-Z_\.]+]] = function.call @noEarlyReturnFn(%[[VAL_71]]) : (!felt.type) -> !felt.type
-// CHECK-NEXT:        %[[VAL_73:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_70]][@outp] : <@EarlyReturn<[]>>, !array.type<2 x !felt.type>
+// CHECK-DAG:         %[[VAL_72:[0-9a-zA-Z_\.]+]] = function.call @noEarlyReturnFn(%[[VAL_71]]) : (!felt.type) -> !felt.type
+// CHECK-DAG:         %[[VAL_73:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_70]][@outp] : <@EarlyReturn<[]>>, !array.type<2 x !felt.type>
 // CHECK-NEXT:        %[[VAL_74:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_75:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_74]]
 // CHECK-NEXT:        %[[VAL_76:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_73]]{{\[}}%[[VAL_75]]] : <2 x !felt.type>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_76]], %[[VAL_72]] : !felt.type, !felt.type
 // CHECK-NEXT:        %[[VAL_77:[0-9a-zA-Z_\.]+]] = function.call @earlyReturnFn(%[[VAL_71]]) : (!felt.type) -> !felt.type
-// CHECK-NEXT:        %[[VAL_78:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_70]][@outp] : <@EarlyReturn<[]>>, !array.type<2 x !felt.type>
 // CHECK-NEXT:        %[[VAL_79:[0-9a-zA-Z_\.]+]] = felt.const  1
 // CHECK-NEXT:        %[[VAL_80:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_79]]
-// CHECK-NEXT:        %[[VAL_81:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_78]]{{\[}}%[[VAL_80]]] : <2 x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[VAL_81:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_73]]{{\[}}%[[VAL_80]]] : <2 x !felt.type>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_81]], %[[VAL_77]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/controlflow/early_return_loop_2A.circom
+++ b/circom/tests/controlflow/early_return_loop_2A.circom
@@ -57,8 +57,8 @@ component main = EarlyReturn();
 // CHECK-NEXT:        function.return %[[V_20]] : !struct.type<@EarlyReturn<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[V_22:[0-9a-zA-Z_\.]+]]: !struct.type<@EarlyReturn<[]>>, %[[V_23:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:        %[[V_24:[0-9a-zA-Z_\.]+]] = function.call @earlyReturnFn(%[[V_23]]) : (!felt.type) -> !felt.type
-// CHECK-NEXT:        %[[V_25:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_22]][@outp] : <@EarlyReturn<[]>>, !felt.type
+// CHECK-DAG:         %[[V_24:[0-9a-zA-Z_\.]+]] = function.call @earlyReturnFn(%[[V_23]]) : (!felt.type) -> !felt.type
+// CHECK-DAG:         %[[V_25:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_22]][@outp] : <@EarlyReturn<[]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[V_25]], %[[V_24]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/controlflow/early_return_loop_2B.circom
+++ b/circom/tests/controlflow/early_return_loop_2B.circom
@@ -59,8 +59,8 @@ component main = EarlyReturn();
 // CHECK-NEXT:        function.return %[[V_16]] : !struct.type<@EarlyReturn<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[V_18:[0-9a-zA-Z_\.]+]]: !struct.type<@EarlyReturn<[]>>, %[[V_19:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:        %[[V_20:[0-9a-zA-Z_\.]+]] = function.call @earlyReturnFn(%[[V_19]]) : (!felt.type) -> !felt.type
-// CHECK-NEXT:        %[[V_21:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_18]][@outp] : <@EarlyReturn<[]>>, !felt.type
+// CHECK-DAG:         %[[V_20:[0-9a-zA-Z_\.]+]] = function.call @earlyReturnFn(%[[V_19]]) : (!felt.type) -> !felt.type
+// CHECK-DAG:         %[[V_21:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_18]][@outp] : <@EarlyReturn<[]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[V_21]], %[[V_20]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/controlflow/early_return_loop_3.circom
+++ b/circom/tests/controlflow/early_return_loop_3.circom
@@ -72,8 +72,8 @@ component main = EarlyReturn();
 // CHECK-NEXT:        function.return %[[V_27]] : !struct.type<@EarlyReturn<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[V_29:[0-9a-zA-Z_\.]+]]: !struct.type<@EarlyReturn<[]>>, %[[V_30:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:        %[[V_31:[0-9a-zA-Z_\.]+]] = function.call @earlyReturnFn(%[[V_30]]) : (!felt.type) -> !felt.type
-// CHECK-NEXT:        %[[V_32:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_29]][@outp] : <@EarlyReturn<[]>>, !felt.type
+// CHECK-DAG:         %[[V_31:[0-9a-zA-Z_\.]+]] = function.call @earlyReturnFn(%[[V_30]]) : (!felt.type) -> !felt.type
+// CHECK-DAG:         %[[V_32:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_29]][@outp] : <@EarlyReturn<[]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[V_32]], %[[V_31]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/controlflow/early_return_loop_4.circom
+++ b/circom/tests/controlflow/early_return_loop_4.circom
@@ -71,8 +71,8 @@ component main = EarlyReturn();
 // CHECK-NEXT:        function.return %[[V_27]] : !struct.type<@EarlyReturn<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[V_29:[0-9a-zA-Z_\.]+]]: !struct.type<@EarlyReturn<[]>>, %[[V_30:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:        %[[V_31:[0-9a-zA-Z_\.]+]] = function.call @earlyReturnFn(%[[V_30]]) : (!felt.type) -> !felt.type
-// CHECK-NEXT:        %[[V_32:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_29]][@outp] : <@EarlyReturn<[]>>, !felt.type
+// CHECK-DAG:         %[[V_31:[0-9a-zA-Z_\.]+]] = function.call @earlyReturnFn(%[[V_30]]) : (!felt.type) -> !felt.type
+// CHECK-DAG:         %[[V_32:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_29]][@outp] : <@EarlyReturn<[]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[V_32]], %[[V_31]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/controlflow/early_return_loop_5.circom
+++ b/circom/tests/controlflow/early_return_loop_5.circom
@@ -79,8 +79,8 @@ component main = EarlyReturn();
 // CHECK-NEXT:        function.return %[[V_30]] : !struct.type<@EarlyReturn<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[V_32:[0-9a-zA-Z_\.]+]]: !struct.type<@EarlyReturn<[]>>, %[[V_33:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:        %[[V_34:[0-9a-zA-Z_\.]+]] = function.call @earlyReturnFn(%[[V_33]]) : (!felt.type) -> !felt.type
-// CHECK-NEXT:        %[[V_35:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_32]][@outp] : <@EarlyReturn<[]>>, !felt.type
+// CHECK-DAG:         %[[V_34:[0-9a-zA-Z_\.]+]] = function.call @earlyReturnFn(%[[V_33]]) : (!felt.type) -> !felt.type
+// CHECK-DAG:         %[[V_35:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_32]][@outp] : <@EarlyReturn<[]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[V_35]], %[[V_34]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/controlflow/loop_multi_iv.circom
+++ b/circom/tests/controlflow/loop_multi_iv.circom
@@ -50,8 +50,8 @@ component main = LoopMultiIV();
 // CHECK-NEXT:        function.return %[[VAL_20]] : !struct.type<@LoopMultiIV<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_22:[0-9a-zA-Z_\.]+]]: !struct.type<@LoopMultiIV<[]>>, %[[VAL_23:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:        %[[VAL_24:[0-9a-zA-Z_\.]+]] = function.call @complicatedLoopFn(%[[VAL_23]]) : (!felt.type) -> !felt.type
-// CHECK-NEXT:        %[[VAL_25:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_22]][@outp] : <@LoopMultiIV<[]>>, !felt.type
+// CHECK-DAG:         %[[VAL_24:[0-9a-zA-Z_\.]+]] = function.call @complicatedLoopFn(%[[VAL_23]]) : (!felt.type) -> !felt.type
+// CHECK-DAG:         %[[VAL_25:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_22]][@outp] : <@LoopMultiIV<[]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_25]], %[[VAL_24]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/declaration_in_template/array_dim_expr_number.circom
+++ b/circom/tests/declaration_in_template/array_dim_expr_number.circom
@@ -32,6 +32,7 @@ component main = A();
 // CHECK-NEXT:        function.return %[[VAL_1]] : !struct.type<@A<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_9:[0-9a-zA-Z_\.]+]]: !struct.type<@A<[]>>, %[[VAL_10:[0-9a-zA-Z_\.]+]]: !array.type<5 x !felt.type>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %[[VAL_18:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_9]][@out] : <@A<[]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_12:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_11]], %[[VAL_11]], %[[VAL_11]], %[[VAL_11]], %[[VAL_11]] : <5 x !felt.type>
 // CHECK-NEXT:        %[[VAL_13:[0-9a-zA-Z_\.]+]] = felt.const  0
@@ -39,7 +40,6 @@ component main = A();
 // CHECK-NEXT:        %[[VAL_15:[0-9a-zA-Z_\.]+]] = felt.const  3
 // CHECK-NEXT:        %[[VAL_16:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_15]]
 // CHECK-NEXT:        %[[VAL_17:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_10]]{{\[}}%[[VAL_16]]] : <5 x !felt.type>, !felt.type
-// CHECK-NEXT:        %[[VAL_18:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_9]][@out] : <@A<[]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_18]], %[[VAL_17]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/declaration_in_template/array_dim_expr_param_B.circom
+++ b/circom/tests/declaration_in_template/array_dim_expr_param_B.circom
@@ -32,6 +32,7 @@ component main = A(12);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_10:[0-9a-zA-Z_\.]+]]: !struct.type<@A<[@s]>>, %[[VAL_11:[0-9a-zA-Z_\.]+]]: !array.type<@s x !felt.type>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[VAL_12:[0-9a-zA-Z_\.]+]] = poly.read_const @s : !felt.type
+// CHECK-NEXT:        %[[VAL_20:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_10]][@out] : <@A<[@s]>>, !array.type<@s x !felt.type>
 // CHECK-NEXT:        %[[VAL_13:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_14:[0-9a-zA-Z_\.]+]] = array.new  : <@s x !felt.type>
 // CHECK-NEXT:        %[[VAL_15:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
@@ -41,7 +42,6 @@ component main = A(12);
 // CHECK-NEXT:        scf.for %[[VAL_19:[0-9a-zA-Z_\.]+]] = %[[VAL_17]] to %[[VAL_16]] step %[[VAL_18]] {
 // CHECK-NEXT:          array.write %[[VAL_14]]{{\[}}%[[VAL_19]]] = %[[VAL_13]] : <@s x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_20:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_10]][@out] : <@A<[@s]>>, !array.type<@s x !felt.type>
 // CHECK-NEXT:        constrain.eq %[[VAL_20]], %[[VAL_11]] : !array.type<@s x !felt.type>, !array.type<@s x !felt.type>
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/from_concrete/assign_array_from_param.circom
+++ b/circom/tests/from_concrete/assign_array_from_param.circom
@@ -30,6 +30,7 @@ component main = Template([[0, 1], [2, 3]]);
 // CHECK-NEXT:        function.return %[[VAL_0]] : !struct.type<@Template<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_10:[0-9a-zA-Z_\.]+]]: !struct.type<@Template<[]>>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %[[VAL_20:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_10]][@ret] : <@Template<[]>>, !array.type<2,2 x !felt.type>
 // CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_12:[0-9a-zA-Z_\.]+]] = felt.const  1
 // CHECK-NEXT:        %[[VAL_13:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_11]], %[[VAL_12]] : <2 x !felt.type>
@@ -41,7 +42,6 @@ component main = Template([[0, 1], [2, 3]]);
 // CHECK-NEXT:        array.insert %[[VAL_17]]{{\[}}%[[VAL_18]]] = %[[VAL_13]] : <2,2 x !felt.type>, <2 x !felt.type>
 // CHECK-NEXT:        %[[VAL_19:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
 // CHECK-NEXT:        array.insert %[[VAL_17]]{{\[}}%[[VAL_19]]] = %[[VAL_16]] : <2,2 x !felt.type>, <2 x !felt.type>
-// CHECK-NEXT:        %[[VAL_20:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_10]][@ret] : <@Template<[]>>, !array.type<2,2 x !felt.type>
 // CHECK-NEXT:        constrain.eq %[[VAL_20]], %[[VAL_17]] : !array.type<2,2 x !felt.type>, !array.type<2,2 x !felt.type>
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/from_concrete/assign_array_from_var.circom
+++ b/circom/tests/from_concrete/assign_array_from_var.circom
@@ -60,6 +60,7 @@ component main = Template();
 // CHECK-NEXT:        function.return %[[VAL_0]] : !struct.type<@Template<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_31:[0-9a-zA-Z_\.]+]]: !struct.type<@Template<[]>>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %[[VAL_62:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_31]][@ret] : <@Template<[]>>, !array.type<2,2 x !felt.type>
 // CHECK-NEXT:        %[[VAL_32:[0-9a-zA-Z_\.]+]] = undef.undef : !array.type<2,2 x !felt.type>
 // CHECK-NEXT:        %[[VAL_33:[0-9a-zA-Z_\.]+]] = undef.undef : !array.type<2 x !felt.type>
 // CHECK-NEXT:        %[[VAL_34:[0-9a-zA-Z_\.]+]] = felt.const  0
@@ -100,7 +101,6 @@ component main = Template();
 // CHECK-NEXT:        %[[VAL_60:[0-9a-zA-Z_\.]+]] = felt.const  1
 // CHECK-NEXT:        %[[VAL_61:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_60]]
 // CHECK-NEXT:        array.insert %[[VAL_32]]{{\[}}%[[VAL_61]]] = %[[VAL_51]] : <2,2 x !felt.type>, <2 x !felt.type>
-// CHECK-NEXT:        %[[VAL_62:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_31]][@ret] : <@Template<[]>>, !array.type<2,2 x !felt.type>
 // CHECK-NEXT:        constrain.eq %[[VAL_62]], %[[VAL_32]] : !array.type<2,2 x !felt.type>, !array.type<2,2 x !felt.type>
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/from_concrete/call_and_return.circom
+++ b/circom/tests/from_concrete/call_and_return.circom
@@ -44,8 +44,8 @@ component main = C();
 // CHECK-NEXT:        function.return %[[VAL_7]] : !struct.type<@C<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_10:[0-9a-zA-Z_\.]+]]: !struct.type<@C<[]>>, %[[VAL_11:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:        %[[VAL_12:[0-9a-zA-Z_\.]+]] = felt.const  12
-// CHECK-NEXT:        %[[VAL_13:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_10]][@out] : <@C<[]>>, !felt.type
+// CHECK-DAG:         %[[VAL_12:[0-9a-zA-Z_\.]+]] = felt.const  12
+// CHECK-DAG:         %[[VAL_13:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_10]][@out] : <@C<[]>>, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }

--- a/circom/tests/from_concrete/fib_input.circom
+++ b/circom/tests/from_concrete/fib_input.circom
@@ -67,37 +67,34 @@ component main = Fibonacci();
 // CHECK-NEXT:        function.return %[[VAL_1]] : !struct.type<@Fibonacci<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_28:[0-9a-zA-Z_\.]+]]: !struct.type<@Fibonacci<[]>>, %[[VAL_29:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:        %[[VAL_30:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_31:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:        %[[VAL_32:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_33:[0-9a-zA-Z_\.]+]]:4 = scf.while (%[[VAL_34:[0-9a-zA-Z_\.]+]] = %[[VAL_30]], %[[VAL_35:[0-9a-zA-Z_\.]+]] = %[[VAL_31]], %[[VAL_36:[0-9a-zA-Z_\.]+]] = %[[VAL_29]], %[[VAL_37:[0-9a-zA-Z_\.]+]] = %[[VAL_32]]) : (!felt.type, !felt.type, !felt.type, !felt.type) -> (!felt.type, !felt.type, !felt.type, !felt.type) {
-// CHECK-NEXT:          %[[VAL_38:[0-9a-zA-Z_\.]+]] = felt.const  2
-// CHECK-NEXT:          %[[VAL_39:[0-9a-zA-Z_\.]+]] = bool.cmp gt(%[[VAL_36]], %[[VAL_38]])
-// CHECK-NEXT:          scf.condition(%[[VAL_39]]) %[[VAL_34]], %[[VAL_35]], %[[VAL_36]], %[[VAL_37]] : !felt.type, !felt.type, !felt.type, !felt.type
+// CHECK-NEXT:        %[[VAL_30:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_28]][@out] : <@Fibonacci<[]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_31:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_32:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_33:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_34:[0-9a-zA-Z_\.]+]]:4 = scf.while (%[[VAL_35:[0-9a-zA-Z_\.]+]] = %[[VAL_31]], %[[VAL_36:[0-9a-zA-Z_\.]+]] = %[[VAL_32]], %[[VAL_37:[0-9a-zA-Z_\.]+]] = %[[VAL_29]], %[[VAL_38:[0-9a-zA-Z_\.]+]] = %[[VAL_33]]) : (!felt.type, !felt.type, !felt.type, !felt.type) -> (!felt.type, !felt.type, !felt.type, !felt.type) {
+// CHECK-NEXT:          %[[VAL_39:[0-9a-zA-Z_\.]+]] = felt.const  2
+// CHECK-NEXT:          %[[VAL_40:[0-9a-zA-Z_\.]+]] = bool.cmp gt(%[[VAL_37]], %[[VAL_39]])
+// CHECK-NEXT:          scf.condition(%[[VAL_40]]) %[[VAL_35]], %[[VAL_36]], %[[VAL_37]], %[[VAL_38]] : !felt.type, !felt.type, !felt.type, !felt.type
 // CHECK-NEXT:        } do {
-// CHECK-NEXT:        ^bb0(%[[VAL_40:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_41:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_42:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_43:[0-9a-zA-Z_\.]+]]: !felt.type):
-// CHECK-NEXT:          %[[VAL_44:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_40]], %[[VAL_41]] : !felt.type, !felt.type
-// CHECK-NEXT:          %[[VAL_45:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:          %[[VAL_46:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_42]], %[[VAL_45]] : !felt.type, !felt.type
-// CHECK-NEXT:          scf.yield %[[VAL_41]], %[[VAL_44]], %[[VAL_46]], %[[VAL_44]] : !felt.type, !felt.type, !felt.type, !felt.type
+// CHECK-NEXT:        ^bb0(%[[VAL_41:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_42:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_43:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_44:[0-9a-zA-Z_\.]+]]: !felt.type):
+// CHECK-NEXT:          %[[VAL_45:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_41]], %[[VAL_42]] : !felt.type, !felt.type
+// CHECK-NEXT:          %[[VAL_46:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_47:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_43]], %[[VAL_46]] : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_42]], %[[VAL_45]], %[[VAL_47]], %[[VAL_45]] : !felt.type, !felt.type, !felt.type, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_47:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:        %[[VAL_48:[0-9a-zA-Z_\.]+]] = bool.cmp eq(%[[VAL_29]], %[[VAL_47]])
-// CHECK-NEXT:        %[[VAL_49:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_48]] -> (!felt.type) {
-// CHECK-NEXT:          %[[VAL_50:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:          scf.yield %[[VAL_50]] : !felt.type
-// CHECK-NEXT:        } else {
-// CHECK-NEXT:          %[[VAL_51:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_33]]#0, %[[VAL_33]]#1 : !felt.type, !felt.type
+// CHECK-NEXT:        %[[VAL_48:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:        %[[VAL_49:[0-9a-zA-Z_\.]+]] = bool.cmp eq(%[[VAL_29]], %[[VAL_48]])
+// CHECK-NEXT:        %[[VAL_50:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_49]] -> (!felt.type) {
+// CHECK-NEXT:          %[[VAL_51:[0-9a-zA-Z_\.]+]] = felt.const  1
 // CHECK-NEXT:          scf.yield %[[VAL_51]] : !felt.type
-// CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_52:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_53:[0-9a-zA-Z_\.]+]] = bool.cmp eq(%[[VAL_29]], %[[VAL_52]])
-// CHECK-NEXT:        %[[VAL_54:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_53]] -> (!felt.type) {
-// CHECK-NEXT:          %[[VAL_55:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_28]][@out] : <@Fibonacci<[]>>, !felt.type
-// CHECK-NEXT:          scf.yield %[[VAL_55]] : !felt.type
 // CHECK-NEXT:        } else {
-// CHECK-NEXT:          %[[VAL_56:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_28]][@out] : <@Fibonacci<[]>>, !felt.type
-// CHECK-NEXT:          scf.yield %[[VAL_56]] : !felt.type
+// CHECK-NEXT:          %[[VAL_52:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_34]]#0, %[[VAL_34]]#1 : !felt.type, !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_52]] : !felt.type
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_53:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_54:[0-9a-zA-Z_\.]+]] = bool.cmp eq(%[[VAL_29]], %[[VAL_53]])
+// CHECK-NEXT:        scf.if %[[VAL_54]] {
+// CHECK-NEXT:        } else {
 // CHECK-NEXT:        }
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/from_concrete/inner_conditional_03.circom
+++ b/circom/tests/from_concrete/inner_conditional_03.circom
@@ -53,6 +53,7 @@ component main = InnerConditional3(3);
 // CHECK-NEXT:        function.return %[[SELF]] : !struct.type<@InnerConditional3<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[SELF:[0-9a-zA-Z_\.]+]]: !struct.type<@InnerConditional3<[]>>, %[[V_19:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %[[V_36:[0-9a-zA-Z_\.]+]] = struct.readf %[[SELF]][@out] : <@InnerConditional3<[]>>, !felt.type
 // CHECK-NEXT:        %[[V_N:[0-9a-zA-Z_\.]+]] = felt.const  3
 // CHECK-NEXT:        %[[V_A0:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[V_I0:[0-9a-zA-Z_\.]+]] = felt.const  1
@@ -75,7 +76,6 @@ component main = InnerConditional3(3);
 // CHECK-NEXT:          %[[V_35:[0-9a-zA-Z_\.]+]] = felt.add %[[V_I2]], %[[V_34]] : !felt.type, !felt.type
 // CHECK-NEXT:          scf.yield %[[V_31]], %[[V_35]] : !felt.type, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[V_36:[0-9a-zA-Z_\.]+]] = struct.readf %[[SELF]][@out] : <@InnerConditional3<[]>>, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }

--- a/circom/tests/loops/confusing_merge.circom
+++ b/circom/tests/loops/confusing_merge.circom
@@ -67,7 +67,8 @@ component main = Foo(3);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_25:[0-9a-zA-Z_\.]+]]: !struct.type<@Foo<[@N]>>, %[[VAL_26:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[VAL_27:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type
-// CHECK-NEXT:        %[[VAL_28:[0-9a-zA-Z_\.]+]] = undef.undef : !array.type<@N x !felt.type>
+// CHECK-NEXT:        %[[VAL_OUTP:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_25]][@outp] : <@Foo<[@N]>>, !array.type<@N x !felt.type>
+// CHECK-NEXT:        %[[VAL_36:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_25]][@internal] : <@Foo<[@N]>>, !array.type<@N x !felt.type>
 // CHECK-NEXT:        %[[VAL_29:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_30:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_31:[0-9a-zA-Z_\.]+]] = %[[VAL_29]]) : (!felt.type) -> !felt.type {
 // CHECK-NEXT:          %[[VAL_32:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_31]], %[[VAL_27]])
@@ -76,7 +77,6 @@ component main = Foo(3);
 // CHECK-NEXT:        ^bb0(%[[VAL_33:[0-9a-zA-Z_\.]+]]: !felt.type):
 // CHECK-NEXT:          %[[VAL_34:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_33]]
 // CHECK-NEXT:          %[[VAL_35:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_26]]{{\[}}%[[VAL_34]]] : <@N x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_36:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_25]][@internal] : <@Foo<[@N]>>, !array.type<@N x !felt.type>
 // CHECK-NEXT:          %[[VAL_37:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_33]]
 // CHECK-NEXT:          %[[VAL_38:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_36]]{{\[}}%[[VAL_37]]] : <@N x !felt.type>, !felt.type
 // CHECK-NEXT:          constrain.eq %[[VAL_38]], %[[VAL_35]] : !felt.type, !felt.type
@@ -91,10 +91,9 @@ component main = Foo(3);
 // CHECK-NEXT:        } do {
 // CHECK-NEXT:        ^bb0(%[[VAL_45:[0-9a-zA-Z_\.]+]]: !felt.type):
 // CHECK-NEXT:          %[[VAL_46:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_45]]
-// CHECK-NEXT:          %[[VAL_47:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_28]]{{\[}}%[[VAL_46]]] : <@N x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_48:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_25]][@outp] : <@Foo<[@N]>>, !array.type<@N x !felt.type>
+// CHECK-NEXT:          %[[VAL_47:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_36]]{{\[}}%[[VAL_46]]] : <@N x !felt.type>, !felt.type
 // CHECK-NEXT:          %[[VAL_49:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_45]]
-// CHECK-NEXT:          %[[VAL_50:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_48]]{{\[}}%[[VAL_49]]] : <@N x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_50:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_OUTP]]{{\[}}%[[VAL_49]]] : <@N x !felt.type>, !felt.type
 // CHECK-NEXT:          constrain.eq %[[VAL_50]], %[[VAL_47]] : !felt.type, !felt.type
 // CHECK-NEXT:          %[[VAL_51:[0-9a-zA-Z_\.]+]] = felt.const  1
 // CHECK-NEXT:          %[[VAL_52:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_45]], %[[VAL_51]] : !felt.type, !felt.type

--- a/circom/tests/loops/fib_input.circom
+++ b/circom/tests/loops/fib_input.circom
@@ -65,11 +65,12 @@ component main = Fibonacci();
 // CHECK-NEXT:        struct.writef %[[VAL_1]][@out] = %[[VAL_21]] : <@Fibonacci<[]>>, !felt.type
 // CHECK-NEXT:        function.return %[[VAL_1]] : !struct.type<@Fibonacci<[]>>
 // CHECK-NEXT:      }
-// CHECK-NEXT:      function.def @constrain(%[[VAL_29:[0-9a-zA-Z_\.]+]]: !struct.type<@Fibonacci<[]>>, %[[VAL_30:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:      function.def @constrain(%[[VAL_28:[0-9a-zA-Z_\.]+]]: !struct.type<@Fibonacci<[]>>, %[[VAL_29:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %[[VAL_30:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_28]][@out] : <@Fibonacci<[]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_31:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_32:[0-9a-zA-Z_\.]+]] = felt.const  1
 // CHECK-NEXT:        %[[VAL_33:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_34:[0-9a-zA-Z_\.]+]]:4 = scf.while (%[[VAL_35:[0-9a-zA-Z_\.]+]] = %[[VAL_31]], %[[VAL_36:[0-9a-zA-Z_\.]+]] = %[[VAL_32]], %[[VAL_37:[0-9a-zA-Z_\.]+]] = %[[VAL_30]], %[[VAL_38:[0-9a-zA-Z_\.]+]] = %[[VAL_33]]) : (!felt.type, !felt.type, !felt.type, !felt.type) -> (!felt.type, !felt.type, !felt.type, !felt.type) {
+// CHECK-NEXT:        %[[VAL_34:[0-9a-zA-Z_\.]+]]:4 = scf.while (%[[VAL_35:[0-9a-zA-Z_\.]+]] = %[[VAL_31]], %[[VAL_36:[0-9a-zA-Z_\.]+]] = %[[VAL_32]], %[[VAL_37:[0-9a-zA-Z_\.]+]] = %[[VAL_29]], %[[VAL_38:[0-9a-zA-Z_\.]+]] = %[[VAL_33]]) : (!felt.type, !felt.type, !felt.type, !felt.type) -> (!felt.type, !felt.type, !felt.type, !felt.type) {
 // CHECK-NEXT:          %[[VAL_39:[0-9a-zA-Z_\.]+]] = felt.const  2
 // CHECK-NEXT:          %[[VAL_40:[0-9a-zA-Z_\.]+]] = bool.cmp gt(%[[VAL_37]], %[[VAL_39]])
 // CHECK-NEXT:          scf.condition(%[[VAL_40]]) %[[VAL_35]], %[[VAL_36]], %[[VAL_37]], %[[VAL_38]] : !felt.type, !felt.type, !felt.type, !felt.type
@@ -80,7 +81,6 @@ component main = Fibonacci();
 // CHECK-NEXT:          %[[VAL_47:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_43]], %[[VAL_46]] : !felt.type, !felt.type
 // CHECK-NEXT:          scf.yield %[[VAL_42]], %[[VAL_45]], %[[VAL_47]], %[[VAL_45]] : !felt.type, !felt.type, !felt.type, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_48:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_29]][@out] : <@Fibonacci<[]>>, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }

--- a/circom/tests/loops/fib_template.circom
+++ b/circom/tests/loops/fib_template.circom
@@ -77,6 +77,7 @@ component main = FibonacciTmpl(5);
 // CHECK-LABEL:     function.def @constrain
 // CHECK-SAME:      (%[[SELF:[0-9a-zA-Z_\.]+]]: !struct.type<@FibonacciTmpl<[@N]>>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[V_N:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type
+// CHECK-NEXT:        %{{[0-9a-zA-Z_\.]+}} = struct.readf %[[SELF]][@out] : <@FibonacciTmpl<[@N]>>, !felt.type
 // CHECK-NEXT:        %[[V_A0:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[V_B0:[0-9a-zA-Z_\.]+]] = felt.const  1
 // CHECK-NEXT:        %[[V_X0:[0-9a-zA-Z_\.]+]] = felt.const  0
@@ -93,20 +94,13 @@ component main = FibonacciTmpl(5);
 // CHECK-NEXT:        }
 // CHECK-NEXT:        %[[V_47:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[V_48:[0-9a-zA-Z_\.]+]] = bool.cmp eq(%[[V_N]], %[[V_47]])
-// CHECK-NEXT:        %[[V_49:[0-9a-zA-Z_\.]+]] = scf.if %[[V_48]] -> (!felt.type) {
-// CHECK-NEXT:          %[[V_50:[0-9a-zA-Z_\.]+]] = struct.readf %[[SELF]][@out] : <@FibonacciTmpl<[@N]>>, !felt.type
-// CHECK-NEXT:          scf.yield %[[V_50]] : !felt.type
+// CHECK-NEXT:        scf.if %[[V_48]] {
 // CHECK-NEXT:        } else {
 // CHECK-NEXT:          %[[V_51:[0-9a-zA-Z_\.]+]] = felt.const  1
 // CHECK-NEXT:          %[[V_52:[0-9a-zA-Z_\.]+]] = bool.cmp eq(%[[V_N]], %[[V_51]])
-// CHECK-NEXT:          %[[V_53:[0-9a-zA-Z_\.]+]] = scf.if %[[V_52]] -> (!felt.type) {
-// CHECK-NEXT:            %[[V_54:[0-9a-zA-Z_\.]+]] = struct.readf %[[SELF]][@out] : <@FibonacciTmpl<[@N]>>, !felt.type
-// CHECK-NEXT:            scf.yield %[[V_54]] : !felt.type
+// CHECK-NEXT:          scf.if %[[V_52]] {
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[V_55:[0-9a-zA-Z_\.]+]] = struct.readf %[[SELF]][@out] : <@FibonacciTmpl<[@N]>>, !felt.type
-// CHECK-NEXT:            scf.yield %[[V_55]] : !felt.type
 // CHECK-NEXT:          }
-// CHECK-NEXT:          scf.yield %[[V_53]] : !felt.type
 // CHECK-NEXT:        }
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/loops/fixed_idx_nested_lhs.circom
+++ b/circom/tests/loops/fixed_idx_nested_lhs.circom
@@ -53,6 +53,7 @@ component main = FixIdxNested();
 // CHECK-NEXT:        function.return %[[VAL_0]] : !struct.type<@FixIdxNested<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_27:[0-9a-zA-Z_\.]+]]: !struct.type<@FixIdxNested<[]>>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %{{[0-9a-zA-Z_\.]+}} = struct.readf %[[VAL_27]][@out] : <@FixIdxNested<[]>>, !array.type<9 x !felt.type>
 // CHECK-NEXT:        %[[VAL_28:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_29:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_28]], %[[VAL_28]], %[[VAL_28]], %[[VAL_28]], %[[VAL_28]], %[[VAL_28]], %[[VAL_28]], %[[VAL_28]], %[[VAL_28]] : <9 x !felt.type>
 // CHECK-NEXT:        %[[VAL_30:[0-9a-zA-Z_\.]+]] = felt.const  8

--- a/circom/tests/loops/fixed_idx_nested_rhs.circom
+++ b/circom/tests/loops/fixed_idx_nested_rhs.circom
@@ -6,7 +6,7 @@ pragma circom 2.0.0;
 template FixIdxNested() {
     signal input in[16];
     signal output out[16];
-    
+
     var arr[16] = [0, 5, 10, 15, 4, 9, 14, 3, 8, 13, 2, 7, 12, 1, 6, 11];
 
     for (var i = 0; i < 16; i++) {
@@ -62,6 +62,7 @@ component main = FixIdxNested();
 // CHECK-NEXT:        function.return %[[VAL_1]] : !struct.type<@FixIdxNested<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_35:[0-9a-zA-Z_\.]+]]: !struct.type<@FixIdxNested<[]>>, %[[VAL_36:[0-9a-zA-Z_\.]+]]: !array.type<16 x !felt.type>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %[[VAL_66:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_35]][@out] : <@FixIdxNested<[]>>, !array.type<16 x !felt.type>
 // CHECK-NEXT:        %[[VAL_37:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_38:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_37]], %[[VAL_37]], %[[VAL_37]], %[[VAL_37]], %[[VAL_37]], %[[VAL_37]], %[[VAL_37]], %[[VAL_37]], %[[VAL_37]], %[[VAL_37]], %[[VAL_37]], %[[VAL_37]], %[[VAL_37]], %[[VAL_37]], %[[VAL_37]], %[[VAL_37]] : <16 x !felt.type>
 // CHECK-NEXT:        %[[VAL_39:[0-9a-zA-Z_\.]+]] = felt.const  0
@@ -92,7 +93,6 @@ component main = FixIdxNested();
 // CHECK-NEXT:          %[[VAL_63:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_55]]{{\[}}%[[VAL_62]]] : <16 x !felt.type>, !felt.type
 // CHECK-NEXT:          %[[VAL_64:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_63]]
 // CHECK-NEXT:          %[[VAL_65:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_36]]{{\[}}%[[VAL_64]]] : <16 x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_66:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_35]][@out] : <@FixIdxNested<[]>>, !array.type<16 x !felt.type>
 // CHECK-NEXT:          %[[VAL_67:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_61]]
 // CHECK-NEXT:          %[[VAL_68:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_66]]{{\[}}%[[VAL_67]]] : <16 x !felt.type>, !felt.type
 // CHECK-NEXT:          constrain.eq %[[VAL_68]], %[[VAL_65]] : !felt.type, !felt.type

--- a/circom/tests/loops/for_known.circom
+++ b/circom/tests/loops/for_known.circom
@@ -40,6 +40,7 @@ component main = ForKnown(10);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_13:[0-9a-zA-Z_\.]+]]: !struct.type<@ForKnown<[@N]>>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[VAL_14:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type
+// CHECK-NEXT:        %[[VAL_26:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_13]][@out] : <@ForKnown<[@N]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_15:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_16:[0-9a-zA-Z_\.]+]] = felt.const  1
 // CHECK-NEXT:        %[[VAL_17:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_18:[0-9a-zA-Z_\.]+]] = %[[VAL_15]], %[[VAL_19:[0-9a-zA-Z_\.]+]] = %[[VAL_16]]) : (!felt.type, !felt.type) -> (!felt.type, !felt.type) {
@@ -52,7 +53,6 @@ component main = ForKnown(10);
 // CHECK-NEXT:          %[[VAL_25:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_22]], %[[VAL_24]] : !felt.type, !felt.type
 // CHECK-NEXT:          scf.yield %[[VAL_23]], %[[VAL_25]] : !felt.type, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_26:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_13]][@out] : <@ForKnown<[@N]>>, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }

--- a/circom/tests/loops/for_unknown.circom
+++ b/circom/tests/loops/for_unknown.circom
@@ -42,6 +42,7 @@ component main = ForUnknown();
 // CHECK-NEXT:      }
 // CHECK-LABEL:     function.def @constrain
 // CHECK-SAME:      (%[[VAL_14:[0-9a-zA-Z_\.]+]]: !struct.type<@ForUnknown<[]>>, %[[VAL_15:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %[[VAL_27:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_14]][@out] : <@ForUnknown<[]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_16:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_17:[0-9a-zA-Z_\.]+]] = felt.const  1
 // CHECK-NEXT:        %[[VAL_19:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_20:[0-9a-zA-Z_\.]+]] = %[[VAL_16]], %[[VAL_21:[0-9a-zA-Z_\.]+]] = %[[VAL_17]])
@@ -55,7 +56,6 @@ component main = ForUnknown();
 // CHECK-NEXT:          %[[VAL_26:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_23]], %[[VAL_25]] : !felt.type, !felt.type
 // CHECK-NEXT:          scf.yield %[[VAL_24]], %[[VAL_26]] : !felt.type, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_27:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_14]][@out] : <@ForUnknown<[]>>, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }

--- a/circom/tests/loops/for_unknown_index.circom
+++ b/circom/tests/loops/for_unknown_index.circom
@@ -44,6 +44,7 @@ component main = ForUnknownIndex();
 // CHECK-NEXT:        function.return %[[VAL_2]] : !struct.type<@ForUnknownIndex<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_16:[0-9a-zA-Z_\.]+]]: !struct.type<@ForUnknownIndex<[]>>, %[[VAL_17:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_18:[0-9a-zA-Z_\.]+]]: !array.type<10 x !felt.type>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %[[VAL_30:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_16]][@out] : <@ForUnknownIndex<[]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_19:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_20:[0-9a-zA-Z_\.]+]] = felt.const  1
 // CHECK-NEXT:        %[[VAL_21:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_22:[0-9a-zA-Z_\.]+]] = %[[VAL_19]], %[[VAL_23:[0-9a-zA-Z_\.]+]] = %[[VAL_20]]) : (!felt.type, !felt.type) -> (!felt.type, !felt.type) {
@@ -56,7 +57,6 @@ component main = ForUnknownIndex();
 // CHECK-NEXT:          %[[VAL_29:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_26]], %[[VAL_28]] : !felt.type, !felt.type
 // CHECK-NEXT:          scf.yield %[[VAL_27]], %[[VAL_29]] : !felt.type, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_30:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_16]][@out] : <@ForUnknownIndex<[]>>, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }

--- a/circom/tests/loops/init_nonzero.circom
+++ b/circom/tests/loops/init_nonzero.circom
@@ -77,6 +77,7 @@ component main = NonZeroInit();
 // CHECK-NEXT:        function.return %[[VAL_1]] : !struct.type<@NonZeroInit<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_36:[0-9a-zA-Z_\.]+]]: !struct.type<@NonZeroInit<[]>>, %[[VAL_37:[0-9a-zA-Z_\.]+]]: !array.type<9 x !felt.type>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %{{[0-9a-zA-Z_\.]+}} = struct.readf %[[VAL_36]][@b] : <@NonZeroInit<[]>>, !array.type<9 x !felt.type>
 // CHECK-NEXT:        %[[VAL_38:[0-9a-zA-Z_\.]+]] = felt.const  4
 // CHECK-NEXT:        %[[VAL_39:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_40:[0-9a-zA-Z_\.]+]] = %[[VAL_38]]) : (!felt.type) -> !felt.type {
 // CHECK-NEXT:          %[[VAL_41:[0-9a-zA-Z_\.]+]] = felt.const  7

--- a/circom/tests/loops/inner_conditional_01.circom
+++ b/circom/tests/loops/inner_conditional_01.circom
@@ -66,6 +66,7 @@ component main = InnerConditional1(10);
 // CHECK-LABEL:     function.def @constrain
 // CHECK-SAME:      (%[[SELF:[0-9a-zA-Z_\.]+]]: !struct.type<@InnerConditional1<[@N]>>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[V_N:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type
+// CHECK-NEXT:        %{{[0-9a-zA-Z_\.]+}} = struct.readf %[[SELF]][@out] : <@InnerConditional1<[@N]>>, !felt.type
 // CHECK-NEXT:        %[[V_A0:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[V_I0:[0-9a-zA-Z_\.]+]] = felt.const  1
 // CHECK-NEXT:        %[[V_21:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_A1:[0-9a-zA-Z_\.]+]] = %[[V_A0]], %[[V_I1:[0-9a-zA-Z_\.]+]] = %[[V_I0]]) : (!felt.type, !felt.type) -> (!felt.type, !felt.type) {
@@ -86,7 +87,6 @@ component main = InnerConditional1(10);
 // CHECK-NEXT:          %[[V_33:[0-9a-zA-Z_\.]+]] = felt.add %[[V_I2]], %[[V_32]] : !felt.type, !felt.type
 // CHECK-NEXT:          scf.yield %[[V_29]], %[[V_33]] : !felt.type, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[V_34:[0-9a-zA-Z_\.]+]] = struct.readf %[[SELF]][@out] : <@InnerConditional1<[@N]>>, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }

--- a/circom/tests/loops/inner_conditional_03.circom
+++ b/circom/tests/loops/inner_conditional_03.circom
@@ -55,6 +55,7 @@ component main = InnerConditional3(3);
 // CHECK-LABEL:     function.def @constrain
 // CHECK-SAME:      (%[[SELF:[0-9a-zA-Z_\.]+]]: !struct.type<@InnerConditional3<[@N]>>, %[[V_IN:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[V_N:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type
+// CHECK-NEXT:        %[[V_36:[0-9a-zA-Z_\.]+]] = struct.readf %[[SELF]][@out] : <@InnerConditional3<[@N]>>, !felt.type
 // CHECK-NEXT:        %[[V_A0:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[V_I0:[0-9a-zA-Z_\.]+]] = felt.const  1
 // CHECK-NEXT:        %[[V_23:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_A1:[0-9a-zA-Z_\.]+]] = %[[V_A0]], %[[V_I1:[0-9a-zA-Z_\.]+]] = %[[V_I0]]) : (!felt.type, !felt.type) -> (!felt.type, !felt.type) {
@@ -75,7 +76,6 @@ component main = InnerConditional3(3);
 // CHECK-NEXT:          %[[V_35:[0-9a-zA-Z_\.]+]] = felt.add %[[V_I2]], %[[V_34]] : !felt.type, !felt.type
 // CHECK-NEXT:          scf.yield %[[V_31]], %[[V_35]] : !felt.type, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[V_36:[0-9a-zA-Z_\.]+]] = struct.readf %[[SELF]][@out] : <@InnerConditional3<[@N]>>, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }

--- a/circom/tests/loops/inner_conditional_04.circom
+++ b/circom/tests/loops/inner_conditional_04.circom
@@ -51,6 +51,7 @@ component main = InnerConditional4(6);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_16:[0-9a-zA-Z_\.]+]]: !struct.type<@InnerConditional4<[@N]>>, %[[VAL_17:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[VAL_18:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type
+// CHECK-NEXT:        %{{[0-9a-zA-Z_\.]+}} = struct.readf %[[VAL_16]][@out] : <@InnerConditional4<[@N]>>, !array.type<@N x !felt.type>
 // CHECK-NEXT:        %[[VAL_19:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_20:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_21:[0-9a-zA-Z_\.]+]] = %[[VAL_19]]) : (!felt.type) -> !felt.type {
 // CHECK-NEXT:          %[[VAL_22:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_21]], %[[VAL_18]])

--- a/circom/tests/loops/inner_conditional_06.circom
+++ b/circom/tests/loops/inner_conditional_06.circom
@@ -57,6 +57,7 @@ component main = InnerConditional6(4);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_20:[0-9a-zA-Z_\.]+]]: !struct.type<@InnerConditional6<[@N]>>, %[[VAL_21:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[VAL_22:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type
+// CHECK-NEXT:        %{{[0-9a-zA-Z_\.]+}} = struct.readf %[[VAL_20]][@out] : <@InnerConditional6<[@N]>>, !array.type<@N x !felt.type>
 // CHECK-NEXT:        %[[VAL_23:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_24:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_25:[0-9a-zA-Z_\.]+]] = %[[VAL_23]]) : (!felt.type) -> !felt.type {
 // CHECK-NEXT:          %[[VAL_26:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_25]], %[[VAL_22]])

--- a/circom/tests/loops/inner_conditional_07.circom
+++ b/circom/tests/loops/inner_conditional_07.circom
@@ -96,6 +96,7 @@ component main = InnerConditional7(3);
 // CHECK-LABEL:     function.def @constrain
 // CHECK-SAME:      (%[[V_47:[0-9a-zA-Z_\.]+]]: !struct.type<@InnerConditional7<[@N]>>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[V_N:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type
+// CHECK-NEXT:        %[[V_87:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_47]][@out] : <@InnerConditional7<[@N]>>, !felt.type
 // CHECK-NEXT:        %[[V_49:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[V_A:[0-9a-zA-Z_\.]+]] = array.new  : <@N x !felt.type>
 // CHECK-NEXT:        %[[V_51:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
@@ -144,7 +145,6 @@ component main = InnerConditional7(3);
 // CHECK-NEXT:          %[[V_I3:[0-9a-zA-Z_\.]+]] = felt.add %[[V_I2]], %[[V_85]] : !felt.type, !felt.type
 // CHECK-NEXT:          scf.yield %[[V_64]]#0, %[[V_I3]] : !array.type<@N x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[V_87:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_47]][@out] : <@InnerConditional7<[@N]>>, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }

--- a/circom/tests/loops/inner_conditional_08.circom
+++ b/circom/tests/loops/inner_conditional_08.circom
@@ -97,6 +97,7 @@ component main = InnerConditional8(4);
 // CHECK-LABEL:     function.def @constrain
 // CHECK-SAME:      (%[[V_47:[0-9a-zA-Z_\.]+]]: !struct.type<@InnerConditional8<[@N]>>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[V_N:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type
+// CHECK-NEXT:        %[[V_87:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_47]][@out] : <@InnerConditional8<[@N]>>, !felt.type
 // CHECK-NEXT:        %[[V_49:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[V_A:[0-9a-zA-Z_\.]+]] = array.new  : <@N x !felt.type>
 // CHECK-NEXT:        %[[V_51:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
@@ -145,7 +146,6 @@ component main = InnerConditional8(4);
 // CHECK-NEXT:          %[[V_86:[0-9a-zA-Z_\.]+]] = felt.add %[[V_62]], %[[V_85]] : !felt.type, !felt.type
 // CHECK-NEXT:          scf.yield %[[V_64]]#0, %[[V_86]] : !array.type<@N x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[V_87:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_47]][@out] : <@InnerConditional8<[@N]>>, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }

--- a/circom/tests/loops/inner_conditional_09.circom
+++ b/circom/tests/loops/inner_conditional_09.circom
@@ -110,6 +110,7 @@ component main = InnerConditional9(4);
 // CHECK-LABEL:     function.def @constrain
 // CHECK-SAME:      (%[[V_56:[0-9a-zA-Z_\.]+]]: !struct.type<@InnerConditional9<[@N]>>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[V_N:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type
+// CHECK-NEXT:        %[[V_105:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_56]][@out] : <@InnerConditional9<[@N]>>, !felt.type
 // CHECK-NEXT:        %[[V_58:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[V_A:[0-9a-zA-Z_\.]+]] = array.new  : <@N x !felt.type>
 // CHECK-NEXT:        %[[V_60:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
@@ -168,7 +169,6 @@ component main = InnerConditional9(4);
 // CHECK-NEXT:          %[[V_104:[0-9a-zA-Z_\.]+]] = felt.add %[[V_71]], %[[V_103]] : !felt.type, !felt.type
 // CHECK-NEXT:          scf.yield %[[V_74]], %[[V_104]] : !array.type<@N x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[V_105:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_56]][@out] : <@InnerConditional9<[@N]>>, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }

--- a/circom/tests/loops/inner_conditional_12.circom
+++ b/circom/tests/loops/inner_conditional_12.circom
@@ -106,6 +106,7 @@ component main = InnerConditional12(4);
 // CHECK-LABEL:     function.def @constrain
 // CHECK-SAME:      (%[[V_56:[0-9a-zA-Z_\.]+]]: !struct.type<@InnerConditional12<[@N]>>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[V_N:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type
+// CHECK-NEXT:        %[[V_105:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_56]][@out] : <@InnerConditional12<[@N]>>, !felt.type
 // CHECK-NEXT:        %[[V_58:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[V_A:[0-9a-zA-Z_\.]+]] = array.new  : <@N x !felt.type>
 // CHECK-NEXT:        %[[V_60:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
@@ -164,7 +165,6 @@ component main = InnerConditional12(4);
 // CHECK-NEXT:          %[[V_104:[0-9a-zA-Z_\.]+]] = felt.add %[[V_71]], %[[V_103]] : !felt.type, !felt.type
 // CHECK-NEXT:          scf.yield %[[V_74]], %[[V_104]] : !array.type<@N x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[V_105:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_56]][@out] : <@InnerConditional12<[@N]>>, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }

--- a/circom/tests/loops/inner_loop_00.circom
+++ b/circom/tests/loops/inner_loop_00.circom
@@ -70,6 +70,7 @@ component main = InnerLoops(2, 3);
 // CHECK-SAME:      (%[[V_IN:[0-9a-zA-Z_\.]+]]: !struct.type<@InnerLoops<[@n, @m]>>, %[[V_36:[0-9a-zA-Z_\.]+]]: !array.type<@m x !felt.type>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[V_N:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
 // CHECK-NEXT:        %[[V_M:[0-9a-zA-Z_\.]+]] = poly.read_const @m : !felt.type
+// CHECK-NEXT:        %[[V_67:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_IN]][@out] : <@InnerLoops<[@n, @m]>>, !felt.type
 // CHECK-NEXT:        %[[V_39:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[V_B:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !felt.type>
 // CHECK-NEXT:        %[[V_41:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
@@ -103,7 +104,6 @@ component main = InnerLoops(2, 3);
 // CHECK-NEXT:          %[[V_66:[0-9a-zA-Z_\.]+]] = felt.add %[[V_52]], %[[V_65]] : !felt.type, !felt.type
 // CHECK-NEXT:          scf.yield %[[V_54]]#0, %[[V_66]] : !array.type<@n x !felt.type>, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[V_67:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_IN]][@out] : <@InnerLoops<[@n, @m]>>, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }

--- a/circom/tests/loops/inner_loop_07.circom
+++ b/circom/tests/loops/inner_loop_07.circom
@@ -53,6 +53,7 @@ component main = InnerLoops(2);
 // CHECK-LABEL:     function.def @constrain
 // CHECK-SAME:      (%[[SELF:[0-9a-zA-Z_\.]+]]: !struct.type<@InnerLoops<[@N]>>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[V_N:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type
+// CHECK-NEXT:        %[[V_46:[0-9a-zA-Z_\.]+]] = struct.readf %[[SELF]][@out] : <@InnerLoops<[@N]>>, !felt.type
 // CHECK-NEXT:        %[[V_A0:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[V_I0:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[V_27:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[V_A1:[0-9a-zA-Z_\.]+]] = %[[V_A0]], %[[V_I1:[0-9a-zA-Z_\.]+]] = %[[V_I0]]) : (!felt.type, !felt.type) -> (!felt.type, !felt.type) {
@@ -76,7 +77,6 @@ component main = InnerLoops(2);
 // CHECK-NEXT:          %[[V_I3:[0-9a-zA-Z_\.]+]] = felt.add %[[V_I2]], %[[V_44]] : !felt.type, !felt.type
 // CHECK-NEXT:          scf.yield %[[V_34]]#0, %[[V_I3]] : !felt.type, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[V_46:[0-9a-zA-Z_\.]+]] = struct.readf %[[SELF]][@out] : <@InnerLoops<[@N]>>, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }

--- a/circom/tests/loops/inner_loop_08.circom
+++ b/circom/tests/loops/inner_loop_08.circom
@@ -60,6 +60,7 @@ component main = InnerLoops(2);
 // CHECK-LABEL:     function.def @constrain
 // CHECK-SAME:      (%[[SELF:[0-9a-zA-Z_\.]+]]: !struct.type<@InnerLoops<[@N]>>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[V_N:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type
+// CHECK-NEXT:        %[[V_58:[0-9a-zA-Z_\.]+]] = struct.readf %[[SELF]][@out] : <@InnerLoops<[@N]>>, !felt.type
 // CHECK-NEXT:        %[[V_A0:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[V_B0:[0-9a-zA-Z_\.]+]] = felt.const  1000
 // CHECK-NEXT:        %[[V_I0:[0-9a-zA-Z_\.]+]] = felt.const  0
@@ -87,7 +88,6 @@ component main = InnerLoops(2);
 // CHECK-NEXT:          %[[V_I3:[0-9a-zA-Z_\.]+]] = felt.add %[[V_I2]], %[[V_56]] : !felt.type, !felt.type
 // CHECK-NEXT:          scf.yield %[[V_44]]#0, %[[V_B4]], %[[V_I3]] : !felt.type, !felt.type, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[V_58:[0-9a-zA-Z_\.]+]] = struct.readf %[[SELF]][@out] : <@InnerLoops<[@N]>>, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }

--- a/circom/tests/loops/inner_loop_09.circom
+++ b/circom/tests/loops/inner_loop_09.circom
@@ -67,6 +67,8 @@ component main = InnerLoops(2);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_34:[0-9a-zA-Z_\.]+]]: !struct.type<@InnerLoops<[@N]>>, %[[VAL_35:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[VAL_36:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type
+// CHECK-NEXT:        %{{[0-9a-zA-Z_\.]+}} = struct.readf %[[VAL_34]][@out] : <@InnerLoops<[@N]>>, !felt.type
+// CHECK-NEXT:        %{{[0-9a-zA-Z_\.]+}} = struct.readf %[[VAL_34]][@out2] : <@InnerLoops<[@N]>>, !array.type<@N x !felt.type>
 // CHECK-NEXT:        %[[VAL_37:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_38:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_39:[0-9a-zA-Z_\.]+]] = felt.const  0
@@ -93,7 +95,6 @@ component main = InnerLoops(2);
 // CHECK-NEXT:          %[[VAL_62:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_47]], %[[VAL_61]] : !felt.type, !felt.type
 // CHECK-NEXT:          scf.yield %[[VAL_49]]#0, %[[VAL_60]], %[[VAL_62]] : !felt.type, !felt.type, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_63:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_34]][@out] : <@InnerLoops<[@N]>>, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }

--- a/circom/tests/loops/known_function.circom
+++ b/circom/tests/loops/known_function.circom
@@ -17,7 +17,7 @@ template KnownFunctionArgs() {
 
     out[0] <-- funWithLoop(4); // 0 + 1 + 2 + 3 + 4 = 10
     out[1] <-- funWithLoop(5); // 0 + 1 + 2 + 3 + 4 + 5 = 15
-    
+
     var acc = 1;
     for (var i = 2; i <= funWithLoop(3); i++) { // 0 + 1 + 2 + 3 = 6
         acc *= i;
@@ -79,6 +79,7 @@ component main = KnownFunctionArgs();
 // CHECK-NEXT:        function.return %[[VAL_12]] : !struct.type<@KnownFunctionArgs<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_37:[0-9a-zA-Z_\.]+]]: !struct.type<@KnownFunctionArgs<[]>>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %{{[0-9a-zA-Z_\.]+}} = struct.readf %[[VAL_37]][@out] : <@KnownFunctionArgs<[]>>, !array.type<3 x !felt.type>
 // CHECK-NEXT:        %[[VAL_38:[0-9a-zA-Z_\.]+]] = felt.const  1
 // CHECK-NEXT:        %[[VAL_39:[0-9a-zA-Z_\.]+]] = felt.const  2
 // CHECK-NEXT:        %[[VAL_40:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_41:[0-9a-zA-Z_\.]+]] = %[[VAL_38]], %[[VAL_42:[0-9a-zA-Z_\.]+]] = %[[VAL_39]]) : (!felt.type, !felt.type) -> (!felt.type, !felt.type) {

--- a/circom/tests/loops/known_signal_value.circom
+++ b/circom/tests/loops/known_signal_value.circom
@@ -38,10 +38,10 @@ component main = KnownLoopViaSignal();
 // CHECK-NEXT:        function.return %[[VAL_0]] : !struct.type<@KnownLoopViaSignal<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_4:[0-9a-zA-Z_\.]+]]: !struct.type<@KnownLoopViaSignal<[]>>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_4]][@y] : <@KnownLoopViaSignal<[]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_4]][@a] : <@KnownLoopViaSignal<[]>>, !struct.type<@accumulate<[]>>
 // CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = undef.undef : !felt.type
 // CHECK-NEXT:        function.call @accumulate::@constrain(%[[VAL_5]], %[[VAL_6]]) : (!struct.type<@accumulate<[]>>, !felt.type) -> ()
-// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_4]][@y] : <@KnownLoopViaSignal<[]>>, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }
@@ -63,6 +63,7 @@ component main = KnownLoopViaSignal();
 // CHECK-NEXT:        function.return %[[VAL_9]] : !struct.type<@accumulate<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_17:[0-9a-zA-Z_\.]+]]: !struct.type<@accumulate<[]>>, %[[VAL_18:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %[[VAL_26:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_17]][@o] : <@accumulate<[]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_19:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_20:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_21:[0-9a-zA-Z_\.]+]] = %[[VAL_19]]) : (!felt.type) -> !felt.type {
 // CHECK-NEXT:          %[[VAL_22:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_21]], %[[VAL_18]])
@@ -73,9 +74,7 @@ component main = KnownLoopViaSignal();
 // CHECK-NEXT:          %[[VAL_25:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_23]], %[[VAL_24]] : !felt.type, !felt.type
 // CHECK-NEXT:          scf.yield %[[VAL_25]] : !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_26:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_17]][@o] : <@accumulate<[]>>, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
-

--- a/circom/tests/loops/simple_variant_idx.circom
+++ b/circom/tests/loops/simple_variant_idx.circom
@@ -44,7 +44,7 @@ component main = SimpleVariantIdx(3);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_17:[0-9a-zA-Z_\.]+]]: !struct.type<@SimpleVariantIdx<[@n]>>, %[[VAL_18:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[VAL_19:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
-// CHECK-NEXT:        %[[VAL_20:[0-9a-zA-Z_\.]+]] = undef.undef : !array.type<@n x !felt.type>
+// CHECK-NEXT:        %[[VAL_20:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_17]][@out] : <@SimpleVariantIdx<[@n]>>, !array.type<@n x !felt.type>
 // CHECK-NEXT:        %[[VAL_21:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_22:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_23:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_24:[0-9a-zA-Z_\.]+]] = %[[VAL_22]], %[[VAL_25:[0-9a-zA-Z_\.]+]] = %[[VAL_21]]) : (!felt.type, !felt.type) -> (!felt.type, !felt.type) {

--- a/circom/tests/loops/unknown_index_from_array.circom
+++ b/circom/tests/loops/unknown_index_from_array.circom
@@ -45,6 +45,7 @@ component main = Example(3);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_18:[0-9a-zA-Z_\.]+]]: !struct.type<@Example<[@n]>>, %[[VAL_19:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_20:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[VAL_21:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %{{[0-9a-zA-Z_\.]+}} = struct.readf %[[VAL_18]][@c] : <@Example<[@n]>>, !array.type<@n x !felt.type>
 // CHECK-NEXT:        %[[VAL_22:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_23:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_24:[0-9a-zA-Z_\.]+]] = %[[VAL_22]]) : (!felt.type) -> !felt.type {
 // CHECK-NEXT:          %[[VAL_25:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_24]], %[[VAL_21]])

--- a/circom/tests/loops/unknown_index_from_function.circom
+++ b/circom/tests/loops/unknown_index_from_function.circom
@@ -50,6 +50,7 @@ component main = Example(3);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_17:[0-9a-zA-Z_\.]+]]: !struct.type<@Example<[@n]>>, %[[VAL_18:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>, %[[VAL_19:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[VAL_20:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %{{[0-9a-zA-Z_\.]+}} = struct.readf %[[VAL_17]][@c] : <@Example<[@n]>>, !array.type<@n x !felt.type>
 // CHECK-NEXT:        %[[VAL_21:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_22:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_23:[0-9a-zA-Z_\.]+]] = %[[VAL_21]]) : (!felt.type) -> !felt.type {
 // CHECK-NEXT:          %[[VAL_24:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_23]], %[[VAL_20]])

--- a/circom/tests/loops/unknown_local_array_index.circom
+++ b/circom/tests/loops/unknown_local_array_index.circom
@@ -88,6 +88,7 @@ component main = ForUnknownIndex();
 // CHECK-NEXT:        function.return %[[VAL_1]] : !struct.type<@ForUnknownIndex<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_56:[0-9a-zA-Z_\.]+]]: !struct.type<@ForUnknownIndex<[]>>, %[[VAL_57:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %[[VAL_108:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_56]][@out] : <@ForUnknownIndex<[]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_58:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_59:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_58]], %[[VAL_58]], %[[VAL_58]], %[[VAL_58]], %[[VAL_58]], %[[VAL_58]], %[[VAL_58]], %[[VAL_58]], %[[VAL_58]], %[[VAL_58]] : <10 x !felt.type>
 // CHECK-NEXT:        %[[VAL_60:[0-9a-zA-Z_\.]+]] = felt.const  0
@@ -139,7 +140,6 @@ component main = ForUnknownIndex();
 // CHECK-NEXT:          %[[VAL_107:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_104]], %[[VAL_106]] : !felt.type, !felt.type
 // CHECK-NEXT:          scf.yield %[[VAL_105]], %[[VAL_107]] : !felt.type, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_108:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_56]][@out] : <@ForUnknownIndex<[]>>, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }

--- a/circom/tests/loops/unknown_loop_component.circom
+++ b/circom/tests/loops/unknown_loop_component.circom
@@ -40,10 +40,10 @@ component main = UnknownLoopComponent();
 // CHECK-NEXT:        function.return %[[VAL_1]] : !struct.type<@UnknownLoopComponent<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_4:[0-9a-zA-Z_\.]+]]: !struct.type<@UnknownLoopComponent<[]>>, %[[VAL_5:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_4]][@bits] : <@UnknownLoopComponent<[]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_4]][@nb] : <@UnknownLoopComponent<[]>>, !struct.type<@nbits<[]>>
 // CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = undef.undef : !felt.type
 // CHECK-NEXT:        function.call @nbits::@constrain(%[[VAL_6]], %[[VAL_7]]) : (!struct.type<@nbits<[]>>, !felt.type) -> ()
-// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_4]][@bits] : <@UnknownLoopComponent<[]>>, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }
@@ -70,6 +70,7 @@ component main = UnknownLoopComponent();
 // CHECK-NEXT:        function.return %[[VAL_10]] : !struct.type<@nbits<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_25:[0-9a-zA-Z_\.]+]]: !struct.type<@nbits<[]>>, %[[VAL_26:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %[[VAL_41:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_25]][@out] : <@nbits<[]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_27:[0-9a-zA-Z_\.]+]] = felt.const  1
 // CHECK-NEXT:        %[[VAL_28:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_29:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_30:[0-9a-zA-Z_\.]+]] = %[[VAL_27]], %[[VAL_31:[0-9a-zA-Z_\.]+]] = %[[VAL_28]]) : (!felt.type, !felt.type) -> (!felt.type, !felt.type) {
@@ -85,7 +86,6 @@ component main = UnknownLoopComponent();
 // CHECK-NEXT:          %[[VAL_40:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_35]], %[[VAL_39]] : !felt.type, !felt.type
 // CHECK-NEXT:          scf.yield %[[VAL_40]], %[[VAL_38]] : !felt.type, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_41:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_25]][@out] : <@nbits<[]>>, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }

--- a/circom/tests/loops/variant_idx_in_loop_01.circom
+++ b/circom/tests/loops/variant_idx_in_loop_01.circom
@@ -40,6 +40,7 @@ component main = VariantIndex(2);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_13:[0-9a-zA-Z_\.]+]]: !struct.type<@VariantIndex<[@n]>>, %[[VAL_14:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[VAL_15:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %{{[0-9a-zA-Z_\.]+}} = struct.readf %[[VAL_13]][@out] : <@VariantIndex<[@n]>>, !array.type<@n x !felt.type>
 // CHECK-NEXT:        %[[VAL_16:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_17:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_18:[0-9a-zA-Z_\.]+]] = %[[VAL_16]]) : (!felt.type) -> !felt.type {
 // CHECK-NEXT:          %[[VAL_19:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_18]], %[[VAL_15]])

--- a/circom/tests/loops/variant_idx_in_loop_02.circom
+++ b/circom/tests/loops/variant_idx_in_loop_02.circom
@@ -57,6 +57,7 @@ component main = VariantIndex(2);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_28:[0-9a-zA-Z_\.]+]]: !struct.type<@VariantIndex<[@n]>>, %[[VAL_29:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[VAL_30:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_49:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_28]][@out] : <@VariantIndex<[@n]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_31:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_32:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !felt.type>
 // CHECK-NEXT:        %[[VAL_33:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
@@ -79,7 +80,6 @@ component main = VariantIndex(2);
 // CHECK-NEXT:          %[[VAL_48:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_43]], %[[VAL_47]] : !felt.type, !felt.type
 // CHECK-NEXT:          scf.yield %[[VAL_48]], %[[VAL_44]] : !felt.type, !array.type<@n x !felt.type>
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_49:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_28]][@out] : <@VariantIndex<[@n]>>, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }

--- a/circom/tests/misc/signal_index.circom
+++ b/circom/tests/misc/signal_index.circom
@@ -47,14 +47,14 @@ component main {public [a, b]} = A();
 // CHECK-NEXT:      }
 // CHECK-LABEL:     function.def @constrain
 // CHECK-SAME:      (%[[V_8:[0-9a-zA-Z_\.]+]]: !struct.type<@A<[]>>, %[[V_9:[0-9a-zA-Z_\.]+]]: !felt.type {llzk.pub}, %[[V_10:[0-9a-zA-Z_\.]+]]: !felt.type {llzk.pub}) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %[[V_17:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_8]][@c] : <@A<[]>>, !felt.type
+// CHECK-NEXT:        %[[V_14:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_8]][@x] : <@A<[]>>, !felt.type
 // CHECK-NEXT:        %[[V_11:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_8]][@cb] : <@A<[]>>, !struct.type<@B<[]>>
 // CHECK-NEXT:        function.call @B::@constrain(%[[V_11]], %[[V_9]], %[[V_10]]) : (!struct.type<@B<[]>>, !felt.type, !felt.type) -> ()
 // CHECK-NEXT:        %[[V_13:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_11]][@c] : <@B<[]>>, !felt.type
-// CHECK-NEXT:        %[[V_14:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_8]][@x] : <@A<[]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[V_14]], %[[V_13]] : !felt.type, !felt.type
 // CHECK-NEXT:        %[[V_15:[0-9a-zA-Z_\.]+]] = felt.const  5
-// CHECK-NEXT:        %[[V_16:[0-9a-zA-Z_\.]+]] = felt.mul %[[V_13]], %[[V_15]] : !felt.type, !felt.type
-// CHECK-NEXT:        %[[V_17:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_8]][@c] : <@A<[]>>, !felt.type
+// CHECK-NEXT:        %[[V_16:[0-9a-zA-Z_\.]+]] = felt.mul %[[V_14]], %[[V_15]] : !felt.type, !felt.type
 // CHECK-NEXT:        constrain.eq %[[V_17]], %[[V_16]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
@@ -70,8 +70,8 @@ component main {public [a, b]} = A();
 // CHECK-NEXT:      }
 // CHECK-LABEL:     function.def @constrain
 // CHECK-SAME:      (%[[V_22:[0-9a-zA-Z_\.]+]]: !struct.type<@B<[]>>, %[[V_23:[0-9a-zA-Z_\.]+]]: !felt.type {llzk.pub}, %[[V_24:[0-9a-zA-Z_\.]+]]: !felt.type {llzk.pub}) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:        %[[V_25:[0-9a-zA-Z_\.]+]] = felt.mul %[[V_23]], %[[V_24]] : !felt.type, !felt.type
-// CHECK-NEXT:        %[[V_26:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_22]][@c] : <@B<[]>>, !felt.type
+// CHECK-DAG:         %[[V_25:[0-9a-zA-Z_\.]+]] = felt.mul %[[V_23]], %[[V_24]] : !felt.type, !felt.type
+// CHECK-DAG:         %[[V_26:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_22]][@c] : <@B<[]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[V_26]], %[[V_25]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/misc/signal_index2.circom
+++ b/circom/tests/misc/signal_index2.circom
@@ -76,7 +76,8 @@ component main {public [a, b]} = A();
 // CHECK-NEXT:        function.return %[[VAL_2]] : !struct.type<@A<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_29:[0-9a-zA-Z_\.]+]]: !struct.type<@A<[]>>, %[[VAL_30:[0-9a-zA-Z_\.]+]]: !array.type<2 x !felt.type> {llzk.pub}, %[[VAL_31:[0-9a-zA-Z_\.]+]]: !array.type<2 x !felt.type> {llzk.pub}) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:        %[[VAL_32:[0-9a-zA-Z_\.]+]] = undef.undef : !array.type<4 x !felt.type>
+// CHECK-NEXT:        %[[VAL_47:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_29]][@c] : <@A<[]>>, !array.type<4 x !felt.type>
+// CHECK-NEXT:        %[[VAL_62:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_29]][@x] : <@A<[]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_33:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_34:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_35:[0-9a-zA-Z_\.]+]] = %[[VAL_33]]) : (!felt.type) -> !felt.type {
 // CHECK-NEXT:          %[[VAL_36:[0-9a-zA-Z_\.]+]] = felt.const  4
@@ -93,7 +94,6 @@ component main {public [a, b]} = A();
 // CHECK-NEXT:            %[[VAL_44:[0-9a-zA-Z_\.]+]] = felt.uintdiv %[[VAL_38]], %[[VAL_43]] : !felt.type, !felt.type
 // CHECK-NEXT:            %[[VAL_45:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_44]]
 // CHECK-NEXT:            %[[VAL_46:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_30]]{{\[}}%[[VAL_45]]] : <2 x !felt.type>, !felt.type
-// CHECK-NEXT:            %[[VAL_47:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_29]][@c] : <@A<[]>>, !array.type<4 x !felt.type>
 // CHECK-NEXT:            %[[VAL_48:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_38]]
 // CHECK-NEXT:            %[[VAL_49:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_47]]{{\[}}%[[VAL_48]]] : <4 x !felt.type>, !felt.type
 // CHECK-NEXT:            constrain.eq %[[VAL_49]], %[[VAL_46]] : !felt.type, !felt.type
@@ -102,9 +102,8 @@ component main {public [a, b]} = A();
 // CHECK-NEXT:            %[[VAL_51:[0-9a-zA-Z_\.]+]] = felt.uintdiv %[[VAL_38]], %[[VAL_50]] : !felt.type, !felt.type
 // CHECK-NEXT:            %[[VAL_52:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_51]]
 // CHECK-NEXT:            %[[VAL_53:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_31]]{{\[}}%[[VAL_52]]] : <2 x !felt.type>, !felt.type
-// CHECK-NEXT:            %[[VAL_54:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_29]][@c] : <@A<[]>>, !array.type<4 x !felt.type>
 // CHECK-NEXT:            %[[VAL_55:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_38]]
-// CHECK-NEXT:            %[[VAL_56:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_54]]{{\[}}%[[VAL_55]]] : <4 x !felt.type>, !felt.type
+// CHECK-NEXT:            %[[VAL_56:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_47]]{{\[}}%[[VAL_55]]] : <4 x !felt.type>, !felt.type
 // CHECK-NEXT:            constrain.eq %[[VAL_56]], %[[VAL_53]] : !felt.type, !felt.type
 // CHECK-NEXT:          }
 // CHECK-NEXT:          %[[VAL_57:[0-9a-zA-Z_\.]+]] = felt.const  1
@@ -113,8 +112,7 @@ component main {public [a, b]} = A();
 // CHECK-NEXT:        }
 // CHECK-NEXT:        %[[VAL_59:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_60:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_59]]
-// CHECK-NEXT:        %[[VAL_61:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_32]]{{\[}}%[[VAL_60]]] : <4 x !felt.type>, !felt.type
-// CHECK-NEXT:        %[[VAL_62:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_29]][@x] : <@A<[]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_61:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_47]]{{\[}}%[[VAL_60]]] : <4 x !felt.type>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_62]], %[[VAL_61]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/operators/arith1.circom
+++ b/circom/tests/operators/arith1.circom
@@ -28,10 +28,10 @@ component main = Arith1();
 // CHECK-NEXT:      }
 // CHECK-LABEL:     function.def @constrain
 // CHECK-SAME:      (%[[VAL_7:[0-9a-zA-Z_\.]+]]: !struct.type<@Arith1<[]>>, %[[VAL_8:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_9:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_10:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %[[VAL_14:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_7]][@x] : <@Arith1<[]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_8]], %[[VAL_9]] : !felt.type, !felt.type
 // CHECK-NEXT:        %[[VAL_12:[0-9a-zA-Z_\.]+]] = felt.const  10
 // CHECK-NEXT:        %[[VAL_13:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_11]], %[[VAL_12]] : !felt.type, !felt.type
-// CHECK-NEXT:        %[[VAL_14:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_7]][@x] : <@Arith1<[]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_14]], %[[VAL_13]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/operators/arith2.circom
+++ b/circom/tests/operators/arith2.circom
@@ -28,10 +28,10 @@ component main = Arith2();
 // CHECK-NEXT:      }
 // CHECK-LABEL:     function.def @constrain
 // CHECK-SAME:      (%[[VAL_7:[0-9a-zA-Z_\.]+]]: !struct.type<@Arith2<[]>>, %[[VAL_8:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_9:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_10:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %[[VAL_14:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_7]][@x] : <@Arith2<[]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_8]], %[[VAL_9]] : !felt.type, !felt.type
 // CHECK-NEXT:        %[[VAL_12:[0-9a-zA-Z_\.]+]] = felt.const  10
 // CHECK-NEXT:        %[[VAL_13:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_11]], %[[VAL_12]] : !felt.type, !felt.type
-// CHECK-NEXT:        %[[VAL_14:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_7]][@x] : <@Arith2<[]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_14]], %[[VAL_13]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/operators/arith_add.circom
+++ b/circom/tests/operators/arith_add.circom
@@ -25,8 +25,8 @@ component main = ArithAdd();
 // CHECK-NEXT:      }
 // CHECK-LABEL:     function.def @constrain
 // CHECK-SAME:      (%[[VAL_4:[0-9a-zA-Z_\.]+]]: !struct.type<@ArithAdd<[]>>, %[[VAL_5:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_6:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_5]], %[[VAL_6]] : !felt.type, !felt.type
-// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_4]][@x] : <@ArithAdd<[]>>, !felt.type
+// CHECK-DAG:         %[[VAL_7:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_5]], %[[VAL_6]] : !felt.type, !felt.type
+// CHECK-DAG:         %[[VAL_8:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_4]][@x] : <@ArithAdd<[]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_8]], %[[VAL_7]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/operators/arith_mod.circom
+++ b/circom/tests/operators/arith_mod.circom
@@ -39,10 +39,10 @@ component main = ArithRemainder();
 // CHECK-NEXT:        function.return %[[VAL_1]] : !struct.type<@ArithRemainder<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_8:[0-9a-zA-Z_\.]+]]: !struct.type<@ArithRemainder<[]>>, %[[VAL_9:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_8]][@inv] : <@ArithRemainder<[]>>, !felt.type
-// CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_8]][@out] : <@ArithRemainder<[]>>, !felt.type
+// CHECK-DAG:         %[[VAL_10:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_8]][@inv] : <@ArithRemainder<[]>>, !felt.type
+// CHECK-DAG:         %[[VAL_11:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_8]][@out] : <@ArithRemainder<[]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_11]], %[[VAL_10]] : !felt.type, !felt.type
-// CHECK-NEXT:        %[[VAL_12:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_9]], %[[VAL_10]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[VAL_12:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_9]], %[[VAL_11]] : !felt.type, !felt.type
 // CHECK-NEXT:        %[[VAL_13:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        constrain.eq %[[VAL_12]], %[[VAL_13]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return

--- a/circom/tests/operators/arith_neg.circom
+++ b/circom/tests/operators/arith_neg.circom
@@ -24,8 +24,8 @@ component main = ArithNeg();
 // CHECK-NEXT:      }
 // CHECK-LABEL:     function.def @constrain
 // CHECK-SAME:      (%[[VAL_3:[0-9a-zA-Z_\.]+]]: !struct.type<@ArithNeg<[]>>, %[[VAL_4:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = felt.neg %[[VAL_4]] : !felt.type
-// CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_3]][@x] : <@ArithNeg<[]>>, !felt.type
+// CHECK-DAG:         %[[VAL_5:[0-9a-zA-Z_\.]+]] = felt.neg %[[VAL_4]] : !felt.type
+// CHECK-DAG:         %[[VAL_6:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_3]][@x] : <@ArithNeg<[]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_6]], %[[VAL_5]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/operators/arith_sub.circom
+++ b/circom/tests/operators/arith_sub.circom
@@ -28,10 +28,10 @@ component main = ArithSubtract();
 // CHECK-NEXT:      }
 // CHECK-LABEL:     function.def @constrain
 // CHECK-SAME:      (%[[VAL_7:[0-9a-zA-Z_\.]+]]: !struct.type<@ArithSubtract<[]>>, %[[VAL_8:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_9:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_10:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %[[VAL_14:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_7]][@x] : <@ArithSubtract<[]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]] = felt.const  10
 // CHECK-NEXT:        %[[VAL_12:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_9]], %[[VAL_11]] : !felt.type, !felt.type
 // CHECK-NEXT:        %[[VAL_13:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_8]], %[[VAL_12]] : !felt.type, !felt.type
-// CHECK-NEXT:        %[[VAL_14:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_7]][@x] : <@ArithSubtract<[]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_14]], %[[VAL_13]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/operators/bitwise_and.circom
+++ b/circom/tests/operators/bitwise_and.circom
@@ -32,9 +32,9 @@ component main = BitwiseAnd();
 // CHECK-LABEL:     function.def @constrain
 // CHECK-SAME:      (%[[VAL_6:[0-9a-zA-Z_\.]+]]: !struct.type<@BitwiseAnd<[]>>, %[[VAL_7:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_6]][@type] : <@BitwiseAnd<[]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_6]][@check_v] : <@BitwiseAnd<[]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_9:[0-9a-zA-Z_\.]+]] = felt.const  32
 // CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_8]], %[[VAL_9]] : !felt.type, !felt.type
-// CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_6]][@check_v] : <@BitwiseAnd<[]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_11]], %[[VAL_10]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/operators/bitwise_comp.circom
+++ b/circom/tests/operators/bitwise_comp.circom
@@ -29,9 +29,9 @@ component main = BitwiseComplement();
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_5:[0-9a-zA-Z_\.]+]]: !struct.type<@BitwiseComplement<[]>>, %[[VAL_6:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_5]][@type] : <@BitwiseComplement<[]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_5]][@check_v] : <@BitwiseComplement<[]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = felt.const  32
 // CHECK-NEXT:        %[[VAL_9:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_7]], %[[VAL_8]] : !felt.type, !felt.type
-// CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_5]][@check_v] : <@BitwiseComplement<[]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_10]], %[[VAL_9]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/operators/bitwise_or.circom
+++ b/circom/tests/operators/bitwise_or.circom
@@ -32,9 +32,9 @@ component main = BitwiseOr();
 // CHECK-LABEL:     function.def @constrain
 // CHECK-SAME:      (%[[VAL_6:[0-9a-zA-Z_\.]+]]: !struct.type<@BitwiseOr<[]>>, %[[VAL_7:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_6]][@type] : <@BitwiseOr<[]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_6]][@check_v] : <@BitwiseOr<[]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_9:[0-9a-zA-Z_\.]+]] = felt.const  32
 // CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_8]], %[[VAL_9]] : !felt.type, !felt.type
-// CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_6]][@check_v] : <@BitwiseOr<[]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_11]], %[[VAL_10]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/operators/bitwise_xor.circom
+++ b/circom/tests/operators/bitwise_xor.circom
@@ -32,9 +32,9 @@ component main = BitwiseXOR();
 // CHECK-LABEL:     function.def @constrain
 // CHECK-SAME:      (%[[VAL_6:[0-9a-zA-Z_\.]+]]: !struct.type<@BitwiseXOR<[]>>, %[[VAL_7:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_6]][@type] : <@BitwiseXOR<[]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_6]][@check_v] : <@BitwiseXOR<[]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_9:[0-9a-zA-Z_\.]+]] = felt.const  32
 // CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_8]], %[[VAL_9]] : !felt.type, !felt.type
-// CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_6]][@check_v] : <@BitwiseXOR<[]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_11]], %[[VAL_10]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/operators/cmp_eq.circom
+++ b/circom/tests/operators/cmp_eq.circom
@@ -46,13 +46,13 @@ component main = CmpEQ(5);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_16:[0-9a-zA-Z_\.]+]]: !struct.type<@CmpEQ<[@n]>>, %[[VAL_17:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[VAL_18:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_24:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_16]][@b] : <@CmpEQ<[@n]>>, !array.type<@n x !felt.type>
 // CHECK-NEXT:        %[[VAL_19:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_20:[0-9a-zA-Z_\.]+]] = bool.cmp eq(%[[VAL_18]], %[[VAL_19]])
 // CHECK-NEXT:        scf.if %[[VAL_20]] {
 // CHECK-NEXT:          %[[VAL_21:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:          %[[VAL_22:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_21]]
 // CHECK-NEXT:          %[[VAL_23:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_17]]{{\[}}%[[VAL_22]]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_24:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_16]][@b] : <@CmpEQ<[@n]>>, !array.type<@n x !felt.type>
 // CHECK-NEXT:          %[[VAL_25:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:          %[[VAL_26:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_25]]
 // CHECK-NEXT:          %[[VAL_27:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_24]]{{\[}}%[[VAL_26]]] : <@n x !felt.type>, !felt.type
@@ -61,10 +61,9 @@ component main = CmpEQ(5);
 // CHECK-NEXT:          %[[VAL_28:[0-9a-zA-Z_\.]+]] = felt.const  1
 // CHECK-NEXT:          %[[VAL_29:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_28]]
 // CHECK-NEXT:          %[[VAL_30:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_17]]{{\[}}%[[VAL_29]]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_31:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_16]][@b] : <@CmpEQ<[@n]>>, !array.type<@n x !felt.type>
 // CHECK-NEXT:          %[[VAL_32:[0-9a-zA-Z_\.]+]] = felt.const  1
 // CHECK-NEXT:          %[[VAL_33:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_32]]
-// CHECK-NEXT:          %[[VAL_34:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_31]]{{\[}}%[[VAL_33]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_34:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_24]]{{\[}}%[[VAL_33]]] : <@n x !felt.type>, !felt.type
 // CHECK-NEXT:          constrain.eq %[[VAL_34]], %[[VAL_30]] : !felt.type, !felt.type
 // CHECK-NEXT:        }
 // CHECK-NEXT:        function.return

--- a/circom/tests/operators/cmp_ge.circom
+++ b/circom/tests/operators/cmp_ge.circom
@@ -43,6 +43,7 @@ component main = CmpGE(5);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_16:[0-9a-zA-Z_\.]+]]: !struct.type<@CmpGE<[@n]>>, %[[VAL_17:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[VAL_18:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_28:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_16]][@b] : <@CmpGE<[@n]>>, !array.type<@n x !felt.type>
 // CHECK-NEXT:        %[[VAL_19:[0-9a-zA-Z_\.]+]] = felt.const  1
 // CHECK-NEXT:        %[[VAL_20:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_18]], %[[VAL_19]] : !felt.type, !felt.type
 // CHECK-NEXT:        %[[VAL_21:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_22:[0-9a-zA-Z_\.]+]] = %[[VAL_20]]) : (!felt.type) -> !felt.type {
@@ -53,7 +54,6 @@ component main = CmpGE(5);
 // CHECK-NEXT:        ^bb0(%[[VAL_25:[0-9a-zA-Z_\.]+]]: !felt.type):
 // CHECK-NEXT:          %[[VAL_26:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_25]]
 // CHECK-NEXT:          %[[VAL_27:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_17]]{{\[}}%[[VAL_26]]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_28:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_16]][@b] : <@CmpGE<[@n]>>, !array.type<@n x !felt.type>
 // CHECK-NEXT:          %[[VAL_29:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_25]]
 // CHECK-NEXT:          %[[VAL_30:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_28]]{{\[}}%[[VAL_29]]] : <@n x !felt.type>, !felt.type
 // CHECK-NEXT:          constrain.eq %[[VAL_30]], %[[VAL_27]] : !felt.type, !felt.type

--- a/circom/tests/operators/cmp_gt.circom
+++ b/circom/tests/operators/cmp_gt.circom
@@ -45,6 +45,7 @@ component main = CmpGT(5);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_18:[0-9a-zA-Z_\.]+]]: !struct.type<@CmpGT<[@n]>>, %[[VAL_19:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[VAL_20:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_30:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_18]][@b] : <@CmpGT<[@n]>>, !array.type<@n x !felt.type>
 // CHECK-NEXT:        %[[VAL_21:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_22:[0-9a-zA-Z_\.]+]] = %[[VAL_20]]) : (!felt.type) -> !felt.type {
 // CHECK-NEXT:          %[[VAL_23:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:          %[[VAL_24:[0-9a-zA-Z_\.]+]] = bool.cmp gt(%[[VAL_22]], %[[VAL_23]])
@@ -55,7 +56,6 @@ component main = CmpGT(5);
 // CHECK-NEXT:          %[[VAL_27:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_25]], %[[VAL_26]] : !felt.type, !felt.type
 // CHECK-NEXT:          %[[VAL_28:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_27]]
 // CHECK-NEXT:          %[[VAL_29:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_19]]{{\[}}%[[VAL_28]]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_30:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_18]][@b] : <@CmpGT<[@n]>>, !array.type<@n x !felt.type>
 // CHECK-NEXT:          %[[VAL_31:[0-9a-zA-Z_\.]+]] = felt.const  1
 // CHECK-NEXT:          %[[VAL_32:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_25]], %[[VAL_31]] : !felt.type, !felt.type
 // CHECK-NEXT:          %[[VAL_33:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_32]]

--- a/circom/tests/operators/cmp_le.circom
+++ b/circom/tests/operators/cmp_le.circom
@@ -43,6 +43,7 @@ component main = CmpLE(5);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_16:[0-9a-zA-Z_\.]+]]: !struct.type<@CmpLE<[@n]>>, %[[VAL_17:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[VAL_18:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_28:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_16]][@b] : <@CmpLE<[@n]>>, !array.type<@n x !felt.type>
 // CHECK-NEXT:        %[[VAL_19:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_20:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_21:[0-9a-zA-Z_\.]+]] = %[[VAL_19]]) : (!felt.type) -> !felt.type {
 // CHECK-NEXT:          %[[VAL_22:[0-9a-zA-Z_\.]+]] = felt.const  1
@@ -53,7 +54,6 @@ component main = CmpLE(5);
 // CHECK-NEXT:        ^bb0(%[[VAL_25:[0-9a-zA-Z_\.]+]]: !felt.type):
 // CHECK-NEXT:          %[[VAL_26:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_25]]
 // CHECK-NEXT:          %[[VAL_27:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_17]]{{\[}}%[[VAL_26]]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_28:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_16]][@b] : <@CmpLE<[@n]>>, !array.type<@n x !felt.type>
 // CHECK-NEXT:          %[[VAL_29:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_25]]
 // CHECK-NEXT:          %[[VAL_30:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_28]]{{\[}}%[[VAL_29]]] : <@n x !felt.type>, !felt.type
 // CHECK-NEXT:          constrain.eq %[[VAL_30]], %[[VAL_27]] : !felt.type, !felt.type

--- a/circom/tests/operators/cmp_lt.circom
+++ b/circom/tests/operators/cmp_lt.circom
@@ -46,13 +46,13 @@ component main = CmpLT(5);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_16:[0-9a-zA-Z_\.]+]]: !struct.type<@CmpLT<[@n]>>, %[[VAL_17:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[VAL_18:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_24:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_16]][@b] : <@CmpLT<[@n]>>, !array.type<@n x !felt.type>
 // CHECK-NEXT:        %[[VAL_19:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_20:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_18]], %[[VAL_19]])
 // CHECK-NEXT:        scf.if %[[VAL_20]] {
 // CHECK-NEXT:          %[[VAL_21:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:          %[[VAL_22:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_21]]
 // CHECK-NEXT:          %[[VAL_23:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_17]]{{\[}}%[[VAL_22]]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_24:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_16]][@b] : <@CmpLT<[@n]>>, !array.type<@n x !felt.type>
 // CHECK-NEXT:          %[[VAL_25:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:          %[[VAL_26:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_25]]
 // CHECK-NEXT:          %[[VAL_27:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_24]]{{\[}}%[[VAL_26]]] : <@n x !felt.type>, !felt.type
@@ -61,10 +61,9 @@ component main = CmpLT(5);
 // CHECK-NEXT:          %[[VAL_28:[0-9a-zA-Z_\.]+]] = felt.const  1
 // CHECK-NEXT:          %[[VAL_29:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_28]]
 // CHECK-NEXT:          %[[VAL_30:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_17]]{{\[}}%[[VAL_29]]] : <@n x !felt.type>, !felt.type
-// CHECK-NEXT:          %[[VAL_31:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_16]][@b] : <@CmpLT<[@n]>>, !array.type<@n x !felt.type>
 // CHECK-NEXT:          %[[VAL_32:[0-9a-zA-Z_\.]+]] = felt.const  1
 // CHECK-NEXT:          %[[VAL_33:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_32]]
-// CHECK-NEXT:          %[[VAL_34:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_31]]{{\[}}%[[VAL_33]]] : <@n x !felt.type>, !felt.type
+// CHECK-NEXT:          %[[VAL_34:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_24]]{{\[}}%[[VAL_33]]] : <@n x !felt.type>, !felt.type
 // CHECK-NEXT:          constrain.eq %[[VAL_34]], %[[VAL_30]] : !felt.type, !felt.type
 // CHECK-NEXT:        }
 // CHECK-NEXT:        function.return

--- a/circom/tests/operators/inline_switch_template.circom
+++ b/circom/tests/operators/inline_switch_template.circom
@@ -52,6 +52,8 @@ component main = MultByInv();
 // CHECK-NEXT:        function.return %[[VAL_1]] : !struct.type<@MultByInv<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_13:[0-9a-zA-Z_\.]+]]: !struct.type<@MultByInv<[]>>, %[[VAL_14:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %[[VAL_23:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_13]][@out] : <@MultByInv<[]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_22:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_13]][@inv] : <@MultByInv<[]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_15:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_16:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_17:[0-9a-zA-Z_\.]+]] = bool.cmp ne(%[[VAL_14]], %[[VAL_16]])
@@ -63,10 +65,8 @@ component main = MultByInv();
 // CHECK-NEXT:          %[[VAL_21:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:          scf.yield %[[VAL_21]] : !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_22:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_13]][@inv] : <@MultByInv<[]>>, !felt.type
-// CHECK-NEXT:        %[[VAL_23:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_13]][@out] : <@MultByInv<[]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_23]], %[[VAL_22]] : !felt.type, !felt.type
-// CHECK-NEXT:        %[[VAL_24:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_14]], %[[VAL_22]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[VAL_24:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_14]], %[[VAL_23]] : !felt.type, !felt.type
 // CHECK-NEXT:        %[[VAL_25:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        constrain.eq %[[VAL_24]], %[[VAL_25]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return

--- a/circom/tests/simple/call_in_constraint_gen_01.circom
+++ b/circom/tests/simple/call_in_constraint_gen_01.circom
@@ -36,8 +36,8 @@ component main = T();
 // CHECK-NEXT:      }
 // CHECK-LABEL:     function.def @constrain
 // CHECK-SAME:      (%[[VAL_3:[0-9a-zA-Z_\.]+]]: !struct.type<@T<[]>>, %[[VAL_4:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = function.call @f(%[[VAL_4]]) : (!felt.type) -> !felt.type
 // CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_3]][@outp] : <@T<[]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = function.call @f(%[[VAL_4]]) : (!felt.type) -> !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_6]], %[[VAL_5]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/simple/call_in_constraint_gen_02.circom
+++ b/circom/tests/simple/call_in_constraint_gen_02.circom
@@ -41,8 +41,8 @@ component main = T();
 // CHECK-NEXT:      }
 // CHECK-LABEL:     function.def @constrain
 // CHECK-SAME:      (%[[VAL_3:[0-9a-zA-Z_\.]+]]: !struct.type<@T<[]>>, %[[VAL_4:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = function.call @f(%[[VAL_4]]) : (!felt.type) -> !felt.type
 // CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_3]][@outp] : <@T<[]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = function.call @f(%[[VAL_4]]) : (!felt.type) -> !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_6]], %[[VAL_5]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/simple/call_in_constraint_gen_03.circom
+++ b/circom/tests/simple/call_in_constraint_gen_03.circom
@@ -52,8 +52,8 @@ component main = T();
 // CHECK-NEXT:      }
 // CHECK-LABEL:     function.def @constrain
 // CHECK-SAME:      (%[[VAL_3:[0-9a-zA-Z_\.]+]]: !struct.type<@T<[]>>, %[[VAL_4:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = function.call @f(%[[VAL_4]]) : (!felt.type) -> !felt.type
 // CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_3]][@outp] : <@T<[]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = function.call @f(%[[VAL_4]]) : (!felt.type) -> !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_6]], %[[VAL_5]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/simple/constrain_before_assign.circom
+++ b/circom/tests/simple/constrain_before_assign.circom
@@ -25,7 +25,6 @@ component main = Template();
 // CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_2]][@outp] : <@Template<[]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = felt.const  7
 // CHECK-NEXT:        constrain.eq %[[VAL_3]], %[[VAL_4]] : !felt.type, !felt.type
-// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_2]][@outp] : <@Template<[]>>, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }

--- a/circom/tests/simple/constrain_before_assign.circom
+++ b/circom/tests/simple/constrain_before_assign.circom
@@ -1,0 +1,32 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --llzk -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
+
+pragma circom 2.0.0;
+
+template Template() {
+    signal output outp;
+    outp === 7;
+    outp <-- 7;
+}
+
+component main = Template();
+
+// CHECK-LABEL: module attributes {veridise.lang = "llzk"} {
+// CHECK-NEXT:    struct.def @Template<[]> {
+// CHECK-NEXT:      struct.field @outp : !felt.type {llzk.pub}
+// CHECK-NEXT:      function.def @compute() -> !struct.type<@Template<[]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_0:[0-9a-zA-Z_\.]+]] = struct.new : <@Template<[]>>
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = felt.const  7
+// CHECK-NEXT:        struct.writef %[[VAL_0]][@outp] = %[[VAL_1]] : <@Template<[]>>, !felt.type
+// CHECK-NEXT:        function.return %[[VAL_0]] : !struct.type<@Template<[]>>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[VAL_2:[0-9a-zA-Z_\.]+]]: !struct.type<@Template<[]>>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_2]][@outp] : <@Template<[]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = felt.const  7
+// CHECK-NEXT:        constrain.eq %[[VAL_3]], %[[VAL_4]] : !felt.type, !felt.type
+// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_2]][@outp] : <@Template<[]>>, !felt.type
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/simple/idiv_2.circom
+++ b/circom/tests/simple/idiv_2.circom
@@ -23,9 +23,9 @@ component main = A(12);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_4:[0-9a-zA-Z_\.]+]]: !struct.type<@A<[@n]>>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_4]][@c] : <@A<[@n]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = felt.const  4
 // CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = felt.uintdiv %[[VAL_5]], %[[VAL_6]] : !felt.type, !felt.type
-// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_4]][@c] : <@A<[@n]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_8]], %[[VAL_7]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/simple/load.circom
+++ b/circom/tests/simple/load.circom
@@ -38,6 +38,7 @@ component main = A(1);
 // CHECK-LABEL:     function.def @constrain
 // CHECK-SAME:      (%[[SELF:[0-9a-zA-Z_\.]+]]: !struct.type<@A<[@n]>>, %[[V_14:[0-9a-zA-Z_\.]+]]: !array.type<3 x !felt.type>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[V_N:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[V_26:[0-9a-zA-Z_\.]+]] = struct.readf %[[SELF]][@out] : <@A<[@n]>>, !felt.type
 // CHECK-NEXT:        %[[V_16:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[V_17:[0-9a-zA-Z_\.]+]] = array.new %[[V_16]], %[[V_16]], %[[V_16]] : <3 x !felt.type>
 // CHECK-NEXT:        %[[V_18:[0-9a-zA-Z_\.]+]] = felt.const  2
@@ -48,7 +49,6 @@ component main = A(1);
 // CHECK-NEXT:        %[[V_23:[0-9a-zA-Z_\.]+]] = array.read %[[V_A]]{{\[}}%[[V_22]]] : <3 x !felt.type>, !felt.type
 // CHECK-NEXT:        %[[V_24:[0-9a-zA-Z_\.]+]] = cast.toindex %[[V_23]]
 // CHECK-NEXT:        %[[V_25:[0-9a-zA-Z_\.]+]] = array.read %[[V_14]]{{\[}}%[[V_24]]] : <3 x !felt.type>, !felt.type
-// CHECK-NEXT:        %[[V_26:[0-9a-zA-Z_\.]+]] = struct.readf %[[SELF]][@out] : <@A<[@n]>>, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }

--- a/circom/tests/simple/loop_and_block.circom
+++ b/circom/tests/simple/loop_and_block.circom
@@ -41,6 +41,7 @@ component main = A(3);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_14:[0-9a-zA-Z_\.]+]]: !struct.type<@A<[@n]>>, %[[VAL_15:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[VAL_16:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %{{[0-9a-zA-Z_\.]+}} = struct.readf %[[VAL_14]][@out] : <@A<[@n]>>, !array.type<@n x !felt.type>
 // CHECK-NEXT:        %[[VAL_17:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_18:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_19:[0-9a-zA-Z_\.]+]] = %[[VAL_17]]) : (!felt.type) -> !felt.type {
 // CHECK-NEXT:          %[[VAL_20:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_19]], %[[VAL_16]])

--- a/circom/tests/simple/read_from_output.circom
+++ b/circom/tests/simple/read_from_output.circom
@@ -28,9 +28,9 @@ component main = ReadFromOutput();
 // CHECK-LABEL:    function.def @constrain
 // CHECK-SAME:     (%[[VAL_3:[0-9a-zA-Z_\.]+]]: !struct.type<@ReadFromOutput<[]>>, %[[VAL_4:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:       %[[VAL_6:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_3]][@outp] : <@ReadFromOutput<[]>>, !felt.type
-// CHECK-NEXT:       constrain.eq %[[VAL_6]], %[[VAL_4]] : !felt.type, !felt.type
 // CHECK-NEXT:       %[[VAL_7:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_3]][@intermediate] : <@ReadFromOutput<[]>>, !felt.type
-// CHECK-NEXT:       constrain.eq %[[VAL_7]], %[[VAL_4]] : !felt.type, !felt.type
+// CHECK-NEXT:       constrain.eq %[[VAL_6]], %[[VAL_4]] : !felt.type, !felt.type
+// CHECK-NEXT:       constrain.eq %[[VAL_7]], %[[VAL_6]] : !felt.type, !felt.type
 // CHECK-NEXT:       function.return
 // CHECK-NEXT:     }
 // CHECK-NEXT:   }

--- a/circom/tests/simple/read_from_output_with_felt_cast.circom
+++ b/circom/tests/simple/read_from_output_with_felt_cast.circom
@@ -28,13 +28,13 @@ component main = ReadFromOutputWithFeltCast();
 // CHECK-NEXT:        function.return %[[VAL_1]] : !struct.type<@ReadFromOutputWithFeltCast<[]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_5:[0-9a-zA-Z_\.]+]]: !struct.type<@ReadFromOutputWithFeltCast<[]>>, %[[VAL_6:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %[[VAL_9:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_5]][@outp] : <@ReadFromOutputWithFeltCast<[]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_5]][@intermediate] : <@ReadFromOutputWithFeltCast<[]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = bool.cmp eq(%[[VAL_6]], %[[VAL_7]])
-// CHECK-NEXT:        %[[VAL_9:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_5]][@outp] : <@ReadFromOutputWithFeltCast<[]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = cast.tofelt %[[VAL_8]] : i1
 // CHECK-NEXT:        constrain.eq %[[VAL_9]], %[[VAL_10]] : !felt.type, !felt.type
-// CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_5]][@intermediate] : <@ReadFromOutputWithFeltCast<[]>>, !felt.type
-// CHECK-NEXT:        constrain.eq %[[VAL_11]], %[[VAL_10]] : !felt.type, !felt.type
+// CHECK-NEXT:        constrain.eq %[[VAL_11]], %[[VAL_9]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }

--- a/circom/tests/simple/simple_01.circom
+++ b/circom/tests/simple/simple_01.circom
@@ -29,8 +29,8 @@ component main = Simple3();
 // CHECK-LABEL:     function.def @constrain
 // CHECK-SAME:      (%[[VAL_2:[0-9a-zA-Z_\.]+]]: !struct.type<@Simple3<[]>>, %[[VAL_3:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_2]][@b] : <@Simple3<[]>>, !felt.type
-// CHECK-NEXT:        constrain.eq %[[VAL_4]], %[[VAL_3]] : !felt.type, !felt.type
 // CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_2]][@c] : <@Simple3<[]>>, !felt.type
+// CHECK-NEXT:        constrain.eq %[[VAL_4]], %[[VAL_3]] : !felt.type, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_5]], %[[VAL_3]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/simple/simple_02.circom
+++ b/circom/tests/simple/simple_02.circom
@@ -33,10 +33,10 @@ component main = Simple4(10);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_7:[0-9a-zA-Z_\.]+]]: !struct.type<@Simple4<[@a]>>, %[[VAL_8:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_9:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = poly.read_const @a : !felt.type
+// CHECK-NEXT:        %[[VAL_14:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_7]][@b] : <@Simple4<[@a]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_12:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_13:[0-9a-zA-Z_\.]+]] = felt.const  11
-// CHECK-NEXT:        %[[VAL_14:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_7]][@b] : <@Simple4<[@a]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_14]], %[[VAL_10]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/simple/simple_03.circom
+++ b/circom/tests/simple/simple_03.circom
@@ -35,8 +35,9 @@ component main = Simple5();
 // CHECK-LABEL:     function.def @constrain
 // CHECK-SAME:      (%[[VAL_4:[0-9a-zA-Z_\.]+]]: !struct.type<@Simple5<[]>>, %[[VAL_5:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_6:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_7:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_4]][@x] : <@Simple5<[]>>, !felt.type
-// CHECK-NEXT:        constrain.eq %[[VAL_8]], %[[VAL_5]] : !felt.type, !felt.type
 // CHECK-NEXT:        %[[VAL_9:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_4]][@y] : <@Simple5<[]>>, !felt.type
+// CHECK-NEXT:        %[[VAL_Z:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_4]][@z] : <@Simple5<[]>>, !felt.type
+// CHECK-NEXT:        constrain.eq %[[VAL_8]], %[[VAL_5]] : !felt.type, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_9]], %[[VAL_6]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/simple/simple_04.circom
+++ b/circom/tests/simple/simple_04.circom
@@ -47,13 +47,13 @@ component main {public [a, b]} = A();
 // CHECK-NEXT:      }
 // CHECK-LABEL:     function.def @constrain
 // CHECK-SAME:      (%[[V_8:[0-9a-zA-Z_\.]+]]: !struct.type<@A<[]>>, %[[V_9:[0-9a-zA-Z_\.]+]]: !felt.type {llzk.pub}, %[[V_10:[0-9a-zA-Z_\.]+]]: !felt.type {llzk.pub}, %[[V_11:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %[[V_17:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_8]][@c] : <@A<[]>>, !felt.type
+// CHECK-NEXT:        %[[V_15:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_8]][@x] : <@A<[]>>, !felt.type
 // CHECK-NEXT:        %[[V_12:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_8]][@cb] : <@A<[]>>, !struct.type<@B<[]>>
 // CHECK-NEXT:        function.call @B::@constrain(%[[V_12]], %[[V_9]], %[[V_10]]) : (!struct.type<@B<[]>>, !felt.type, !felt.type) -> ()
 // CHECK-NEXT:        %[[V_14:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_12]][@c] : <@B<[]>>, !felt.type
-// CHECK-NEXT:        %[[V_15:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_8]][@x] : <@A<[]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[V_15]], %[[V_14]] : !felt.type, !felt.type
-// CHECK-NEXT:        %[[V_16:[0-9a-zA-Z_\.]+]] = felt.mul %[[V_14]], %[[V_11]] : !felt.type, !felt.type
-// CHECK-NEXT:        %[[V_17:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_8]][@c] : <@A<[]>>, !felt.type
+// CHECK-NEXT:        %[[V_16:[0-9a-zA-Z_\.]+]] = felt.mul %[[V_15]], %[[V_11]] : !felt.type, !felt.type
 // CHECK-NEXT:        constrain.eq %[[V_17]], %[[V_16]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
@@ -69,8 +69,8 @@ component main {public [a, b]} = A();
 // CHECK-NEXT:      }
 // CHECK-LABEL:     function.def @constrain
 // CHECK-SAME:      (%[[V_22:[0-9a-zA-Z_\.]+]]: !struct.type<@B<[]>>, %[[V_23:[0-9a-zA-Z_\.]+]]: !felt.type {llzk.pub}, %[[V_24:[0-9a-zA-Z_\.]+]]: !felt.type {llzk.pub}) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:        %[[V_25:[0-9a-zA-Z_\.]+]] = felt.mul %[[V_23]], %[[V_24]] : !felt.type, !felt.type
-// CHECK-NEXT:        %[[V_26:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_22]][@c] : <@B<[]>>, !felt.type
+// CHECK-DAG:         %[[V_25:[0-9a-zA-Z_\.]+]] = felt.mul %[[V_23]], %[[V_24]] : !felt.type, !felt.type
+// CHECK-DAG:         %[[V_26:[0-9a-zA-Z_\.]+]] = struct.readf %[[V_22]][@c] : <@B<[]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[V_26]], %[[V_25]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/simple/simple_05.circom
+++ b/circom/tests/simple/simple_05.circom
@@ -26,9 +26,9 @@ component main = A();
 // CHECK-NEXT:      }
 // CHECK-LABEL:     function.def @constrain
 // CHECK-SAME:      (%[[VAL_6:[0-9a-zA-Z_\.]+]]: !struct.type<@A<[]>>, %[[VAL_7:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_8:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_9:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        %[[VAL_12:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_6]][@out] : <@A<[]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_7]], %[[VAL_8]] : !felt.type, !felt.type
 // CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_10]], %[[VAL_9]] : !felt.type, !felt.type
-// CHECK-NEXT:        %[[VAL_12:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_6]][@out] : <@A<[]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_12]], %[[VAL_11]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/subcmps/array_copy_constraints.circom
+++ b/circom/tests/subcmps/array_copy_constraints.circom
@@ -43,10 +43,10 @@ component main = Caller(5);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_5:[0-9a-zA-Z_\.]+]]: !struct.type<@Caller<[@n]>>, %[[VAL_6:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_5]][@outp] : <@Caller<[@n]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_5]][@op] : <@Caller<[@n]>>, !struct.type<@Sum<[@n]>>
 // CHECK-NEXT:        function.call @Sum::@constrain(%[[VAL_8]], %[[VAL_6]]) : (!struct.type<@Sum<[@n]>>, !array.type<@n x !felt.type>) -> ()
 // CHECK-NEXT:        %[[VAL_9:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_8]][@outp] : <@Sum<[@n]>>, !felt.type
-// CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_5]][@outp] : <@Caller<[@n]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_10]], %[[VAL_9]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
@@ -75,6 +75,7 @@ component main = Caller(5);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_27:[0-9a-zA-Z_\.]+]]: !struct.type<@Sum<[@n]>>, %[[VAL_28:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[VAL_29:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type
+// CHECK-NEXT:        %[[VAL_43:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_27]][@outp] : <@Sum<[@n]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_30:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_31:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_32:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_33:[0-9a-zA-Z_\.]+]] = %[[VAL_30]], %[[VAL_34:[0-9a-zA-Z_\.]+]] = %[[VAL_31]]) : (!felt.type, !felt.type) -> (!felt.type, !felt.type) {
@@ -89,7 +90,6 @@ component main = Caller(5);
 // CHECK-NEXT:          %[[VAL_42:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_37]], %[[VAL_41]] : !felt.type, !felt.type
 // CHECK-NEXT:          scf.yield %[[VAL_40]], %[[VAL_42]] : !felt.type, !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_43:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_27]][@outp] : <@Sum<[@n]>>, !felt.type
 // CHECK-NEXT:        constrain.eq %[[VAL_43]], %[[VAL_32]]#0 : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }

--- a/circom/tests/type_conversions/bool_2.circom
+++ b/circom/tests/type_conversions/bool_2.circom
@@ -59,6 +59,7 @@ component main = A(555);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_18:[0-9a-zA-Z_\.]+]]: !struct.type<@A<[@x]>>, %[[VAL_19:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[VAL_20:[0-9a-zA-Z_\.]+]] = poly.read_const @x : !felt.type
+// CHECK-NEXT:        %[[VAL_UNUSED:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_18]][@out] : <@A<[@x]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_21:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:        %[[VAL_22:[0-9a-zA-Z_\.]+]] = function.call @binop_bool(%[[VAL_19]], %[[VAL_20]]) : (!felt.type, !felt.type) -> !felt.type
 // CHECK-NEXT:        %[[VAL_23:[0-9a-zA-Z_\.]+]] = felt.const  0
@@ -70,7 +71,6 @@ component main = A(555);
 // CHECK-NEXT:          %[[VAL_27:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:          scf.yield %[[VAL_27]] : !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_28:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_18]][@out] : <@A<[@x]>>, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }

--- a/circom/tests/type_conversions/bool_3.circom
+++ b/circom/tests/type_conversions/bool_3.circom
@@ -42,19 +42,19 @@ component main = A(99);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_11:[0-9a-zA-Z_\.]+]]: !struct.type<@A<[@x]>>, %[[VAL_12:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:        %[[VAL_13:[0-9a-zA-Z_\.]+]] = poly.read_const @x : !felt.type
-// CHECK-NEXT:        %[[VAL_14:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_14:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_11]][@out] : <@A<[@x]>>, !felt.type
 // CHECK-NEXT:        %[[VAL_15:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_16:[0-9a-zA-Z_\.]+]] = bool.cmp ne(%[[VAL_12]], %[[VAL_15]])
-// CHECK-NEXT:        %[[VAL_17:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:        %[[VAL_18:[0-9a-zA-Z_\.]+]] = bool.cmp ne(%[[VAL_13]], %[[VAL_17]])
-// CHECK-NEXT:        %[[VAL_19:[0-9a-zA-Z_\.]+]] = bool.or %[[VAL_16]], %[[VAL_18]] : i1, i1
-// CHECK-NEXT:        %[[VAL_20:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_19]] -> (!felt.type) {
-// CHECK-NEXT:          %[[VAL_21:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:          scf.yield %[[VAL_21]] : !felt.type
+// CHECK-NEXT:        %[[VAL_16:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_17:[0-9a-zA-Z_\.]+]] = bool.cmp ne(%[[VAL_12]], %[[VAL_16]])
+// CHECK-NEXT:        %[[VAL_18:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:        %[[VAL_19:[0-9a-zA-Z_\.]+]] = bool.cmp ne(%[[VAL_13]], %[[VAL_18]])
+// CHECK-NEXT:        %[[VAL_20:[0-9a-zA-Z_\.]+]] = bool.or %[[VAL_17]], %[[VAL_19]] : i1, i1
+// CHECK-NEXT:        %[[VAL_21:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_20]] -> (!felt.type) {
+// CHECK-NEXT:          %[[VAL_22:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          scf.yield %[[VAL_22]] : !felt.type
 // CHECK-NEXT:        } else {
-// CHECK-NEXT:          scf.yield %[[VAL_14]] : !felt.type
+// CHECK-NEXT:          scf.yield %[[VAL_15]] : !felt.type
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[VAL_22:[0-9a-zA-Z_\.]+]] = struct.readf %[[VAL_11]][@out] : <@A<[@x]>>, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }

--- a/flake.lock
+++ b/flake.lock
@@ -88,11 +88,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769624604,
-        "narHash": "sha256-ia5jqvrlN+3w35KlFYT3qq0MV9bhTlscLmGAL00qtj0=",
+        "lastModified": 1769721193,
+        "narHash": "sha256-odbLNJDG/4mc0LmRdL1mRTHMdf/bkmcv3ypBUKjRj1w=",
         "ref": "refs/heads/main",
-        "rev": "dcfd4069d3898a957e78b6d3fa235d6bd8afc292",
-        "revCount": 325,
+        "rev": "48dca086579da61b18a9ce1cb9113405480da85b",
+        "revCount": 326,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/project-llzk/llzk-rs"

--- a/llzk_backend/src/module.rs
+++ b/llzk_backend/src/module.rs
@@ -511,6 +511,25 @@ fn gen_template_llzk<'ast, 'ctx, T: TemplateLike>(
         })?;
     }
 
+    // Insert read operations for struct fields into constrain functions.
+    let location = Location::unknown(codegen.context);
+    let builder = OpBuilder::new(codegen.context);
+    println!("Number of fields: {}", new_struct.get_field_defs().len());
+    for field in new_struct.get_field_defs() {
+        let field_name = field.field_name();
+        constrain_ctx.block_ctx.declare_name_if_not_present(field_name, || {
+            let readf = r#struct::readf(
+                &builder,
+                location,
+                field.field_type(),
+                constrain_func.self_value_of_constrain()?,
+                field_name,
+            )?;
+            println!("readf = {readf}");
+            Ok(readf)
+        })?;
+    }
+
     // Insert the Operations created from variable Declaration statements and map the circom
     // variable name to LLZK op result Value (do this in each function).
     for (name, op) in declarations.decl_inits {

--- a/llzk_backend/src/module.rs
+++ b/llzk_backend/src/module.rs
@@ -512,14 +512,14 @@ fn gen_template_llzk<'ast, 'ctx, T: TemplateLike>(
     for field in new_struct.get_field_defs() {
         let field_name = field.field_name();
         constrain_ctx.block_ctx.declare_name_if_not_present(field_name, || {
-            let readf = r#struct::readf(
+            r#struct::readf(
                 &builder,
                 location,
                 field.field_type(),
                 constrain_func.self_value_of_constrain()?,
                 field_name,
-            )?;
-            Ok(readf)
+            )
+            .map_err(Into::into)
         })?;
     }
 

--- a/llzk_backend/src/module.rs
+++ b/llzk_backend/src/module.rs
@@ -514,7 +514,6 @@ fn gen_template_llzk<'ast, 'ctx, T: TemplateLike>(
     // Insert read operations for struct fields into constrain functions.
     let location = Location::unknown(codegen.context);
     let builder = OpBuilder::new(codegen.context);
-    println!("Number of fields: {}", new_struct.get_field_defs().len());
     for field in new_struct.get_field_defs() {
         let field_name = field.field_name();
         constrain_ctx.block_ctx.declare_name_if_not_present(field_name, || {
@@ -525,7 +524,6 @@ fn gen_template_llzk<'ast, 'ctx, T: TemplateLike>(
                 constrain_func.self_value_of_constrain()?,
                 field_name,
             )?;
-            println!("readf = {readf}");
             Ok(readf)
         })?;
     }

--- a/llzk_backend/src/shared.rs
+++ b/llzk_backend/src/shared.rs
@@ -674,20 +674,23 @@ pub fn set_operand_if_undef<'ctx, 'op>(
 /// If the operation the value comes from is in an inner block, moves the op right after the parent
 /// op that is in the same block as the op about to be moved.
 ///
+/// If the value is already before the op in a different but dominating block,
+/// this function does nothing.
+///
 /// # Panics
 ///
-/// If the parent search reaches the top, meaning that the value comes from an op in a block that
-/// is a 'parent' of the other op or that the value's op is not owned by a block.
+/// If the value's op is not owned by a block.
 pub fn insert_after_if_op_result<'ctx, 'val, 'op>(
     val: Value<'ctx, 'val>,
     op: OperationRef<'ctx, 'op>,
 ) -> Result<()> {
-    if let Ok(mut owner) = op_result_owner(val) {
+    if let Ok(owner) = op_result_owner(val) {
         anyhow::ensure!(owner.block().is_some(), "reference op must belong to a block");
         if let Some(op_block) = op.block() {
-            owner = find_parent_in_block(op_block, owner).expect("parent op not found");
-        };
-        move_op_after(&owner, &op);
+            if let Some(owner) = find_parent_in_block(op_block, owner) {
+                move_op_after(&owner, &op);
+            }
+        }
     }
     Ok(())
 }

--- a/llzk_backend/src/template.rs
+++ b/llzk_backend/src/template.rs
@@ -57,7 +57,6 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::convert::TryFrom;
-use std::ops::Deref;
 use std::rc::Rc;
 
 /// Alias for `Option<T>` to make it clear what the meaning of the option is within the
@@ -982,9 +981,12 @@ where
                             [] => {
                                 // The `<--` operator is witness generation only so code for the RHS
                                 // expression should only be generated in the compute function.
+                                // The constrain function just reads that field from "self" struct.
+                                // However, we already inserted these reads at the beginning of the
+                                // constrain function in `gen_template_llzk`.
                                 let compute_only = template.compute_only();
                                 let signal_type = template.get_signal_type(var)?;
-                                let _: () = rhe
+                                rhe
                                     .gen_llzk_in_template(codegen, &compute_only)?
                                     .and_then_same(|fc, val| {
                                         let location = codegen.location_from_meta(meta);
@@ -1006,22 +1008,7 @@ where
                                             .into(),
                                         )?;
                                         fc.block_ctx.set_named_value(var.clone(), value)
-                                    })?;
-                                // The constrain function just reads that field from "self" struct.
-                                let constrain_only = template.constrain_only();
-                                (&constrain_only).and_then_same(|fc, _| {
-                                    let val = fc.append_op_unnamed_result(
-                                        r#struct::readf(
-                                            &OpBuilder::new(codegen.context.deref()),
-                                            codegen.location_from_meta(meta),
-                                            signal_type,
-                                            fc.func.self_value_of_constrain()?,
-                                            var,
-                                        )?
-                                        .into(),
-                                    )?;
-                                    fc.block_ctx.set_named_value(var.clone(), val)
-                                })
+                                    })
                             }
                             access => rhe
                                 .gen_llzk_in_template(codegen, &template.compute_only())?
@@ -1069,30 +1056,20 @@ where
                                         fc.block_ctx.set_named_value(var.clone(), value)
                                     },
                                     |fc, val| {
-                                        // Read value of field from "self" struct and generate
-                                        // equality constraint with 'val'.
+                                        // Get value of field from "self" struct (already generated at
+                                        // the beginning of the constrain function, see `gen_template_llzk`)
+                                        // and generate equality constraint with 'val'.
                                         let location = codegen.location_from_meta(meta);
-                                        let builder = OpBuilder::new(codegen.context.deref());
-                                        let val_from_read = fc.append_op_unnamed_result(
-                                            r#struct::readf(
-                                                &builder,
-                                                location,
-                                                signal_type,
-                                                fc.func.self_value_of_constrain()?,
-                                                var,
-                                            )?
-                                            .into(),
-                                        )?;
+                                        let signal_val = fc.block_ctx.get_named_value(var)?;
                                         let (lhs, rhs) = unify_constrain_eq_types(
                                             fc,
                                             location,
-                                            val_from_read,
+                                            *signal_val,
                                             val,
                                         )?;
                                         fc.append_op_no_result(
                                             constrain::eq(location, lhs, rhs).into(),
-                                        )?;
-                                        fc.block_ctx.set_named_value(var.clone(), rhs)
+                                        )
                                     },
                                 )
                             }

--- a/llzk_backend/src/write_chain.rs
+++ b/llzk_backend/src/write_chain.rs
@@ -254,20 +254,10 @@ impl<'ast> WriteChain<'ast> {
         fc: &mut FunctionContext<'ctx, '_, '_, 'val>,
         location: Location<'ctx>,
     ) -> Result<Value<'ctx, 'val>> {
-        if target.is_constrain() {
-            // Read value from field of "self" struct.
-            let expected_type = fc.block_ctx.get_named_value(var).unwrap().r#type();
-            let self_value = fc.func.self_value_of_constrain()?;
-            fc.append_op_unnamed_result(r#struct::readf(
-                &OpBuilder::new(codegen.context),
-                location,
-                expected_type,
-                self_value,
-                var,
-            )?)
-        } else {
-            fc.block_ctx.get_named_value(var).copied()
-        }
+        // Both compute and constrain functions hshould have the `var` defined:
+        // compute from an existing assignment, or constrain from pre-generation
+        // of the `readf` in `gen_template_llzk`.
+        fc.block_ctx.get_named_value(var).copied()
     }
 
     /// Handle [WriteChain::Root] case of [`WriteChain::get_value`] other than

--- a/llzk_backend/src/write_chain.rs
+++ b/llzk_backend/src/write_chain.rs
@@ -251,7 +251,7 @@ impl<'ast> WriteChain<'ast> {
         var: &str,
         fc: &mut FunctionContext<'ctx, '_, '_, 'val>,
     ) -> Result<Value<'ctx, 'val>> {
-        // Both compute and constrain functions hshould have the `var` defined:
+        // Both compute and constrain functions should have the `var` defined:
         // compute from an existing assignment, or constrain from pre-generation
         // of the `readf` in `gen_template_llzk`.
         fc.block_ctx.get_named_value(var).copied()

--- a/llzk_backend/src/write_chain.rs
+++ b/llzk_backend/src/write_chain.rs
@@ -21,7 +21,6 @@ use llzk::prelude::FuncDefOpLike as _;
 use llzk::prelude::Location;
 use llzk::prelude::OperationLike as _;
 use llzk::prelude::Value;
-use llzk::prelude::ValueLike as _;
 use llzk::value_ext::replace_all_uses;
 use program_structure::ast::Access;
 use program_structure::ast::AssignOp;
@@ -62,6 +61,7 @@ impl WriteTarget {
         matches!(self, WriteTarget::Compute)
     }
     /// Returns true if the target is `@constrain`.
+    #[allow(unused)]
     #[inline]
     fn is_constrain(&self) -> bool {
         matches!(self, WriteTarget::Constrain)
@@ -249,10 +249,7 @@ impl<'ast> WriteChain<'ast> {
     fn get_root_signal<'ctx, 'val>(
         &self,
         var: &str,
-        target: WriteTarget,
-        codegen: &LlzkCodegen<'ast, 'ctx, impl ProgramLike>,
         fc: &mut FunctionContext<'ctx, '_, '_, 'val>,
-        location: Location<'ctx>,
     ) -> Result<Value<'ctx, 'val>> {
         // Both compute and constrain functions hshould have the `var` defined:
         // compute from an existing assignment, or constrain from pre-generation
@@ -369,7 +366,7 @@ impl<'ast> WriteChain<'ast> {
     ) -> Result<Value<'ctx, 'val>> {
         match self {
             WriteChain::Root { var, op: RootWriteOp::Signal } => {
-                self.get_root_signal(var, target, codegen, fc, location)
+                self.get_root_signal(var, fc)
             }
             WriteChain::Root { var, .. } => self.get_root_value(var, fc),
             WriteChain::Array { indices, prev } => self.get_array_value(


### PR DESCRIPTION
Resolves https://github.com/project-llzk/circom/issues/311

- Pre-reads struct fields in constrain functions, since they're read-only in that context, rather than waiting for assign operations to generate field reads (which leads to bugs in `===` cases, per the original issue).
- Updates all affected test cases as minimally as possible