### PR TITLE
Handle "easier" cases of arrays with non-trivial dimensions

### DIFF
--- a/circom/tests/arrays/array_dimensions_05.circom
+++ b/circom/tests/arrays/array_dimensions_05.circom
@@ -1,9 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --stabilize --llzk --llzk_plaintext -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// COM: The `@outp` field is not instantiated, so it's not clear what the array size is.
-// COM: This can be refined when https://github.com/project-llzk/circom/issues/320
-// COM: is implemented.
 
 pragma circom 2.0.0;
 
@@ -14,24 +11,32 @@ template ArrayDims(N) {
 
 component main = ArrayDims(7);
 
-// CHECK: #[[$ATTR_0:[0-9a-zA-Z_\.]+]] = affine_map<()[s0] -> (s0)>
 // CHECK-LABEL: module attributes {llzk.lang, llzk.main = !struct.type<@ArrayDims::@ArrayDims<[7]>>} {
 // CHECK-NEXT:    poly.template @ArrayDims {
 // CHECK-NEXT:      poly.param @N
+// CHECK-NEXT:      poly.expr @M {
+// CHECK-NEXT:        %[[VAL_0:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = llzk.nondet : !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_0]], %[[VAL_2]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:        poly.yield %[[VAL_3]] : !felt.type<"bn128">
+// CHECK-NEXT:      }
 // CHECK-NEXT:      struct.def @ArrayDims {
-// CHECK-NEXT:        struct.member @outp : !array.type<#[[$ATTR_0]] x !felt.type<"bn128">> {llzk.pub}
+// CHECK-NEXT:        struct.member @outp : !array.type<@M x !felt.type<"bn128">> {llzk.pub}
 // CHECK-NEXT:        function.def @compute() -> !struct.type<@ArrayDims::@ArrayDims<[@N]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
-// CHECK-NEXT:          %[[VAL_0:[0-9a-zA-Z_\.]+]] = struct.new : <@ArrayDims::@ArrayDims<[@N]>>
-// CHECK-NEXT:          %[[VAL_1:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_2:[0-9a-zA-Z_\.]+]] = felt.const  1
-// CHECK-NEXT:          %[[VAL_3:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_1]], %[[VAL_2]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:          function.return %[[VAL_0]] : !struct.type<@ArrayDims::@ArrayDims<[@N]>>
-// CHECK-NEXT:        }
-// CHECK-NEXT:        function.def @constrain(%[[VAL_4:[0-9a-zA-Z_\.]+]]: !struct.type<@ArrayDims::@ArrayDims<[@N]>>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_4:[0-9a-zA-Z_\.]+]] = struct.new : <@ArrayDims::@ArrayDims<[@N]>>
+// CHECK-NEXT:          %[[VAL_6:[0-9a-zA-Z_\.]+]] = poly.read_const @M : !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_5:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_6:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_4]][@outp] : <@ArrayDims::@ArrayDims<[@N]>>, !array.type<#[[$ATTR_0]] x !felt.type<"bn128">>
-// CHECK-NEXT:          %[[VAL_7:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:          %[[VAL_7:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
 // CHECK-NEXT:          %[[VAL_8:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_5]], %[[VAL_7]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          function.return %[[VAL_4]] : !struct.type<@ArrayDims::@ArrayDims<[@N]>>
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.def @constrain(%[[VAL_9:[0-9a-zA-Z_\.]+]]: !struct.type<@ArrayDims::@ArrayDims<[@N]>>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_11:[0-9a-zA-Z_\.]+]] = poly.read_const @M : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_10:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_12:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_9]][@outp] : <@ArrayDims::@ArrayDims<[@N]>>, !array.type<@M x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_13:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_14:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_10]], %[[VAL_13]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:          function.return
 // CHECK-NEXT:        }
 // CHECK-NEXT:      }

--- a/circom/tests/arrays/array_dimensions_06.circom
+++ b/circom/tests/arrays/array_dimensions_06.circom
@@ -1,8 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --stabilize --llzk --llzk_plaintext -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL: *
-// COM: Template parameters expressions are currently unsupported as array dimensions for inputs.
 
 pragma circom 2.0.0;
 
@@ -12,4 +10,27 @@ template ArrayDims(N) {
 
 component main = ArrayDims(7);
 
-// CHECK-LABEL: module attributes {
+// CHECK-LABEL: module attributes {llzk.lang, llzk.main = !struct.type<@ArrayDims::@ArrayDims<[7]>>} {
+// CHECK-NEXT:    poly.template @ArrayDims {
+// CHECK-NEXT:      poly.param @N
+// CHECK-NEXT:      poly.expr @N_Add_1 {
+// CHECK-NEXT:        %[[VAL_0:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_0]], %[[VAL_1]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:        poly.yield %[[VAL_2]] : !felt.type<"bn128">
+// CHECK-NEXT:      }
+// CHECK-NEXT:      struct.def @ArrayDims {
+// CHECK-NEXT:        function.def @compute(%[[VAL_3:[0-9a-zA-Z_\.]+]]: !array.type<@N_Add_1 x !felt.type<"bn128">>) -> !struct.type<@ArrayDims::@ArrayDims<[@N]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
+// CHECK-NEXT:          %[[VAL_4:[0-9a-zA-Z_\.]+]] = struct.new : <@ArrayDims::@ArrayDims<[@N]>>
+// CHECK-NEXT:          %[[VAL_5:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_6:[0-9a-zA-Z_\.]+]] = poly.read_const @N_Add_1 : !felt.type<"bn128">
+// CHECK-NEXT:          function.return %[[VAL_4]] : !struct.type<@ArrayDims::@ArrayDims<[@N]>>
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.def @constrain(%[[VAL_7:[0-9a-zA-Z_\.]+]]: !struct.type<@ArrayDims::@ArrayDims<[@N]>>, %[[VAL_8:[0-9a-zA-Z_\.]+]]: !array.type<@N_Add_1 x !felt.type<"bn128">>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_9:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_10:[0-9a-zA-Z_\.]+]] = poly.read_const @N_Add_1 : !felt.type<"bn128">
+// CHECK-NEXT:          function.return
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/arrays/array_dimensions_08.circom
+++ b/circom/tests/arrays/array_dimensions_08.circom
@@ -17,8 +17,8 @@ component main = ArrayDims(7, 2);
 // CHECK-NEXT:      struct.def @ArrayDims {
 // CHECK-NEXT:        function.def @compute() -> !struct.type<@ArrayDims::@ArrayDims<[@N, @M]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
 // CHECK-NEXT:          %[[VAL_0:[0-9a-zA-Z_\.]+]] = struct.new : <@ArrayDims::@ArrayDims<[@N, @M]>>
-// CHECK-NEXT:          %[[VAL_1:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_2:[0-9a-zA-Z_\.]+]] = poly.read_const @M : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_1:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_3:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:          %[[VAL_4:[0-9a-zA-Z_\.]+]] = array.new  : <@M x !felt.type<"bn128">>
 // CHECK-NEXT:          %[[VAL_5:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
@@ -39,8 +39,8 @@ component main = ArrayDims(7, 2);
 // CHECK-NEXT:          function.return %[[VAL_0]] : !struct.type<@ArrayDims::@ArrayDims<[@N, @M]>>
 // CHECK-NEXT:        }
 // CHECK-NEXT:        function.def @constrain(%[[VAL_16:[0-9a-zA-Z_\.]+]]: !struct.type<@ArrayDims::@ArrayDims<[@N, @M]>>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:          %[[VAL_17:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_18:[0-9a-zA-Z_\.]+]] = poly.read_const @M : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_17:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_19:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:          %[[VAL_20:[0-9a-zA-Z_\.]+]] = array.new  : <@M x !felt.type<"bn128">>
 // CHECK-NEXT:          %[[VAL_21:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index

--- a/circom/tests/arrays/array_dimensions_09.circom
+++ b/circom/tests/arrays/array_dimensions_09.circom
@@ -11,42 +11,49 @@ template ArrayDims(N, M) {
 
 component main = ArrayDims(7, 2);
 
-// CHECK: #[[$ATTR_0:[0-9a-zA-Z_\.]+]] = affine_map<()[s0] -> (s0)>
 // CHECK-LABEL: module attributes {llzk.lang, llzk.main = !struct.type<@ArrayDims::@ArrayDims<[7, 2]>>} {
 // CHECK-NEXT:    poly.template @ArrayDims {
 // CHECK-NEXT:      poly.param @N
 // CHECK-NEXT:      poly.param @M
+// CHECK-NEXT:      poly.expr @D {
+// CHECK-NEXT:        %[[VAL_0:[0-9a-zA-Z_\.]+]] = poly.read_const @M : !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = llzk.nondet : !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_1]], %[[VAL_0]] : !felt.type<"bn128">, !felt.type<"bn128">
+// COM:               TODO: there is a lot of dead code generated here currently...
+// CHECK:             poly.yield %[[VAL_3]] : !felt.type<"bn128">
+// CHECK-NEXT:      }
 // CHECK-NEXT:      struct.def @ArrayDims {
 // CHECK-NEXT:        function.def @compute() -> !struct.type<@ArrayDims::@ArrayDims<[@N, @M]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
-// CHECK-NEXT:          %[[VAL_0:[0-9a-zA-Z_\.]+]] = struct.new : <@ArrayDims::@ArrayDims<[@N, @M]>>
-// CHECK-NEXT:          %[[VAL_1:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_2:[0-9a-zA-Z_\.]+]] = poly.read_const @M : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_3:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_1]], %[[VAL_2]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_4:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:          %[[VAL_5:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_3]] : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_6:[0-9a-zA-Z_\.]+]] = array.new{(){{\[}}%[[VAL_5]]]} : <#[[$ATTR_0]] x !felt.type<"bn128">>
-// CHECK-NEXT:          %[[VAL_7:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[VAL_8:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_6]], %[[VAL_7]] : <#[[$ATTR_0]] x !felt.type<"bn128">>
-// CHECK-NEXT:          %[[VAL_9:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[VAL_10:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:          scf.for %[[VAL_11:[0-9a-zA-Z_\.]+]] = %[[VAL_9]] to %[[VAL_8]] step %[[VAL_10]] {
-// CHECK-NEXT:            array.write %[[VAL_6]]{{\[}}%[[VAL_11]]] = %[[VAL_4]] : <#[[$ATTR_0]] x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_13:[0-9a-zA-Z_\.]+]] = struct.new : <@ArrayDims::@ArrayDims<[@N, @M]>>
+// CHECK-NEXT:          %[[VAL_14:[0-9a-zA-Z_\.]+]] = poly.read_const @D : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_15:[0-9a-zA-Z_\.]+]] = poly.read_const @M : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_16:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_17:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_16]], %[[VAL_15]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_18:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_19:[0-9a-zA-Z_\.]+]] = array.new  : <@D x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_20:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_21:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_19]], %[[VAL_20]] : <@D x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_22:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_23:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          scf.for %[[VAL_24:[0-9a-zA-Z_\.]+]] = %[[VAL_22]] to %[[VAL_21]] step %[[VAL_23]] {
+// CHECK-NEXT:            array.write %[[VAL_19]]{{\[}}%[[VAL_24]]] = %[[VAL_18]] : <@D x !felt.type<"bn128">>, !felt.type<"bn128">
 // CHECK-NEXT:          }
-// CHECK-NEXT:          function.return %[[VAL_0]] : !struct.type<@ArrayDims::@ArrayDims<[@N, @M]>>
+// CHECK-NEXT:          function.return %[[VAL_13]] : !struct.type<@ArrayDims::@ArrayDims<[@N, @M]>>
 // CHECK-NEXT:        }
-// CHECK-NEXT:        function.def @constrain(%[[VAL_12:[0-9a-zA-Z_\.]+]]: !struct.type<@ArrayDims::@ArrayDims<[@N, @M]>>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:          %[[VAL_13:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_14:[0-9a-zA-Z_\.]+]] = poly.read_const @M : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_15:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_13]], %[[VAL_14]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_16:[0-9a-zA-Z_\.]+]] = felt.const  0
-// CHECK-NEXT:          %[[VAL_17:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_15]] : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_18:[0-9a-zA-Z_\.]+]] = array.new{(){{\[}}%[[VAL_17]]]} : <#[[$ATTR_0]] x !felt.type<"bn128">>
-// CHECK-NEXT:          %[[VAL_19:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[VAL_20:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_18]], %[[VAL_19]] : <#[[$ATTR_0]] x !felt.type<"bn128">>
-// CHECK-NEXT:          %[[VAL_21:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[VAL_22:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:          scf.for %[[VAL_23:[0-9a-zA-Z_\.]+]] = %[[VAL_21]] to %[[VAL_20]] step %[[VAL_22]] {
-// CHECK-NEXT:            array.write %[[VAL_18]]{{\[}}%[[VAL_23]]] = %[[VAL_16]] : <#[[$ATTR_0]] x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:        function.def @constrain(%[[VAL_25:[0-9a-zA-Z_\.]+]]: !struct.type<@ArrayDims::@ArrayDims<[@N, @M]>>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_26:[0-9a-zA-Z_\.]+]] = poly.read_const @D : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_27:[0-9a-zA-Z_\.]+]] = poly.read_const @M : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_28:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_29:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_28]], %[[VAL_27]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_30:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_31:[0-9a-zA-Z_\.]+]] = array.new  : <@D x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_32:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_33:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_31]], %[[VAL_32]] : <@D x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_34:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_35:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          scf.for %[[VAL_36:[0-9a-zA-Z_\.]+]] = %[[VAL_34]] to %[[VAL_33]] step %[[VAL_35]] {
+// CHECK-NEXT:            array.write %[[VAL_31]]{{\[}}%[[VAL_36]]] = %[[VAL_30]] : <@D x !felt.type<"bn128">>, !felt.type<"bn128">
 // CHECK-NEXT:          }
 // CHECK-NEXT:          function.return
 // CHECK-NEXT:        }

--- a/circom/tests/arrays/array_dimensions_10.circom
+++ b/circom/tests/arrays/array_dimensions_10.circom
@@ -1,0 +1,52 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --stabilize --llzk --llzk_plaintext -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
+
+pragma circom 2.0.0;
+
+template ArrayDims() {
+    var a[2] = [123, 675];
+    signal output outp[a[1]];
+}
+
+component main = ArrayDims();
+
+// CHECK-LABEL: module attributes {llzk.lang, llzk.main = !struct.type<@ArrayDims::@ArrayDims<[]>>} {
+// CHECK-NEXT:    poly.template @ArrayDims {
+// CHECK-NEXT:      poly.expr @"a[1]" {
+// CHECK-NEXT:        %[[VAL_0:[0-9a-zA-Z_\.]+]] = llzk.nondet : !array.type<2 x !felt.type<"bn128">>
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_1]], %[[VAL_1]] : <2 x !felt.type<"bn128">>
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = felt.const  123 : <"bn128">
+// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = felt.const  675 : <"bn128">
+// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_3]], %[[VAL_4]] : <2 x !felt.type<"bn128">>
+// CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_6]] : !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_5]]{{\[}}%[[VAL_7]]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:        poly.yield %[[VAL_8]] : !felt.type<"bn128">
+// CHECK-NEXT:      }
+// CHECK-NEXT:      struct.def @ArrayDims {
+// CHECK-NEXT:        struct.member @outp : !array.type<@"a[1]" x !felt.type<"bn128">> {llzk.pub}
+// CHECK-NEXT:        function.def @compute() -> !struct.type<@ArrayDims::@ArrayDims<[]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
+// CHECK-NEXT:          %[[VAL_9:[0-9a-zA-Z_\.]+]] = struct.new : <@ArrayDims::@ArrayDims<[]>>
+// CHECK-NEXT:          %[[VAL_10:[0-9a-zA-Z_\.]+]] = poly.read_const @"a[1]" : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_11:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_12:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_11]], %[[VAL_11]] : <2 x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_13:[0-9a-zA-Z_\.]+]] = felt.const  123 : <"bn128">
+// CHECK-NEXT:          %[[VAL_14:[0-9a-zA-Z_\.]+]] = felt.const  675 : <"bn128">
+// CHECK-NEXT:          %[[VAL_15:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_13]], %[[VAL_14]] : <2 x !felt.type<"bn128">>
+// CHECK-NEXT:          function.return %[[VAL_9]] : !struct.type<@ArrayDims::@ArrayDims<[]>>
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.def @constrain(%[[VAL_16:[0-9a-zA-Z_\.]+]]: !struct.type<@ArrayDims::@ArrayDims<[]>>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_17:[0-9a-zA-Z_\.]+]] = poly.read_const @"a[1]" : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_18:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_16]][@outp] : <@ArrayDims::@ArrayDims<[]>>, !array.type<@"a[1]" x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_19:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_20:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_19]], %[[VAL_19]] : <2 x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_21:[0-9a-zA-Z_\.]+]] = felt.const  123 : <"bn128">
+// CHECK-NEXT:          %[[VAL_22:[0-9a-zA-Z_\.]+]] = felt.const  675 : <"bn128">
+// CHECK-NEXT:          %[[VAL_23:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_21]], %[[VAL_22]] : <2 x !felt.type<"bn128">>
+// CHECK-NEXT:          function.return
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/arrays/array_dimensions_11.circom
+++ b/circom/tests/arrays/array_dimensions_11.circom
@@ -1,0 +1,131 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --stabilize --llzk --llzk_plaintext -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
+
+pragma circom 2.0.0;
+
+template EvilArrayDims(N) {
+    var x = 12;
+    var a[2] = [123, 675];
+    x = 6;
+    signal input in[x];
+    a[1] = N + x;
+    signal output out1[a[1]];
+    signal output out2[N > 12 ? a[0] + a[1] : 0];
+}
+
+component main = EvilArrayDims(7);
+
+// CHECK-LABEL: module attributes {llzk.lang, llzk.main = !struct.type<@EvilArrayDims::@EvilArrayDims<[7]>>} {
+// CHECK-NEXT:    poly.template @EvilArrayDims {
+// CHECK-NEXT:      poly.param @N
+// CHECK-NEXT:      poly.expr @"N_Greater_12?a[0]_Add_a[1]:0" {
+// CHECK-NEXT:        %[[VAL_0:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = llzk.nondet : !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = felt.const  12 : <"bn128">
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = llzk.nondet : !array.type<2 x !felt.type<"bn128">>
+// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_4]], %[[VAL_4]] : <2 x !felt.type<"bn128">>
+// CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = felt.const  123 : <"bn128">
+// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = felt.const  675 : <"bn128">
+// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_6]], %[[VAL_7]] : <2 x !felt.type<"bn128">>
+// CHECK-NEXT:        %[[VAL_9:[0-9a-zA-Z_\.]+]] = felt.const  6 : <"bn128">
+// CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_0]], %[[VAL_9]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:        %[[VAL_12:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_11]] : !felt.type<"bn128">
+// CHECK-NEXT:        array.write %[[VAL_8]]{{\[}}%[[VAL_12]]] = %[[VAL_10]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_13:[0-9a-zA-Z_\.]+]] = felt.const  12 : <"bn128">
+// CHECK-NEXT:        %[[VAL_14:[0-9a-zA-Z_\.]+]] = bool.cmp gt(%[[VAL_0]], %[[VAL_13]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_15:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_14]] -> (!felt.type<"bn128">) {
+// CHECK-NEXT:          %[[VAL_16:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_17:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_16]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_18:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_8]]{{\[}}%[[VAL_17]]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_19:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_20:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_19]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_21:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_8]]{{\[}}%[[VAL_20]]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_22:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_18]], %[[VAL_21]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          scf.yield %[[VAL_22]] : !felt.type<"bn128">
+// CHECK-NEXT:        } else {
+// CHECK-NEXT:          %[[VAL_23:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          scf.yield %[[VAL_23]] : !felt.type<"bn128">
+// CHECK-NEXT:        }
+// CHECK-NEXT:        poly.yield %[[VAL_15]] : !felt.type<"bn128">
+// CHECK-NEXT:      }
+// CHECK-NEXT:      poly.expr @"a[1]" {
+// CHECK-NEXT:        %[[VAL_24:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_25:[0-9a-zA-Z_\.]+]] = llzk.nondet : !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_26:[0-9a-zA-Z_\.]+]] = felt.const  12 : <"bn128">
+// CHECK-NEXT:        %[[VAL_27:[0-9a-zA-Z_\.]+]] = llzk.nondet : !array.type<2 x !felt.type<"bn128">>
+// CHECK-NEXT:        %[[VAL_28:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:        %[[VAL_29:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_28]], %[[VAL_28]] : <2 x !felt.type<"bn128">>
+// CHECK-NEXT:        %[[VAL_30:[0-9a-zA-Z_\.]+]] = felt.const  123 : <"bn128">
+// CHECK-NEXT:        %[[VAL_31:[0-9a-zA-Z_\.]+]] = felt.const  675 : <"bn128">
+// CHECK-NEXT:        %[[VAL_32:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_30]], %[[VAL_31]] : <2 x !felt.type<"bn128">>
+// CHECK-NEXT:        %[[VAL_33:[0-9a-zA-Z_\.]+]] = felt.const  6 : <"bn128">
+// CHECK-NEXT:        %[[VAL_34:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_24]], %[[VAL_33]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_35:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:        %[[VAL_36:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_35]] : !felt.type<"bn128">
+// CHECK-NEXT:        array.write %[[VAL_32]]{{\[}}%[[VAL_36]]] = %[[VAL_34]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_37:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:        %[[VAL_38:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_37]] : !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_39:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_32]]{{\[}}%[[VAL_38]]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:        poly.yield %[[VAL_39]] : !felt.type<"bn128">
+// CHECK-NEXT:      }
+// CHECK-NEXT:      poly.expr @x {
+// CHECK-NEXT:        %[[VAL_40:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_41:[0-9a-zA-Z_\.]+]] = llzk.nondet : !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_42:[0-9a-zA-Z_\.]+]] = felt.const  12 : <"bn128">
+// CHECK-NEXT:        %[[VAL_43:[0-9a-zA-Z_\.]+]] = llzk.nondet : !array.type<2 x !felt.type<"bn128">>
+// CHECK-NEXT:        %[[VAL_44:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:        %[[VAL_45:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_44]], %[[VAL_44]] : <2 x !felt.type<"bn128">>
+// CHECK-NEXT:        %[[VAL_46:[0-9a-zA-Z_\.]+]] = felt.const  123 : <"bn128">
+// CHECK-NEXT:        %[[VAL_47:[0-9a-zA-Z_\.]+]] = felt.const  675 : <"bn128">
+// CHECK-NEXT:        %[[VAL_48:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_46]], %[[VAL_47]] : <2 x !felt.type<"bn128">>
+// CHECK-NEXT:        %[[VAL_49:[0-9a-zA-Z_\.]+]] = felt.const  6 : <"bn128">
+// CHECK-NEXT:        poly.yield %[[VAL_49]] : !felt.type<"bn128">
+// CHECK-NEXT:      }
+// CHECK-NEXT:      struct.def @EvilArrayDims {
+// CHECK-NEXT:        struct.member @out1 : !array.type<@"a[1]" x !felt.type<"bn128">> {llzk.pub}
+// CHECK-NEXT:        struct.member @out2 : !array.type<@"N_Greater_12?a[0]_Add_a[1]:0" x !felt.type<"bn128">> {llzk.pub}
+// CHECK-NEXT:        function.def @compute(%[[VAL_50:[0-9a-zA-Z_\.]+]]: !array.type<@x x !felt.type<"bn128">>) -> !struct.type<@EvilArrayDims::@EvilArrayDims<[@N]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
+// CHECK-NEXT:          %[[VAL_51:[0-9a-zA-Z_\.]+]] = struct.new : <@EvilArrayDims::@EvilArrayDims<[@N]>>
+// CHECK-NEXT:          %[[VAL_52:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_53:[0-9a-zA-Z_\.]+]] = poly.read_const @"N_Greater_12?a[0]_Add_a[1]:0" : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_54:[0-9a-zA-Z_\.]+]] = poly.read_const @"a[1]" : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_55:[0-9a-zA-Z_\.]+]] = poly.read_const @x : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_56:[0-9a-zA-Z_\.]+]] = felt.const  12 : <"bn128">
+// CHECK-NEXT:          %[[VAL_57:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_58:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_57]], %[[VAL_57]] : <2 x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_59:[0-9a-zA-Z_\.]+]] = felt.const  123 : <"bn128">
+// CHECK-NEXT:          %[[VAL_60:[0-9a-zA-Z_\.]+]] = felt.const  675 : <"bn128">
+// CHECK-NEXT:          %[[VAL_61:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_59]], %[[VAL_60]] : <2 x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_62:[0-9a-zA-Z_\.]+]] = felt.const  6 : <"bn128">
+// CHECK-NEXT:          %[[VAL_63:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_52]], %[[VAL_62]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_64:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_65:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_64]] : !felt.type<"bn128">
+// CHECK-NEXT:          array.write %[[VAL_61]]{{\[}}%[[VAL_65]]] = %[[VAL_63]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:          function.return %[[VAL_51]] : !struct.type<@EvilArrayDims::@EvilArrayDims<[@N]>>
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.def @constrain(%[[VAL_66:[0-9a-zA-Z_\.]+]]: !struct.type<@EvilArrayDims::@EvilArrayDims<[@N]>>, %[[VAL_67:[0-9a-zA-Z_\.]+]]: !array.type<@x x !felt.type<"bn128">>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_68:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_69:[0-9a-zA-Z_\.]+]] = poly.read_const @"N_Greater_12?a[0]_Add_a[1]:0" : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_70:[0-9a-zA-Z_\.]+]] = poly.read_const @"a[1]" : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_71:[0-9a-zA-Z_\.]+]] = poly.read_const @x : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_72:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_66]][@out1] : <@EvilArrayDims::@EvilArrayDims<[@N]>>, !array.type<@"a[1]" x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_73:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_66]][@out2] : <@EvilArrayDims::@EvilArrayDims<[@N]>>, !array.type<@"N_Greater_12?a[0]_Add_a[1]:0" x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_74:[0-9a-zA-Z_\.]+]] = felt.const  12 : <"bn128">
+// CHECK-NEXT:          %[[VAL_75:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_76:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_75]], %[[VAL_75]] : <2 x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_77:[0-9a-zA-Z_\.]+]] = felt.const  123 : <"bn128">
+// CHECK-NEXT:          %[[VAL_78:[0-9a-zA-Z_\.]+]] = felt.const  675 : <"bn128">
+// CHECK-NEXT:          %[[VAL_79:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_77]], %[[VAL_78]] : <2 x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_80:[0-9a-zA-Z_\.]+]] = felt.const  6 : <"bn128">
+// CHECK-NEXT:          %[[VAL_81:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_68]], %[[VAL_80]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_82:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_83:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_82]] : !felt.type<"bn128">
+// CHECK-NEXT:          array.write %[[VAL_79]]{{\[}}%[[VAL_83]]] = %[[VAL_81]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:          function.return
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/arrays/array_dimensions_12.circom
+++ b/circom/tests/arrays/array_dimensions_12.circom
@@ -1,0 +1,36 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --stabilize --llzk --llzk_plaintext -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
+// XFAIL:.*
+// COM: LLZK does not (currently) allow `function.call` in `poly.expr` which is generated to define the dimension of `out2` here.
+
+pragma circom 2.0.0;
+
+function earlyReturnFn(in) {
+    var i = 0;
+    while (i < 6) {
+        return in;
+        assert(0 == 1); // Unreachable because of the early return above
+        i++;
+    }
+    return -1;
+}
+
+template EvilArrayDims(N) {
+    var x = 12;
+    var a[2] = [123, 675];
+    x = 6;
+    signal input in[x];
+    a[1] = N + x;
+    signal output out1[a[1]];
+    if (earlyReturnFn(N) > 0) {
+        a[1] = N + 2;
+    } else {
+        a[1] = N * 2;
+    }
+    signal output out2[N > 12 ? a[0] + a[1] : 0];
+}
+
+component main = EvilArrayDims(7);
+
+// CHECK-LABEL: module attributes {

--- a/circom/tests/arrays/array_dimensions_13.circom
+++ b/circom/tests/arrays/array_dimensions_13.circom
@@ -1,0 +1,144 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --stabilize --llzk --llzk_plaintext -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
+
+pragma circom 2.0.0;
+
+template EvilArrayDims(N, M) {
+    var x;
+    if (N > 99) {
+        var D = N + M;
+        var arr[D];
+        arr[D-1] = 99;
+        x = arr[D-1];
+    } else {
+        var D = N * M + 1;
+        var arr[D];
+        arr[D-1] = 77;
+        x = arr[D-1];
+    }
+}
+
+component main = EvilArrayDims(7, 2);
+
+// CHECK: #[[$ATTR_0:[0-9a-zA-Z_\.]+]] = affine_map<()[s0] -> (s0)>
+//
+// CHECK-LABEL: module attributes {llzk.lang, llzk.main = !struct.type<@EvilArrayDims::@EvilArrayDims<[7, 2]>>} {
+// CHECK-NEXT:    poly.template @EvilArrayDims {
+// CHECK-NEXT:      poly.param @N
+// CHECK-NEXT:      poly.param @M
+// CHECK-NEXT:      struct.def @EvilArrayDims {
+// CHECK-NEXT:        function.def @compute() -> !struct.type<@EvilArrayDims::@EvilArrayDims<[@N, @M]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
+// CHECK-NEXT:          %[[VAL_0:[0-9a-zA-Z_\.]+]] = struct.new : <@EvilArrayDims::@EvilArrayDims<[@N, @M]>>
+// CHECK-NEXT:          %[[VAL_1:[0-9a-zA-Z_\.]+]] = poly.read_const @M : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_2:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_3:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_4:[0-9a-zA-Z_\.]+]] = felt.const  99 : <"bn128">
+// CHECK-NEXT:          %[[VAL_5:[0-9a-zA-Z_\.]+]] = bool.cmp gt(%[[VAL_2]], %[[VAL_4]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_6:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_5]] -> (!felt.type<"bn128">) {
+// CHECK-NEXT:            %[[VAL_7:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_2]], %[[VAL_1]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_8:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:            %[[VAL_9:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_7]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_10:[0-9a-zA-Z_\.]+]] = array.new{(){{\[}}%[[VAL_9]]]} : <#[[$ATTR_0]] x !felt.type<"bn128">>
+// CHECK-NEXT:            %[[VAL_11:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:            %[[VAL_12:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_10]], %[[VAL_11]] : <#[[$ATTR_0]] x !felt.type<"bn128">>
+// CHECK-NEXT:            %[[VAL_13:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:            %[[VAL_14:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:            scf.for %[[VAL_15:[0-9a-zA-Z_\.]+]] = %[[VAL_13]] to %[[VAL_12]] step %[[VAL_14]] {
+// CHECK-NEXT:              array.write %[[VAL_10]]{{\[}}%[[VAL_15]]] = %[[VAL_8]] : <#[[$ATTR_0]] x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            }
+// CHECK-NEXT:            %[[VAL_16:[0-9a-zA-Z_\.]+]] = felt.const  99 : <"bn128">
+// CHECK-NEXT:            %[[VAL_17:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_18:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_7]], %[[VAL_17]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_19:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_18]] : !felt.type<"bn128">
+// CHECK-NEXT:            array.write %[[VAL_10]]{{\[}}%[[VAL_19]]] = %[[VAL_16]] : <#[[$ATTR_0]] x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_20:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_21:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_7]], %[[VAL_20]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_22:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_21]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_23:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_10]]{{\[}}%[[VAL_22]]] : <#[[$ATTR_0]] x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_23]] : !felt.type<"bn128">
+// CHECK-NEXT:          } else {
+// CHECK-NEXT:            %[[VAL_24:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_2]], %[[VAL_1]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_25:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_26:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_24]], %[[VAL_25]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_27:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:            %[[VAL_28:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_26]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_29:[0-9a-zA-Z_\.]+]] = array.new{(){{\[}}%[[VAL_28]]]} : <#[[$ATTR_0]] x !felt.type<"bn128">>
+// CHECK-NEXT:            %[[VAL_30:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:            %[[VAL_31:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_29]], %[[VAL_30]] : <#[[$ATTR_0]] x !felt.type<"bn128">>
+// CHECK-NEXT:            %[[VAL_32:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:            %[[VAL_33:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:            scf.for %[[VAL_34:[0-9a-zA-Z_\.]+]] = %[[VAL_32]] to %[[VAL_31]] step %[[VAL_33]] {
+// CHECK-NEXT:              array.write %[[VAL_29]]{{\[}}%[[VAL_34]]] = %[[VAL_27]] : <#[[$ATTR_0]] x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            }
+// CHECK-NEXT:            %[[VAL_35:[0-9a-zA-Z_\.]+]] = felt.const  77 : <"bn128">
+// CHECK-NEXT:            %[[VAL_36:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_37:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_26]], %[[VAL_36]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_38:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_37]] : !felt.type<"bn128">
+// CHECK-NEXT:            array.write %[[VAL_29]]{{\[}}%[[VAL_38]]] = %[[VAL_35]] : <#[[$ATTR_0]] x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_39:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_40:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_26]], %[[VAL_39]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_41:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_40]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_42:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_29]]{{\[}}%[[VAL_41]]] : <#[[$ATTR_0]] x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_42]] : !felt.type<"bn128">
+// CHECK-NEXT:          }
+// CHECK-NEXT:          function.return %[[VAL_0]] : !struct.type<@EvilArrayDims::@EvilArrayDims<[@N, @M]>>
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.def @constrain(%[[VAL_43:[0-9a-zA-Z_\.]+]]: !struct.type<@EvilArrayDims::@EvilArrayDims<[@N, @M]>>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_44:[0-9a-zA-Z_\.]+]] = poly.read_const @M : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_45:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_46:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_47:[0-9a-zA-Z_\.]+]] = felt.const  99 : <"bn128">
+// CHECK-NEXT:          %[[VAL_48:[0-9a-zA-Z_\.]+]] = bool.cmp gt(%[[VAL_45]], %[[VAL_47]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_49:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_48]] -> (!felt.type<"bn128">) {
+// CHECK-NEXT:            %[[VAL_50:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_45]], %[[VAL_44]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_51:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:            %[[VAL_52:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_50]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_53:[0-9a-zA-Z_\.]+]] = array.new{(){{\[}}%[[VAL_52]]]} : <#[[$ATTR_0]] x !felt.type<"bn128">>
+// CHECK-NEXT:            %[[VAL_54:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:            %[[VAL_55:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_53]], %[[VAL_54]] : <#[[$ATTR_0]] x !felt.type<"bn128">>
+// CHECK-NEXT:            %[[VAL_56:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:            %[[VAL_57:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:            scf.for %[[VAL_58:[0-9a-zA-Z_\.]+]] = %[[VAL_56]] to %[[VAL_55]] step %[[VAL_57]] {
+// CHECK-NEXT:              array.write %[[VAL_53]]{{\[}}%[[VAL_58]]] = %[[VAL_51]] : <#[[$ATTR_0]] x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            }
+// CHECK-NEXT:            %[[VAL_59:[0-9a-zA-Z_\.]+]] = felt.const  99 : <"bn128">
+// CHECK-NEXT:            %[[VAL_60:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_61:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_50]], %[[VAL_60]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_62:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_61]] : !felt.type<"bn128">
+// CHECK-NEXT:            array.write %[[VAL_53]]{{\[}}%[[VAL_62]]] = %[[VAL_59]] : <#[[$ATTR_0]] x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_63:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_64:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_50]], %[[VAL_63]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_65:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_64]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_66:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_53]]{{\[}}%[[VAL_65]]] : <#[[$ATTR_0]] x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_66]] : !felt.type<"bn128">
+// CHECK-NEXT:          } else {
+// CHECK-NEXT:            %[[VAL_67:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_45]], %[[VAL_44]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_68:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_69:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_67]], %[[VAL_68]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_70:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:            %[[VAL_71:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_69]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_72:[0-9a-zA-Z_\.]+]] = array.new{(){{\[}}%[[VAL_71]]]} : <#[[$ATTR_0]] x !felt.type<"bn128">>
+// CHECK-NEXT:            %[[VAL_73:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:            %[[VAL_74:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_72]], %[[VAL_73]] : <#[[$ATTR_0]] x !felt.type<"bn128">>
+// CHECK-NEXT:            %[[VAL_75:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:            %[[VAL_76:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:            scf.for %[[VAL_77:[0-9a-zA-Z_\.]+]] = %[[VAL_75]] to %[[VAL_74]] step %[[VAL_76]] {
+// CHECK-NEXT:              array.write %[[VAL_72]]{{\[}}%[[VAL_77]]] = %[[VAL_70]] : <#[[$ATTR_0]] x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            }
+// CHECK-NEXT:            %[[VAL_78:[0-9a-zA-Z_\.]+]] = felt.const  77 : <"bn128">
+// CHECK-NEXT:            %[[VAL_79:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_80:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_69]], %[[VAL_79]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_81:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_80]] : !felt.type<"bn128">
+// CHECK-NEXT:            array.write %[[VAL_72]]{{\[}}%[[VAL_81]]] = %[[VAL_78]] : <#[[$ATTR_0]] x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_82:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_83:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_69]], %[[VAL_82]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_84:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_83]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_85:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_72]]{{\[}}%[[VAL_84]]] : <#[[$ATTR_0]] x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_85]] : !felt.type<"bn128">
+// CHECK-NEXT:          }
+// CHECK-NEXT:          function.return
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/arrays/unknown_index_constrained.circom
+++ b/circom/tests/arrays/unknown_index_constrained.circom
@@ -1,7 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --stabilize --llzk --llzk_plaintext -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL:.*
 
 pragma circom 2.0.0;
 
@@ -67,5 +66,425 @@ template ForUnknownIndex(n) {
 
 component main = ForUnknownIndex(252);
 
-// CHECK-LABEL: module attributes {
-// CHECK: struct.def @Num2Bits
+// CHECK-LABEL: module attributes {llzk.lang, llzk.main = !struct.type<@ForUnknownIndex::@ForUnknownIndex<[252]>>} {
+// CHECK-NEXT:    poly.template @ForUnknownIndex {
+// CHECK-NEXT:      poly.param @n
+// CHECK-NEXT:      struct.def @ForUnknownIndex {
+// CHECK-NEXT:        struct.member @out : !felt.type<"bn128"> {llzk.pub}
+// CHECK-NEXT:        struct.member @get : !struct.type<@GreaterEqThan::@GreaterEqThan<[@n]>>
+// CHECK-NEXT:        struct.member @get$inputs : !pod.type<[@in: !array.type<2 x !felt.type<"bn128">>]>
+// CHECK-NEXT:        struct.member @lt : !struct.type<@LessThan::@LessThan<[@n]>>
+// CHECK-NEXT:        struct.member @lt$inputs : !pod.type<[@in: !array.type<2 x !felt.type<"bn128">>]>
+// CHECK-NEXT:        function.def @compute(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) -> !struct.type<@ForUnknownIndex::@ForUnknownIndex<[@n]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
+// CHECK-NEXT:          %[[VAL_1:[0-9a-zA-Z_\.]+]] = struct.new : <@ForUnknownIndex::@ForUnknownIndex<[@n]>>
+// CHECK-NEXT:          %[[VAL_2:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_3:[0-9a-zA-Z_\.]+]] = arith.constant 2 : index
+// CHECK-NEXT:          %[[VAL_4:[0-9a-zA-Z_\.]+]] = pod.new { @count = %[[VAL_3]] }  : <[@count: index, @comp: !struct.type<@GreaterEqThan::@GreaterEqThan<[@n]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:          %[[VAL_5:[0-9a-zA-Z_\.]+]] = pod.new : <[@in: !array.type<2 x !felt.type<"bn128">>]>
+// CHECK-NEXT:          %[[VAL_6:[0-9a-zA-Z_\.]+]] = arith.constant 2 : index
+// CHECK-NEXT:          %[[VAL_7:[0-9a-zA-Z_\.]+]] = pod.new { @count = %[[VAL_6]] }  : <[@count: index, @comp: !struct.type<@LessThan::@LessThan<[@n]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:          %[[VAL_8:[0-9a-zA-Z_\.]+]] = pod.new : <[@in: !array.type<2 x !felt.type<"bn128">>]>
+// CHECK-NEXT:          %[[VAL_9:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_10:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_9]], %[[VAL_9]], %[[VAL_9]], %[[VAL_9]], %[[VAL_9]], %[[VAL_9]], %[[VAL_9]], %[[VAL_9]], %[[VAL_9]], %[[VAL_9]] : <10 x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_11:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_12:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_13:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
+// CHECK-NEXT:          %[[VAL_14:[0-9a-zA-Z_\.]+]] = felt.const  3 : <"bn128">
+// CHECK-NEXT:          %[[VAL_15:[0-9a-zA-Z_\.]+]] = felt.const  4 : <"bn128">
+// CHECK-NEXT:          %[[VAL_16:[0-9a-zA-Z_\.]+]] = felt.const  5 : <"bn128">
+// CHECK-NEXT:          %[[VAL_17:[0-9a-zA-Z_\.]+]] = felt.const  6 : <"bn128">
+// CHECK-NEXT:          %[[VAL_18:[0-9a-zA-Z_\.]+]] = felt.const  7 : <"bn128">
+// CHECK-NEXT:          %[[VAL_19:[0-9a-zA-Z_\.]+]] = felt.const  8 : <"bn128">
+// CHECK-NEXT:          %[[VAL_20:[0-9a-zA-Z_\.]+]] = felt.const  9 : <"bn128">
+// CHECK-NEXT:          %[[VAL_21:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_11]], %[[VAL_12]], %[[VAL_13]], %[[VAL_14]], %[[VAL_15]], %[[VAL_16]], %[[VAL_17]], %[[VAL_18]], %[[VAL_19]], %[[VAL_20]] : <10 x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_22:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_5]][@in] : <[@in: !array.type<2 x !felt.type<"bn128">>]>, !array.type<2 x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_23:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_24:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_23]] : !felt.type<"bn128">
+// CHECK-NEXT:          array.write %[[VAL_22]]{{\[}}%[[VAL_24]]] = %[[VAL_0]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:          pod.write %[[VAL_5]][@in] = %[[VAL_22]] : <[@in: !array.type<2 x !felt.type<"bn128">>]>, !array.type<2 x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_25:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_4]][@count] : <[@count: index, @comp: !struct.type<@GreaterEqThan::@GreaterEqThan<[@n]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:          %[[VAL_26:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          %[[VAL_27:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_25]], %[[VAL_26]] : index
+// CHECK-NEXT:          pod.write %[[VAL_4]][@count] = %[[VAL_27]] : <[@count: index, @comp: !struct.type<@GreaterEqThan::@GreaterEqThan<[@n]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:          %[[VAL_28:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_29:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_27]], %[[VAL_28]] : index
+// CHECK-NEXT:          scf.if %[[VAL_29]] {
+// CHECK-NEXT:            %[[VAL_30:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_5]][@in] : <[@in: !array.type<2 x !felt.type<"bn128">>]>, !array.type<2 x !felt.type<"bn128">>
+// CHECK-NEXT:            %[[VAL_31:[0-9a-zA-Z_\.]+]] = function.call @GreaterEqThan::@GreaterEqThan::@compute(%[[VAL_30]]) : (!array.type<2 x !felt.type<"bn128">>) -> !struct.type<@GreaterEqThan::@GreaterEqThan<[@n]>>
+// CHECK-NEXT:            pod.write %[[VAL_4]][@comp] = %[[VAL_31]] : <[@count: index, @comp: !struct.type<@GreaterEqThan::@GreaterEqThan<[@n]>>, @params: !pod.type<[]>]>, !struct.type<@GreaterEqThan::@GreaterEqThan<[@n]>>
+// CHECK-NEXT:          } else {
+// CHECK-NEXT:          }
+// CHECK-NEXT:          %[[VAL_32:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_33:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_5]][@in] : <[@in: !array.type<2 x !felt.type<"bn128">>]>, !array.type<2 x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_34:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_35:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_34]] : !felt.type<"bn128">
+// CHECK-NEXT:          array.write %[[VAL_33]]{{\[}}%[[VAL_35]]] = %[[VAL_32]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:          pod.write %[[VAL_5]][@in] = %[[VAL_33]] : <[@in: !array.type<2 x !felt.type<"bn128">>]>, !array.type<2 x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_36:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_4]][@count] : <[@count: index, @comp: !struct.type<@GreaterEqThan::@GreaterEqThan<[@n]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:          %[[VAL_37:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          %[[VAL_38:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_36]], %[[VAL_37]] : index
+// CHECK-NEXT:          pod.write %[[VAL_4]][@count] = %[[VAL_38]] : <[@count: index, @comp: !struct.type<@GreaterEqThan::@GreaterEqThan<[@n]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:          %[[VAL_39:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_40:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_38]], %[[VAL_39]] : index
+// CHECK-NEXT:          scf.if %[[VAL_40]] {
+// CHECK-NEXT:            %[[VAL_41:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_5]][@in] : <[@in: !array.type<2 x !felt.type<"bn128">>]>, !array.type<2 x !felt.type<"bn128">>
+// CHECK-NEXT:            %[[VAL_42:[0-9a-zA-Z_\.]+]] = function.call @GreaterEqThan::@GreaterEqThan::@compute(%[[VAL_41]]) : (!array.type<2 x !felt.type<"bn128">>) -> !struct.type<@GreaterEqThan::@GreaterEqThan<[@n]>>
+// CHECK-NEXT:            pod.write %[[VAL_4]][@comp] = %[[VAL_42]] : <[@count: index, @comp: !struct.type<@GreaterEqThan::@GreaterEqThan<[@n]>>, @params: !pod.type<[]>]>, !struct.type<@GreaterEqThan::@GreaterEqThan<[@n]>>
+// CHECK-NEXT:          } else {
+// CHECK-NEXT:          }
+// CHECK-NEXT:          %[[VAL_43:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_8]][@in] : <[@in: !array.type<2 x !felt.type<"bn128">>]>, !array.type<2 x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_44:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_45:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_44]] : !felt.type<"bn128">
+// CHECK-NEXT:          array.write %[[VAL_43]]{{\[}}%[[VAL_45]]] = %[[VAL_0]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:          pod.write %[[VAL_8]][@in] = %[[VAL_43]] : <[@in: !array.type<2 x !felt.type<"bn128">>]>, !array.type<2 x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_46:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_7]][@count] : <[@count: index, @comp: !struct.type<@LessThan::@LessThan<[@n]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:          %[[VAL_47:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          %[[VAL_48:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_46]], %[[VAL_47]] : index
+// CHECK-NEXT:          pod.write %[[VAL_7]][@count] = %[[VAL_48]] : <[@count: index, @comp: !struct.type<@LessThan::@LessThan<[@n]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:          %[[VAL_49:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_50:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_48]], %[[VAL_49]] : index
+// CHECK-NEXT:          scf.if %[[VAL_50]] {
+// CHECK-NEXT:            %[[VAL_51:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_8]][@in] : <[@in: !array.type<2 x !felt.type<"bn128">>]>, !array.type<2 x !felt.type<"bn128">>
+// CHECK-NEXT:            %[[VAL_52:[0-9a-zA-Z_\.]+]] = function.call @LessThan::@LessThan::@compute(%[[VAL_51]]) : (!array.type<2 x !felt.type<"bn128">>) -> !struct.type<@LessThan::@LessThan<[@n]>>
+// CHECK-NEXT:            pod.write %[[VAL_7]][@comp] = %[[VAL_52]] : <[@count: index, @comp: !struct.type<@LessThan::@LessThan<[@n]>>, @params: !pod.type<[]>]>, !struct.type<@LessThan::@LessThan<[@n]>>
+// CHECK-NEXT:          } else {
+// CHECK-NEXT:          }
+// CHECK-NEXT:          %[[VAL_53:[0-9a-zA-Z_\.]+]] = felt.const  10 : <"bn128">
+// CHECK-NEXT:          %[[VAL_54:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_8]][@in] : <[@in: !array.type<2 x !felt.type<"bn128">>]>, !array.type<2 x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_55:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_56:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_55]] : !felt.type<"bn128">
+// CHECK-NEXT:          array.write %[[VAL_54]]{{\[}}%[[VAL_56]]] = %[[VAL_53]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:          pod.write %[[VAL_8]][@in] = %[[VAL_54]] : <[@in: !array.type<2 x !felt.type<"bn128">>]>, !array.type<2 x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_57:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_7]][@count] : <[@count: index, @comp: !struct.type<@LessThan::@LessThan<[@n]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:          %[[VAL_58:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          %[[VAL_59:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_57]], %[[VAL_58]] : index
+// CHECK-NEXT:          pod.write %[[VAL_7]][@count] = %[[VAL_59]] : <[@count: index, @comp: !struct.type<@LessThan::@LessThan<[@n]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:          %[[VAL_60:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_61:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_59]], %[[VAL_60]] : index
+// CHECK-NEXT:          scf.if %[[VAL_61]] {
+// CHECK-NEXT:            %[[VAL_62:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_8]][@in] : <[@in: !array.type<2 x !felt.type<"bn128">>]>, !array.type<2 x !felt.type<"bn128">>
+// CHECK-NEXT:            %[[VAL_63:[0-9a-zA-Z_\.]+]] = function.call @LessThan::@LessThan::@compute(%[[VAL_62]]) : (!array.type<2 x !felt.type<"bn128">>) -> !struct.type<@LessThan::@LessThan<[@n]>>
+// CHECK-NEXT:            pod.write %[[VAL_7]][@comp] = %[[VAL_63]] : <[@count: index, @comp: !struct.type<@LessThan::@LessThan<[@n]>>, @params: !pod.type<[]>]>, !struct.type<@LessThan::@LessThan<[@n]>>
+// CHECK-NEXT:          } else {
+// CHECK-NEXT:          }
+// CHECK-NEXT:          %[[VAL_64:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_0]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_65:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_21]]{{\[}}%[[VAL_64]]] : <10 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:          struct.writem %[[VAL_1]][@out] = %[[VAL_65]] : <@ForUnknownIndex::@ForUnknownIndex<[@n]>>, !felt.type<"bn128">
+// CHECK-NEXT:          struct.writem %[[VAL_1]][@get$inputs] = %[[VAL_5]] : <@ForUnknownIndex::@ForUnknownIndex<[@n]>>, !pod.type<[@in: !array.type<2 x !felt.type<"bn128">>]>
+// CHECK-NEXT:          %[[VAL_66:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_4]][@comp] : <[@count: index, @comp: !struct.type<@GreaterEqThan::@GreaterEqThan<[@n]>>, @params: !pod.type<[]>]>, !struct.type<@GreaterEqThan::@GreaterEqThan<[@n]>>
+// CHECK-NEXT:          struct.writem %[[VAL_1]][@get] = %[[VAL_66]] : <@ForUnknownIndex::@ForUnknownIndex<[@n]>>, !struct.type<@GreaterEqThan::@GreaterEqThan<[@n]>>
+// CHECK-NEXT:          struct.writem %[[VAL_1]][@lt$inputs] = %[[VAL_8]] : <@ForUnknownIndex::@ForUnknownIndex<[@n]>>, !pod.type<[@in: !array.type<2 x !felt.type<"bn128">>]>
+// CHECK-NEXT:          %[[VAL_67:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_7]][@comp] : <[@count: index, @comp: !struct.type<@LessThan::@LessThan<[@n]>>, @params: !pod.type<[]>]>, !struct.type<@LessThan::@LessThan<[@n]>>
+// CHECK-NEXT:          struct.writem %[[VAL_1]][@lt] = %[[VAL_67]] : <@ForUnknownIndex::@ForUnknownIndex<[@n]>>, !struct.type<@LessThan::@LessThan<[@n]>>
+// CHECK-NEXT:          function.return %[[VAL_1]] : !struct.type<@ForUnknownIndex::@ForUnknownIndex<[@n]>>
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.def @constrain(%[[VAL_68:[0-9a-zA-Z_\.]+]]: !struct.type<@ForUnknownIndex::@ForUnknownIndex<[@n]>>, %[[VAL_69:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_70:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_71:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_68]][@out] : <@ForUnknownIndex::@ForUnknownIndex<[@n]>>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_72:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_68]][@get] : <@ForUnknownIndex::@ForUnknownIndex<[@n]>>, !struct.type<@GreaterEqThan::@GreaterEqThan<[@n]>>
+// CHECK-NEXT:          %[[VAL_73:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_68]][@get$inputs] : <@ForUnknownIndex::@ForUnknownIndex<[@n]>>, !pod.type<[@in: !array.type<2 x !felt.type<"bn128">>]>
+// CHECK-NEXT:          %[[VAL_74:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_68]][@lt] : <@ForUnknownIndex::@ForUnknownIndex<[@n]>>, !struct.type<@LessThan::@LessThan<[@n]>>
+// CHECK-NEXT:          %[[VAL_75:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_68]][@lt$inputs] : <@ForUnknownIndex::@ForUnknownIndex<[@n]>>, !pod.type<[@in: !array.type<2 x !felt.type<"bn128">>]>
+// CHECK-NEXT:          %[[VAL_76:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_77:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_76]], %[[VAL_76]], %[[VAL_76]], %[[VAL_76]], %[[VAL_76]], %[[VAL_76]], %[[VAL_76]], %[[VAL_76]], %[[VAL_76]], %[[VAL_76]] : <10 x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_78:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_79:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_80:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
+// CHECK-NEXT:          %[[VAL_81:[0-9a-zA-Z_\.]+]] = felt.const  3 : <"bn128">
+// CHECK-NEXT:          %[[VAL_82:[0-9a-zA-Z_\.]+]] = felt.const  4 : <"bn128">
+// CHECK-NEXT:          %[[VAL_83:[0-9a-zA-Z_\.]+]] = felt.const  5 : <"bn128">
+// CHECK-NEXT:          %[[VAL_84:[0-9a-zA-Z_\.]+]] = felt.const  6 : <"bn128">
+// CHECK-NEXT:          %[[VAL_85:[0-9a-zA-Z_\.]+]] = felt.const  7 : <"bn128">
+// CHECK-NEXT:          %[[VAL_86:[0-9a-zA-Z_\.]+]] = felt.const  8 : <"bn128">
+// CHECK-NEXT:          %[[VAL_87:[0-9a-zA-Z_\.]+]] = felt.const  9 : <"bn128">
+// CHECK-NEXT:          %[[VAL_88:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_78]], %[[VAL_79]], %[[VAL_80]], %[[VAL_81]], %[[VAL_82]], %[[VAL_83]], %[[VAL_84]], %[[VAL_85]], %[[VAL_86]], %[[VAL_87]] : <10 x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_89:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_73]][@in] : <[@in: !array.type<2 x !felt.type<"bn128">>]>, !array.type<2 x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_90:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_91:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_90]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_92:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_89]]{{\[}}%[[VAL_91]]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:          constrain.eq %[[VAL_92]], %[[VAL_69]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_93:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_94:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_73]][@in] : <[@in: !array.type<2 x !felt.type<"bn128">>]>, !array.type<2 x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_95:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_96:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_95]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_97:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_94]]{{\[}}%[[VAL_96]]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:          constrain.eq %[[VAL_97]], %[[VAL_93]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_98:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_72]][@out] : <@GreaterEqThan::@GreaterEqThan<[@n]>>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_99:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          constrain.eq %[[VAL_98]], %[[VAL_99]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_100:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_75]][@in] : <[@in: !array.type<2 x !felt.type<"bn128">>]>, !array.type<2 x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_101:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_102:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_101]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_103:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_100]]{{\[}}%[[VAL_102]]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:          constrain.eq %[[VAL_103]], %[[VAL_69]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_104:[0-9a-zA-Z_\.]+]] = felt.const  10 : <"bn128">
+// CHECK-NEXT:          %[[VAL_105:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_75]][@in] : <[@in: !array.type<2 x !felt.type<"bn128">>]>, !array.type<2 x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_106:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_107:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_106]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_108:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_105]]{{\[}}%[[VAL_107]]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:          constrain.eq %[[VAL_108]], %[[VAL_104]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_109:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_74]][@out] : <@LessThan::@LessThan<[@n]>>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_110:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          constrain.eq %[[VAL_109]], %[[VAL_110]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_111:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_73]][@in] : <[@in: !array.type<2 x !felt.type<"bn128">>]>, !array.type<2 x !felt.type<"bn128">>
+// CHECK-NEXT:          function.call @GreaterEqThan::@GreaterEqThan::@constrain(%[[VAL_72]], %[[VAL_111]]) : (!struct.type<@GreaterEqThan::@GreaterEqThan<[@n]>>, !array.type<2 x !felt.type<"bn128">>) -> ()
+// CHECK-NEXT:          %[[VAL_112:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_75]][@in] : <[@in: !array.type<2 x !felt.type<"bn128">>]>, !array.type<2 x !felt.type<"bn128">>
+// CHECK-NEXT:          function.call @LessThan::@LessThan::@constrain(%[[VAL_74]], %[[VAL_112]]) : (!struct.type<@LessThan::@LessThan<[@n]>>, !array.type<2 x !felt.type<"bn128">>) -> ()
+// CHECK-NEXT:          function.return
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    poly.template @GreaterEqThan {
+// CHECK-NEXT:      poly.param @n
+// CHECK-NEXT:      struct.def @GreaterEqThan {
+// CHECK-NEXT:        struct.member @out : !felt.type<"bn128"> {llzk.pub}
+// CHECK-NEXT:        struct.member @lt : !struct.type<@LessThan::@LessThan<[@n]>>
+// CHECK-NEXT:        struct.member @lt$inputs : !pod.type<[@in: !array.type<2 x !felt.type<"bn128">>]>
+// CHECK-NEXT:        function.def @compute(%[[VAL_113:[0-9a-zA-Z_\.]+]]: !array.type<2 x !felt.type<"bn128">>) -> !struct.type<@GreaterEqThan::@GreaterEqThan<[@n]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
+// CHECK-NEXT:          %[[VAL_114:[0-9a-zA-Z_\.]+]] = struct.new : <@GreaterEqThan::@GreaterEqThan<[@n]>>
+// CHECK-NEXT:          %[[VAL_115:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_116:[0-9a-zA-Z_\.]+]] = arith.constant 2 : index
+// CHECK-NEXT:          %[[VAL_117:[0-9a-zA-Z_\.]+]] = pod.new { @count = %[[VAL_116]] }  : <[@count: index, @comp: !struct.type<@LessThan::@LessThan<[@n]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:          %[[VAL_118:[0-9a-zA-Z_\.]+]] = pod.new : <[@in: !array.type<2 x !felt.type<"bn128">>]>
+// CHECK-NEXT:          %[[VAL_119:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_120:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_119]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_121:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_113]]{{\[}}%[[VAL_120]]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_122:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_118]][@in] : <[@in: !array.type<2 x !felt.type<"bn128">>]>, !array.type<2 x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_123:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_124:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_123]] : !felt.type<"bn128">
+// CHECK-NEXT:          array.write %[[VAL_122]]{{\[}}%[[VAL_124]]] = %[[VAL_121]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:          pod.write %[[VAL_118]][@in] = %[[VAL_122]] : <[@in: !array.type<2 x !felt.type<"bn128">>]>, !array.type<2 x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_125:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_117]][@count] : <[@count: index, @comp: !struct.type<@LessThan::@LessThan<[@n]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:          %[[VAL_126:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          %[[VAL_127:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_125]], %[[VAL_126]] : index
+// CHECK-NEXT:          pod.write %[[VAL_117]][@count] = %[[VAL_127]] : <[@count: index, @comp: !struct.type<@LessThan::@LessThan<[@n]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:          %[[VAL_128:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_129:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_127]], %[[VAL_128]] : index
+// CHECK-NEXT:          scf.if %[[VAL_129]] {
+// CHECK-NEXT:            %[[VAL_130:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_118]][@in] : <[@in: !array.type<2 x !felt.type<"bn128">>]>, !array.type<2 x !felt.type<"bn128">>
+// CHECK-NEXT:            %[[VAL_131:[0-9a-zA-Z_\.]+]] = function.call @LessThan::@LessThan::@compute(%[[VAL_130]]) : (!array.type<2 x !felt.type<"bn128">>) -> !struct.type<@LessThan::@LessThan<[@n]>>
+// CHECK-NEXT:            pod.write %[[VAL_117]][@comp] = %[[VAL_131]] : <[@count: index, @comp: !struct.type<@LessThan::@LessThan<[@n]>>, @params: !pod.type<[]>]>, !struct.type<@LessThan::@LessThan<[@n]>>
+// CHECK-NEXT:          } else {
+// CHECK-NEXT:          }
+// CHECK-NEXT:          %[[VAL_132:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_133:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_132]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_134:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_113]]{{\[}}%[[VAL_133]]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_135:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_136:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_134]], %[[VAL_135]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_137:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_118]][@in] : <[@in: !array.type<2 x !felt.type<"bn128">>]>, !array.type<2 x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_138:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_139:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_138]] : !felt.type<"bn128">
+// CHECK-NEXT:          array.write %[[VAL_137]]{{\[}}%[[VAL_139]]] = %[[VAL_136]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:          pod.write %[[VAL_118]][@in] = %[[VAL_137]] : <[@in: !array.type<2 x !felt.type<"bn128">>]>, !array.type<2 x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_140:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_117]][@count] : <[@count: index, @comp: !struct.type<@LessThan::@LessThan<[@n]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:          %[[VAL_141:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          %[[VAL_142:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_140]], %[[VAL_141]] : index
+// CHECK-NEXT:          pod.write %[[VAL_117]][@count] = %[[VAL_142]] : <[@count: index, @comp: !struct.type<@LessThan::@LessThan<[@n]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:          %[[VAL_143:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_144:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_142]], %[[VAL_143]] : index
+// CHECK-NEXT:          scf.if %[[VAL_144]] {
+// CHECK-NEXT:            %[[VAL_145:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_118]][@in] : <[@in: !array.type<2 x !felt.type<"bn128">>]>, !array.type<2 x !felt.type<"bn128">>
+// CHECK-NEXT:            %[[VAL_146:[0-9a-zA-Z_\.]+]] = function.call @LessThan::@LessThan::@compute(%[[VAL_145]]) : (!array.type<2 x !felt.type<"bn128">>) -> !struct.type<@LessThan::@LessThan<[@n]>>
+// CHECK-NEXT:            pod.write %[[VAL_117]][@comp] = %[[VAL_146]] : <[@count: index, @comp: !struct.type<@LessThan::@LessThan<[@n]>>, @params: !pod.type<[]>]>, !struct.type<@LessThan::@LessThan<[@n]>>
+// CHECK-NEXT:          } else {
+// CHECK-NEXT:          }
+// CHECK-NEXT:          %[[VAL_147:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_117]][@comp] : <[@count: index, @comp: !struct.type<@LessThan::@LessThan<[@n]>>, @params: !pod.type<[]>]>, !struct.type<@LessThan::@LessThan<[@n]>>
+// CHECK-NEXT:          %[[VAL_148:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_147]][@out] : <@LessThan::@LessThan<[@n]>>, !felt.type<"bn128">
+// CHECK-NEXT:          struct.writem %[[VAL_114]][@out] = %[[VAL_148]] : <@GreaterEqThan::@GreaterEqThan<[@n]>>, !felt.type<"bn128">
+// CHECK-NEXT:          struct.writem %[[VAL_114]][@lt$inputs] = %[[VAL_118]] : <@GreaterEqThan::@GreaterEqThan<[@n]>>, !pod.type<[@in: !array.type<2 x !felt.type<"bn128">>]>
+// CHECK-NEXT:          %[[VAL_149:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_117]][@comp] : <[@count: index, @comp: !struct.type<@LessThan::@LessThan<[@n]>>, @params: !pod.type<[]>]>, !struct.type<@LessThan::@LessThan<[@n]>>
+// CHECK-NEXT:          struct.writem %[[VAL_114]][@lt] = %[[VAL_149]] : <@GreaterEqThan::@GreaterEqThan<[@n]>>, !struct.type<@LessThan::@LessThan<[@n]>>
+// CHECK-NEXT:          function.return %[[VAL_114]] : !struct.type<@GreaterEqThan::@GreaterEqThan<[@n]>>
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.def @constrain(%[[VAL_150:[0-9a-zA-Z_\.]+]]: !struct.type<@GreaterEqThan::@GreaterEqThan<[@n]>>, %[[VAL_151:[0-9a-zA-Z_\.]+]]: !array.type<2 x !felt.type<"bn128">>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_152:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_153:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_150]][@out] : <@GreaterEqThan::@GreaterEqThan<[@n]>>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_154:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_150]][@lt] : <@GreaterEqThan::@GreaterEqThan<[@n]>>, !struct.type<@LessThan::@LessThan<[@n]>>
+// CHECK-NEXT:          %[[VAL_155:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_150]][@lt$inputs] : <@GreaterEqThan::@GreaterEqThan<[@n]>>, !pod.type<[@in: !array.type<2 x !felt.type<"bn128">>]>
+// CHECK-NEXT:          %[[VAL_156:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_157:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_156]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_158:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_151]]{{\[}}%[[VAL_157]]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_159:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_155]][@in] : <[@in: !array.type<2 x !felt.type<"bn128">>]>, !array.type<2 x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_160:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_161:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_160]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_162:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_159]]{{\[}}%[[VAL_161]]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:          constrain.eq %[[VAL_162]], %[[VAL_158]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_163:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_164:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_163]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_165:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_151]]{{\[}}%[[VAL_164]]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_166:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_167:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_165]], %[[VAL_166]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_168:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_155]][@in] : <[@in: !array.type<2 x !felt.type<"bn128">>]>, !array.type<2 x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_169:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_170:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_169]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_171:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_168]]{{\[}}%[[VAL_170]]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:          constrain.eq %[[VAL_171]], %[[VAL_167]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_172:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_154]][@out] : <@LessThan::@LessThan<[@n]>>, !felt.type<"bn128">
+// CHECK-NEXT:          constrain.eq %[[VAL_153]], %[[VAL_172]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_173:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_155]][@in] : <[@in: !array.type<2 x !felt.type<"bn128">>]>, !array.type<2 x !felt.type<"bn128">>
+// CHECK-NEXT:          function.call @LessThan::@LessThan::@constrain(%[[VAL_154]], %[[VAL_173]]) : (!struct.type<@LessThan::@LessThan<[@n]>>, !array.type<2 x !felt.type<"bn128">>) -> ()
+// CHECK-NEXT:          function.return
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    poly.template @LessThan {
+// CHECK-NEXT:      poly.param @n
+// CHECK-NEXT:      poly.expr @n_Add_1 {
+// CHECK-NEXT:        %[[VAL_174:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_175:[0-9a-zA-Z_\.]+]] = felt.const  252 : <"bn128">
+// CHECK-NEXT:        %[[VAL_176:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_174]], %[[VAL_175]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:        bool.assert %[[VAL_176]], "assertion failed"
+// CHECK-NEXT:        %[[VAL_177:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:        %[[VAL_178:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_174]], %[[VAL_177]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:        poly.yield %[[VAL_178]] : !felt.type<"bn128">
+// CHECK-NEXT:      }
+// CHECK-NEXT:      struct.def @LessThan {
+// CHECK-NEXT:        struct.member @out : !felt.type<"bn128"> {llzk.pub}
+// CHECK-NEXT:        struct.member @n2b : !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>
+// CHECK-NEXT:        struct.member @n2b$inputs : !pod.type<[@in: !felt.type<"bn128">]>
+// CHECK-NEXT:        function.def @compute(%[[VAL_179:[0-9a-zA-Z_\.]+]]: !array.type<2 x !felt.type<"bn128">>) -> !struct.type<@LessThan::@LessThan<[@n]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
+// CHECK-NEXT:          %[[VAL_180:[0-9a-zA-Z_\.]+]] = struct.new : <@LessThan::@LessThan<[@n]>>
+// CHECK-NEXT:          %[[VAL_181:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_182:[0-9a-zA-Z_\.]+]] = poly.read_const @n_Add_1 : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_183:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          %[[VAL_184:[0-9a-zA-Z_\.]+]] = pod.new { @count = %[[VAL_183]] }  : <[@count: index, @comp: !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:          %[[VAL_185:[0-9a-zA-Z_\.]+]] = pod.new : <[@in: !felt.type<"bn128">]>
+// CHECK-NEXT:          %[[VAL_186:[0-9a-zA-Z_\.]+]] = felt.const  252 : <"bn128">
+// CHECK-NEXT:          %[[VAL_187:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_181]], %[[VAL_186]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          bool.assert %[[VAL_187]], "assertion failed"
+// CHECK-NEXT:          %[[VAL_188:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_189:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_188]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_190:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_179]]{{\[}}%[[VAL_189]]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_191:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_192:[0-9a-zA-Z_\.]+]] = felt.shl %[[VAL_191]], %[[VAL_181]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_193:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_190]], %[[VAL_192]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_194:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_195:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_194]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_196:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_179]]{{\[}}%[[VAL_195]]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_197:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_193]], %[[VAL_196]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          pod.write %[[VAL_185]][@in] = %[[VAL_197]] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_198:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_184]][@count] : <[@count: index, @comp: !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:          %[[VAL_199:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          %[[VAL_200:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_198]], %[[VAL_199]] : index
+// CHECK-NEXT:          pod.write %[[VAL_184]][@count] = %[[VAL_200]] : <[@count: index, @comp: !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:          %[[VAL_201:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_202:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_200]], %[[VAL_201]] : index
+// CHECK-NEXT:          scf.if %[[VAL_202]] {
+// CHECK-NEXT:            %[[VAL_203:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_185]][@in] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_204:[0-9a-zA-Z_\.]+]] = function.call @Num2Bits::@Num2Bits::@compute(%[[VAL_203]]) : (!felt.type<"bn128">) -> !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>
+// CHECK-NEXT:            pod.write %[[VAL_184]][@comp] = %[[VAL_204]] : <[@count: index, @comp: !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>, @params: !pod.type<[]>]>, !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>
+// CHECK-NEXT:          } else {
+// CHECK-NEXT:          }
+// CHECK-NEXT:          %[[VAL_205:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_206:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_184]][@comp] : <[@count: index, @comp: !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>, @params: !pod.type<[]>]>, !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>
+// CHECK-NEXT:          %[[VAL_207:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_206]][@out] : <@Num2Bits::@Num2Bits<[@n_Add_1]>>, !array.type<@n x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_208:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_181]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_209:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_207]]{{\[}}%[[VAL_208]]] : <@n x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_210:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_205]], %[[VAL_209]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          struct.writem %[[VAL_180]][@out] = %[[VAL_210]] : <@LessThan::@LessThan<[@n]>>, !felt.type<"bn128">
+// CHECK-NEXT:          struct.writem %[[VAL_180]][@n2b$inputs] = %[[VAL_185]] : <@LessThan::@LessThan<[@n]>>, !pod.type<[@in: !felt.type<"bn128">]>
+// CHECK-NEXT:          %[[VAL_211:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_184]][@comp] : <[@count: index, @comp: !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>, @params: !pod.type<[]>]>, !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>
+// CHECK-NEXT:          struct.writem %[[VAL_180]][@n2b] = %[[VAL_211]] : <@LessThan::@LessThan<[@n]>>, !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>
+// CHECK-NEXT:          function.return %[[VAL_180]] : !struct.type<@LessThan::@LessThan<[@n]>>
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.def @constrain(%[[VAL_212:[0-9a-zA-Z_\.]+]]: !struct.type<@LessThan::@LessThan<[@n]>>, %[[VAL_213:[0-9a-zA-Z_\.]+]]: !array.type<2 x !felt.type<"bn128">>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_214:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_215:[0-9a-zA-Z_\.]+]] = poly.read_const @n_Add_1 : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_216:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_212]][@out] : <@LessThan::@LessThan<[@n]>>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_217:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_212]][@n2b] : <@LessThan::@LessThan<[@n]>>, !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>
+// CHECK-NEXT:          %[[VAL_218:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_212]][@n2b$inputs] : <@LessThan::@LessThan<[@n]>>, !pod.type<[@in: !felt.type<"bn128">]>
+// CHECK-NEXT:          %[[VAL_219:[0-9a-zA-Z_\.]+]] = felt.const  252 : <"bn128">
+// CHECK-NEXT:          %[[VAL_220:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_214]], %[[VAL_219]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          bool.assert %[[VAL_220]], "assertion failed"
+// CHECK-NEXT:          %[[VAL_221:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_222:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_221]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_223:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_213]]{{\[}}%[[VAL_222]]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_224:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_225:[0-9a-zA-Z_\.]+]] = felt.shl %[[VAL_224]], %[[VAL_214]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_226:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_223]], %[[VAL_225]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_227:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_228:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_227]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_229:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_213]]{{\[}}%[[VAL_228]]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_230:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_226]], %[[VAL_229]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_231:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_218]][@in] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:          constrain.eq %[[VAL_231]], %[[VAL_230]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_232:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_233:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_217]][@out] : <@Num2Bits::@Num2Bits<[@n_Add_1]>>, !array.type<@n x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_234:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_214]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_235:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_233]]{{\[}}%[[VAL_234]]] : <@n x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_236:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_232]], %[[VAL_235]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          constrain.eq %[[VAL_216]], %[[VAL_236]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_237:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_218]][@in] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:          function.call @Num2Bits::@Num2Bits::@constrain(%[[VAL_217]], %[[VAL_237]]) : (!struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>, !felt.type<"bn128">) -> ()
+// CHECK-NEXT:          function.return
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    poly.template @Num2Bits {
+// CHECK-NEXT:      poly.param @n
+// CHECK-NEXT:      struct.def @Num2Bits {
+// CHECK-NEXT:        struct.member @out : !array.type<@n x !felt.type<"bn128">> {llzk.pub}
+// CHECK-NEXT:        function.def @compute(%[[VAL_238:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) -> !struct.type<@Num2Bits::@Num2Bits<[@n]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
+// CHECK-NEXT:          %[[VAL_239:[0-9a-zA-Z_\.]+]] = struct.new : <@Num2Bits::@Num2Bits<[@n]>>
+// CHECK-NEXT:          %[[VAL_240:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_241:[0-9a-zA-Z_\.]+]] = llzk.nondet : !array.type<@n x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_242:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_243:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_244:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_245:[0-9a-zA-Z_\.]+]]:3 = scf.while (%[[VAL_246:[0-9a-zA-Z_\.]+]] = %[[VAL_243]], %[[VAL_247:[0-9a-zA-Z_\.]+]] = %[[VAL_244]], %[[VAL_248:[0-9a-zA-Z_\.]+]] = %[[VAL_242]]) : (!felt.type<"bn128">, !felt.type<"bn128">, !felt.type<"bn128">) -> (!felt.type<"bn128">, !felt.type<"bn128">, !felt.type<"bn128">) {
+// CHECK-NEXT:            %[[VAL_249:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_247]], %[[VAL_240]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.condition(%[[VAL_249]]) %[[VAL_246]], %[[VAL_247]], %[[VAL_248]] : !felt.type<"bn128">, !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          } do {
+// CHECK-NEXT:          ^bb0(%[[VAL_250:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">, %[[VAL_251:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">, %[[VAL_252:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
+// CHECK-NEXT:            %[[VAL_253:[0-9a-zA-Z_\.]+]] = felt.shr %[[VAL_238]], %[[VAL_251]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_254:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_255:[0-9a-zA-Z_\.]+]] = felt.bit_and %[[VAL_253]], %[[VAL_254]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_256:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_251]] : !felt.type<"bn128">
+// CHECK-NEXT:            array.write %[[VAL_241]]{{\[}}%[[VAL_256]]] = %[[VAL_255]] : <@n x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_257:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_251]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_258:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_241]]{{\[}}%[[VAL_257]]] : <@n x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_259:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_258]], %[[VAL_243]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_260:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_252]], %[[VAL_259]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_261:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_250]], %[[VAL_250]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_262:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_263:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_251]], %[[VAL_262]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_261]], %[[VAL_263]], %[[VAL_260]] : !felt.type<"bn128">, !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          }
+// CHECK-NEXT:          struct.writem %[[VAL_239]][@out] = %[[VAL_241]] : <@Num2Bits::@Num2Bits<[@n]>>, !array.type<@n x !felt.type<"bn128">>
+// CHECK-NEXT:          function.return %[[VAL_239]] : !struct.type<@Num2Bits::@Num2Bits<[@n]>>
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.def @constrain(%[[VAL_264:[0-9a-zA-Z_\.]+]]: !struct.type<@Num2Bits::@Num2Bits<[@n]>>, %[[VAL_265:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_266:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_267:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_264]][@out] : <@Num2Bits::@Num2Bits<[@n]>>, !array.type<@n x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_268:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_269:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_270:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_271:[0-9a-zA-Z_\.]+]]:3 = scf.while (%[[VAL_272:[0-9a-zA-Z_\.]+]] = %[[VAL_269]], %[[VAL_273:[0-9a-zA-Z_\.]+]] = %[[VAL_270]], %[[VAL_274:[0-9a-zA-Z_\.]+]] = %[[VAL_268]]) : (!felt.type<"bn128">, !felt.type<"bn128">, !felt.type<"bn128">) -> (!felt.type<"bn128">, !felt.type<"bn128">, !felt.type<"bn128">) {
+// CHECK-NEXT:            %[[VAL_275:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_273]], %[[VAL_266]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.condition(%[[VAL_275]]) %[[VAL_272]], %[[VAL_273]], %[[VAL_274]] : !felt.type<"bn128">, !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          } do {
+// CHECK-NEXT:          ^bb0(%[[VAL_276:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">, %[[VAL_277:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">, %[[VAL_278:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
+// CHECK-NEXT:            %[[VAL_279:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_277]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_280:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_267]]{{\[}}%[[VAL_279]]] : <@n x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_281:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_277]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_282:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_267]]{{\[}}%[[VAL_281]]] : <@n x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_283:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_284:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_282]], %[[VAL_283]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_285:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_280]], %[[VAL_284]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_286:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:            constrain.eq %[[VAL_285]], %[[VAL_286]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_287:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_277]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_288:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_267]]{{\[}}%[[VAL_287]]] : <@n x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_289:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_288]], %[[VAL_269]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_290:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_278]], %[[VAL_289]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_291:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_276]], %[[VAL_276]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_292:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_293:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_277]], %[[VAL_292]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_291]], %[[VAL_293]], %[[VAL_290]] : !felt.type<"bn128">, !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          }
+// CHECK-NEXT:          constrain.eq %[[VAL_271]]#2, %[[VAL_265]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          function.return
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/circom_doc_examples/17.circom
+++ b/circom/tests/circom_doc_examples/17.circom
@@ -2,6 +2,7 @@
 // RUN: rm -rf %t && mkdir %t && %circom --stabilize --llzk --llzk_plaintext -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
 // XFAIL:.*
+// COM: failure related to the "TODO" on `DeclarationInfo::visit`
 
 pragma circom 2.1.5;
 

--- a/circom/tests/circom_doc_examples/21.circom
+++ b/circom/tests/circom_doc_examples/21.circom
@@ -2,6 +2,7 @@
 // RUN: rm -rf %t && mkdir %t && %circom --stabilize --llzk --llzk_plaintext -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
 // XFAIL:.*
+// related to the "TODO" in `cast_to_expected_type_if_needed()`
 
 pragma circom 2.1.0;
 

--- a/circom/tests/circom_doc_examples/22.circom
+++ b/circom/tests/circom_doc_examples/22.circom
@@ -24,8 +24,8 @@ component main = Ex(3, 3);
 // CHECK-NEXT:        struct.member @out : !array.type<@m x !felt.type<"bn128">> {llzk.pub}
 // CHECK-NEXT:        function.def @compute(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type<"bn128">>) -> !struct.type<@Ex::@Ex<[@n, @m]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
 // CHECK-NEXT:          %[[VAL_1:[0-9a-zA-Z_\.]+]] = struct.new : <@Ex::@Ex<[@n, @m]>>
-// CHECK-NEXT:          %[[VAL_2:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_3:[0-9a-zA-Z_\.]+]] = poly.read_const @m : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_2:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_4:[0-9a-zA-Z_\.]+]] = llzk.nondet : !array.type<@m x !felt.type<"bn128">>
 // CHECK-NEXT:          %[[VAL_5:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:          %[[VAL_6:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_7:[0-9a-zA-Z_\.]+]] = %[[VAL_5]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
@@ -45,8 +45,8 @@ component main = Ex(3, 3);
 // CHECK-NEXT:          function.return %[[VAL_1]] : !struct.type<@Ex::@Ex<[@n, @m]>>
 // CHECK-NEXT:        }
 // CHECK-NEXT:        function.def @constrain(%[[VAL_15:[0-9a-zA-Z_\.]+]]: !struct.type<@Ex::@Ex<[@n, @m]>>, %[[VAL_16:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type<"bn128">>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:          %[[VAL_17:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_18:[0-9a-zA-Z_\.]+]] = poly.read_const @m : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_17:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_19:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_15]][@out] : <@Ex::@Ex<[@n, @m]>>, !array.type<@m x !felt.type<"bn128">>
 // CHECK-NEXT:          %[[VAL_20:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:          %[[VAL_21:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_22:[0-9a-zA-Z_\.]+]] = %[[VAL_20]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {

--- a/circom/tests/circom_doc_examples/23.circom
+++ b/circom/tests/circom_doc_examples/23.circom
@@ -2,6 +2,7 @@
 // RUN: rm -rf %t && mkdir %t && %circom --stabilize --llzk --llzk_plaintext -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
 // XFAIL:.*
+// related to the "TODO" in `cast_to_expected_type_if_needed()`
 
 pragma circom 2.1.0;
 

--- a/circom/tests/declaration_in_template/array_dim_expr_var.circom
+++ b/circom/tests/declaration_in_template/array_dim_expr_var.circom
@@ -1,7 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --stabilize --llzk --llzk_plaintext -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL:.*
 
 pragma circom 2.0.0;
 
@@ -13,4 +12,43 @@ template A() {
 
 component main = A();
 
-// CHECK-LABEL: module attributes {
+// CHECK-LABEL: module attributes {llzk.lang, llzk.main = !struct.type<@A::@A<[]>>} {
+// CHECK-NEXT:    poly.template @A {
+// CHECK-NEXT:      poly.expr @s {
+// CHECK-NEXT:        %[[VAL_0:[0-9a-zA-Z_\.]+]] = llzk.nondet : !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = felt.const  6 : <"bn128">
+// CHECK-NEXT:        poly.yield %[[VAL_1]] : !felt.type<"bn128">
+// CHECK-NEXT:      }
+// CHECK-NEXT:      struct.def @A {
+// CHECK-NEXT:        function.def @compute(%[[VAL_2:[0-9a-zA-Z_\.]+]]: !array.type<@s x !felt.type<"bn128">>) -> !struct.type<@A::@A<[]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
+// CHECK-NEXT:          %[[VAL_3:[0-9a-zA-Z_\.]+]] = struct.new : <@A::@A<[]>>
+// CHECK-NEXT:          %[[VAL_4:[0-9a-zA-Z_\.]+]] = poly.read_const @s : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_5:[0-9a-zA-Z_\.]+]] = felt.const  6 : <"bn128">
+// CHECK-NEXT:          %[[VAL_6:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_7:[0-9a-zA-Z_\.]+]] = array.new  : <@s x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_8:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_9:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_7]], %[[VAL_8]] : <@s x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_10:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_11:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          scf.for %[[VAL_12:[0-9a-zA-Z_\.]+]] = %[[VAL_10]] to %[[VAL_9]] step %[[VAL_11]] {
+// CHECK-NEXT:            array.write %[[VAL_7]]{{\[}}%[[VAL_12]]] = %[[VAL_6]] : <@s x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:          }
+// CHECK-NEXT:          function.return %[[VAL_3]] : !struct.type<@A::@A<[]>>
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.def @constrain(%[[VAL_13:[0-9a-zA-Z_\.]+]]: !struct.type<@A::@A<[]>>, %[[VAL_14:[0-9a-zA-Z_\.]+]]: !array.type<@s x !felt.type<"bn128">>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_15:[0-9a-zA-Z_\.]+]] = poly.read_const @s : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_16:[0-9a-zA-Z_\.]+]] = felt.const  6 : <"bn128">
+// CHECK-NEXT:          %[[VAL_17:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_18:[0-9a-zA-Z_\.]+]] = array.new  : <@s x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_19:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_20:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_18]], %[[VAL_19]] : <@s x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_21:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_22:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          scf.for %[[VAL_23:[0-9a-zA-Z_\.]+]] = %[[VAL_21]] to %[[VAL_20]] step %[[VAL_22]] {
+// CHECK-NEXT:            array.write %[[VAL_18]]{{\[}}%[[VAL_23]]] = %[[VAL_17]] : <@s x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:          }
+// CHECK-NEXT:          function.return
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/loops/inner_loop_00.circom
+++ b/circom/tests/loops/inner_loop_00.circom
@@ -27,8 +27,8 @@ component main = InnerLoops(2, 3);
 // CHECK-NEXT:        struct.member @out : !felt.type<"bn128"> {llzk.pub}
 // CHECK-NEXT:        function.def @compute(%[[V_IN:[0-9a-zA-Z_\.]+]]: !array.type<@m x !felt.type<"bn128">>) -> !struct.type<@InnerLoops::@InnerLoops<[@n, @m]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
 // CHECK-NEXT:          %[[V_1:[0-9a-zA-Z_\.]+]] = struct.new : <@InnerLoops::@InnerLoops<[@n, @m]>>
-// CHECK-NEXT:          %[[V_N:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
 // CHECK-NEXT:          %[[V_M:[0-9a-zA-Z_\.]+]] = poly.read_const @m : !felt.type<"bn128">
+// CHECK-NEXT:          %[[V_N:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
 // CHECK-NEXT:          %[[V_4:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:          %[[V_B:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !felt.type<"bn128">>
 // CHECK-NEXT:          %[[V_6:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
@@ -69,8 +69,8 @@ component main = InnerLoops(2, 3);
 // CHECK-NEXT:          function.return %[[V_1]] : !struct.type<@InnerLoops::@InnerLoops<[@n, @m]>>
 // CHECK-NEXT:        }
 // CHECK-NEXT:        function.def @constrain(%[[V_IN:[0-9a-zA-Z_\.]+]]: !struct.type<@InnerLoops::@InnerLoops<[@n, @m]>>, %[[V_36:[0-9a-zA-Z_\.]+]]: !array.type<@m x !felt.type<"bn128">>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:          %[[V_N:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
 // CHECK-NEXT:          %[[V_M:[0-9a-zA-Z_\.]+]] = poly.read_const @m : !felt.type<"bn128">
+// CHECK-NEXT:          %[[V_N:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
 // CHECK-NEXT:          %[[V_67:[0-9a-zA-Z_\.]+]] = struct.readm %[[V_IN]][@out] : <@InnerLoops::@InnerLoops<[@n, @m]>>, !felt.type<"bn128">
 // CHECK-NEXT:          %[[V_39:[0-9a-zA-Z_\.]+]] = felt.const  0
 // CHECK-NEXT:          %[[V_B:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !felt.type<"bn128">>

--- a/circom/tests/loops/inner_loop_05.circom
+++ b/circom/tests/loops/inner_loop_05.circom
@@ -1,7 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --stabilize --llzk --llzk_plaintext -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL:.*
 
 pragma circom 2.0.0;
 
@@ -18,4 +17,74 @@ template Num2Bits(n) {
 
 component main = Num2Bits(2);
 
-// CHECK-LABEL: module attributes {
+// CHECK-LABEL: module attributes {llzk.lang, llzk.main = !struct.type<@Num2Bits::@Num2Bits<[2]>>} {
+// CHECK-NEXT:    poly.template @Num2Bits {
+// CHECK-NEXT:      poly.param @n
+// CHECK-NEXT:      poly.expr @n_Mul_n {
+// CHECK-NEXT:        %[[VAL_0:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_0]], %[[VAL_0]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:        poly.yield %[[VAL_1]] : !felt.type<"bn128">
+// CHECK-NEXT:      }
+// CHECK-NEXT:      struct.def @Num2Bits {
+// CHECK-NEXT:        struct.member @out : !array.type<@n_Mul_n x !felt.type<"bn128">> {llzk.pub}
+// CHECK-NEXT:        function.def @compute(%[[VAL_2:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) -> !struct.type<@Num2Bits::@Num2Bits<[@n]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
+// CHECK-NEXT:          %[[VAL_3:[0-9a-zA-Z_\.]+]] = struct.new : <@Num2Bits::@Num2Bits<[@n]>>
+// CHECK-NEXT:          %[[VAL_4:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_5:[0-9a-zA-Z_\.]+]] = poly.read_const @n_Mul_n : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_6:[0-9a-zA-Z_\.]+]] = llzk.nondet : !array.type<@n_Mul_n x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_7:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_8:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_9:[0-9a-zA-Z_\.]+]] = %[[VAL_7]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
+// CHECK-NEXT:            %[[VAL_10:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_9]], %[[VAL_4]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.condition(%[[VAL_10]]) %[[VAL_9]] : !felt.type<"bn128">
+// CHECK-NEXT:          } do {
+// CHECK-NEXT:          ^bb0(%[[VAL_11:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
+// CHECK-NEXT:            %[[VAL_12:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:            %[[VAL_13:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_14:[0-9a-zA-Z_\.]+]] = %[[VAL_12]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
+// CHECK-NEXT:              %[[VAL_15:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_14]], %[[VAL_4]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:              scf.condition(%[[VAL_15]]) %[[VAL_14]] : !felt.type<"bn128">
+// CHECK-NEXT:            } do {
+// CHECK-NEXT:            ^bb0(%[[VAL_16:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
+// CHECK-NEXT:              %[[VAL_17:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_11]], %[[VAL_4]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_18:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_17]], %[[VAL_16]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_19:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_18]] : !felt.type<"bn128">
+// CHECK-NEXT:              array.write %[[VAL_6]]{{\[}}%[[VAL_19]]] = %[[VAL_2]] : <@n_Mul_n x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_20:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:              %[[VAL_21:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_16]], %[[VAL_20]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:              scf.yield %[[VAL_21]] : !felt.type<"bn128">
+// CHECK-NEXT:            }
+// CHECK-NEXT:            %[[VAL_22:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_23:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_11]], %[[VAL_22]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_23]] : !felt.type<"bn128">
+// CHECK-NEXT:          }
+// CHECK-NEXT:          struct.writem %[[VAL_3]][@out] = %[[VAL_6]] : <@Num2Bits::@Num2Bits<[@n]>>, !array.type<@n_Mul_n x !felt.type<"bn128">>
+// CHECK-NEXT:          function.return %[[VAL_3]] : !struct.type<@Num2Bits::@Num2Bits<[@n]>>
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.def @constrain(%[[VAL_24:[0-9a-zA-Z_\.]+]]: !struct.type<@Num2Bits::@Num2Bits<[@n]>>, %[[VAL_25:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_26:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_27:[0-9a-zA-Z_\.]+]] = poly.read_const @n_Mul_n : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_28:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_24]][@out] : <@Num2Bits::@Num2Bits<[@n]>>, !array.type<@n_Mul_n x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_29:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_30:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_31:[0-9a-zA-Z_\.]+]] = %[[VAL_29]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
+// CHECK-NEXT:            %[[VAL_32:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_31]], %[[VAL_26]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.condition(%[[VAL_32]]) %[[VAL_31]] : !felt.type<"bn128">
+// CHECK-NEXT:          } do {
+// CHECK-NEXT:          ^bb0(%[[VAL_33:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
+// CHECK-NEXT:            %[[VAL_34:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:            %[[VAL_35:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_36:[0-9a-zA-Z_\.]+]] = %[[VAL_34]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
+// CHECK-NEXT:              %[[VAL_37:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_36]], %[[VAL_26]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:              scf.condition(%[[VAL_37]]) %[[VAL_36]] : !felt.type<"bn128">
+// CHECK-NEXT:            } do {
+// CHECK-NEXT:            ^bb0(%[[VAL_38:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
+// CHECK-NEXT:              %[[VAL_39:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:              %[[VAL_40:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_38]], %[[VAL_39]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:              scf.yield %[[VAL_40]] : !felt.type<"bn128">
+// CHECK-NEXT:            }
+// CHECK-NEXT:            %[[VAL_41:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_42:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_33]], %[[VAL_41]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_42]] : !felt.type<"bn128">
+// CHECK-NEXT:          }
+// CHECK-NEXT:          function.return
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/loops/unknown_loop_index.circom
+++ b/circom/tests/loops/unknown_loop_index.circom
@@ -1,7 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --stabilize --llzk --llzk_plaintext -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL:.*
 
 pragma circom 2.0.0;
 
@@ -69,4 +68,312 @@ template UnknownLoopIndex(n) {
 
 component main = UnknownLoopIndex(100);
 
-// CHECK-LABEL: module attributes {
+// CHECK-LABEL: module attributes {llzk.lang, llzk.main = !struct.type<@UnknownLoopIndex::@UnknownLoopIndex<[100]>>} {
+// CHECK-NEXT:    poly.template @CountDown {
+// CHECK-NEXT:      poly.param @n
+// CHECK-NEXT:      struct.def @CountDown {
+// CHECK-NEXT:        struct.member @out : !felt.type<"bn128"> {llzk.pub}
+// CHECK-NEXT:        function.def @compute(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) -> !struct.type<@CountDown::@CountDown<[@n]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
+// CHECK-NEXT:          %[[VAL_1:[0-9a-zA-Z_\.]+]] = struct.new : <@CountDown::@CountDown<[@n]>>
+// CHECK-NEXT:          %[[VAL_2:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_3:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_4:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_2]], %[[VAL_3]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_5:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_6:[0-9a-zA-Z_\.]+]] = %[[VAL_2]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
+// CHECK-NEXT:            %[[VAL_7:[0-9a-zA-Z_\.]+]] = bool.cmp gt(%[[VAL_4]], %[[VAL_0]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.condition(%[[VAL_7]]) %[[VAL_6]] : !felt.type<"bn128">
+// CHECK-NEXT:          } do {
+// CHECK-NEXT:          ^bb0(%[[VAL_8:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
+// CHECK-NEXT:            %[[VAL_9:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_10:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_8]], %[[VAL_9]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_10]] : !felt.type<"bn128">
+// CHECK-NEXT:          }
+// CHECK-NEXT:          struct.writem %[[VAL_1]][@out] = %[[VAL_4]] : <@CountDown::@CountDown<[@n]>>, !felt.type<"bn128">
+// CHECK-NEXT:          function.return %[[VAL_1]] : !struct.type<@CountDown::@CountDown<[@n]>>
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.def @constrain(%[[VAL_11:[0-9a-zA-Z_\.]+]]: !struct.type<@CountDown::@CountDown<[@n]>>, %[[VAL_12:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_13:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_14:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_11]][@out] : <@CountDown::@CountDown<[@n]>>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_15:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_16:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_13]], %[[VAL_15]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_17:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_18:[0-9a-zA-Z_\.]+]] = %[[VAL_13]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
+// CHECK-NEXT:            %[[VAL_19:[0-9a-zA-Z_\.]+]] = bool.cmp gt(%[[VAL_16]], %[[VAL_12]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.condition(%[[VAL_19]]) %[[VAL_18]] : !felt.type<"bn128">
+// CHECK-NEXT:          } do {
+// CHECK-NEXT:          ^bb0(%[[VAL_20:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
+// CHECK-NEXT:            %[[VAL_21:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_22:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_20]], %[[VAL_21]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_22]] : !felt.type<"bn128">
+// CHECK-NEXT:          }
+// CHECK-NEXT:          constrain.eq %[[VAL_12]], %[[VAL_16]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          function.return
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    poly.template @LessThan {
+// CHECK-NEXT:      poly.param @n
+// CHECK-NEXT:      poly.expr @n_Add_1 {
+// CHECK-NEXT:        %[[VAL_23:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_24:[0-9a-zA-Z_\.]+]] = felt.const  252 : <"bn128">
+// CHECK-NEXT:        %[[VAL_25:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_23]], %[[VAL_24]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:        bool.assert %[[VAL_25]], "assertion failed"
+// CHECK-NEXT:        %[[VAL_26:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:        %[[VAL_27:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_23]], %[[VAL_26]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:        poly.yield %[[VAL_27]] : !felt.type<"bn128">
+// CHECK-NEXT:      }
+// CHECK-NEXT:      struct.def @LessThan {
+// CHECK-NEXT:        struct.member @out : !felt.type<"bn128"> {llzk.pub}
+// CHECK-NEXT:        struct.member @n2b : !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>
+// CHECK-NEXT:        struct.member @n2b$inputs : !pod.type<[@in: !felt.type<"bn128">]>
+// CHECK-NEXT:        function.def @compute(%[[VAL_28:[0-9a-zA-Z_\.]+]]: !array.type<2 x !felt.type<"bn128">>) -> !struct.type<@LessThan::@LessThan<[@n]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
+// CHECK-NEXT:          %[[VAL_29:[0-9a-zA-Z_\.]+]] = struct.new : <@LessThan::@LessThan<[@n]>>
+// CHECK-NEXT:          %[[VAL_30:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_31:[0-9a-zA-Z_\.]+]] = poly.read_const @n_Add_1 : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_32:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          %[[VAL_33:[0-9a-zA-Z_\.]+]] = pod.new { @count = %[[VAL_32]] }  : <[@count: index, @comp: !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:          %[[VAL_34:[0-9a-zA-Z_\.]+]] = pod.new : <[@in: !felt.type<"bn128">]>
+// CHECK-NEXT:          %[[VAL_35:[0-9a-zA-Z_\.]+]] = felt.const  252 : <"bn128">
+// CHECK-NEXT:          %[[VAL_36:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_30]], %[[VAL_35]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          bool.assert %[[VAL_36]], "assertion failed"
+// CHECK-NEXT:          %[[VAL_37:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_38:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_37]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_39:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_28]]{{\[}}%[[VAL_38]]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_40:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_41:[0-9a-zA-Z_\.]+]] = felt.shl %[[VAL_40]], %[[VAL_30]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_42:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_39]], %[[VAL_41]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_43:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_44:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_43]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_45:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_28]]{{\[}}%[[VAL_44]]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_46:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_42]], %[[VAL_45]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          pod.write %[[VAL_34]][@in] = %[[VAL_46]] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_47:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_33]][@count] : <[@count: index, @comp: !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:          %[[VAL_48:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          %[[VAL_49:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_47]], %[[VAL_48]] : index
+// CHECK-NEXT:          pod.write %[[VAL_33]][@count] = %[[VAL_49]] : <[@count: index, @comp: !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:          %[[VAL_50:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_51:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_49]], %[[VAL_50]] : index
+// CHECK-NEXT:          scf.if %[[VAL_51]] {
+// CHECK-NEXT:            %[[VAL_52:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_34]][@in] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_53:[0-9a-zA-Z_\.]+]] = function.call @Num2Bits::@Num2Bits::@compute(%[[VAL_52]]) : (!felt.type<"bn128">) -> !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>
+// CHECK-NEXT:            pod.write %[[VAL_33]][@comp] = %[[VAL_53]] : <[@count: index, @comp: !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>, @params: !pod.type<[]>]>, !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>
+// CHECK-NEXT:          } else {
+// CHECK-NEXT:          }
+// CHECK-NEXT:          %[[VAL_54:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_55:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_33]][@comp] : <[@count: index, @comp: !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>, @params: !pod.type<[]>]>, !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>
+// CHECK-NEXT:          %[[VAL_56:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_55]][@out] : <@Num2Bits::@Num2Bits<[@n_Add_1]>>, !array.type<@n x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_57:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_30]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_58:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_56]]{{\[}}%[[VAL_57]]] : <@n x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_59:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_54]], %[[VAL_58]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          struct.writem %[[VAL_29]][@out] = %[[VAL_59]] : <@LessThan::@LessThan<[@n]>>, !felt.type<"bn128">
+// CHECK-NEXT:          struct.writem %[[VAL_29]][@n2b$inputs] = %[[VAL_34]] : <@LessThan::@LessThan<[@n]>>, !pod.type<[@in: !felt.type<"bn128">]>
+// CHECK-NEXT:          %[[VAL_60:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_33]][@comp] : <[@count: index, @comp: !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>, @params: !pod.type<[]>]>, !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>
+// CHECK-NEXT:          struct.writem %[[VAL_29]][@n2b] = %[[VAL_60]] : <@LessThan::@LessThan<[@n]>>, !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>
+// CHECK-NEXT:          function.return %[[VAL_29]] : !struct.type<@LessThan::@LessThan<[@n]>>
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.def @constrain(%[[VAL_61:[0-9a-zA-Z_\.]+]]: !struct.type<@LessThan::@LessThan<[@n]>>, %[[VAL_62:[0-9a-zA-Z_\.]+]]: !array.type<2 x !felt.type<"bn128">>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_63:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_64:[0-9a-zA-Z_\.]+]] = poly.read_const @n_Add_1 : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_65:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_61]][@out] : <@LessThan::@LessThan<[@n]>>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_66:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_61]][@n2b] : <@LessThan::@LessThan<[@n]>>, !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>
+// CHECK-NEXT:          %[[VAL_67:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_61]][@n2b$inputs] : <@LessThan::@LessThan<[@n]>>, !pod.type<[@in: !felt.type<"bn128">]>
+// CHECK-NEXT:          %[[VAL_68:[0-9a-zA-Z_\.]+]] = felt.const  252 : <"bn128">
+// CHECK-NEXT:          %[[VAL_69:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_63]], %[[VAL_68]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          bool.assert %[[VAL_69]], "assertion failed"
+// CHECK-NEXT:          %[[VAL_70:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_71:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_70]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_72:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_62]]{{\[}}%[[VAL_71]]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_73:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_74:[0-9a-zA-Z_\.]+]] = felt.shl %[[VAL_73]], %[[VAL_63]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_75:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_72]], %[[VAL_74]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_76:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_77:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_76]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_78:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_62]]{{\[}}%[[VAL_77]]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_79:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_75]], %[[VAL_78]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_80:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_67]][@in] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:          constrain.eq %[[VAL_80]], %[[VAL_79]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_81:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_82:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_66]][@out] : <@Num2Bits::@Num2Bits<[@n_Add_1]>>, !array.type<@n x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_83:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_63]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_84:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_82]]{{\[}}%[[VAL_83]]] : <@n x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_85:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_81]], %[[VAL_84]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          constrain.eq %[[VAL_65]], %[[VAL_85]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_86:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_67]][@in] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:          function.call @Num2Bits::@Num2Bits::@constrain(%[[VAL_66]], %[[VAL_86]]) : (!struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>, !felt.type<"bn128">) -> ()
+// CHECK-NEXT:          function.return
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    poly.template @Num2Bits {
+// CHECK-NEXT:      poly.param @n
+// CHECK-NEXT:      struct.def @Num2Bits {
+// CHECK-NEXT:        struct.member @out : !array.type<@n x !felt.type<"bn128">> {llzk.pub}
+// CHECK-NEXT:        function.def @compute(%[[VAL_87:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) -> !struct.type<@Num2Bits::@Num2Bits<[@n]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
+// CHECK-NEXT:          %[[VAL_88:[0-9a-zA-Z_\.]+]] = struct.new : <@Num2Bits::@Num2Bits<[@n]>>
+// CHECK-NEXT:          %[[VAL_89:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_90:[0-9a-zA-Z_\.]+]] = llzk.nondet : !array.type<@n x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_91:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_92:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_93:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_94:[0-9a-zA-Z_\.]+]]:3 = scf.while (%[[VAL_95:[0-9a-zA-Z_\.]+]] = %[[VAL_92]], %[[VAL_96:[0-9a-zA-Z_\.]+]] = %[[VAL_93]], %[[VAL_97:[0-9a-zA-Z_\.]+]] = %[[VAL_91]]) : (!felt.type<"bn128">, !felt.type<"bn128">, !felt.type<"bn128">) -> (!felt.type<"bn128">, !felt.type<"bn128">, !felt.type<"bn128">) {
+// CHECK-NEXT:            %[[VAL_98:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_96]], %[[VAL_89]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.condition(%[[VAL_98]]) %[[VAL_95]], %[[VAL_96]], %[[VAL_97]] : !felt.type<"bn128">, !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          } do {
+// CHECK-NEXT:          ^bb0(%[[VAL_99:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">, %[[VAL_100:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">, %[[VAL_101:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
+// CHECK-NEXT:            %[[VAL_102:[0-9a-zA-Z_\.]+]] = felt.shr %[[VAL_87]], %[[VAL_100]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_103:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_104:[0-9a-zA-Z_\.]+]] = felt.bit_and %[[VAL_102]], %[[VAL_103]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_105:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_100]] : !felt.type<"bn128">
+// CHECK-NEXT:            array.write %[[VAL_90]]{{\[}}%[[VAL_105]]] = %[[VAL_104]] : <@n x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_106:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_100]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_107:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_90]]{{\[}}%[[VAL_106]]] : <@n x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_108:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_107]], %[[VAL_92]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_109:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_101]], %[[VAL_108]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_110:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_99]], %[[VAL_99]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_111:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_112:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_100]], %[[VAL_111]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_110]], %[[VAL_112]], %[[VAL_109]] : !felt.type<"bn128">, !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          }
+// CHECK-NEXT:          struct.writem %[[VAL_88]][@out] = %[[VAL_90]] : <@Num2Bits::@Num2Bits<[@n]>>, !array.type<@n x !felt.type<"bn128">>
+// CHECK-NEXT:          function.return %[[VAL_88]] : !struct.type<@Num2Bits::@Num2Bits<[@n]>>
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.def @constrain(%[[VAL_113:[0-9a-zA-Z_\.]+]]: !struct.type<@Num2Bits::@Num2Bits<[@n]>>, %[[VAL_114:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_115:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_116:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_113]][@out] : <@Num2Bits::@Num2Bits<[@n]>>, !array.type<@n x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_117:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_118:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_119:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_120:[0-9a-zA-Z_\.]+]]:3 = scf.while (%[[VAL_121:[0-9a-zA-Z_\.]+]] = %[[VAL_118]], %[[VAL_122:[0-9a-zA-Z_\.]+]] = %[[VAL_119]], %[[VAL_123:[0-9a-zA-Z_\.]+]] = %[[VAL_117]]) : (!felt.type<"bn128">, !felt.type<"bn128">, !felt.type<"bn128">) -> (!felt.type<"bn128">, !felt.type<"bn128">, !felt.type<"bn128">) {
+// CHECK-NEXT:            %[[VAL_124:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_122]], %[[VAL_115]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.condition(%[[VAL_124]]) %[[VAL_121]], %[[VAL_122]], %[[VAL_123]] : !felt.type<"bn128">, !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          } do {
+// CHECK-NEXT:          ^bb0(%[[VAL_125:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">, %[[VAL_126:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">, %[[VAL_127:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
+// CHECK-NEXT:            %[[VAL_128:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_126]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_129:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_116]]{{\[}}%[[VAL_128]]] : <@n x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_130:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_126]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_131:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_116]]{{\[}}%[[VAL_130]]] : <@n x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_132:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_133:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_131]], %[[VAL_132]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_134:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_129]], %[[VAL_133]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_135:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:            constrain.eq %[[VAL_134]], %[[VAL_135]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_136:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_126]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_137:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_116]]{{\[}}%[[VAL_136]]] : <@n x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_138:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_137]], %[[VAL_118]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_139:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_127]], %[[VAL_138]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_140:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_125]], %[[VAL_125]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_141:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_142:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_126]], %[[VAL_141]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_140]], %[[VAL_142]], %[[VAL_139]] : !felt.type<"bn128">, !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          }
+// CHECK-NEXT:          constrain.eq %[[VAL_120]]#2, %[[VAL_114]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          function.return
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    poly.template @UnknownLoopIndex {
+// CHECK-NEXT:      poly.param @n
+// CHECK-NEXT:      struct.def @UnknownLoopIndex {
+// CHECK-NEXT:        struct.member @out : !felt.type<"bn128"> {llzk.pub}
+// CHECK-NEXT:        struct.member @c : !struct.type<@CountDown::@CountDown<[@n]>>
+// CHECK-NEXT:        struct.member @c$inputs : !pod.type<[@in: !felt.type<"bn128">]>
+// CHECK-NEXT:        struct.member @lt : !struct.type<@LessThan::@LessThan<[@n]>>
+// CHECK-NEXT:        struct.member @lt$inputs : !pod.type<[@in: !array.type<2 x !felt.type<"bn128">>]>
+// CHECK-NEXT:        function.def @compute(%[[VAL_143:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">, %[[VAL_144:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type<"bn128">>) -> !struct.type<@UnknownLoopIndex::@UnknownLoopIndex<[@n]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
+// CHECK-NEXT:          %[[VAL_145:[0-9a-zA-Z_\.]+]] = struct.new : <@UnknownLoopIndex::@UnknownLoopIndex<[@n]>>
+// CHECK-NEXT:          %[[VAL_146:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_147:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          %[[VAL_148:[0-9a-zA-Z_\.]+]] = pod.new { @count = %[[VAL_147]] }  : <[@count: index, @comp: !struct.type<@CountDown::@CountDown<[@n]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:          %[[VAL_149:[0-9a-zA-Z_\.]+]] = pod.new : <[@in: !felt.type<"bn128">]>
+// CHECK-NEXT:          %[[VAL_150:[0-9a-zA-Z_\.]+]] = arith.constant 2 : index
+// CHECK-NEXT:          %[[VAL_151:[0-9a-zA-Z_\.]+]] = pod.new { @count = %[[VAL_150]] }  : <[@count: index, @comp: !struct.type<@LessThan::@LessThan<[@n]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:          %[[VAL_152:[0-9a-zA-Z_\.]+]] = pod.new : <[@in: !array.type<2 x !felt.type<"bn128">>]>
+// CHECK-NEXT:          %[[VAL_153:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_152]][@in] : <[@in: !array.type<2 x !felt.type<"bn128">>]>, !array.type<2 x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_154:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_155:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_154]] : !felt.type<"bn128">
+// CHECK-NEXT:          array.write %[[VAL_153]]{{\[}}%[[VAL_155]]] = %[[VAL_143]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:          pod.write %[[VAL_152]][@in] = %[[VAL_153]] : <[@in: !array.type<2 x !felt.type<"bn128">>]>, !array.type<2 x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_156:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_151]][@count] : <[@count: index, @comp: !struct.type<@LessThan::@LessThan<[@n]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:          %[[VAL_157:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          %[[VAL_158:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_156]], %[[VAL_157]] : index
+// CHECK-NEXT:          pod.write %[[VAL_151]][@count] = %[[VAL_158]] : <[@count: index, @comp: !struct.type<@LessThan::@LessThan<[@n]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:          %[[VAL_159:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_160:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_158]], %[[VAL_159]] : index
+// CHECK-NEXT:          scf.if %[[VAL_160]] {
+// CHECK-NEXT:            %[[VAL_161:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_152]][@in] : <[@in: !array.type<2 x !felt.type<"bn128">>]>, !array.type<2 x !felt.type<"bn128">>
+// CHECK-NEXT:            %[[VAL_162:[0-9a-zA-Z_\.]+]] = function.call @LessThan::@LessThan::@compute(%[[VAL_161]]) : (!array.type<2 x !felt.type<"bn128">>) -> !struct.type<@LessThan::@LessThan<[@n]>>
+// CHECK-NEXT:            pod.write %[[VAL_151]][@comp] = %[[VAL_162]] : <[@count: index, @comp: !struct.type<@LessThan::@LessThan<[@n]>>, @params: !pod.type<[]>]>, !struct.type<@LessThan::@LessThan<[@n]>>
+// CHECK-NEXT:          } else {
+// CHECK-NEXT:          }
+// CHECK-NEXT:          %[[VAL_163:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_152]][@in] : <[@in: !array.type<2 x !felt.type<"bn128">>]>, !array.type<2 x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_164:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_165:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_164]] : !felt.type<"bn128">
+// CHECK-NEXT:          array.write %[[VAL_163]]{{\[}}%[[VAL_165]]] = %[[VAL_146]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:          pod.write %[[VAL_152]][@in] = %[[VAL_163]] : <[@in: !array.type<2 x !felt.type<"bn128">>]>, !array.type<2 x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_166:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_151]][@count] : <[@count: index, @comp: !struct.type<@LessThan::@LessThan<[@n]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:          %[[VAL_167:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          %[[VAL_168:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_166]], %[[VAL_167]] : index
+// CHECK-NEXT:          pod.write %[[VAL_151]][@count] = %[[VAL_168]] : <[@count: index, @comp: !struct.type<@LessThan::@LessThan<[@n]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:          %[[VAL_169:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_170:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_168]], %[[VAL_169]] : index
+// CHECK-NEXT:          scf.if %[[VAL_170]] {
+// CHECK-NEXT:            %[[VAL_171:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_152]][@in] : <[@in: !array.type<2 x !felt.type<"bn128">>]>, !array.type<2 x !felt.type<"bn128">>
+// CHECK-NEXT:            %[[VAL_172:[0-9a-zA-Z_\.]+]] = function.call @LessThan::@LessThan::@compute(%[[VAL_171]]) : (!array.type<2 x !felt.type<"bn128">>) -> !struct.type<@LessThan::@LessThan<[@n]>>
+// CHECK-NEXT:            pod.write %[[VAL_151]][@comp] = %[[VAL_172]] : <[@count: index, @comp: !struct.type<@LessThan::@LessThan<[@n]>>, @params: !pod.type<[]>]>, !struct.type<@LessThan::@LessThan<[@n]>>
+// CHECK-NEXT:          } else {
+// CHECK-NEXT:          }
+// CHECK-NEXT:          pod.write %[[VAL_149]][@in] = %[[VAL_143]] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_173:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_148]][@count] : <[@count: index, @comp: !struct.type<@CountDown::@CountDown<[@n]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:          %[[VAL_174:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          %[[VAL_175:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_173]], %[[VAL_174]] : index
+// CHECK-NEXT:          pod.write %[[VAL_148]][@count] = %[[VAL_175]] : <[@count: index, @comp: !struct.type<@CountDown::@CountDown<[@n]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:          %[[VAL_176:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_177:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_175]], %[[VAL_176]] : index
+// CHECK-NEXT:          scf.if %[[VAL_177]] {
+// CHECK-NEXT:            %[[VAL_178:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_149]][@in] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_179:[0-9a-zA-Z_\.]+]] = function.call @CountDown::@CountDown::@compute(%[[VAL_178]]) : (!felt.type<"bn128">) -> !struct.type<@CountDown::@CountDown<[@n]>>
+// CHECK-NEXT:            pod.write %[[VAL_148]][@comp] = %[[VAL_179]] : <[@count: index, @comp: !struct.type<@CountDown::@CountDown<[@n]>>, @params: !pod.type<[]>]>, !struct.type<@CountDown::@CountDown<[@n]>>
+// CHECK-NEXT:          } else {
+// CHECK-NEXT:          }
+// CHECK-NEXT:          %[[VAL_180:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_148]][@comp] : <[@count: index, @comp: !struct.type<@CountDown::@CountDown<[@n]>>, @params: !pod.type<[]>]>, !struct.type<@CountDown::@CountDown<[@n]>>
+// CHECK-NEXT:          %[[VAL_181:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_180]][@out] : <@CountDown::@CountDown<[@n]>>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_182:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_181]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_183:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_144]]{{\[}}%[[VAL_182]]] : <@n x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:          struct.writem %[[VAL_145]][@out] = %[[VAL_183]] : <@UnknownLoopIndex::@UnknownLoopIndex<[@n]>>, !felt.type<"bn128">
+// CHECK-NEXT:          struct.writem %[[VAL_145]][@c$inputs] = %[[VAL_149]] : <@UnknownLoopIndex::@UnknownLoopIndex<[@n]>>, !pod.type<[@in: !felt.type<"bn128">]>
+// CHECK-NEXT:          %[[VAL_184:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_148]][@comp] : <[@count: index, @comp: !struct.type<@CountDown::@CountDown<[@n]>>, @params: !pod.type<[]>]>, !struct.type<@CountDown::@CountDown<[@n]>>
+// CHECK-NEXT:          struct.writem %[[VAL_145]][@c] = %[[VAL_184]] : <@UnknownLoopIndex::@UnknownLoopIndex<[@n]>>, !struct.type<@CountDown::@CountDown<[@n]>>
+// CHECK-NEXT:          struct.writem %[[VAL_145]][@lt$inputs] = %[[VAL_152]] : <@UnknownLoopIndex::@UnknownLoopIndex<[@n]>>, !pod.type<[@in: !array.type<2 x !felt.type<"bn128">>]>
+// CHECK-NEXT:          %[[VAL_185:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_151]][@comp] : <[@count: index, @comp: !struct.type<@LessThan::@LessThan<[@n]>>, @params: !pod.type<[]>]>, !struct.type<@LessThan::@LessThan<[@n]>>
+// CHECK-NEXT:          struct.writem %[[VAL_145]][@lt] = %[[VAL_185]] : <@UnknownLoopIndex::@UnknownLoopIndex<[@n]>>, !struct.type<@LessThan::@LessThan<[@n]>>
+// CHECK-NEXT:          function.return %[[VAL_145]] : !struct.type<@UnknownLoopIndex::@UnknownLoopIndex<[@n]>>
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.def @constrain(%[[VAL_186:[0-9a-zA-Z_\.]+]]: !struct.type<@UnknownLoopIndex::@UnknownLoopIndex<[@n]>>, %[[VAL_187:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">, %[[VAL_188:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type<"bn128">>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_189:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_190:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_186]][@out] : <@UnknownLoopIndex::@UnknownLoopIndex<[@n]>>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_191:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_186]][@c] : <@UnknownLoopIndex::@UnknownLoopIndex<[@n]>>, !struct.type<@CountDown::@CountDown<[@n]>>
+// CHECK-NEXT:          %[[VAL_192:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_186]][@c$inputs] : <@UnknownLoopIndex::@UnknownLoopIndex<[@n]>>, !pod.type<[@in: !felt.type<"bn128">]>
+// CHECK-NEXT:          %[[VAL_193:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_186]][@lt] : <@UnknownLoopIndex::@UnknownLoopIndex<[@n]>>, !struct.type<@LessThan::@LessThan<[@n]>>
+// CHECK-NEXT:          %[[VAL_194:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_186]][@lt$inputs] : <@UnknownLoopIndex::@UnknownLoopIndex<[@n]>>, !pod.type<[@in: !array.type<2 x !felt.type<"bn128">>]>
+// CHECK-NEXT:          %[[VAL_195:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_194]][@in] : <[@in: !array.type<2 x !felt.type<"bn128">>]>, !array.type<2 x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_196:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_197:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_196]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_198:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_195]]{{\[}}%[[VAL_197]]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:          constrain.eq %[[VAL_198]], %[[VAL_187]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_199:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_194]][@in] : <[@in: !array.type<2 x !felt.type<"bn128">>]>, !array.type<2 x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_200:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_201:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_200]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_202:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_199]]{{\[}}%[[VAL_201]]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:          constrain.eq %[[VAL_202]], %[[VAL_189]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_203:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_193]][@out] : <@LessThan::@LessThan<[@n]>>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_204:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          constrain.eq %[[VAL_203]], %[[VAL_204]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_205:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_192]][@in] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:          constrain.eq %[[VAL_205]], %[[VAL_187]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_206:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_192]][@in] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:          function.call @CountDown::@CountDown::@constrain(%[[VAL_191]], %[[VAL_206]]) : (!struct.type<@CountDown::@CountDown<[@n]>>, !felt.type<"bn128">) -> ()
+// CHECK-NEXT:          %[[VAL_207:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_194]][@in] : <[@in: !array.type<2 x !felt.type<"bn128">>]>, !array.type<2 x !felt.type<"bn128">>
+// CHECK-NEXT:          function.call @LessThan::@LessThan::@constrain(%[[VAL_193]], %[[VAL_207]]) : (!struct.type<@LessThan::@LessThan<[@n]>>, !array.type<2 x !felt.type<"bn128">>) -> ()
+// CHECK-NEXT:          function.return
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/loops/variant_idx_in_loop_03.circom
+++ b/circom/tests/loops/variant_idx_in_loop_03.circom
@@ -1,7 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --stabilize --llzk --llzk_plaintext -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL:.*
 
 pragma circom 2.0.0;
 
@@ -18,4 +17,57 @@ template VariantIndex(n) {
 
 component main = VariantIndex(2);
 
-// CHECK-LABEL: module attributes {
+// CHECK-LABEL: module attributes {llzk.lang, llzk.main = !struct.type<@VariantIndex::@VariantIndex<[2]>>} {
+// CHECK-NEXT:    poly.template @VariantIndex {
+// CHECK-NEXT:      poly.param @n
+// CHECK-NEXT:      poly.expr @n_Mul_n {
+// CHECK-NEXT:        %[[VAL_0:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_0]], %[[VAL_0]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:        poly.yield %[[VAL_1]] : !felt.type<"bn128">
+// CHECK-NEXT:      }
+// CHECK-NEXT:      struct.def @VariantIndex {
+// CHECK-NEXT:        struct.member @out : !array.type<@n_Mul_n x !felt.type<"bn128">> {llzk.pub}
+// CHECK-NEXT:        function.def @compute(%[[VAL_2:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) -> !struct.type<@VariantIndex::@VariantIndex<[@n]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
+// CHECK-NEXT:          %[[VAL_3:[0-9a-zA-Z_\.]+]] = struct.new : <@VariantIndex::@VariantIndex<[@n]>>
+// CHECK-NEXT:          %[[VAL_4:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_5:[0-9a-zA-Z_\.]+]] = poly.read_const @n_Mul_n : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_6:[0-9a-zA-Z_\.]+]] = llzk.nondet : !array.type<@n_Mul_n x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_7:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_8:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_9:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_10:[0-9a-zA-Z_\.]+]] = %[[VAL_8]], %[[VAL_11:[0-9a-zA-Z_\.]+]] = %[[VAL_7]]) : (!felt.type<"bn128">, !felt.type<"bn128">) -> (!felt.type<"bn128">, !felt.type<"bn128">) {
+// CHECK-NEXT:            %[[VAL_12:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_10]], %[[VAL_4]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.condition(%[[VAL_12]]) %[[VAL_10]], %[[VAL_11]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          } do {
+// CHECK-NEXT:          ^bb0(%[[VAL_13:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">, %[[VAL_14:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
+// CHECK-NEXT:            %[[VAL_15:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_14]], %[[VAL_13]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_16:[0-9a-zA-Z_\.]+]] = felt.shr %[[VAL_2]], %[[VAL_13]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_17:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_15]] : !felt.type<"bn128">
+// CHECK-NEXT:            array.write %[[VAL_6]]{{\[}}%[[VAL_17]]] = %[[VAL_16]] : <@n_Mul_n x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_18:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_19:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_13]], %[[VAL_18]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_19]], %[[VAL_15]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          }
+// CHECK-NEXT:          struct.writem %[[VAL_3]][@out] = %[[VAL_6]] : <@VariantIndex::@VariantIndex<[@n]>>, !array.type<@n_Mul_n x !felt.type<"bn128">>
+// CHECK-NEXT:          function.return %[[VAL_3]] : !struct.type<@VariantIndex::@VariantIndex<[@n]>>
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.def @constrain(%[[VAL_20:[0-9a-zA-Z_\.]+]]: !struct.type<@VariantIndex::@VariantIndex<[@n]>>, %[[VAL_21:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_22:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_23:[0-9a-zA-Z_\.]+]] = poly.read_const @n_Mul_n : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_24:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_20]][@out] : <@VariantIndex::@VariantIndex<[@n]>>, !array.type<@n_Mul_n x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_25:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_26:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_27:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_28:[0-9a-zA-Z_\.]+]] = %[[VAL_26]], %[[VAL_29:[0-9a-zA-Z_\.]+]] = %[[VAL_25]]) : (!felt.type<"bn128">, !felt.type<"bn128">) -> (!felt.type<"bn128">, !felt.type<"bn128">) {
+// CHECK-NEXT:            %[[VAL_30:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_28]], %[[VAL_22]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.condition(%[[VAL_30]]) %[[VAL_28]], %[[VAL_29]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          } do {
+// CHECK-NEXT:          ^bb0(%[[VAL_31:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">, %[[VAL_32:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
+// CHECK-NEXT:            %[[VAL_33:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_32]], %[[VAL_31]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_34:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_35:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_31]], %[[VAL_34]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_35]], %[[VAL_33]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          }
+// CHECK-NEXT:          function.return
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/simple/create_component.circom
+++ b/circom/tests/simple/create_component.circom
@@ -1,7 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --stabilize --llzk --llzk_plaintext -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL:.*
 
 pragma circom 2.0.0;
 
@@ -17,4 +16,65 @@ template A(n) {
 
 component main = A(5);
 
-// CHECK-LABEL: module attributes {
+// CHECK-LABEL: module attributes {llzk.lang, llzk.main = !struct.type<@A::@A<[5]>>} {
+// CHECK-NEXT:    poly.template @A {
+// CHECK-NEXT:      poly.param @n
+// CHECK-NEXT:      poly.expr @n_Mul_n {
+// CHECK-NEXT:        %[[VAL_0:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_0]], %[[VAL_0]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:        poly.yield %[[VAL_1]] : !felt.type<"bn128">
+// CHECK-NEXT:      }
+// CHECK-NEXT:      struct.def @A {
+// CHECK-NEXT:        struct.member @x : !struct.type<@B::@B<[@n_Mul_n]>>
+// CHECK-NEXT:        struct.member @x$inputs : !pod.type<[@inB: !felt.type<"bn128">]>
+// CHECK-NEXT:        function.def @compute(%[[VAL_2:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) -> !struct.type<@A::@A<[@n]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
+// CHECK-NEXT:          %[[VAL_3:[0-9a-zA-Z_\.]+]] = struct.new : <@A::@A<[@n]>>
+// CHECK-NEXT:          %[[VAL_4:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_5:[0-9a-zA-Z_\.]+]] = poly.read_const @n_Mul_n : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_6:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          %[[VAL_7:[0-9a-zA-Z_\.]+]] = pod.new { @count = %[[VAL_6]] }  : <[@count: index, @comp: !struct.type<@B::@B<[@n_Mul_n]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:          %[[VAL_8:[0-9a-zA-Z_\.]+]] = pod.new : <[@inB: !felt.type<"bn128">]>
+// CHECK-NEXT:          pod.write %[[VAL_8]][@inB] = %[[VAL_2]] : <[@inB: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_9:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_7]][@count] : <[@count: index, @comp: !struct.type<@B::@B<[@n_Mul_n]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:          %[[VAL_10:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          %[[VAL_11:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_9]], %[[VAL_10]] : index
+// CHECK-NEXT:          pod.write %[[VAL_7]][@count] = %[[VAL_11]] : <[@count: index, @comp: !struct.type<@B::@B<[@n_Mul_n]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:          %[[VAL_12:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_13:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_11]], %[[VAL_12]] : index
+// CHECK-NEXT:          scf.if %[[VAL_13]] {
+// CHECK-NEXT:            %[[VAL_14:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_8]][@inB] : <[@inB: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_15:[0-9a-zA-Z_\.]+]] = function.call @B::@B::@compute(%[[VAL_14]]) : (!felt.type<"bn128">) -> !struct.type<@B::@B<[@n_Mul_n]>>
+// CHECK-NEXT:            pod.write %[[VAL_7]][@comp] = %[[VAL_15]] : <[@count: index, @comp: !struct.type<@B::@B<[@n_Mul_n]>>, @params: !pod.type<[]>]>, !struct.type<@B::@B<[@n_Mul_n]>>
+// CHECK-NEXT:          } else {
+// CHECK-NEXT:          }
+// CHECK-NEXT:          struct.writem %[[VAL_3]][@x$inputs] = %[[VAL_8]] : <@A::@A<[@n]>>, !pod.type<[@inB: !felt.type<"bn128">]>
+// CHECK-NEXT:          %[[VAL_16:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_7]][@comp] : <[@count: index, @comp: !struct.type<@B::@B<[@n_Mul_n]>>, @params: !pod.type<[]>]>, !struct.type<@B::@B<[@n_Mul_n]>>
+// CHECK-NEXT:          struct.writem %[[VAL_3]][@x] = %[[VAL_16]] : <@A::@A<[@n]>>, !struct.type<@B::@B<[@n_Mul_n]>>
+// CHECK-NEXT:          function.return %[[VAL_3]] : !struct.type<@A::@A<[@n]>>
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.def @constrain(%[[VAL_17:[0-9a-zA-Z_\.]+]]: !struct.type<@A::@A<[@n]>>, %[[VAL_18:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_19:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_20:[0-9a-zA-Z_\.]+]] = poly.read_const @n_Mul_n : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_21:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_17]][@x] : <@A::@A<[@n]>>, !struct.type<@B::@B<[@n_Mul_n]>>
+// CHECK-NEXT:          %[[VAL_22:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_17]][@x$inputs] : <@A::@A<[@n]>>, !pod.type<[@inB: !felt.type<"bn128">]>
+// CHECK-NEXT:          %[[VAL_23:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_22]][@inB] : <[@inB: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:          function.call @B::@B::@constrain(%[[VAL_21]], %[[VAL_23]]) : (!struct.type<@B::@B<[@n_Mul_n]>>, !felt.type<"bn128">) -> ()
+// CHECK-NEXT:          function.return
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    poly.template @B {
+// CHECK-NEXT:      poly.param @n
+// CHECK-NEXT:      struct.def @B {
+// CHECK-NEXT:        function.def @compute(%[[VAL_24:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) -> !struct.type<@B::@B<[@n]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
+// CHECK-NEXT:          %[[VAL_25:[0-9a-zA-Z_\.]+]] = struct.new : <@B::@B<[@n]>>
+// CHECK-NEXT:          %[[VAL_26:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
+// CHECK-NEXT:          function.return %[[VAL_25]] : !struct.type<@B::@B<[@n]>>
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.def @constrain(%[[VAL_27:[0-9a-zA-Z_\.]+]]: !struct.type<@B::@B<[@n]>>, %[[VAL_28:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_29:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
+// CHECK-NEXT:          function.return
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/subcmps/subcmps4.circom
+++ b/circom/tests/subcmps/subcmps4.circom
@@ -1,7 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --stabilize --llzk --llzk_plaintext -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL:.*
 
 pragma circom 2.0.0;
 
@@ -38,4 +37,207 @@ template SubCmps4(n) {
 
 component main = SubCmps4(3);
 
-// CHECK-LABEL: module attributes {
+// CHECK-LABEL: module attributes {llzk.lang, llzk.main = !struct.type<@SubCmps4::@SubCmps4<[3]>>} {
+// CHECK-NEXT:    poly.template @SubCmps4 {
+// CHECK-NEXT:      poly.param @n
+// CHECK-NEXT:      poly.expr @n_Mul_2 {
+// CHECK-NEXT:        %[[VAL_0:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_0]], %[[VAL_1]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:        poly.yield %[[VAL_2]] : !felt.type<"bn128">
+// CHECK-NEXT:      }
+// CHECK-NEXT:      struct.def @SubCmps4 {
+// CHECK-NEXT:        struct.member @outp : !array.type<2 x !felt.type<"bn128">> {llzk.pub}
+// CHECK-NEXT:        struct.member @a : !struct.type<@Sum::@Sum<[@n]>>
+// CHECK-NEXT:        struct.member @a$inputs : !pod.type<[@inp: !array.type<@n x !felt.type<"bn128">>]>
+// CHECK-NEXT:        struct.member @b : !struct.type<@Sum::@Sum<[@n]>>
+// CHECK-NEXT:        struct.member @b$inputs : !pod.type<[@inp: !array.type<@n x !felt.type<"bn128">>]>
+// CHECK-NEXT:        function.def @compute(%[[VAL_3:[0-9a-zA-Z_\.]+]]: !array.type<@n_Mul_2 x !felt.type<"bn128">>) -> !struct.type<@SubCmps4::@SubCmps4<[@n]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
+// CHECK-NEXT:          %[[VAL_4:[0-9a-zA-Z_\.]+]] = struct.new : <@SubCmps4::@SubCmps4<[@n]>>
+// CHECK-NEXT:          %[[VAL_5:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_6:[0-9a-zA-Z_\.]+]] = poly.read_const @n_Mul_2 : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_7:[0-9a-zA-Z_\.]+]] = llzk.nondet : !array.type<2 x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_8:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_5]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_9:[0-9a-zA-Z_\.]+]] = pod.new { @count = %[[VAL_8]] }  : <[@count: index, @comp: !struct.type<@Sum::@Sum<[@n]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:          %[[VAL_10:[0-9a-zA-Z_\.]+]] = pod.new : <[@inp: !array.type<@n x !felt.type<"bn128">>]>
+// CHECK-NEXT:          %[[VAL_11:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_5]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_12:[0-9a-zA-Z_\.]+]] = pod.new { @count = %[[VAL_11]] }  : <[@count: index, @comp: !struct.type<@Sum::@Sum<[@n]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:          %[[VAL_13:[0-9a-zA-Z_\.]+]] = pod.new : <[@inp: !array.type<@n x !felt.type<"bn128">>]>
+// CHECK-NEXT:          %[[VAL_14:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_15:[0-9a-zA-Z_\.]+]]:3 = scf.while (%[[VAL_16:[0-9a-zA-Z_\.]+]] = %[[VAL_10]], %[[VAL_17:[0-9a-zA-Z_\.]+]] = %[[VAL_13]], %[[VAL_18:[0-9a-zA-Z_\.]+]] = %[[VAL_14]]) : (!pod.type<[@inp: !array.type<@n x !felt.type<"bn128">>]>, !pod.type<[@inp: !array.type<@n x !felt.type<"bn128">>]>, !felt.type<"bn128">) -> (!pod.type<[@inp: !array.type<@n x !felt.type<"bn128">>]>, !pod.type<[@inp: !array.type<@n x !felt.type<"bn128">>]>, !felt.type<"bn128">) {
+// CHECK-NEXT:            %[[VAL_19:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
+// CHECK-NEXT:            %[[VAL_20:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_5]], %[[VAL_19]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_21:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_18]], %[[VAL_20]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.condition(%[[VAL_21]]) %[[VAL_16]], %[[VAL_17]], %[[VAL_18]] : !pod.type<[@inp: !array.type<@n x !felt.type<"bn128">>]>, !pod.type<[@inp: !array.type<@n x !felt.type<"bn128">>]>, !felt.type<"bn128">
+// CHECK-NEXT:          } do {
+// CHECK-NEXT:          ^bb0(%[[VAL_22:[0-9a-zA-Z_\.]+]]: !pod.type<[@inp: !array.type<@n x !felt.type<"bn128">>]>, %[[VAL_23:[0-9a-zA-Z_\.]+]]: !pod.type<[@inp: !array.type<@n x !felt.type<"bn128">>]>, %[[VAL_24:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
+// CHECK-NEXT:            %[[VAL_25:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
+// CHECK-NEXT:            %[[VAL_26:[0-9a-zA-Z_\.]+]] = felt.umod %[[VAL_24]], %[[VAL_25]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_27:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:            %[[VAL_28:[0-9a-zA-Z_\.]+]] = bool.cmp eq(%[[VAL_26]], %[[VAL_27]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_29:[0-9a-zA-Z_\.]+]]:2 = scf.if %[[VAL_28]] -> (!pod.type<[@inp: !array.type<@n x !felt.type<"bn128">>]>, !pod.type<[@inp: !array.type<@n x !felt.type<"bn128">>]>) {
+// CHECK-NEXT:              %[[VAL_30:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_24]] : !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_31:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_3]]{{\[}}%[[VAL_30]]] : <@n_Mul_2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_32:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_22]][@inp] : <[@inp: !array.type<@n x !felt.type<"bn128">>]>, !array.type<@n x !felt.type<"bn128">>
+// CHECK-NEXT:              %[[VAL_33:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
+// CHECK-NEXT:              %[[VAL_34:[0-9a-zA-Z_\.]+]] = felt.uintdiv %[[VAL_24]], %[[VAL_33]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_35:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_34]] : !felt.type<"bn128">
+// CHECK-NEXT:              array.write %[[VAL_32]]{{\[}}%[[VAL_35]]] = %[[VAL_31]] : <@n x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:              pod.write %[[VAL_22]][@inp] = %[[VAL_32]] : <[@inp: !array.type<@n x !felt.type<"bn128">>]>, !array.type<@n x !felt.type<"bn128">>
+// CHECK-NEXT:              %[[VAL_36:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_9]][@count] : <[@count: index, @comp: !struct.type<@Sum::@Sum<[@n]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:              %[[VAL_37:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:              %[[VAL_38:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_36]], %[[VAL_37]] : index
+// CHECK-NEXT:              pod.write %[[VAL_9]][@count] = %[[VAL_38]] : <[@count: index, @comp: !struct.type<@Sum::@Sum<[@n]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:              %[[VAL_39:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:              %[[VAL_40:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_38]], %[[VAL_39]] : index
+// CHECK-NEXT:              scf.if %[[VAL_40]] {
+// CHECK-NEXT:                %[[VAL_41:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_22]][@inp] : <[@inp: !array.type<@n x !felt.type<"bn128">>]>, !array.type<@n x !felt.type<"bn128">>
+// CHECK-NEXT:                %[[VAL_42:[0-9a-zA-Z_\.]+]] = function.call @Sum::@Sum::@compute(%[[VAL_41]]) : (!array.type<@n x !felt.type<"bn128">>) -> !struct.type<@Sum::@Sum<[@n]>>
+// CHECK-NEXT:                pod.write %[[VAL_9]][@comp] = %[[VAL_42]] : <[@count: index, @comp: !struct.type<@Sum::@Sum<[@n]>>, @params: !pod.type<[]>]>, !struct.type<@Sum::@Sum<[@n]>>
+// CHECK-NEXT:              } else {
+// CHECK-NEXT:              }
+// CHECK-NEXT:              scf.yield %[[VAL_22]], %[[VAL_23]] : !pod.type<[@inp: !array.type<@n x !felt.type<"bn128">>]>, !pod.type<[@inp: !array.type<@n x !felt.type<"bn128">>]>
+// CHECK-NEXT:            } else {
+// CHECK-NEXT:              %[[VAL_43:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_24]] : !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_44:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_3]]{{\[}}%[[VAL_43]]] : <@n_Mul_2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_45:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_23]][@inp] : <[@inp: !array.type<@n x !felt.type<"bn128">>]>, !array.type<@n x !felt.type<"bn128">>
+// CHECK-NEXT:              %[[VAL_46:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
+// CHECK-NEXT:              %[[VAL_47:[0-9a-zA-Z_\.]+]] = felt.uintdiv %[[VAL_24]], %[[VAL_46]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_48:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_47]] : !felt.type<"bn128">
+// CHECK-NEXT:              array.write %[[VAL_45]]{{\[}}%[[VAL_48]]] = %[[VAL_44]] : <@n x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:              pod.write %[[VAL_23]][@inp] = %[[VAL_45]] : <[@inp: !array.type<@n x !felt.type<"bn128">>]>, !array.type<@n x !felt.type<"bn128">>
+// CHECK-NEXT:              %[[VAL_49:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_12]][@count] : <[@count: index, @comp: !struct.type<@Sum::@Sum<[@n]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:              %[[VAL_50:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:              %[[VAL_51:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_49]], %[[VAL_50]] : index
+// CHECK-NEXT:              pod.write %[[VAL_12]][@count] = %[[VAL_51]] : <[@count: index, @comp: !struct.type<@Sum::@Sum<[@n]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:              %[[VAL_52:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:              %[[VAL_53:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_51]], %[[VAL_52]] : index
+// CHECK-NEXT:              scf.if %[[VAL_53]] {
+// CHECK-NEXT:                %[[VAL_54:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_23]][@inp] : <[@inp: !array.type<@n x !felt.type<"bn128">>]>, !array.type<@n x !felt.type<"bn128">>
+// CHECK-NEXT:                %[[VAL_55:[0-9a-zA-Z_\.]+]] = function.call @Sum::@Sum::@compute(%[[VAL_54]]) : (!array.type<@n x !felt.type<"bn128">>) -> !struct.type<@Sum::@Sum<[@n]>>
+// CHECK-NEXT:                pod.write %[[VAL_12]][@comp] = %[[VAL_55]] : <[@count: index, @comp: !struct.type<@Sum::@Sum<[@n]>>, @params: !pod.type<[]>]>, !struct.type<@Sum::@Sum<[@n]>>
+// CHECK-NEXT:              } else {
+// CHECK-NEXT:              }
+// CHECK-NEXT:              scf.yield %[[VAL_22]], %[[VAL_23]] : !pod.type<[@inp: !array.type<@n x !felt.type<"bn128">>]>, !pod.type<[@inp: !array.type<@n x !felt.type<"bn128">>]>
+// CHECK-NEXT:            }
+// CHECK-NEXT:            %[[VAL_56:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_57:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_24]], %[[VAL_56]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_29]]#0, %[[VAL_29]]#1, %[[VAL_57]] : !pod.type<[@inp: !array.type<@n x !felt.type<"bn128">>]>, !pod.type<[@inp: !array.type<@n x !felt.type<"bn128">>]>, !felt.type<"bn128">
+// CHECK-NEXT:          }
+// CHECK-NEXT:          %[[VAL_58:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_9]][@comp] : <[@count: index, @comp: !struct.type<@Sum::@Sum<[@n]>>, @params: !pod.type<[]>]>, !struct.type<@Sum::@Sum<[@n]>>
+// CHECK-NEXT:          %[[VAL_59:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_58]][@outp] : <@Sum::@Sum<[@n]>>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_60:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_61:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_60]] : !felt.type<"bn128">
+// CHECK-NEXT:          array.write %[[VAL_7]]{{\[}}%[[VAL_61]]] = %[[VAL_59]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_62:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_12]][@comp] : <[@count: index, @comp: !struct.type<@Sum::@Sum<[@n]>>, @params: !pod.type<[]>]>, !struct.type<@Sum::@Sum<[@n]>>
+// CHECK-NEXT:          %[[VAL_63:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_62]][@outp] : <@Sum::@Sum<[@n]>>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_64:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_65:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_64]] : !felt.type<"bn128">
+// CHECK-NEXT:          array.write %[[VAL_7]]{{\[}}%[[VAL_65]]] = %[[VAL_63]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:          struct.writem %[[VAL_4]][@a$inputs] = %[[VAL_15]]#0 : <@SubCmps4::@SubCmps4<[@n]>>, !pod.type<[@inp: !array.type<@n x !felt.type<"bn128">>]>
+// CHECK-NEXT:          %[[VAL_66:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_9]][@comp] : <[@count: index, @comp: !struct.type<@Sum::@Sum<[@n]>>, @params: !pod.type<[]>]>, !struct.type<@Sum::@Sum<[@n]>>
+// CHECK-NEXT:          struct.writem %[[VAL_4]][@a] = %[[VAL_66]] : <@SubCmps4::@SubCmps4<[@n]>>, !struct.type<@Sum::@Sum<[@n]>>
+// CHECK-NEXT:          struct.writem %[[VAL_4]][@b$inputs] = %[[VAL_15]]#1 : <@SubCmps4::@SubCmps4<[@n]>>, !pod.type<[@inp: !array.type<@n x !felt.type<"bn128">>]>
+// CHECK-NEXT:          %[[VAL_67:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_12]][@comp] : <[@count: index, @comp: !struct.type<@Sum::@Sum<[@n]>>, @params: !pod.type<[]>]>, !struct.type<@Sum::@Sum<[@n]>>
+// CHECK-NEXT:          struct.writem %[[VAL_4]][@b] = %[[VAL_67]] : <@SubCmps4::@SubCmps4<[@n]>>, !struct.type<@Sum::@Sum<[@n]>>
+// CHECK-NEXT:          struct.writem %[[VAL_4]][@outp] = %[[VAL_7]] : <@SubCmps4::@SubCmps4<[@n]>>, !array.type<2 x !felt.type<"bn128">>
+// CHECK-NEXT:          function.return %[[VAL_4]] : !struct.type<@SubCmps4::@SubCmps4<[@n]>>
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.def @constrain(%[[VAL_68:[0-9a-zA-Z_\.]+]]: !struct.type<@SubCmps4::@SubCmps4<[@n]>>, %[[VAL_69:[0-9a-zA-Z_\.]+]]: !array.type<@n_Mul_2 x !felt.type<"bn128">>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_70:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_71:[0-9a-zA-Z_\.]+]] = poly.read_const @n_Mul_2 : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_72:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_68]][@outp] : <@SubCmps4::@SubCmps4<[@n]>>, !array.type<2 x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_73:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_68]][@a] : <@SubCmps4::@SubCmps4<[@n]>>, !struct.type<@Sum::@Sum<[@n]>>
+// CHECK-NEXT:          %[[VAL_74:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_68]][@a$inputs] : <@SubCmps4::@SubCmps4<[@n]>>, !pod.type<[@inp: !array.type<@n x !felt.type<"bn128">>]>
+// CHECK-NEXT:          %[[VAL_75:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_68]][@b] : <@SubCmps4::@SubCmps4<[@n]>>, !struct.type<@Sum::@Sum<[@n]>>
+// CHECK-NEXT:          %[[VAL_76:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_68]][@b$inputs] : <@SubCmps4::@SubCmps4<[@n]>>, !pod.type<[@inp: !array.type<@n x !felt.type<"bn128">>]>
+// CHECK-NEXT:          %[[VAL_77:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_78:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_79:[0-9a-zA-Z_\.]+]] = %[[VAL_77]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
+// CHECK-NEXT:            %[[VAL_80:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
+// CHECK-NEXT:            %[[VAL_81:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_70]], %[[VAL_80]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_82:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_79]], %[[VAL_81]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.condition(%[[VAL_82]]) %[[VAL_79]] : !felt.type<"bn128">
+// CHECK-NEXT:          } do {
+// CHECK-NEXT:          ^bb0(%[[VAL_83:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
+// CHECK-NEXT:            %[[VAL_84:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
+// CHECK-NEXT:            %[[VAL_85:[0-9a-zA-Z_\.]+]] = felt.umod %[[VAL_83]], %[[VAL_84]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_86:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:            %[[VAL_87:[0-9a-zA-Z_\.]+]] = bool.cmp eq(%[[VAL_85]], %[[VAL_86]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.if %[[VAL_87]] {
+// CHECK-NEXT:              %[[VAL_88:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_83]] : !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_89:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_69]]{{\[}}%[[VAL_88]]] : <@n_Mul_2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_90:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_74]][@inp] : <[@inp: !array.type<@n x !felt.type<"bn128">>]>, !array.type<@n x !felt.type<"bn128">>
+// CHECK-NEXT:              %[[VAL_91:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
+// CHECK-NEXT:              %[[VAL_92:[0-9a-zA-Z_\.]+]] = felt.uintdiv %[[VAL_83]], %[[VAL_91]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_93:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_92]] : !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_94:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_90]]{{\[}}%[[VAL_93]]] : <@n x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:              constrain.eq %[[VAL_94]], %[[VAL_89]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            } else {
+// CHECK-NEXT:              %[[VAL_95:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_83]] : !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_96:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_69]]{{\[}}%[[VAL_95]]] : <@n_Mul_2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_97:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_76]][@inp] : <[@inp: !array.type<@n x !felt.type<"bn128">>]>, !array.type<@n x !felt.type<"bn128">>
+// CHECK-NEXT:              %[[VAL_98:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
+// CHECK-NEXT:              %[[VAL_99:[0-9a-zA-Z_\.]+]] = felt.uintdiv %[[VAL_83]], %[[VAL_98]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_100:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_99]] : !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_101:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_97]]{{\[}}%[[VAL_100]]] : <@n x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:              constrain.eq %[[VAL_101]], %[[VAL_96]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            }
+// CHECK-NEXT:            %[[VAL_102:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_103:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_83]], %[[VAL_102]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_103]] : !felt.type<"bn128">
+// CHECK-NEXT:          }
+// CHECK-NEXT:          %[[VAL_104:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_74]][@inp] : <[@inp: !array.type<@n x !felt.type<"bn128">>]>, !array.type<@n x !felt.type<"bn128">>
+// CHECK-NEXT:          function.call @Sum::@Sum::@constrain(%[[VAL_73]], %[[VAL_104]]) : (!struct.type<@Sum::@Sum<[@n]>>, !array.type<@n x !felt.type<"bn128">>) -> ()
+// CHECK-NEXT:          %[[VAL_105:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_76]][@inp] : <[@inp: !array.type<@n x !felt.type<"bn128">>]>, !array.type<@n x !felt.type<"bn128">>
+// CHECK-NEXT:          function.call @Sum::@Sum::@constrain(%[[VAL_75]], %[[VAL_105]]) : (!struct.type<@Sum::@Sum<[@n]>>, !array.type<@n x !felt.type<"bn128">>) -> ()
+// CHECK-NEXT:          function.return
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    poly.template @Sum {
+// CHECK-NEXT:      poly.param @n
+// CHECK-NEXT:      struct.def @Sum {
+// CHECK-NEXT:        struct.member @outp : !felt.type<"bn128"> {llzk.pub}
+// CHECK-NEXT:        function.def @compute(%[[VAL_106:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type<"bn128">>) -> !struct.type<@Sum::@Sum<[@n]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
+// CHECK-NEXT:          %[[VAL_107:[0-9a-zA-Z_\.]+]] = struct.new : <@Sum::@Sum<[@n]>>
+// CHECK-NEXT:          %[[VAL_108:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_109:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_110:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_111:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_112:[0-9a-zA-Z_\.]+]] = %[[VAL_110]], %[[VAL_113:[0-9a-zA-Z_\.]+]] = %[[VAL_109]]) : (!felt.type<"bn128">, !felt.type<"bn128">) -> (!felt.type<"bn128">, !felt.type<"bn128">) {
+// CHECK-NEXT:            %[[VAL_114:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_112]], %[[VAL_108]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.condition(%[[VAL_114]]) %[[VAL_112]], %[[VAL_113]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          } do {
+// CHECK-NEXT:          ^bb0(%[[VAL_115:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">, %[[VAL_116:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
+// CHECK-NEXT:            %[[VAL_117:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_115]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_118:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_106]]{{\[}}%[[VAL_117]]] : <@n x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_119:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_116]], %[[VAL_118]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_120:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_121:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_115]], %[[VAL_120]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_121]], %[[VAL_119]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          }
+// CHECK-NEXT:          struct.writem %[[VAL_107]][@outp] = %[[VAL_111]]#1 : <@Sum::@Sum<[@n]>>, !felt.type<"bn128">
+// CHECK-NEXT:          function.return %[[VAL_107]] : !struct.type<@Sum::@Sum<[@n]>>
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.def @constrain(%[[VAL_122:[0-9a-zA-Z_\.]+]]: !struct.type<@Sum::@Sum<[@n]>>, %[[VAL_123:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type<"bn128">>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_124:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_125:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_122]][@outp] : <@Sum::@Sum<[@n]>>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_126:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_127:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_128:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_129:[0-9a-zA-Z_\.]+]] = %[[VAL_127]], %[[VAL_130:[0-9a-zA-Z_\.]+]] = %[[VAL_126]]) : (!felt.type<"bn128">, !felt.type<"bn128">) -> (!felt.type<"bn128">, !felt.type<"bn128">) {
+// CHECK-NEXT:            %[[VAL_131:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_129]], %[[VAL_124]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.condition(%[[VAL_131]]) %[[VAL_129]], %[[VAL_130]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          } do {
+// CHECK-NEXT:          ^bb0(%[[VAL_132:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">, %[[VAL_133:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
+// CHECK-NEXT:            %[[VAL_134:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_132]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_135:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_123]]{{\[}}%[[VAL_134]]] : <@n x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_136:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_133]], %[[VAL_135]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_137:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_138:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_132]], %[[VAL_137]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_138]], %[[VAL_136]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          }
+// CHECK-NEXT:          constrain.eq %[[VAL_125]], %[[VAL_128]]#1 : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          function.return
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/llzk_backend/src/function.rs
+++ b/llzk_backend/src/function.rs
@@ -5,117 +5,69 @@
 //! [Expression](program_structure::abstract_syntax_tree::ast::Expression) and
 //! [Statement](program_structure::abstract_syntax_tree::ast::Statement) nodes.
 
-use crate::function::felt::is_felt_type;
-use crate::function_ext::FunctionLike as _;
 use crate::gen_context::BlockContextStack;
+use crate::gen_context::BlockGenContext;
 use crate::gen_context::GenWithCircomScopeHandling;
+use crate::gen_context::GenerateLLZKInAnyBlock;
 use crate::gen_context::NestedBlockInfo;
-use crate::lvalue::Lvalue;
-use crate::lvalue::Root;
+use crate::gen_context::CIRCOM_RETURN_MARKER_ATTR;
+use crate::gen_context::OPERAND_VAL_NAMES;
+use crate::gen_context::VAR_NAME_HAD_RETURN;
+use crate::gen_context::VAR_NAME_RETURN_VAL;
 use crate::program_ext::ProgramLike;
-use crate::shared;
-use crate::shared::append_tail;
-use crate::shared::is_bool;
-use crate::shared::is_index;
-use crate::shared::new_array_type;
 use crate::shared::next_in_block_mut;
 use crate::shared::no_results;
 use crate::shared::parent_operation_mut;
 use crate::shared::region_with_block;
 use crate::shared::remove_from_parent;
-use crate::shared::replace_uses_with_new_block_argument;
 use crate::shared::single_result_as_value;
-use crate::shared::ArrayDimension;
-use crate::shared::ArrayDimensionResult;
-use crate::shared::DimExprConverter;
 use crate::shared::LlzkCodegen;
-use crate::subcmp::names::COUNT;
 use crate::subcmp::NoSubcmps;
 use crate::subcmp::SubcmpInfo;
 use crate::template::TemplateContext;
 use crate::try_for_loop_heuristic;
 use crate::write_chain::NoSignalsInfo;
 use crate::write_chain::SignalWriteInfo;
-use anyhow::anyhow;
 use anyhow::Context as _;
 use anyhow::Result;
 use llzk::dialect;
-use llzk::dialect::array;
-use llzk::dialect::array::ArrayCtor;
 use llzk::dialect::bool;
-use llzk::dialect::cast;
-use llzk::dialect::constrain;
-use llzk::dialect::felt;
 use llzk::dialect::function;
-use llzk::dialect::pod;
-use llzk::dialect::poly;
 use llzk::operation::erase_op;
 use llzk::operation::WalkOperationMutLike as _;
-use llzk::prelude::is_array_type;
 use llzk::prelude::melior_dialects::arith;
-use llzk::prelude::melior_dialects::index;
 use llzk::prelude::melior_dialects::scf;
 use llzk::prelude::melior_dialects::scf::is_scf_if;
 use llzk::prelude::melior_dialects::scf::is_scf_yield;
-use llzk::prelude::ArrayType;
 use llzk::prelude::Attribute;
 use llzk::prelude::Block;
 use llzk::prelude::BlockLike as _;
 use llzk::prelude::BlockRef;
-use llzk::prelude::FlatSymbolRefAttribute;
 use llzk::prelude::FuncDefOpLike as _;
 use llzk::prelude::FuncDefOpRefMut;
-use llzk::prelude::IntegerAttribute;
 use llzk::prelude::Location;
 use llzk::prelude::LoopBoundsAttribute;
 use llzk::prelude::Operation;
 use llzk::prelude::OperationLike as _;
 use llzk::prelude::OperationMutLike;
-use llzk::prelude::OperationRef;
 use llzk::prelude::OperationRefMut;
-use llzk::prelude::PodType;
 use llzk::prelude::Region;
 use llzk::prelude::RegionLike as _;
-use llzk::prelude::StructType;
 use llzk::prelude::Type;
 use llzk::prelude::Value;
 use llzk::prelude::ValueLike as _;
 use llzk::prelude::WalkOrder;
 use llzk::prelude::WalkResult;
-use llzk::prelude::FUNC_NAME_COMPUTE;
-use llzk::prelude::FUNC_NAME_CONSTRAIN;
 use llzk::value_ext::has_uses;
-use melior::dialect::ods::math;
-use melior::ir::AttributeLike as _;
-use melior::ir::TypeLike as _;
-use num_bigint_dig::BigInt;
-use num_traits::Zero;
 use program_structure::ast::Access;
 use program_structure::ast::Expression;
-use program_structure::ast::ExpressionInfixOpcode;
-use program_structure::ast::ExpressionPrefixOpcode;
 use program_structure::ast::Meta;
 use program_structure::ast::Statement;
 use program_structure::ast::VariableType;
 use program_structure::error_code::ReportCode;
 use std::collections::HashMap;
-use std::convert::TryFrom;
-use std::convert::TryInto;
-use std::iter::zip;
 use std::ops::Deref;
 use std::ops::DerefMut;
-
-/// Special variable name used to reference the return Value throughout the
-/// conversion of circom return locations to LLZK return locations.
-const VAR_NAME_RETURN_VAL: &str = "**return_val**";
-/// Special variable name used to reference the status of whether or not a circom block
-/// had a `return` when translating to an LLZK block that cannot contain a `return`.
-const VAR_NAME_HAD_RETURN: &str = "**had_return**";
-/// LLZK attribute used to mark yield/return ops generated from circom return statements.
-const CIRCOM_RETURN_MARKER_ATTR: &str = "from_circom_return";
-/// LLZK attribute used to attach comma-separated list of variable names for the operands
-/// of an `scf.yield` op.
-const OPERAND_VAL_NAMES: &str = "operand_val_names";
 
 /// Contains references to information providers.
 ///
@@ -175,8 +127,31 @@ where
 {
     /// The function reference.
     pub(crate) func: FuncDefOpRefMut<'ctx, 'func>,
-    /// Nested block context within the function.
-    pub(crate) block_ctx: BlockContextStack<'ctx, 'blk, 'val>,
+    /// Base block generation context.
+    pub(crate) base: BlockGenContext<'ctx, 'blk, 'val>,
+}
+
+/// Allows calling through to functions on the [`BlockGenContext`].
+impl<'ctx, 'blk, 'val> std::ops::Deref for FunctionContext<'ctx, '_, 'blk, 'val>
+where
+    'ctx: 'blk,
+    'blk: 'val,
+{
+    type Target = BlockGenContext<'ctx, 'blk, 'val>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.base
+    }
+}
+
+impl<'ctx, 'blk, 'val> std::ops::DerefMut for FunctionContext<'ctx, '_, 'blk, 'val>
+where
+    'ctx: 'blk,
+    'blk: 'val,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.base
+    }
 }
 
 /// Cache block yield/return result value while performing early-return refactoring.
@@ -236,7 +211,7 @@ where
         func: FuncDefOpRefMut<'ctx, 'func>,
         param_name_to_value: HashMap<String, Value<'ctx, 'val>>,
     ) -> Result<Self> {
-        let mut block_ctx = BlockContextStack::new(func.deref(), param_name_to_value)?;
+        let mut block_ctx = BlockContextStack::from_function(func.deref(), param_name_to_value)?;
         if FREE_FUNC {
             // Ensure the specially-named values are declared in free functions.
             block_ctx.declare_name_if_not_present(VAR_NAME_RETURN_VAL, || {
@@ -250,7 +225,7 @@ where
                     .new_nondet_at_location(codegen.location_unknown(), codegen.bool_type().into())
             })?;
         }
-        Ok(Self { func, block_ctx })
+        Ok(Self { func, base: BlockGenContext::new(block_ctx) })
     }
 
     /// Get the return type of the function.
@@ -260,34 +235,6 @@ where
             .expect("`function_type` attr must exist")
             .result(0)
             .expect("LLZK function must return a single result")
-    }
-
-    /// Append an operation.
-    pub fn append_op(&mut self, op: Operation<'ctx>) -> OperationRef<'ctx, 'val> {
-        self.block_ctx.append_current_block(op)
-    }
-
-    /// Append an operation that must produce no results.
-    pub fn append_op_no_result(&mut self, op: Operation<'ctx>) -> Result<()> {
-        no_results(self.append_op(op))
-    }
-
-    /// Append an operation that must produce a single result and is NOT associated with a variable
-    /// name in the circom code.
-    pub fn append_op_unnamed_result(&mut self, op: Operation<'ctx>) -> Result<Value<'ctx, 'val>> {
-        single_result_as_value(self.append_op(op))
-    }
-
-    /// Append an operation that must produce a single result and store the mapping of the circom
-    /// variable name to the result Value.
-    pub fn append_op_named_result(
-        &mut self,
-        op: Operation<'ctx>,
-        name: String,
-    ) -> Result<Value<'ctx, 'val>> {
-        let v = self.append_op_unnamed_result(op)?;
-        self.block_ctx.set_named_value(name, v)?;
-        Ok(v)
     }
 
     /// Generate and append an op to carry the value from a circom return statement. It will
@@ -309,222 +256,6 @@ where
         self.append_op_no_result(op)
     }
 
-    /// Generate and append a `read_const` operation for the given template binding name and store
-    /// the mapping in the block context so all references to that binding name can reuse the Value.
-    #[inline]
-    pub fn append_initial_read_const(
-        &mut self,
-        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        location: Location<'ctx>,
-        name: &str,
-    ) -> Result<()> {
-        self.block_ctx.declare_name_ensure_not_present(
-            name,
-            poly::read_const(location, name, codegen.felt_type().into()),
-        )
-    }
-
-    /// Insert cast operations as needed to make `lhs` and `rhs` have compatible types for equality
-    /// constraints.
-    #[inline]
-    fn unify_constrain_eq_types(
-        &mut self,
-        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        location: Location<'ctx>,
-        lhs: Value<'ctx, 'val>,
-        rhs: Value<'ctx, 'val>,
-    ) -> Result<(Value<'ctx, 'val>, Value<'ctx, 'val>)> {
-        match (lhs.r#type(), rhs.r#type()) {
-            (t0, t1) if is_felt_type(t0) && !is_felt_type(t1) => {
-                Ok((lhs, self.cast_to_felt(codegen, location, rhs)?))
-            }
-            (t0, t1) if !is_felt_type(t0) && is_felt_type(t1) => {
-                Ok((self.cast_to_felt(codegen, location, lhs)?, rhs))
-            }
-            _ => Ok((lhs, rhs)),
-        }
-    }
-
-    /// Generate a `constrain.eq` operation for the given values, casting to compatible felt types
-    /// if necessary.
-    pub fn append_constrain_eq(
-        &mut self,
-        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        location: Location<'ctx>,
-        lhs: Value<'ctx, 'val>,
-        rhs: Value<'ctx, 'val>,
-    ) -> Result<()> {
-        let (lhs, rhs) = self.unify_constrain_eq_types(codegen, location, lhs, rhs)?;
-        self.append_op_no_result(constrain::eq(location, lhs, rhs).into())
-    }
-
-    /// Generate an `array.write` or `array.insert` operation appropriate for the number of indices
-    /// and the [ArrayType] of the `arr_ref` value.
-    pub fn append_array_write(
-        &mut self,
-        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        arr_ref: Value<'ctx, 'val>,
-        indices: &[Value<'ctx, 'val>],
-        location: Location<'ctx>,
-        rvalue: Value<'ctx, 'val>,
-        var_name: Option<&str>,
-    ) -> Result<()> {
-        let arr_ty = ArrayType::try_from(arr_ref.r#type()).with_context(|| {
-            let v = var_name.map_or(String::from("array"), |s| format!("'{s}'"));
-            format!("Conflicting types to write {v} at {location}")
-        })?;
-        let arr_ty_dims = arr_ty.dims();
-        let write_op = match indices.len().cmp(&arr_ty_dims.len()) {
-            std::cmp::Ordering::Equal => {
-                // Indexing all dimensions requires an `array.write`
-                let rvalue = self.cast_to_expected_type_if_needed(
-                    codegen,
-                    location,
-                    rvalue,
-                    arr_ty.element_type(),
-                )?;
-                array::write(location, arr_ref, indices, rvalue)
-            }
-            std::cmp::Ordering::Less => {
-                // Indexing a subset of dimensions requires an `array.insert`
-                array::insert(location, arr_ref, indices, rvalue)
-            }
-            std::cmp::Ordering::Greater => {
-                let v = var_name.map_or(String::from("array"), |s| format!("'{s}'"));
-                anyhow::bail!("Too many indices to write {v} at {location}");
-            }
-        };
-        self.append_op_no_result(write_op)
-    }
-
-    /// Generate an `array.read` or `array.extract` operation appropriate for the number of indices
-    /// and the [ArrayType] of the `arr_ref` value.
-    pub fn append_array_read(
-        &mut self,
-        arr_ref: Value<'ctx, 'val>,
-        indices: &[Value<'ctx, 'val>],
-        location: Location<'ctx>,
-        var_name: Option<&str>,
-    ) -> Result<Value<'ctx, 'val>> {
-        let arr_ty = ArrayType::try_from(arr_ref.r#type()).with_context(|| {
-            let v = var_name.map_or(String::from("array"), |s| format!("'{s}'"));
-            format!("Conflicting types to read {v} at {location}")
-        })?;
-        let arr_ty_dims = arr_ty.dims();
-        let array_get_op = match indices.len().cmp(&arr_ty_dims.len()) {
-            std::cmp::Ordering::Equal => {
-                // Indexing all dimensions requires an `array.read`
-                array::read(location, arr_ty.element_type(), arr_ref, indices)
-            }
-            std::cmp::Ordering::Less => {
-                // Indexing a subset of dimensions requires an `array.extract`
-                let reduced_dims: Vec<_> =
-                    arr_ty_dims.iter().skip(indices.len()).copied().collect();
-                let reduced_type = ArrayType::new(arr_ty.element_type().into(), &reduced_dims);
-                array::extract(location, reduced_type.into(), arr_ref, indices)
-            }
-            std::cmp::Ordering::Greater => {
-                let v = var_name.map_or(String::from("array"), |s| format!("'{s}'"));
-                anyhow::bail!("Too many indices to read {v} at {location}");
-            }
-        };
-        self.append_op_unnamed_result(array_get_op)
-    }
-
-    /// Create a cast to felt (field element) type.
-    #[inline]
-    pub fn cast_to_felt(
-        &mut self,
-        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        location: Location<'ctx>,
-        val: Value<'ctx, 'val>,
-    ) -> Result<Value<'ctx, 'val>> {
-        self.append_op_unnamed_result(cast::tofelt(location, val, Some(codegen.felt_type())))
-    }
-
-    /// Create a cast to felt (field element) type if the given value is not already a felt.
-    #[inline]
-    pub fn cast_to_felt_if_needed(
-        &mut self,
-        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        location: Location<'ctx>,
-        val: Value<'ctx, 'val>,
-    ) -> Result<Value<'ctx, 'val>> {
-        if !is_felt_type(val.r#type()) {
-            self.cast_to_felt(codegen, location, val)
-        } else {
-            Ok(val)
-        }
-    }
-
-    /// Create a cast to index type if the given value is not already an index.
-    #[inline]
-    pub fn cast_to_index_if_needed(
-        &mut self,
-        location: Location<'ctx>,
-        val: Value<'ctx, 'val>,
-    ) -> Result<Value<'ctx, 'val>> {
-        if !is_index(val.r#type()) {
-            self.append_op_unnamed_result(cast::toindex(location, val).into())
-        } else {
-            Ok(val)
-        }
-    }
-
-    /// Create a cast to bool type (i1) if the given value is not already a bool.
-    #[inline]
-    pub fn cast_to_bool_if_needed(
-        &mut self,
-        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        location: Location<'ctx>,
-        val: Value<'ctx, 'val>,
-    ) -> Result<Value<'ctx, 'val>> {
-        // The conversion to bool is simply to check `!=0` which is the same as
-        // `normalize()` in `modular_arithmetic.rs`.
-        if is_felt_type(val.r#type()) {
-            let zero = self
-                .append_op_unnamed_result(codegen.new_felt_const_op(&BigInt::zero(), location)?)?;
-            self.append_op_unnamed_result(bool::ne(location, val, zero)?)
-        } else if is_index(val.r#type()) {
-            let zero = self.append_op_unnamed_result(codegen.new_index_const_op(0, location))?;
-            self.append_op_unnamed_result(index::cmp(
-                codegen.context,
-                arith::CmpiPredicate::Ne,
-                val,
-                zero,
-                location,
-            ))
-        } else {
-            assert!(is_bool(val.r#type()));
-            Ok(val)
-        }
-    }
-
-    /// Create an op to cast `val` to match the `expected` type.
-    #[inline]
-    pub fn cast_to_expected_type_if_needed(
-        &mut self,
-        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        location: Location<'ctx>,
-        val: Value<'ctx, 'val>,
-        expected: Type<'ctx>,
-    ) -> Result<Value<'ctx, 'val>> {
-        if expected == val.r#type() {
-            Ok(val)
-        } else if is_felt_type(expected) {
-            self.cast_to_felt_if_needed(codegen, location, val)
-        } else if is_index(expected) {
-            self.cast_to_index_if_needed(location, val)
-        } else if is_bool(expected) {
-            self.cast_to_bool_if_needed(codegen, location, val)
-        } else {
-            anyhow::bail!(
-                "Unsupported 'expected' type '{expected}' with value type {}",
-                val.r#type()
-            )
-        }
-    }
-
     /// Create an op to cast `val` to match the return type of the function.
     #[inline]
     pub fn cast_to_return_type_if_needed(
@@ -533,578 +264,8 @@ where
         location: Location<'ctx>,
         val: Value<'ctx, 'val>,
     ) -> Result<Value<'ctx, 'val>> {
-        self.cast_to_expected_type_if_needed(codegen, location, val, self.return_type())
-    }
-
-    /// Copy the values in the source array into the destination array.
-    /// Assumes both arrays have the same number of dimensions, but each dimension
-    /// may be wider/narrower than the destination type.
-    /// General overview: create a N-dimensional nested for loop to copy. If the
-    /// indices are out-of-bounds, then the array is default-filled. Otherwise,
-    /// copy elements into destination
-    fn copy_into_array(
-        &mut self,
-        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        meta: &Meta,
-        dst: Value<'ctx, 'val>,
-        dst_ty: ArrayType<'ctx>,
-        src: Value<'ctx, 'val>,
-        src_ty: ArrayType<'ctx>,
-    ) -> Result<()>
-    where
-        'val: 'blk,
-    {
-        let elem_ty = dst_ty.element_type();
-        assert!(elem_ty == src_ty.element_type());
-        assert!(dst_ty.num_dims() == src_ty.num_dims());
-
-        let location = codegen.location_from_meta(meta);
-
-        let bounds = zip(src_ty.dims(), dst_ty.dims())
-            .map(|(src_dim, dest_dim)| {
-                let src_val = self.array_dim_attr_to_idx_val(codegen, location, src_dim)?;
-                let dest_val = self.array_dim_attr_to_idx_val(codegen, location, dest_dim)?;
-                let condition = self.append_op_unnamed_result(arith::cmpi(
-                    codegen.context,
-                    arith::CmpiPredicate::Ult,
-                    src_val,
-                    dest_val,
-                    location,
-                ))?;
-                let if_op = self.generate_simple_scf_if(
-                    codegen,
-                    meta,
-                    condition,
-                    |_| Ok(src_val),
-                    |_| Ok(dest_val),
-                )?;
-                self.append_op_unnamed_result(if_op)
-            })
-            .collect::<Result<Vec<_>>>()?;
-
-        self.gen_loop_nest(codegen, location, &bounds, move |fc, indices| {
-            let read = fc.append_op_unnamed_result(array::read(location, elem_ty, src, indices))?;
-            fc.append_op_no_result(array::write(location, dst, indices, read))
-        })
-    }
-
-    /// Perform a direct assignment of `rvalue` to `var`. In many cases this is handled
-    /// by updating the variable name map to have `var` -> `rvalue`, but special handling
-    /// is required during array assignments where `rvalue` is a different width than the
-    /// destination array (this requires 0-filling or truncation).
-    pub fn handle_simple_assignment(
-        &mut self,
-        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        meta: &Meta,
-        var: &String,
-        rvalue: Value<'ctx, 'val>,
-    ) -> Result<()>
-    where
-        'val: 'blk,
-    {
-        // Since there's no simple assignment in LLZK, just update the mapped Value
-        // which essentially propagates the assignment. The exception here is the ArrayType case:
-        // Circom allows (with a warning) arrays to be assigned to array variables
-        // of differing widths (wider/narrower) as long as both arrays have
-        // the same number of dimensions (e.g., var x[2][2] = y, where y is var[1][7], is allowed).
-        // If the dimension is wider, the values are truncated, and if they are narrower,
-        // the array is left in its current state.
-        let Ok(existing) = self.block_ctx.get_named_value(var) else {
-            // Otherwise, set the var to point to rvalue
-            return self.block_ctx.set_named_value(var.clone(), rvalue);
-        };
-        if existing.r#type() == rvalue.r#type() {
-            // Replace existing value reference to rvalue
-            return self.block_ctx.set_named_value(var.clone(), rvalue);
-        }
-        if is_array_type(existing.r#type()) && is_array_type(rvalue.r#type()) {
-            let existing_arr_ty = ArrayType::try_from(existing.r#type()).unwrap();
-            let new_arr_ty = ArrayType::try_from(rvalue.r#type()).unwrap();
-            if existing_arr_ty.element_type() == new_arr_ty.element_type()
-                && existing_arr_ty.num_dims() == new_arr_ty.num_dims()
-                && existing_arr_ty.dims() != new_arr_ty.dims()
-            {
-                // Copy values from the rvalue into the existing array.
-                // No need to update named value here.
-                return self.copy_into_array(
-                    codegen,
-                    meta,
-                    *existing,
-                    existing_arr_ty,
-                    rvalue,
-                    new_arr_ty,
-                );
-            }
-        }
-        anyhow::bail!(
-            "could not assign value of type '{}' to '{var}', which has type '{}'",
-            rvalue.r#type(),
-            existing.r#type()
-        )
-    }
-
-    /// Generate LLZK code in the current function for a circom prefix operation.
-    pub fn gen_prefix_op(
-        &mut self,
-        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        meta: &Meta,
-        op: &ExpressionPrefixOpcode,
-        rhs: Value<'ctx, 'val>,
-    ) -> Result<Value<'ctx, 'val>> {
-        let mut get_negative_idx = || {
-            let zero = self.append_op_unnamed_result(index::constant(
-                codegen.context,
-                IntegerAttribute::new(rhs.r#type(), 0),
-                codegen.location_from_meta(meta),
-            ))?;
-            self.append_op_unnamed_result(index::sub(zero, rhs, codegen.location_from_meta(meta)))
-        };
-        match op {
-            ExpressionPrefixOpcode::Sub => {
-                if is_felt_type(rhs.r#type()) {
-                    return self.append_op_unnamed_result(felt::neg(
-                        codegen.location_from_meta(meta),
-                        rhs,
-                    )?);
-                }
-                // For index negation, we need to subtract from zero.
-                if shared::is_index(rhs.r#type()) {
-                    return get_negative_idx();
-                }
-            }
-            ExpressionPrefixOpcode::BoolNot => {
-                if shared::is_bool(rhs.r#type()) {
-                    return self.append_op_unnamed_result(bool::not(
-                        codegen.location_from_meta(meta),
-                        rhs,
-                    )?);
-                }
-            }
-            ExpressionPrefixOpcode::Complement => {
-                if is_felt_type(rhs.r#type()) {
-                    return self.append_op_unnamed_result(felt::bit_not(
-                        codegen.location_from_meta(meta),
-                        rhs,
-                    )?);
-                }
-                // For index negation, we need to subtract one from the negative
-                // value (for the identity that `~x == -x - 1`).
-                if shared::is_index(rhs.r#type()) {
-                    let negative_idx = get_negative_idx()?;
-                    let one = self.append_op_unnamed_result(index::constant(
-                        codegen.context,
-                        IntegerAttribute::new(rhs.r#type(), 1),
-                        codegen.location_from_meta(meta),
-                    ))?;
-                    return self.append_op_unnamed_result(index::sub(
-                        negative_idx,
-                        one,
-                        codegen.location_from_meta(meta),
-                    ));
-                }
-            }
-        }
-        let err_msg = format!(
-            "Cannot generate LLZK for prefix {:?} with operand type '{}'",
-            self,
-            rhs.r#type()
-        );
-        codegen.emit_circom_error(meta, err_msg.as_str(), ReportCode::PrefixOperatorWithWrongTypes);
-        Err(anyhow!(err_msg))
-    }
-
-    /// If both operands have types that match the respective filter predicates, generate the
-    /// operation using the provided generator function and return the result, otherwise None.
-    #[inline]
-    fn gen_infix_op_if_types_are(
-        &mut self,
-        lhs_type_filter: impl FnOnce(Type) -> bool,
-        rhs_type_filter: impl FnOnce(Type) -> bool,
-        lhs: Value<'ctx, 'val>,
-        rhs: Value<'ctx, 'val>,
-        op_gen_fn: impl FnOnce(&mut Self) -> Result<Operation<'ctx>>,
-    ) -> Result<Option<Value<'ctx, 'val>>> {
-        if lhs_type_filter(lhs.r#type()) && rhs_type_filter(rhs.r#type()) {
-            let op_res = op_gen_fn(self)?;
-            self.append_op_unnamed_result(op_res).map(Option::Some)
-        } else {
-            Ok(None)
-        }
-    }
-
-    /// Generate LLZK code in the current function for an infix operation.
-    pub fn gen_infix_op(
-        &mut self,
-        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        meta: &Meta,
-        op: &ExpressionInfixOpcode,
-        lhs: Value<'ctx, 'val>,
-        rhs: Value<'ctx, 'val>,
-    ) -> Result<Value<'ctx, 'val>> {
-        // Macro to handle the common pattern for type checks for op selection.
-        macro_rules! try_callback_for_type {
-            ($type_check:path, $cb:expr) => {{
-                if let Some(result) =
-                    self.gen_infix_op_if_types_are($type_check, $type_check, lhs, rhs, $cb)?
-                {
-                    return Ok(result);
-                }
-            }};
-        }
-
-        macro_rules! generic_op_callback {
-            ($op_path:path) => {{
-                |_| {
-                    let loc = codegen.location_from_meta(meta);
-                    $op_path(loc, lhs, rhs).map_err(Into::into)
-                }
-            }};
-        }
-
-        macro_rules! try_felt_op {
-            ($op_path:path) => {{
-                try_callback_for_type!(is_felt_type, generic_op_callback!($op_path));
-            }};
-        }
-
-        macro_rules! try_bool_op {
-            ($op_path:path) => {{
-                let loc = codegen.location_from_meta(meta);
-                let lhs = self.cast_to_bool_if_needed(codegen, loc, lhs)?;
-                let rhs = self.cast_to_bool_if_needed(codegen, loc, rhs)?;
-                return self.append_op_unnamed_result($op_path(loc, lhs, rhs)?);
-            }};
-        }
-
-        macro_rules! try_index_op {
-            ($op_path:path) => {{
-                try_callback_for_type!(shared::is_index, |_| {
-                    let loc = codegen.location_from_meta(meta);
-                    Ok($op_path(lhs, rhs, loc))
-                });
-            }};
-        }
-
-        macro_rules! try_math_op {
-            ($op_path:path) => {{
-                try_callback_for_type!(shared::is_index, |_| {
-                    let loc = codegen.location_from_meta(meta);
-                    Ok(Operation::from($op_path(codegen.context, lhs, rhs, loc)))
-                });
-            }};
-        }
-
-        // Macro to handle the common pattern for felt and index type checks.
-        // For index operations that use felt:: module and simple index operations.
-        macro_rules! try_felt_or_index_op {
-            ($felt_op:path, $index_op:path) => {{
-                try_felt_op!($felt_op);
-                try_index_op!($index_op);
-            }};
-        }
-
-        macro_rules! try_felt_or_math_op {
-            ($felt_op:path, $math_op:path) => {{
-                try_felt_op!($felt_op);
-                try_math_op!($math_op);
-            }};
-        }
-
-        // Macro to handle the common pattern for felt and index type checks.
-        // For comparison operations that use bool:: module and index::cmpi.
-        macro_rules! try_bool_cmp_op {
-            ($bool_op:path, $cmp:ident) => {{
-                try_felt_op!($bool_op);
-                try_callback_for_type!(shared::is_index, |_| {
-                    let loc = codegen.location_from_meta(meta);
-                    Ok(index::cmp(codegen.context, arith::CmpiPredicate::$cmp, lhs, rhs, loc))
-                });
-            }};
-        }
-
-        match op {
-            ExpressionInfixOpcode::Add => {
-                try_felt_or_index_op!(felt::add, index::add);
-            }
-            ExpressionInfixOpcode::Sub => {
-                try_felt_or_index_op!(felt::sub, index::sub);
-            }
-            ExpressionInfixOpcode::Mul => {
-                try_felt_or_index_op!(felt::mul, index::mul);
-            }
-            ExpressionInfixOpcode::Div => {
-                try_felt_or_index_op!(felt::div, index::divu);
-            }
-            ExpressionInfixOpcode::IntDiv => {
-                try_felt_or_index_op!(felt::uintdiv, index::divu);
-            }
-            ExpressionInfixOpcode::Mod => {
-                try_felt_or_index_op!(felt::umod, index::remu);
-            }
-            ExpressionInfixOpcode::Pow => {
-                try_felt_or_math_op!(felt::pow, math::ipowi);
-            }
-            ExpressionInfixOpcode::ShiftL => {
-                try_felt_or_index_op!(felt::shl, index::shl);
-            }
-            ExpressionInfixOpcode::ShiftR => {
-                try_felt_or_index_op!(felt::shr, index::shru);
-            }
-            ExpressionInfixOpcode::LesserEq => {
-                try_bool_cmp_op!(bool::le, Ule);
-            }
-            ExpressionInfixOpcode::GreaterEq => {
-                try_bool_cmp_op!(bool::ge, Uge);
-            }
-            ExpressionInfixOpcode::Lesser => {
-                try_bool_cmp_op!(bool::lt, Ult);
-            }
-            ExpressionInfixOpcode::Greater => {
-                try_bool_cmp_op!(bool::gt, Ugt);
-            }
-            ExpressionInfixOpcode::Eq => {
-                try_bool_cmp_op!(bool::eq, Eq);
-            }
-            ExpressionInfixOpcode::NotEq => {
-                try_bool_cmp_op!(bool::ne, Ne);
-            }
-            ExpressionInfixOpcode::BoolOr => {
-                try_bool_op!(bool::or);
-            }
-            ExpressionInfixOpcode::BoolAnd => {
-                try_bool_op!(bool::and);
-            }
-            ExpressionInfixOpcode::BitOr => {
-                try_felt_or_index_op!(felt::bit_or, index::or);
-            }
-            ExpressionInfixOpcode::BitAnd => {
-                try_felt_or_index_op!(felt::bit_and, index::and);
-            }
-            ExpressionInfixOpcode::BitXor => {
-                try_felt_or_index_op!(felt::bit_xor, index::xor);
-            }
-        }
-        let err_msg = format!(
-            "Cannot generate LLZK for infix {:?} with LHS type '{}' and RHS type '{}'",
-            op,
-            lhs.r#type(),
-            rhs.r#type()
-        );
-        codegen.emit_circom_error(meta, err_msg.as_str(), ReportCode::InfixOperatorWithWrongTypes);
-        Err(anyhow!(err_msg))
-    }
-
-    /// Create a new `scf.yield` op, in the given block, that yields multiple values with associated
-    /// variable names. Create an [Attribute] containing comma-separated list of `value_names`
-    /// and attach it to the `scf.yield` op using the [OPERAND_VAL_NAMES] attribute key.
-    fn append_multi_operand_yield_to_block(
-        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        block: BlockRef<'ctx, 'val>,
-        values: &[Value<'ctx, 'val>],
-        value_names: &[String],
-        location: Location<'ctx>,
-    ) -> Result<()> {
-        assert_eq!(values.len(), value_names.len(), "requires one name per value");
-        let mut op = scf::r#yield(values, location);
-        op.set_attribute(OPERAND_VAL_NAMES, codegen.list_to_attribute(value_names));
-        no_results(block.append_operation(op))
-    }
-
-    /// Generate an `scf.if` op based on the given [NestedBlockInfo] for each branch and update the
-    /// block context with the results of the `scf.if` op mapped to the given names.
-    pub fn gen_scf_if(
-        &mut self,
-        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        location: Location<'ctx>,
-        condition: Value<'ctx, 'val>,
-        mut then_info: NestedBlockInfo<'ctx, 'blk, 'val>,
-        else_info: NestedBlockInfo<'ctx, 'blk, 'val>,
-    ) -> Result<()> {
-        // Ensure both blocks will yield the same set of variables.
-        then_info.add_missing_values(&else_info, self)?;
-
-        // Split `then_block_info.var_overwrites` into ordered lists of names and values. The
-        // ordering of names here defines the ordering of results from the `scf.if` op and
-        // thus the ordering of operands to `scf.yield` ops in both branches.
-        let mut overwrites_sorted: Vec<_> = then_info.var_overwrites.into_iter().collect();
-        if codegen.config.stabilize {
-            // Sort by circom variable names to ensure a stable order.
-            overwrites_sorted.sort_by(|(name_a, _), (name_b, _)| name_a.cmp(name_b));
-        }
-        let (overwrite_names, then_values): (Vec<_>, Vec<_>) =
-            overwrites_sorted.into_iter().unzip();
-
-        // Create list of values to yield from the `else` block in the same order
-        // as `overwrite_names`, again using current-scope values for missing keys.
-        let else_values = overwrite_names
-            .iter()
-            .map(|name| {
-                else_info
-                    .var_overwrites
-                    .get(name)
-                    .map_or_else(|| self.block_ctx.get_named_value(name).cloned(), |v| Ok(*v))
-            })
-            .collect::<Result<Vec<_>>>()?;
-
-        // Insert `scf.yield` at the end of each block.
-        Self::append_multi_operand_yield_to_block(
-            codegen,
-            then_info.block,
-            &then_values,
-            &overwrite_names,
-            location,
-        )?;
-        Self::append_multi_operand_yield_to_block(
-            codegen,
-            else_info.block,
-            &else_values,
-            &overwrite_names,
-            location,
-        )?;
-
-        // Use `overwrite_names` and the current block context to get the types of
-        // the named values to define the result types of the `scf.if` op.
-        let result_types = overwrite_names
-            .iter()
-            .map(|name| {
-                self.block_ctx
-                    .get_named_value(name)
-                    .inspect_err(|e| eprintln!("\nERROR: {e:?}"))
-                    .map(|v| v.r#type())
-            })
-            .collect::<Result<Vec<_>>>()?;
-
-        // Cast condition value to bool type if needed.
-        let condition = self.cast_to_bool_if_needed(codegen, location, condition)?;
-        // Generate the `scf.if` op for the circom `IfThenElse` statement.
-        let scf_if_op = self.append_op(scf::r#if(
-            condition,
-            &result_types,
-            then_info.region,
-            else_info.region,
-            location,
-        ));
-
-        // Update the current block context with results from the `scf.if` op.
-        overwrite_names
-            .into_iter()
-            .zip(scf_if_op.results())
-            .try_for_each(|(name, result)| self.block_ctx.set_named_value(name, result.into()))?;
-        Ok(())
-    }
-
-    /// Generate one region for either the then-arm or else-arm of a simple scf.if operation.
-    /// Used by [Self::generate_simple_scf_if].
-    /// The `value_gen` function is called to generate the value to be yielded from the arm.
-    fn generate_simple_scf_if_arm<F>(
-        &mut self,
-        location: Location<'ctx>,
-        value_gen: F,
-    ) -> Result<(Region<'ctx>, Value<'ctx, 'val>)>
-    where
-        F: FnOnce(&mut Self) -> Result<Value<'ctx, 'val>>,
-    {
-        let region = Region::new();
-        let block = region.append_block(Block::new(&[]));
-        self.block_ctx.push(block);
-        let arm_val = value_gen(self)?;
-        self.block_ctx.pop();
-        no_results(block.append_operation(scf::r#yield(&[arm_val], location)))?;
-        Ok((region, arm_val))
-    }
-
-    /// Generate a simple scf.if operation that yields the given `then_value` or `else_value`
-    /// depending on the `condition` value. Unlike [Self::gen_scf_if], this assumes that the
-    /// then and else arms do not modify the current block context and only produce values.
-    pub fn generate_simple_scf_if<F1, F2>(
-        &mut self,
-        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        meta: &Meta,
-        condition: Value<'ctx, 'val>,
-        then_value_gen: F1,
-        else_value_gen: F2,
-    ) -> Result<Operation<'ctx>>
-    where
-        F1: FnOnce(&mut Self) -> Result<Value<'ctx, 'val>>,
-        F2: FnOnce(&mut Self) -> Result<Value<'ctx, 'val>>,
-    {
-        let location = codegen.location_from_meta(meta);
-
-        let (then_region, then_value) =
-            self.generate_simple_scf_if_arm(location, then_value_gen)?;
-        let (else_region, else_value) =
-            self.generate_simple_scf_if_arm(location, else_value_gen)?;
-
-        // Ensure then_value and else_value have the same types
-        assert_eq!(
-            then_value.r#type(),
-            else_value.r#type(),
-            "then and else branches of scf.if must have matching value types"
-        );
-
-        Ok(scf::r#if(condition, &[then_value.r#type()], then_region, else_region, location))
-    }
-
-    /// Generate a simple `scf.for` op that doesn't need to override variables
-    /// in the block context.
-    /// The body function (`body_fn`) accepts a `Block` with a single argument representing
-    /// the for-loop induction variable and is used to fill in the `scf.for` op.
-    pub fn gen_simple_scf_for(
-        &mut self,
-        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        location: Location<'ctx>,
-        start: Value<'ctx, 'val>,
-        step: Value<'ctx, 'val>,
-        end: Value<'ctx, 'val>,
-        body_fn: impl FnOnce(&mut Block<'ctx>) -> Result<()>,
-    ) -> Result<()> {
-        let block_arg = (codegen.index_type(), location);
-        let mut block = Block::new(&[block_arg]);
-        body_fn(&mut block)?;
-        let region = Region::new();
-        region.append_block(block);
-        let scf_op = scf::r#for(start, end, step, region, location);
-        self.append_op_no_result(scf_op)
-    }
-
-    /// Generate a simple `scf.for` op with normalized start=0 and step=1.
-    #[inline]
-    pub fn gen_normalized_scf_for(
-        &mut self,
-        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        location: Location<'ctx>,
-        end: Value<'ctx, 'val>,
-        body_fn: impl FnOnce(&mut Block<'ctx>) -> Result<()>,
-    ) -> Result<()> {
-        let start = self.append_op_unnamed_result(codegen.new_index_const_op(0, location))?;
-        let step = self.append_op_unnamed_result(codegen.new_index_const_op(1, location))?;
-        self.gen_simple_scf_for(codegen, location, start, step, end, body_fn)
-    }
-
-    /// Generates IR for decreasing the counter of a subcomponent.
-    ///
-    /// Returns a [`Value`] with the updated counter.
-    pub fn gen_subcmp_decrease_counter(
-        &mut self,
-        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        location: Location<'ctx>,
-        subcmp_memory: Value<'ctx, 'val>,
-        amount: u32,
-    ) -> Result<Value<'ctx, 'val>> {
-        let counter = self.append_op_unnamed_result(codegen.new_pod_read_op(
-            subcmp_memory,
-            COUNT,
-            location,
-        )?)?;
-        let one = self.append_op_unnamed_result(codegen.new_index_const_op(amount, location))?;
-        let counter = self.append_op_unnamed_result(arith::subi(counter, one, location))?;
-        self.append_op_no_result(codegen.new_pod_write_op(
-            location,
-            subcmp_memory,
-            COUNT,
-            counter,
-        ))?;
-        Ok(counter)
+        let return_ty = self.return_type();
+        self.cast_to_expected_type_if_needed(codegen, location, val, return_ty)
     }
 
     /// Generates a `scf.if` block that runs the 'then' branch if the given value is 0.
@@ -1132,408 +293,6 @@ where
         else_region.first_block().unwrap().append_operation(scf::r#yield(&[], location));
 
         self.append_op_no_result(scf::r#if(cmp, &[], then_region, else_region, location))
-    }
-
-    /// Decomposes the given value of [`PodType`] into a sequence of values in declaration order.
-    pub fn gen_decompose_pod(
-        &mut self,
-        pod: Value<'ctx, 'val>,
-        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        location: Location<'ctx>,
-    ) -> Result<Vec<Value<'ctx, 'val>>> {
-        PodType::try_from(pod.r#type())?
-            .get_records()
-            .into_iter()
-            .map(|record| {
-                let record_name = codegen.flat_sym(record.name().as_string_ref().as_str()?);
-                self.append_op_unnamed_result(pod::read(
-                    location,
-                    pod,
-                    record_name,
-                    record.r#type(),
-                ))
-            })
-            .collect()
-    }
-
-    /// Generates a call to `@compute` for the given struct type.
-    ///
-    /// The arguments for the call are given as a value of [`PodType`] representing the inputs of
-    /// the subcomponent.
-    ///
-    /// # TODO
-    ///
-    /// Map operands are missing.
-    pub fn gen_compute_call(
-        &mut self,
-        struct_type: StructType<'ctx>,
-        inputs: Value<'ctx, 'val>,
-        location: Location<'ctx>,
-        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-    ) -> Result<Value<'ctx, 'val>> {
-        let input_values = self.gen_decompose_pod(inputs, codegen, location)?;
-        let func_name = append_tail(&struct_type.name(), FUNC_NAME_COMPUTE.as_ref());
-        self.append_op_unnamed_result(
-            function::call(
-                codegen.op_builder(),
-                location,
-                func_name,
-                &input_values,
-                &[struct_type],
-            )?
-            .into(),
-        )
-    }
-
-    /// Generates a call to `@constrain` for the given struct type.
-    ///
-    /// The arguments for the call are given as a value of [`PodType`] representing the inputs of
-    /// the subcomponent.
-    pub fn gen_constrain_call(
-        &mut self,
-        subcmp: Value<'ctx, 'val>,
-        inputs: Value<'ctx, 'val>,
-        location: Location<'ctx>,
-        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-    ) -> Result<()> {
-        let mut call_args = vec![subcmp];
-        call_args.extend(self.gen_decompose_pod(inputs, codegen, location)?);
-        let func_name = append_tail(
-            &StructType::try_from(subcmp.r#type())?.name(),
-            FUNC_NAME_CONSTRAIN.as_ref(),
-        );
-        let return_types: [Type; 0] = [];
-        self.append_op_no_result(
-            function::call(codegen.op_builder(), location, func_name, &call_args, &return_types)?
-                .into(),
-        )
-    }
-
-    /// Convert a dimension [Attribute] from an [ArrayType] into a [`Value`] of index type,
-    /// generating the necessary IR if the attribute is a symbol reference to a struct param.
-    pub fn array_dim_attr_to_idx_val(
-        &mut self,
-        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        location: Location<'ctx>,
-        dim: Attribute<'ctx>,
-    ) -> Result<Value<'ctx, 'val>> {
-        if IntegerAttribute::try_from(dim).is_ok() {
-            if !dim.r#type().is_index() {
-                anyhow::bail!(
-                    "expected index type for array dimension attribute, got '{}'",
-                    dim.r#type()
-                );
-            }
-            return self.append_op_unnamed_result(arith::constant(codegen.context, dim, location));
-        }
-        if let Ok(sym_ref) = FlatSymbolRefAttribute::try_from(dim) {
-            return self.append_op_unnamed_result(poly::read_const(
-                location,
-                sym_ref.value(),
-                codegen.index_type(),
-            ));
-        }
-        unreachable!("Unhandled attribute in array dimensions {}", dim)
-    }
-
-    /// Creates a loop nest from a list of array dimension attributes.
-    ///
-    /// The body of the inner-most loop is defined by the given closure, which accepts a list of
-    /// values representing the current value of each loop's induction variable.
-    pub fn gen_loop_nest_from_attrs(
-        &mut self,
-        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        location: Location<'ctx>,
-        dims: &[Attribute<'ctx>],
-        body: impl FnOnce(&mut Self, &[Value<'ctx, 'val>]) -> Result<()>,
-    ) -> Result<()>
-    where
-        'val: 'blk,
-    {
-        // Create values from the dimensions
-        let dim_values = dims
-            .iter()
-            .map(|dim| self.array_dim_attr_to_idx_val(codegen, location, *dim))
-            .collect::<Result<Vec<_>>>()?;
-
-        self.gen_loop_nest(codegen, location, &dim_values, body)
-    }
-
-    /// Creates a loop nest from a list of array dimension values.
-    ///
-    /// The body of the inner-most loop is defined by the given closure, which accepts a list of
-    /// values representing the current value of each loop's induction variable.
-    pub fn gen_loop_nest(
-        &mut self,
-        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        location: Location<'ctx>,
-        dim_values: &[Value<'ctx, 'val>],
-        body: impl FnOnce(&mut Self, &[Value<'ctx, 'val>]) -> Result<()>,
-    ) -> Result<()>
-    where
-        'val: 'blk,
-    {
-        let zero = self.append_op_unnamed_result(codegen.new_index_const_op(0, location))?;
-        let one = self.append_op_unnamed_result(codegen.new_index_const_op(1, location))?;
-
-        let loop_block_args = [(codegen.index_type(), location)];
-        let top_block = *self.block_ctx.top_block();
-        let mut loop_vars: Vec<Value> = vec![];
-        // Create the loop nest
-        let mut block: Option<BlockRef<'_, '_>> = None;
-        for dim in dim_values {
-            let op = scf::r#for(zero, *dim, one, region_with_block(&loop_block_args), location);
-            let loop_op = match &block {
-                Some(block_ref) => block_ref.append_operation(op),
-                None => self.append_op(op),
-            };
-            block = Some(
-                loop_op
-                    .region(0)?
-                    .first_block()
-                    .ok_or_else(|| anyhow::anyhow!("region is missing first block"))?,
-            );
-            // Accumulate the induction variables for later giving all of them to the callback.
-            loop_vars.push(block.unwrap().argument(0)?.into());
-        }
-
-        // Unwrap the block after creating the loop nest.
-        let mut block = block.ok_or_else(|| anyhow::anyhow!("no loops created"))?;
-        // Push the block of the inner-most loop s.t. the user can use `self` and ops will get added
-        // to the right block.
-        self.block_ctx.push(block);
-        body(self, &loop_vars)?;
-        self.block_ctx.pop();
-
-        // Traverse the stack of blocks until we reach the block where we inserted the whole nest.
-        // For each block traversed this way add the scf terminator op.
-        while block != top_block {
-            block.append_operation(scf::r#yield(&[], location));
-            block = block
-                .parent_operation()
-                .and_then(|op| op.block())
-                .ok_or_else(|| anyhow::anyhow!("detached block while creating loop nest"))?;
-        }
-
-        Ok(())
-    }
-
-    /// Creates LLZK ops for array indexing from the collection of elements.
-    pub fn gen_index_ops<'ast, 'info, E>(
-        &mut self,
-        indices: impl IntoIterator<Item = &'ast E>,
-        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        location: Location<'ctx>,
-        info: InfoProviders<'info>,
-    ) -> Result<Vec<Value<'ctx, 'val>>>
-    where
-        E: GenerateLLZKInFunction<'ctx, 'func, 'blk, 'val, Output = Value<'ctx, 'val>> + 'ast,
-    {
-        indices
-            .into_iter()
-            .map(|e| {
-                let val = e.gen_llzk_in_function(codegen, self, info)?;
-                self.append_op_unnamed_result(cast::toindex(location, val))
-            })
-            .collect()
-    }
-
-    /// Implementation for [Expression::UniformArray] after conversion of dimension
-    /// expression. Useful because dimension generation differs between function
-    /// and template contexts due to template parameters, but the actual array generation
-    /// is otherwise the same.
-    pub fn generate_uniform_array(
-        &mut self,
-        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        location: Location<'ctx>,
-        value: Value<'ctx, 'val>,
-        dimension: &ArrayDimension<'ctx, 'val>,
-    ) -> Result<Value<'ctx, 'val>> {
-        // Ensure all symbols are of index type
-        let dimension = &self.transform_symbols_to_index(location, dimension)?;
-        let const_dim = IntegerAttribute::try_from(dimension);
-        if let Ok(subarr_ty) = ArrayType::try_from(value.r#type()) {
-            let arr_ty = dimension.new_array_type(&subarr_ty.into());
-            let mut symbols_sto = vec![];
-            // The array.new constructor doesn't accept arrays as initializer values,
-            // so we instead create the array empty and use array.insert to insert values.
-            let ctor = if let Some(symbols) = dimension.value_range()? {
-                symbols_sto.push(symbols);
-                ArrayCtor::MapDimSlice(&symbols_sto, &[0])
-            } else {
-                ArrayCtor::Empty
-            };
-            let new_arr =
-                self.append_op_unnamed_result(codegen.new_array_new_op(location, arr_ty, ctor))?;
-            if let Ok(const_dim) = const_dim {
-                for idx in 0..const_dim.value() {
-                    let idx_val =
-                        self.append_op_unnamed_result(codegen.new_index_const_op(idx, location))?;
-                    self.append_op_no_result(array::insert(location, new_arr, &[idx_val], value))?;
-                }
-            } else {
-                let dim = self.append_op_unnamed_result(codegen.new_index_const_op(0, location))?;
-                let array_len =
-                    self.append_op_unnamed_result(array::len(location, new_arr, dim))?;
-                self.gen_normalized_scf_for(codegen, location, array_len, |b| {
-                    let induction_var = b.argument(0)?;
-                    b.append_operation(array::insert(
-                        location,
-                        new_arr,
-                        &[induction_var.into()],
-                        value,
-                    ));
-                    b.append_operation(scf::r#yield(&[], location));
-                    Ok(())
-                })?;
-            };
-            // Output value is still the newly created array
-            Ok(new_arr)
-        } else {
-            let arr_ty = dimension.new_array_type(&value.r#type());
-            if let Ok(const_dim) = const_dim {
-                let values = vec![value; usize::try_from(const_dim.value())?];
-                self.append_op_unnamed_result(codegen.new_array_new_op(
-                    location,
-                    arr_ty,
-                    ArrayCtor::Values(&values),
-                ))
-            } else {
-                let mut v_sto = vec![];
-                let ctor = if let Ok(Some(v)) = dimension.value_range() {
-                    v_sto.push(v);
-                    ArrayCtor::MapDimSlice(&v_sto, &[0])
-                } else {
-                    ArrayCtor::Empty
-                };
-                let array_ref = self
-                    .append_op_unnamed_result(codegen.new_array_new_op(location, arr_ty, ctor))?;
-                let dim = self.append_op_unnamed_result(codegen.new_index_const_op(0, location))?;
-                let array_len =
-                    self.append_op_unnamed_result(array::len(location, array_ref, dim))?;
-                self.gen_normalized_scf_for(codegen, location, array_len, |b| {
-                    let induction_var = b.argument(0)?;
-                    b.append_operation(array::write(
-                        location,
-                        array_ref,
-                        &[induction_var.into()],
-                        value,
-                    ));
-                    b.append_operation(scf::r#yield(&[], location));
-                    Ok(())
-                })?;
-                Ok(array_ref)
-            }
-        }
-    }
-
-    /// Generate an `scf.while` op based on the given [NestedBlockInfo] and update the
-    /// block context with the results of the `scf.while` op mapped to the given names.
-    pub fn gen_scf_while(
-        &mut self,
-        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        location: Location<'ctx>,
-        condition: Value<'ctx, 'val>,
-        loop_cond_info: NestedBlockInfo<'ctx, 'blk, 'val>,
-        loop_body_info: NestedBlockInfo<'ctx, 'blk, 'val>,
-        loop_bounds: Option<LoopBoundsAttribute<'ctx>>,
-    ) -> Result<bool> {
-        // ASSERT: loop condition was a single Expression so there are no variable overwrites.
-        assert!(loop_cond_info.var_overwrites.is_empty());
-
-        // Split `loop_body_info.var_overwrites` into ordered lists of names and values. The
-        // ordering of names here defines the ordering of the loop-carried variables for the
-        // `scf.while` op and thus the ordering of operands for `scf.yield` and `scf.condition`.
-        let mut overwrites_sorted: Vec<_> = loop_body_info.var_overwrites.into_iter().collect();
-        if codegen.config.stabilize {
-            // Sort by circom variable names to ensure a stable order.
-            overwrites_sorted.sort_by(|(name_a, _), (name_b, _)| name_a.cmp(name_b));
-        }
-        let (loop_carried_var_names, body_yield_values): (Vec<_>, Vec<_>) =
-            overwrites_sorted.into_iter().unzip();
-
-        // Append the loop body block with an `scf.yield`
-        Self::append_multi_operand_yield_to_block(
-            codegen,
-            loop_body_info.block,
-            &body_yield_values,
-            &loop_carried_var_names,
-            location,
-        )?;
-
-        // Use `loop_carried_var_names` and the current block context to build a list of types of
-        // the loop-carried variables, add BlockArguments of those types in both blocks, and
-        // replace uses of the overwritten variables in both blocks with references to the new
-        // BlockArguments Values.
-        let mut loop_carried_types = Vec::new();
-        // Additionally, track if `VAR_NAME_HAD_RETURN` is among the loop-carried variables
-        // (indicating there was a return somewhere within the loop body) to later update the
-        // loop condition to ensure iteration stops when a return occurs.
-        let mut return_flag: Option<Value> = None;
-        for name in loop_carried_var_names.iter() {
-            let orig_val = self.block_ctx.get_named_value(name).unwrap();
-            loop_carried_types.push(orig_val.r#type());
-            replace_uses_with_new_block_argument(loop_body_info.block, orig_val, location);
-            let f = replace_uses_with_new_block_argument(loop_cond_info.block, orig_val, location);
-            if name == VAR_NAME_HAD_RETURN {
-                return_flag = Some(f);
-            }
-        }
-
-        // In the loop condition block, ensure the condition has bool type and generate an
-        // `scf.condition` op with the condition value and the loop-carried variables.
-        {
-            let mut condition = self.cast_to_bool_if_needed(codegen, location, condition)?;
-            // If there is a return within the loop, add prefix "!<VAR_NAME_HAD_RETURN> &&" to the
-            // loop condition to ensure the loop terminates when the return occurs.
-            if let Some(flag) = return_flag {
-                let not_return_flag = single_result_as_value(
-                    loop_cond_info.block.append_operation(bool::r#not(location, flag)?.into()),
-                )?;
-                condition =
-                    single_result_as_value(loop_cond_info.block.append_operation(
-                        bool::and(location, not_return_flag, condition)?.into(),
-                    ))?;
-            }
-            // Pass the block arguments as the initial values to the condition op.
-            let block_arg_values = (0..loop_cond_info.block.argument_count())
-                .map(|i| loop_cond_info.block.argument(i).map_err(Into::into).map(Value::from))
-                .collect::<Result<Vec<Value>>>()?;
-            no_results(loop_cond_info.block.append_operation(scf::condition(
-                condition,
-                &block_arg_values,
-                location,
-            )))?;
-        }
-
-        // Create list of initial values of the loop-carried variables (i.e. the overwritten
-        // variables, in the order of `loop_carried_var_names`) to pass into the `scf.while`.
-        let initial_values = loop_carried_var_names
-            .iter()
-            .map(|name| self.block_ctx.get_named_value(name).cloned())
-            .collect::<Result<Vec<_>>>()?;
-
-        // Generate the `scf.while` op for the circom `While` statement, adding `loopbounds`
-        // attribute if given, and append it to the current block.
-        let mut scf_op = scf::r#while(
-            &initial_values,
-            &loop_carried_types,
-            loop_cond_info.region,
-            loop_body_info.region,
-            location,
-        );
-        if let Some(loop_bounds) = loop_bounds {
-            scf_op.set_attribute("llzk.loopbounds", loop_bounds.into());
-        }
-        let scf_op = self.append_op(scf_op);
-
-        // Update the current block context with results from the `scf.while` op.
-        loop_carried_var_names
-            .into_iter()
-            .zip(scf_op.results())
-            .try_for_each(|(name, result)| self.block_ctx.set_named_value(name, result.into()))?;
-
-        Ok(return_flag.is_some())
     }
 
     /// Finalizes the context.
@@ -1707,107 +466,6 @@ where
 
         Ok(())
     }
-
-    /// Cast all symbols passed to affine_maps into index types, which is required
-    /// for affine_map usage.
-    #[inline]
-    fn transform_symbols_to_index(
-        &mut self,
-        location: Location<'ctx>,
-        dimension: &ArrayDimension<'ctx, 'val>,
-    ) -> Result<ArrayDimension<'ctx, 'val>> {
-        dimension.transform(|val| self.cast_to_index_if_needed(location, val))
-    }
-
-    /// Handle a [Statement::Declaration] by generating a nondet felt value with the given
-    /// dimensions and declaring it in the current block context.
-    pub fn gen_declaration(
-        &mut self,
-        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        meta: &Meta,
-        name: &str,
-        dimensions: &[Expression],
-    ) -> Result<()> {
-        if self.block_ctx.is_name_present(name) {
-            return Ok(());
-        }
-        // If generating from VCP, there are cases where the `sugar_cleaner` added new
-        // declarations that only have `MemoryKnowledge` but not `dimensions` in the AST. So
-        // check `MemoryKnowledge` first (if not generating from VCP, this will always be
-        // empty so `dimensions` will be used).
-        let mk = meta.get_memory_knowledge();
-        let dims = if mk.has_concrete_dimensions() {
-            (mk.get_concrete_dimensions(), codegen).try_into()?
-        } else {
-            self.get_dim_exprs(codegen, dimensions)?
-        };
-        if codegen.config.verbose {
-            println!("Declaring variable '{name}' with dimensions {dims:?}");
-        }
-        let op = dims.new_nondet_felt_of_dimensions(codegen, meta)?;
-        self.block_ctx.declare_name_ensure_not_present(name, op)
-    }
-}
-
-impl<'ctx, 'func, 'blk, 'val> DimExprConverter<'ctx, 'val>
-    for FunctionContext<'ctx, 'func, 'blk, 'val>
-where
-    'ctx: 'func,
-    'func: 'blk,
-    'blk: 'val,
-{
-    fn get_dim_expr(
-        &self,
-        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        expr: &Expression,
-    ) -> Result<ArrayDimensionResult<'ctx, 'val>> {
-        // First try to compute statically, falling back to literal computation if all values are
-        // not compile-time constants or if the final result does not properly convert to i64.
-        if let Some(integer) = shared::try_compute_as_i64(expr, codegen.prime())? {
-            ArrayDimensionResult::new(codegen.index_attr(integer).into(), &[])
-        } else {
-            #[allow(unused_variables)] // TODO: TEMP
-            match expr {
-                Expression::Number(_, _) => {
-                    unreachable!("handled by try_compute_as_i64")
-                }
-                Expression::Variable { meta, name, access } => match access.as_slice() {
-                    [] => {
-                        if let Ok(v) = self.block_ctx.get_named_value(name) {
-                            let id_map = codegen.identity_affine_map_attr()?;
-                            ArrayDimensionResult::new(id_map, &[*v])
-                        } else {
-                            todo!("Handle Variable expression in dimension for non-integer, non-template parameter attributes in FunctionContext")
-                        }
-                    }
-                    a => {
-                        todo!("Handle Variable expression with accesses in FunctionContext")
-                    }
-                },
-                Expression::InfixOp { meta, lhe, infix_op, rhe } => {
-                    todo!("Handle Infix expression in dimension for non-integer attributes")
-                }
-                Expression::PrefixOp { meta, prefix_op, rhe } => {
-                    todo!("Handle Prefix expression in dimension for non-integer attributes")
-                }
-                Expression::InlineSwitchOp { meta, cond, if_true, if_false } => {
-                    todo!(
-                        "Handle InlineSwitchOp expression in dimension for non-integer attributes"
-                    )
-                }
-                Expression::Call { meta, id, args } => {
-                    todo!("Handle Call expression in dimension")
-                }
-                // The remaining cases do not produce a scalar value.
-                // i.e. ParallelOp, ArrayInLine, UniformArray, BusCall, AnonymousComp, Tuple
-                // Give the same error that the circom type checker gives. The type checker ran
-                // earlier so this should technically be unreachable.
-                _ => {
-                    unreachable!("Array indexes and lengths must be single arithmetic expressions")
-                }
-            }
-        }
-    }
 }
 
 /// The [FunctionContext] directly accesses a single [BlockContextStack] for circom scope handling.
@@ -1836,13 +494,13 @@ where
     ) -> Result<()>
     where
         H: Fn(
-            &mut FunctionContext<'ctx, 'func, 'blk, 'val>,
+            &mut BlockGenContext<'ctx, 'blk, 'val>,
             &mut NestedBlockInfo<'ctx, 'blk, 'val>,
             HashMap<String, Value<'ctx, 'val>>,
         ) -> Result<()>,
     {
         let popped = self.block_ctx.pop();
-        overwrite_handler(self, overwrite_data, popped)
+        overwrite_handler(&mut self.base, overwrite_data, popped)
     }
 }
 
@@ -1858,11 +516,10 @@ where
     'func: 'blk,
     'blk: 'val,
 {
-    /// Output type of the generator function. [Statement] nodes do not produce a value so this
-    /// should be the unit type whereas [Expression] nodes produce a Value.
+    /// Output type of the generator function.
     type Output;
 
-    /// Generates LLZK IR from [Statement] and [Expression] nodes in a circom function.
+    /// Generates LLZK IR from [Statement] nodes in a circom function.
     fn gen_llzk_in_function<'info>(
         &self,
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
@@ -1980,8 +637,8 @@ where
         fc.append_op_no_result(op)
     })?;
 
-    let condition = function.block_ctx.get_named_value(VAR_NAME_HAD_RETURN)?;
-    function.append_op_no_result(scf::r#if(*condition, &[], then_region, Region::new(), location))
+    let condition = *function.block_ctx.get_named_value(VAR_NAME_HAD_RETURN)?;
+    function.append_op_no_result(scf::r#if(condition, &[], then_region, Region::new(), location))
 }
 
 /// Generate LLZK code for a circom [Statement::IfThenElse].
@@ -2017,7 +674,7 @@ where
     }
 
     let location = codegen.location_from_meta(meta);
-    let condition = cond.gen_llzk_in_function(codegen, function, info)?;
+    let condition = cond.gen_llzk_in_block(codegen, function, info)?;
 
     // Check if one or both blocks end with a return in circom. The `scf.if` op used in LLZK cannot
     // have returns nested within other blocks like circom allows. Use of `append_circom_return()`
@@ -2095,7 +752,7 @@ where
     let mut loop_cond_info = NestedBlockInfo::default();
     let cond_result = function.gen_in_given_block_with_new_circom_scope_and_cache_overwrites(
         loop_cond_info.block,
-        |fc| cond.gen_llzk_in_function(codegen, fc, info),
+        |fc| cond.gen_llzk_in_block(codegen, fc, info),
         &mut loop_cond_info,
     )?;
     let mut loop_body_info = NestedBlockInfo::default();
@@ -2223,7 +880,7 @@ where
                     // per `type_analysis/src/analyzers/functions_free_of_template_elements.rs`
                     unreachable!("Function uses template operators");
                 }
-                let rvalue = rhe.gen_llzk_in_function(codegen, function, info)?;
+                let rvalue = rhe.gen_llzk_in_block(codegen, function, info)?;
                 match access.as_slice() {
                     [] => {
                         function.handle_simple_assignment(codegen, meta, var, rvalue)?;
@@ -2235,7 +892,7 @@ where
                             .map(|access| {
                                 let idx = match access {
                                     Access::ArrayAccess(index_expr) => {
-                                        index_expr.gen_llzk_in_function(codegen, function, info)
+                                        index_expr.gen_llzk_in_block(codegen, function, info)
                                     }
                                     #[allow(unused_variables)] // TODO: TEMP
                                     Access::ComponentAccess(name) => {
@@ -2245,10 +902,10 @@ where
                                 function.cast_to_index_if_needed(location, idx)
                             })
                             .collect::<Result<Vec<Value<'_, '_>>>>()?;
-                        let arr_ref = function.block_ctx.get_named_value(var)?;
+                        let arr_ref = *function.block_ctx.get_named_value(var)?;
                         function.append_array_write(
                             codegen,
-                            *arr_ref,
+                            arr_ref,
                             indices,
                             location,
                             rvalue,
@@ -2264,7 +921,7 @@ where
                     unreachable!("Function uses template operators");
                 }
                 // Just visit and drop the resulting Value since it's unused.
-                rhe.gen_llzk_in_function(codegen, function, info).map(drop)?;
+                rhe.gen_llzk_in_block(codegen, function, info).map(drop)?;
                 Ok(false)
             }
             Statement::IfThenElse { meta, cond, if_case, else_case } => {
@@ -2274,7 +931,7 @@ where
                 gen_while(codegen, function, info, meta, cond, stmt, None)
             }
             Statement::Return { meta, value } => {
-                let value = value.gen_llzk_in_function(codegen, function, info)?;
+                let value = value.gen_llzk_in_block(codegen, function, info)?;
                 let location = codegen.location_from_meta(meta);
                 function.append_circom_return(codegen, location, value)?;
                 // circom allows unreachable code after a return but it is not processed
@@ -2284,7 +941,7 @@ where
                 Ok(true)
             }
             Statement::Assert { meta, arg } => {
-                let cond = arg.gen_llzk_in_function(codegen, function, info)?;
+                let cond = arg.gen_llzk_in_block(codegen, function, info)?;
                 let location = codegen.location_from_meta(meta);
                 let cond = function.cast_to_bool_if_needed(codegen, location, cond)?;
                 let msg = Some("assertion failed");
@@ -2305,169 +962,6 @@ where
             Statement::ConstraintEquality { .. } => {
                 // per `type_analysis/src/analyzers/functions_free_of_template_elements.rs`
                 unreachable!("Function uses template operators");
-            }
-        }
-    }
-}
-
-/// This handles translation of circom [Expression] nodes within functions and templates (i.e.
-/// [crate::template::GenerateLLZKInTemplate] implementation for [Expression] directly calls this).
-/// Therefore, it must handle things that are not legal in functions such as [Expression::BusCall]
-/// and [Access::ComponentAccess]. The `type_analysis_user::analyse_project()` pass that runs before
-/// the LLZK translation pass ensures that these illegal constructs do not appear in pure functions.
-impl<'ctx, 'func, 'blk, 'val> GenerateLLZKInFunction<'ctx, 'func, 'blk, 'val> for Expression
-where
-    'ctx: 'func,
-    'func: 'blk,
-    'blk: 'val,
-{
-    type Output = Value<'ctx, 'val>;
-
-    fn gen_llzk_in_function<'info>(
-        &self,
-        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        function: &mut FunctionContext<'ctx, 'func, 'blk, 'val>,
-        info: InfoProviders<'info>,
-    ) -> Result<Self::Output> {
-        match self {
-            Expression::Number(meta, big_int) => {
-                // Convert the BigInt to an LLZK `felt.const` op. The user of the Expression is
-                // responsible for converting this `felt.type` value to another type if needed.
-                function.append_op_unnamed_result(
-                    codegen.new_felt_const_op(big_int, codegen.location_from_meta(meta))?,
-                )
-            }
-            Expression::Variable { meta, name, access } => {
-                let lvalue = Lvalue::new(
-                    name,
-                    if info.subcmp_info.is_subcmp(name) { Root::Signal } else { Root::Var },
-                    access,
-                );
-                lvalue.get_value(
-                    codegen,
-                    function,
-                    info.subcmp_info,
-                    codegen.location_from_meta(meta),
-                    None,
-                )
-            }
-            Expression::InfixOp { meta, lhe, infix_op, rhe } => {
-                let lhs = lhe.gen_llzk_in_function(codegen, function, info)?;
-                let rhs = rhe.gen_llzk_in_function(codegen, function, info)?;
-                function.gen_infix_op(codegen, meta, infix_op, lhs, rhs)
-            }
-            Expression::PrefixOp { meta, prefix_op, rhe } => {
-                let rhs = rhe.gen_llzk_in_function(codegen, function, info)?;
-                function.gen_prefix_op(codegen, meta, prefix_op, rhs)
-            }
-            Expression::InlineSwitchOp { meta, cond, if_true, if_false } => {
-                let location = codegen.location_from_meta(meta);
-                // Ensure the condition is a bool type.
-                let cond_val = cond.gen_llzk_in_function(codegen, function, info)?;
-                let condition = function.cast_to_bool_if_needed(codegen, location, cond_val)?;
-                let scf_if_op = function.generate_simple_scf_if(
-                    codegen,
-                    meta,
-                    condition,
-                    |fc| if_true.gen_llzk_in_function(codegen, fc, info),
-                    |fc| if_false.gen_llzk_in_function(codegen, fc, info),
-                )?;
-
-                function.append_op_unnamed_result(scf_if_op)
-            }
-            Expression::ArrayInLine { meta, values } => {
-                let location = codegen.location_from_meta(meta);
-                // Multi-dimensional arrays are made up of array values as their elements
-                let values = values
-                    .iter()
-                    .map(|val_expr| val_expr.gen_llzk_in_function(codegen, function, info))
-                    .collect::<Result<Vec<Value>>>()?;
-                let value_ty =
-                    values.first().expect("Array must have at least one element").r#type();
-                assert!(
-                    values.iter().all(|&v| v.r#type() == value_ty),
-                    "All array elements must have the same type"
-                );
-                if let Ok(subarr_ty) = ArrayType::try_from(value_ty) {
-                    // For subarrays, we need to create a new array then insert the values
-                    let dim = codegen.index_attr(i64::try_from(values.len())?);
-                    let arr_ty = new_array_type(dim.into(), &subarr_ty);
-                    let new_arr = function.append_op_unnamed_result(codegen.new_array_new_op(
-                        location,
-                        arr_ty,
-                        ArrayCtor::Empty,
-                    ))?;
-                    for (idx, val) in values.iter().enumerate() {
-                        let idx_val = function.append_op_unnamed_result(
-                            codegen.new_index_const_op(i64::try_from(idx)?, location),
-                        )?;
-                        function.append_op_no_result(array::insert(
-                            location,
-                            new_arr,
-                            &[idx_val],
-                            *val,
-                        ))?;
-                    }
-
-                    // Output value is still the newly created array
-                    Ok(new_arr)
-                } else {
-                    let dim = codegen.index_attr(i64::try_from(values.len())?);
-                    let arr_ty = ArrayType::new(value_ty.into(), &[dim.into()]);
-                    function.append_op_unnamed_result(codegen.new_array_new_op(
-                        location,
-                        arr_ty,
-                        ArrayCtor::Values(&values),
-                    ))
-                }
-            }
-            Expression::UniformArray { meta, value, dimension } => {
-                let location = codegen.location_from_meta(meta);
-                // Multi-dimensional arrays are made up of array values as their elements
-                let value = value.gen_llzk_in_function(codegen, function, info)?;
-                let dim =
-                    function.get_dim_expr(codegen, dimension).and_then(ArrayDimension::try_from)?;
-                function.generate_uniform_array(codegen, location, value, &dim)
-            }
-            Expression::Call { meta, id, args } => {
-                let location = codegen.location_from_meta(meta);
-                let target_function_data = codegen.program.get_function_data(id);
-                // Visit each argument and collect the resulting LLZK Values for both functions.
-                let param_types = target_function_data.get_type_of_params(codegen);
-                assert_eq!(param_types.len(), args.len(), "Argument-parameter count mismatch");
-                let call_operands = args
-                    .iter()
-                    .zip(param_types)
-                    .map(|(arg, expected_type)| {
-                        let operand_val = arg.gen_llzk_in_function(codegen, function, info)?;
-                        function.cast_to_expected_type_if_needed(
-                            codegen,
-                            location,
-                            operand_val,
-                            expected_type,
-                        )
-                    })
-                    .collect::<Result<Vec<Value>>>()?;
-                // Create the CallOp in each function using the collected args.
-                function.append_op_unnamed_result(
-                    function::call(
-                        codegen.op_builder(),
-                        location,
-                        codegen.flat_sym(id),
-                        &call_operands,
-                        &[target_function_data.get_type_of_return(codegen)],
-                    )?
-                    .into(),
-                )
-            }
-            #[allow(unused_variables)] // TODO: TEMP
-            Expression::BusCall { meta, id, args } => {
-                todo!("Handle BusCall expression")
-            }
-            Expression::AnonymousComp { .. } => unreachable!("removed by 'syntax_sugar_remover'"),
-            Expression::Tuple { .. } => unreachable!("removed by 'syntax_sugar_remover'"),
-            Expression::ParallelOp { .. } => {
-                unreachable!("handled in templates, illegal in pure functions")
             }
         }
     }

--- a/llzk_backend/src/function.rs
+++ b/llzk_backend/src/function.rs
@@ -2,8 +2,8 @@
 //! structs. The [FunctionContext] carries information about the current LLZK function
 //! being generated and some helpers related to generating code within the function. The
 //! [GenerateLLZKInFunction] trait provides the visitor to generate LLZK IR for all circom
-//! [Expression](program_structure::abstract_syntax_tree::ast::Expression) and
-//! [Statement](program_structure::abstract_syntax_tree::ast::Statement) nodes.
+//! [Expression](program_structure::ast::Expression) and
+//! [Statement](program_structure::ast::Statement) nodes.
 
 use crate::gen_context::BlockContextStack;
 use crate::gen_context::BlockGenContext;
@@ -59,7 +59,6 @@ use llzk::prelude::ValueLike as _;
 use llzk::prelude::WalkOrder;
 use llzk::prelude::WalkResult;
 use llzk::value_ext::has_uses;
-use program_structure::ast::Access;
 use program_structure::ast::Expression;
 use program_structure::ast::Meta;
 use program_structure::ast::Statement;
@@ -205,11 +204,13 @@ where
     'func: 'blk,
     'blk: 'val,
 {
-    /// Create a new [FunctionContext] for the given function with an initial name-to-value mapping.
-    pub fn new<const FREE_FUNC: bool>(
+    /// Create a new [FunctionContext] for the given function with an initial name-to-value mapping
+    /// and set of visible `poly.param` and `poly.expr` names.
+    pub fn new<'n, const FREE_FUNC: bool>(
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
         func: FuncDefOpRefMut<'ctx, 'func>,
         param_name_to_value: HashMap<String, Value<'ctx, 'val>>,
+        poly_template_binding_names: impl IntoIterator<Item = &'n String>,
     ) -> Result<Self> {
         let mut block_ctx = BlockContextStack::from_function(func.deref(), param_name_to_value)?;
         if FREE_FUNC {
@@ -225,7 +226,11 @@ where
                     .new_nondet_at_location(codegen.location_unknown(), codegen.bool_type().into())
             })?;
         }
-        Ok(Self { func, base: BlockGenContext::new(block_ctx) })
+        Ok(Self {
+            func,
+            base: BlockGenContext::new(block_ctx, poly_template_binding_names)
+                .with_poly_template_binding_locals(codegen, codegen.location_unknown())?,
+        })
     }
 
     /// Get the return type of the function.
@@ -847,6 +852,7 @@ where
         function: &mut FunctionContext<'ctx, 'func, 'blk, 'val>,
         info: InfoProviders<'info>,
     ) -> Result<Self::Output> {
+        let _guard = codegen.trace_statement(self);
         match self {
             Statement::InitializationBlock { xtype, initializations, .. } => {
                 if let VariableType::Signal(..) = xtype {
@@ -880,39 +886,9 @@ where
                     // per `type_analysis/src/analyzers/functions_free_of_template_elements.rs`
                     unreachable!("Function uses template operators");
                 }
-                let rvalue = rhe.gen_llzk_in_block(codegen, function, info)?;
-                match access.as_slice() {
-                    [] => {
-                        function.handle_simple_assignment(codegen, meta, var, rvalue)?;
-                    }
-                    a => {
-                        let location = codegen.location_from_meta(meta);
-                        let indices = &a
-                            .iter()
-                            .map(|access| {
-                                let idx = match access {
-                                    Access::ArrayAccess(index_expr) => {
-                                        index_expr.gen_llzk_in_block(codegen, function, info)
-                                    }
-                                    #[allow(unused_variables)] // TODO: TEMP
-                                    Access::ComponentAccess(name) => {
-                                        todo!("Handle Substitution component access in function")
-                                    }
-                                }?;
-                                function.cast_to_index_if_needed(location, idx)
-                            })
-                            .collect::<Result<Vec<Value<'_, '_>>>>()?;
-                        let arr_ref = *function.block_ctx.get_named_value(var)?;
-                        function.append_array_write(
-                            codegen,
-                            arr_ref,
-                            indices,
-                            location,
-                            rvalue,
-                            Some(var),
-                        )?;
-                    }
-                }
+                function.handle_substitution_stmt_nonsignal(
+                    codegen, info, meta, var, access, op, rhe,
+                )?;
                 Ok(false)
             }
             Statement::UnderscoreSubstitution { op, rhe, .. } => {
@@ -942,10 +918,7 @@ where
             }
             Statement::Assert { meta, arg } => {
                 let cond = arg.gen_llzk_in_block(codegen, function, info)?;
-                let location = codegen.location_from_meta(meta);
-                let cond = function.cast_to_bool_if_needed(codegen, location, cond)?;
-                let msg = Some("assertion failed");
-                function.append_op_no_result(dialect::bool::assert(location, cond, msg)?)?;
+                function.append_assert(codegen, codegen.location_from_meta(meta), cond)?;
                 Ok(false)
             }
             Statement::LogCall { meta, .. } => {

--- a/llzk_backend/src/gen_context.rs
+++ b/llzk_backend/src/gen_context.rs
@@ -1,21 +1,91 @@
 //! Handles circom var scoping and LLZK blocks stack management.
 
-use crate::function::FunctionContext;
+use crate::function::InfoProviders;
+use crate::function_ext::FunctionLike as _;
+use crate::lvalue::Lvalue;
+use crate::lvalue::Root;
+use crate::program_ext::ProgramLike;
+use crate::shared;
+use crate::shared::append_tail;
+use crate::shared::is_bool;
+use crate::shared::is_index;
+use crate::shared::new_array_type;
+use crate::shared::no_results;
+use crate::shared::region_with_block;
+use crate::shared::replace_uses_with_new_block_argument;
 use crate::shared::single_result_as_value;
+use crate::shared::ArrayDimension;
+use crate::shared::ArrayDimensionResult;
+use crate::shared::DimExprConverter;
+use crate::shared::LlzkCodegen;
+use crate::subcmp::names::COUNT;
 use anyhow::anyhow;
 use anyhow::ensure;
+use anyhow::Context as _;
 use anyhow::Result;
+use llzk::dialect::array;
+use llzk::dialect::array::ArrayCtor;
+use llzk::dialect::bool;
+use llzk::dialect::cast;
+use llzk::dialect::constrain;
+use llzk::dialect::felt;
+use llzk::dialect::function;
+use llzk::dialect::pod;
+use llzk::dialect::poly;
+use llzk::prelude::is_array_type;
+use llzk::prelude::is_felt_type;
+use llzk::prelude::melior_dialects::arith;
+use llzk::prelude::melior_dialects::index;
+use llzk::prelude::melior_dialects::scf;
+use llzk::prelude::ArrayType;
+use llzk::prelude::Attribute;
 use llzk::prelude::Block;
 use llzk::prelude::BlockLike as _;
 use llzk::prelude::BlockRef;
+use llzk::prelude::FlatSymbolRefAttribute;
 use llzk::prelude::FuncDefOp;
+use llzk::prelude::IntegerAttribute;
+use llzk::prelude::Location;
+use llzk::prelude::LoopBoundsAttribute;
 use llzk::prelude::Operation;
 use llzk::prelude::OperationLike as _;
+use llzk::prelude::OperationMutLike as _;
 use llzk::prelude::OperationRef;
+use llzk::prelude::PodType;
 use llzk::prelude::Region;
 use llzk::prelude::RegionLike as _;
+use llzk::prelude::StructType;
+use llzk::prelude::Type;
 use llzk::prelude::Value;
+use llzk::prelude::ValueLike as _;
+use llzk::prelude::FUNC_NAME_COMPUTE;
+use llzk::prelude::FUNC_NAME_CONSTRAIN;
+use melior::dialect::ods::math;
+use melior::ir::AttributeLike as _;
+use melior::ir::TypeLike as _;
+use num_bigint_dig::BigInt;
+use num_traits::Zero;
+use program_structure::ast::Expression;
+use program_structure::ast::ExpressionInfixOpcode;
+use program_structure::ast::ExpressionPrefixOpcode;
+use program_structure::ast::Meta;
+use program_structure::error_code::ReportCode;
 use std::collections::HashMap;
+use std::convert::TryFrom;
+use std::convert::TryInto;
+use std::iter::zip;
+
+/// Special variable name used to reference the return Value throughout the
+/// conversion of circom return locations to LLZK return locations.
+pub(crate) const VAR_NAME_RETURN_VAL: &str = "**return_val**";
+/// Special variable name used to reference the status of whether or not a circom block
+/// had a `return` when translating to an LLZK block that cannot contain a `return`.
+pub(crate) const VAR_NAME_HAD_RETURN: &str = "**had_return**";
+/// LLZK attribute used to mark yield/return ops generated from circom return statements.
+pub(crate) const CIRCOM_RETURN_MARKER_ATTR: &str = "from_circom_return";
+/// LLZK attribute used to attach comma-separated list of variable names for the operands
+/// of an `scf.yield` op.
+pub(crate) const OPERAND_VAL_NAMES: &str = "operand_val_names";
 
 /// Single frame in the [BlockContextStack].
 ///
@@ -121,15 +191,20 @@ where
     'ctx: 'blk,
     'blk: 'val,
 {
+    /// Create a new [BlockContextStack] with the given root block.
+    pub fn new(root: BlockRef<'ctx, 'blk>) -> Self {
+        Self { root: BlockContext::new(root), other_blocks: Default::default() }
+    }
+
     /// Create a new [BlockContextStack] for the given function with an initial name-to-value
     /// mapping containing function parameters.
-    pub fn new(
+    pub fn from_function(
         func: &FuncDefOp<'ctx>,
         param_name_to_value: HashMap<String, Value<'ctx, 'val>>,
     ) -> Result<Self> {
         let root_block =
             func.region(0)?.first_block().ok_or_else(|| anyhow!("missing function entry block"))?;
-        Ok(BlockContextStack {
+        Ok(Self {
             root: BlockContext::new_with_params(root_block, param_name_to_value),
             other_blocks: Default::default(),
         })
@@ -352,18 +427,17 @@ impl Default for NestedBlockInfo<'_, '_, '_> {
     }
 }
 
-impl<'ctx, 'func, 'blk, 'val> NestedBlockInfo<'ctx, 'blk, 'val>
+impl<'ctx, 'blk, 'val> NestedBlockInfo<'ctx, 'blk, 'val>
 where
-    'ctx: 'func,
-    'func: 'blk,
+    'ctx: 'blk,
     'blk: 'val,
 {
     /// Update `self.var_overwrites` to ensure it has all keys from `other.var_overwrites`, using
-    /// values from the current scope in the [FunctionContext] for missing keys.
+    /// values from the current scope in the [BlockGenContext] for missing keys.
     pub fn add_missing_values(
         &mut self,
         other: &NestedBlockInfo<'ctx, 'blk, 'val>,
-        fc: &FunctionContext<'ctx, 'func, 'blk, 'val>,
+        fc: &BlockGenContext<'ctx, 'blk, 'val>,
     ) -> Result<()> {
         for name in other.var_overwrites.keys() {
             if !self.var_overwrites.contains_key(name) {
@@ -403,7 +477,7 @@ where
     ) -> Result<()>
     where
         H: Fn(
-            &mut FunctionContext<'ctx, 'func, 'blk, 'val>,
+            &mut BlockGenContext<'ctx, 'blk, 'val>,
             &mut NestedBlockInfo<'ctx, 'blk, 'val>,
             HashMap<String, Value<'ctx, 'val>>,
         ) -> Result<()>;
@@ -421,7 +495,7 @@ where
     ) -> Result<R>
     where
         H: Fn(
-            &mut FunctionContext<'ctx, 'func, 'blk, 'val>,
+            &mut BlockGenContext<'ctx, 'blk, 'val>,
             &mut NestedBlockInfo<'ctx, 'blk, 'val>,
             HashMap<String, Value<'ctx, 'val>>,
         ) -> Result<()>,
@@ -494,4 +568,1548 @@ where
 /// Helper function for creating an error reporting that the given block is not part of the stack.
 fn block_not_in_stack(block: BlockRef) -> anyhow::Error {
     anyhow!("Block {block:?} is not part of the stack")
+}
+
+/// Holds the block context stack for generating LLZK IR within an LLZK Block body.
+///
+/// 'ctx: lifetime of the `LlzkContext` and generated `Module`
+/// 'blk: lifetime of the generated `Block` instances within functions
+/// 'val: lifetime of the generated `Value` or `Operation` instances within blocks
+#[derive(Debug)]
+pub struct BlockGenContext<'ctx, 'blk, 'val>
+where
+    'ctx: 'blk,
+    'blk: 'val,
+{
+    /// Nested block context within the root block.
+    pub(crate) block_ctx: BlockContextStack<'ctx, 'blk, 'val>,
+}
+
+impl<'ctx, 'blk, 'val> BlockGenContext<'ctx, 'blk, 'val>
+where
+    'ctx: 'blk,
+    'blk: 'val,
+{
+    /// Create a new [BlockGenContext] with the given block context stack.
+    pub fn new(block_ctx: BlockContextStack<'ctx, 'blk, 'val>) -> Self {
+        Self { block_ctx }
+    }
+
+    /// Append an operation.
+    pub fn append_op(&mut self, op: Operation<'ctx>) -> OperationRef<'ctx, 'val> {
+        self.block_ctx.append_current_block(op)
+    }
+
+    /// Append an operation that must produce no results.
+    pub fn append_op_no_result(&mut self, op: Operation<'ctx>) -> Result<()> {
+        no_results(self.append_op(op))
+    }
+
+    /// Append an operation that must produce a single result and is NOT associated with a variable
+    /// name in the circom code.
+    pub fn append_op_unnamed_result(&mut self, op: Operation<'ctx>) -> Result<Value<'ctx, 'val>> {
+        single_result_as_value(self.append_op(op))
+    }
+
+    /// Append an operation that must produce a single result and store the mapping of the circom
+    /// variable name to the result Value.
+    pub fn append_op_named_result(
+        &mut self,
+        op: Operation<'ctx>,
+        name: String,
+    ) -> Result<Value<'ctx, 'val>> {
+        let v = self.append_op_unnamed_result(op)?;
+        self.block_ctx.set_named_value(name, v)?;
+        Ok(v)
+    }
+
+    /// Generate and append a `read_const` operation for the given template binding name and store
+    /// the mapping in the block context so all references to that binding name can reuse the Value.
+    #[inline]
+    pub fn append_initial_read_const(
+        &mut self,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+        location: Location<'ctx>,
+        name: &str,
+    ) -> Result<()> {
+        self.block_ctx.declare_name_ensure_not_present(
+            name,
+            poly::read_const(location, name, codegen.felt_type().into()),
+        )
+    }
+
+    /// Insert cast operations as needed to make `lhs` and `rhs` have compatible types for equality
+    /// constraints.
+    #[inline]
+    fn unify_constrain_eq_types(
+        &mut self,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+        location: Location<'ctx>,
+        lhs: Value<'ctx, 'val>,
+        rhs: Value<'ctx, 'val>,
+    ) -> Result<(Value<'ctx, 'val>, Value<'ctx, 'val>)> {
+        match (lhs.r#type(), rhs.r#type()) {
+            (t0, t1) if is_felt_type(t0) && !is_felt_type(t1) => {
+                Ok((lhs, self.cast_to_felt(codegen, location, rhs)?))
+            }
+            (t0, t1) if !is_felt_type(t0) && is_felt_type(t1) => {
+                Ok((self.cast_to_felt(codegen, location, lhs)?, rhs))
+            }
+            _ => Ok((lhs, rhs)),
+        }
+    }
+
+    /// Generate a `constrain.eq` operation for the given values, casting to compatible felt types
+    /// if necessary.
+    pub fn append_constrain_eq(
+        &mut self,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+        location: Location<'ctx>,
+        lhs: Value<'ctx, 'val>,
+        rhs: Value<'ctx, 'val>,
+    ) -> Result<()> {
+        let (lhs, rhs) = self.unify_constrain_eq_types(codegen, location, lhs, rhs)?;
+        self.append_op_no_result(constrain::eq(location, lhs, rhs).into())
+    }
+
+    /// Generate an `array.write` or `array.insert` operation appropriate for the number of indices
+    /// and the [ArrayType] of the `arr_ref` value.
+    pub fn append_array_write(
+        &mut self,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+        arr_ref: Value<'ctx, 'val>,
+        indices: &[Value<'ctx, 'val>],
+        location: Location<'ctx>,
+        rvalue: Value<'ctx, 'val>,
+        var_name: Option<&str>,
+    ) -> Result<()> {
+        let arr_ty = ArrayType::try_from(arr_ref.r#type()).with_context(|| {
+            let v = var_name.map_or(String::from("array"), |s| format!("'{s}'"));
+            format!("Conflicting types to write {v} at {location}")
+        })?;
+        let arr_ty_dims = arr_ty.dims();
+        let write_op = match indices.len().cmp(&arr_ty_dims.len()) {
+            std::cmp::Ordering::Equal => {
+                // Indexing all dimensions requires an `array.write`
+                let rvalue = self.cast_to_expected_type_if_needed(
+                    codegen,
+                    location,
+                    rvalue,
+                    arr_ty.element_type(),
+                )?;
+                array::write(location, arr_ref, indices, rvalue)
+            }
+            std::cmp::Ordering::Less => {
+                // Indexing a subset of dimensions requires an `array.insert`
+                array::insert(location, arr_ref, indices, rvalue)
+            }
+            std::cmp::Ordering::Greater => {
+                let v = var_name.map_or(String::from("array"), |s| format!("'{s}'"));
+                anyhow::bail!("Too many indices to write {v} at {location}");
+            }
+        };
+        self.append_op_no_result(write_op)
+    }
+
+    /// Generate an `array.read` or `array.extract` operation appropriate for the number of indices
+    /// and the [ArrayType] of the `arr_ref` value.
+    pub fn append_array_read(
+        &mut self,
+        arr_ref: Value<'ctx, 'val>,
+        indices: &[Value<'ctx, 'val>],
+        location: Location<'ctx>,
+        var_name: Option<&str>,
+    ) -> Result<Value<'ctx, 'val>> {
+        let arr_ty = ArrayType::try_from(arr_ref.r#type()).with_context(|| {
+            let v = var_name.map_or(String::from("array"), |s| format!("'{s}'"));
+            format!("Conflicting types to read {v} at {location}")
+        })?;
+        let arr_ty_dims = arr_ty.dims();
+        let array_get_op = match indices.len().cmp(&arr_ty_dims.len()) {
+            std::cmp::Ordering::Equal => {
+                // Indexing all dimensions requires an `array.read`
+                array::read(location, arr_ty.element_type(), arr_ref, indices)
+            }
+            std::cmp::Ordering::Less => {
+                // Indexing a subset of dimensions requires an `array.extract`
+                let reduced_dims: Vec<_> =
+                    arr_ty_dims.iter().skip(indices.len()).copied().collect();
+                let reduced_type = ArrayType::new(arr_ty.element_type().into(), &reduced_dims);
+                array::extract(location, reduced_type.into(), arr_ref, indices)
+            }
+            std::cmp::Ordering::Greater => {
+                let v = var_name.map_or(String::from("array"), |s| format!("'{s}'"));
+                anyhow::bail!("Too many indices to read {v} at {location}");
+            }
+        };
+        self.append_op_unnamed_result(array_get_op)
+    }
+
+    /// Create a cast to felt (field element) type.
+    #[inline]
+    pub fn cast_to_felt(
+        &mut self,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+        location: Location<'ctx>,
+        val: Value<'ctx, 'val>,
+    ) -> Result<Value<'ctx, 'val>> {
+        self.append_op_unnamed_result(cast::tofelt(location, val, Some(codegen.felt_type())))
+    }
+
+    /// Create a cast to felt (field element) type if the given value is not already a felt.
+    #[inline]
+    pub fn cast_to_felt_if_needed(
+        &mut self,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+        location: Location<'ctx>,
+        val: Value<'ctx, 'val>,
+    ) -> Result<Value<'ctx, 'val>> {
+        if !is_felt_type(val.r#type()) {
+            self.cast_to_felt(codegen, location, val)
+        } else {
+            Ok(val)
+        }
+    }
+
+    /// Create a cast to index type if the given value is not already an index.
+    #[inline]
+    pub fn cast_to_index_if_needed(
+        &mut self,
+        location: Location<'ctx>,
+        val: Value<'ctx, 'val>,
+    ) -> Result<Value<'ctx, 'val>> {
+        if !is_index(val.r#type()) {
+            self.append_op_unnamed_result(cast::toindex(location, val).into())
+        } else {
+            Ok(val)
+        }
+    }
+
+    /// Create a cast to bool type (i1) if the given value is not already a bool.
+    #[inline]
+    pub fn cast_to_bool_if_needed(
+        &mut self,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+        location: Location<'ctx>,
+        val: Value<'ctx, 'val>,
+    ) -> Result<Value<'ctx, 'val>> {
+        // The conversion to bool is simply to check `!=0` which is the same as
+        // `normalize()` in `modular_arithmetic.rs`.
+        if is_felt_type(val.r#type()) {
+            let zero = self
+                .append_op_unnamed_result(codegen.new_felt_const_op(&BigInt::zero(), location)?)?;
+            self.append_op_unnamed_result(bool::ne(location, val, zero)?)
+        } else if is_index(val.r#type()) {
+            let zero = self.append_op_unnamed_result(codegen.new_index_const_op(0, location))?;
+            self.append_op_unnamed_result(index::cmp(
+                codegen.context,
+                arith::CmpiPredicate::Ne,
+                val,
+                zero,
+                location,
+            ))
+        } else {
+            assert!(is_bool(val.r#type()));
+            Ok(val)
+        }
+    }
+
+    /// Create an op to cast `val` to match the `expected` type.
+    #[inline]
+    pub fn cast_to_expected_type_if_needed(
+        &mut self,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+        location: Location<'ctx>,
+        val: Value<'ctx, 'val>,
+        expected: Type<'ctx>,
+    ) -> Result<Value<'ctx, 'val>> {
+        if expected == val.r#type() {
+            Ok(val)
+        } else if is_felt_type(expected) {
+            self.cast_to_felt_if_needed(codegen, location, val)
+        } else if is_index(expected) {
+            self.cast_to_index_if_needed(location, val)
+        } else if is_bool(expected) {
+            self.cast_to_bool_if_needed(codegen, location, val)
+        } else {
+            anyhow::bail!(
+                "Unsupported 'expected' type '{expected}' with value type {}",
+                val.r#type()
+            )
+        }
+    }
+
+    /// Copy the values in the source array into the destination array.
+    /// Assumes both arrays have the same number of dimensions, but each dimension
+    /// may be wider/narrower than the destination type.
+    /// General overview: create a N-dimensional nested for loop to copy. If the
+    /// indices are out-of-bounds, then the array is default-filled. Otherwise,
+    /// copy elements into destination
+    fn copy_into_array(
+        &mut self,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+        meta: &Meta,
+        dst: Value<'ctx, 'val>,
+        dst_ty: ArrayType<'ctx>,
+        src: Value<'ctx, 'val>,
+        src_ty: ArrayType<'ctx>,
+    ) -> Result<()>
+    where
+        'val: 'blk,
+    {
+        let elem_ty = dst_ty.element_type();
+        assert!(elem_ty == src_ty.element_type());
+        assert!(dst_ty.num_dims() == src_ty.num_dims());
+
+        let location = codegen.location_from_meta(meta);
+
+        let bounds = zip(src_ty.dims(), dst_ty.dims())
+            .map(|(src_dim, dest_dim)| {
+                let src_val = self.array_dim_attr_to_idx_val(codegen, location, src_dim)?;
+                let dest_val = self.array_dim_attr_to_idx_val(codegen, location, dest_dim)?;
+                let condition = self.append_op_unnamed_result(arith::cmpi(
+                    codegen.context,
+                    arith::CmpiPredicate::Ult,
+                    src_val,
+                    dest_val,
+                    location,
+                ))?;
+                let if_op = self.generate_simple_scf_if(
+                    codegen,
+                    meta,
+                    condition,
+                    |_| Ok(src_val),
+                    |_| Ok(dest_val),
+                )?;
+                self.append_op_unnamed_result(if_op)
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        self.gen_loop_nest(codegen, location, &bounds, move |fc, indices| {
+            let read = fc.append_op_unnamed_result(array::read(location, elem_ty, src, indices))?;
+            fc.append_op_no_result(array::write(location, dst, indices, read))
+        })
+    }
+
+    /// Perform a direct assignment of `rvalue` to `var`. In many cases this is handled
+    /// by updating the variable name map to have `var` -> `rvalue`, but special handling
+    /// is required during array assignments where `rvalue` is a different width than the
+    /// destination array (this requires 0-filling or truncation).
+    pub fn handle_simple_assignment(
+        &mut self,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+        meta: &Meta,
+        var: &String,
+        rvalue: Value<'ctx, 'val>,
+    ) -> Result<()>
+    where
+        'val: 'blk,
+    {
+        // Since there's no simple assignment in LLZK, just update the mapped Value
+        // which essentially propagates the assignment. The exception here is the ArrayType case:
+        // Circom allows (with a warning) arrays to be assigned to array variables
+        // of differing widths (wider/narrower) as long as both arrays have
+        // the same number of dimensions (e.g., var x[2][2] = y, where y is var[1][7], is allowed).
+        // If the dimension is wider, the values are truncated, and if they are narrower,
+        // the array is left in its current state.
+        let Ok(existing) = self.block_ctx.get_named_value(var) else {
+            // Otherwise, set the var to point to rvalue
+            return self.block_ctx.set_named_value(var.clone(), rvalue);
+        };
+        if existing.r#type() == rvalue.r#type() {
+            // Replace existing value reference to rvalue
+            return self.block_ctx.set_named_value(var.clone(), rvalue);
+        }
+        if is_array_type(existing.r#type()) && is_array_type(rvalue.r#type()) {
+            let existing_arr_ty = ArrayType::try_from(existing.r#type()).unwrap();
+            let new_arr_ty = ArrayType::try_from(rvalue.r#type()).unwrap();
+            if existing_arr_ty.element_type() == new_arr_ty.element_type()
+                && existing_arr_ty.num_dims() == new_arr_ty.num_dims()
+                && existing_arr_ty.dims() != new_arr_ty.dims()
+            {
+                // Copy values from the rvalue into the existing array.
+                // No need to update named value here.
+                return self.copy_into_array(
+                    codegen,
+                    meta,
+                    *existing,
+                    existing_arr_ty,
+                    rvalue,
+                    new_arr_ty,
+                );
+            }
+        }
+        anyhow::bail!(
+            "could not assign value of type '{}' to '{var}', which has type '{}'",
+            rvalue.r#type(),
+            existing.r#type()
+        )
+    }
+
+    /// Creates LLZK ops for array indexing from the collection of elements.
+    pub fn gen_index_ops<'ast, 'info, E>(
+        &mut self,
+        indices: impl IntoIterator<Item = &'ast E>,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+        location: Location<'ctx>,
+        info: InfoProviders<'info>,
+    ) -> Result<Vec<Value<'ctx, 'val>>>
+    where
+        E: GenerateLLZKInAnyBlock<'ctx, 'blk, 'val> + 'ast,
+    {
+        indices
+            .into_iter()
+            .map(|e| {
+                let val = e.gen_llzk_in_block(codegen, self, info)?;
+                self.append_op_unnamed_result(cast::toindex(location, val))
+            })
+            .collect()
+    }
+
+    /// Generate LLZK code in the current function for a circom prefix operation.
+    pub fn gen_prefix_op(
+        &mut self,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+        meta: &Meta,
+        op: &ExpressionPrefixOpcode,
+        rhs: Value<'ctx, 'val>,
+    ) -> Result<Value<'ctx, 'val>> {
+        let mut get_negative_idx = || {
+            let zero = self.append_op_unnamed_result(index::constant(
+                codegen.context,
+                IntegerAttribute::new(rhs.r#type(), 0),
+                codegen.location_from_meta(meta),
+            ))?;
+            self.append_op_unnamed_result(index::sub(zero, rhs, codegen.location_from_meta(meta)))
+        };
+        match op {
+            ExpressionPrefixOpcode::Sub => {
+                if is_felt_type(rhs.r#type()) {
+                    return self.append_op_unnamed_result(felt::neg(
+                        codegen.location_from_meta(meta),
+                        rhs,
+                    )?);
+                }
+                // For index negation, we need to subtract from zero.
+                if shared::is_index(rhs.r#type()) {
+                    return get_negative_idx();
+                }
+            }
+            ExpressionPrefixOpcode::BoolNot => {
+                if shared::is_bool(rhs.r#type()) {
+                    return self.append_op_unnamed_result(bool::not(
+                        codegen.location_from_meta(meta),
+                        rhs,
+                    )?);
+                }
+            }
+            ExpressionPrefixOpcode::Complement => {
+                if is_felt_type(rhs.r#type()) {
+                    return self.append_op_unnamed_result(felt::bit_not(
+                        codegen.location_from_meta(meta),
+                        rhs,
+                    )?);
+                }
+                // For index negation, we need to subtract one from the negative
+                // value (for the identity that `~x == -x - 1`).
+                if shared::is_index(rhs.r#type()) {
+                    let negative_idx = get_negative_idx()?;
+                    let one = self.append_op_unnamed_result(index::constant(
+                        codegen.context,
+                        IntegerAttribute::new(rhs.r#type(), 1),
+                        codegen.location_from_meta(meta),
+                    ))?;
+                    return self.append_op_unnamed_result(index::sub(
+                        negative_idx,
+                        one,
+                        codegen.location_from_meta(meta),
+                    ));
+                }
+            }
+        }
+        let err_msg = format!(
+            "Cannot generate LLZK for prefix {:?} with operand type '{}'",
+            self,
+            rhs.r#type()
+        );
+        codegen.emit_circom_error(meta, err_msg.as_str(), ReportCode::PrefixOperatorWithWrongTypes);
+        Err(anyhow!(err_msg))
+    }
+
+    /// If both operands have types that match the respective filter predicates, generate the
+    /// operation using the provided generator function and return the result, otherwise None.
+    #[inline]
+    fn gen_infix_op_if_types_are(
+        &mut self,
+        lhs_type_filter: impl FnOnce(Type) -> bool,
+        rhs_type_filter: impl FnOnce(Type) -> bool,
+        lhs: Value<'ctx, 'val>,
+        rhs: Value<'ctx, 'val>,
+        op_gen_fn: impl FnOnce(&mut Self) -> Result<Operation<'ctx>>,
+    ) -> Result<Option<Value<'ctx, 'val>>> {
+        if lhs_type_filter(lhs.r#type()) && rhs_type_filter(rhs.r#type()) {
+            let op_res = op_gen_fn(self)?;
+            self.append_op_unnamed_result(op_res).map(Option::Some)
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Generate LLZK code in the current function for an infix operation.
+    pub fn gen_infix_op(
+        &mut self,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+        meta: &Meta,
+        op: &ExpressionInfixOpcode,
+        lhs: Value<'ctx, 'val>,
+        rhs: Value<'ctx, 'val>,
+    ) -> Result<Value<'ctx, 'val>> {
+        // Macro to handle the common pattern for type checks for op selection.
+        macro_rules! try_callback_for_type {
+            ($type_check:path, $cb:expr) => {{
+                if let Some(result) =
+                    self.gen_infix_op_if_types_are($type_check, $type_check, lhs, rhs, $cb)?
+                {
+                    return Ok(result);
+                }
+            }};
+        }
+
+        macro_rules! generic_op_callback {
+            ($op_path:path) => {{
+                |_| {
+                    let loc = codegen.location_from_meta(meta);
+                    $op_path(loc, lhs, rhs).map_err(Into::into)
+                }
+            }};
+        }
+
+        macro_rules! try_felt_op {
+            ($op_path:path) => {{
+                try_callback_for_type!(is_felt_type, generic_op_callback!($op_path));
+            }};
+        }
+
+        macro_rules! try_bool_op {
+            ($op_path:path) => {{
+                let loc = codegen.location_from_meta(meta);
+                let lhs = self.cast_to_bool_if_needed(codegen, loc, lhs)?;
+                let rhs = self.cast_to_bool_if_needed(codegen, loc, rhs)?;
+                return self.append_op_unnamed_result($op_path(loc, lhs, rhs)?);
+            }};
+        }
+
+        macro_rules! try_index_op {
+            ($op_path:path) => {{
+                try_callback_for_type!(shared::is_index, |_| {
+                    let loc = codegen.location_from_meta(meta);
+                    Ok($op_path(lhs, rhs, loc))
+                });
+            }};
+        }
+
+        macro_rules! try_math_op {
+            ($op_path:path) => {{
+                try_callback_for_type!(shared::is_index, |_| {
+                    let loc = codegen.location_from_meta(meta);
+                    Ok(Operation::from($op_path(codegen.context, lhs, rhs, loc)))
+                });
+            }};
+        }
+
+        // Macro to handle the common pattern for felt and index type checks.
+        // For index operations that use felt:: module and simple index operations.
+        macro_rules! try_felt_or_index_op {
+            ($felt_op:path, $index_op:path) => {{
+                try_felt_op!($felt_op);
+                try_index_op!($index_op);
+            }};
+        }
+
+        macro_rules! try_felt_or_math_op {
+            ($felt_op:path, $math_op:path) => {{
+                try_felt_op!($felt_op);
+                try_math_op!($math_op);
+            }};
+        }
+
+        // Macro to handle the common pattern for felt and index type checks.
+        // For comparison operations that use bool:: module and index::cmpi.
+        macro_rules! try_bool_cmp_op {
+            ($bool_op:path, $cmp:ident) => {{
+                try_felt_op!($bool_op);
+                try_callback_for_type!(shared::is_index, |_| {
+                    let loc = codegen.location_from_meta(meta);
+                    Ok(index::cmp(codegen.context, arith::CmpiPredicate::$cmp, lhs, rhs, loc))
+                });
+            }};
+        }
+
+        match op {
+            ExpressionInfixOpcode::Add => {
+                try_felt_or_index_op!(felt::add, index::add);
+            }
+            ExpressionInfixOpcode::Sub => {
+                try_felt_or_index_op!(felt::sub, index::sub);
+            }
+            ExpressionInfixOpcode::Mul => {
+                try_felt_or_index_op!(felt::mul, index::mul);
+            }
+            ExpressionInfixOpcode::Div => {
+                try_felt_or_index_op!(felt::div, index::divu);
+            }
+            ExpressionInfixOpcode::IntDiv => {
+                try_felt_or_index_op!(felt::uintdiv, index::divu);
+            }
+            ExpressionInfixOpcode::Mod => {
+                try_felt_or_index_op!(felt::umod, index::remu);
+            }
+            ExpressionInfixOpcode::Pow => {
+                try_felt_or_math_op!(felt::pow, math::ipowi);
+            }
+            ExpressionInfixOpcode::ShiftL => {
+                try_felt_or_index_op!(felt::shl, index::shl);
+            }
+            ExpressionInfixOpcode::ShiftR => {
+                try_felt_or_index_op!(felt::shr, index::shru);
+            }
+            ExpressionInfixOpcode::LesserEq => {
+                try_bool_cmp_op!(bool::le, Ule);
+            }
+            ExpressionInfixOpcode::GreaterEq => {
+                try_bool_cmp_op!(bool::ge, Uge);
+            }
+            ExpressionInfixOpcode::Lesser => {
+                try_bool_cmp_op!(bool::lt, Ult);
+            }
+            ExpressionInfixOpcode::Greater => {
+                try_bool_cmp_op!(bool::gt, Ugt);
+            }
+            ExpressionInfixOpcode::Eq => {
+                try_bool_cmp_op!(bool::eq, Eq);
+            }
+            ExpressionInfixOpcode::NotEq => {
+                try_bool_cmp_op!(bool::ne, Ne);
+            }
+            ExpressionInfixOpcode::BoolOr => {
+                try_bool_op!(bool::or);
+            }
+            ExpressionInfixOpcode::BoolAnd => {
+                try_bool_op!(bool::and);
+            }
+            ExpressionInfixOpcode::BitOr => {
+                try_felt_or_index_op!(felt::bit_or, index::or);
+            }
+            ExpressionInfixOpcode::BitAnd => {
+                try_felt_or_index_op!(felt::bit_and, index::and);
+            }
+            ExpressionInfixOpcode::BitXor => {
+                try_felt_or_index_op!(felt::bit_xor, index::xor);
+            }
+        }
+        let err_msg = format!(
+            "Cannot generate LLZK for infix {:?} with LHS type '{}' and RHS type '{}'",
+            op,
+            lhs.r#type(),
+            rhs.r#type()
+        );
+        codegen.emit_circom_error(meta, err_msg.as_str(), ReportCode::InfixOperatorWithWrongTypes);
+        Err(anyhow!(err_msg))
+    }
+
+    /// Create a new `scf.yield` op, in the given block, that yields multiple values with associated
+    /// variable names. Create an [Attribute] containing comma-separated list of `value_names`
+    /// and attach it to the `scf.yield` op using the [OPERAND_VAL_NAMES] attribute key.
+    fn append_multi_operand_yield_to_block(
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+        block: BlockRef<'ctx, 'val>,
+        values: &[Value<'ctx, 'val>],
+        value_names: &[String],
+        location: Location<'ctx>,
+    ) -> Result<()> {
+        assert_eq!(values.len(), value_names.len(), "requires one name per value");
+        let mut op = scf::r#yield(values, location);
+        op.set_attribute(OPERAND_VAL_NAMES, codegen.list_to_attribute(value_names));
+        no_results(block.append_operation(op))
+    }
+
+    /// Generate an `scf.if` op based on the given [NestedBlockInfo] for each branch and update the
+    /// block context with the results of the `scf.if` op mapped to the given names.
+    pub fn gen_scf_if(
+        &mut self,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+        location: Location<'ctx>,
+        condition: Value<'ctx, 'val>,
+        mut then_info: NestedBlockInfo<'ctx, 'blk, 'val>,
+        else_info: NestedBlockInfo<'ctx, 'blk, 'val>,
+    ) -> Result<()> {
+        // Ensure both blocks will yield the same set of variables.
+        then_info.add_missing_values(&else_info, self)?;
+
+        // Split `then_block_info.var_overwrites` into ordered lists of names and values. The
+        // ordering of names here defines the ordering of results from the `scf.if` op and
+        // thus the ordering of operands to `scf.yield` ops in both branches.
+        let mut overwrites_sorted: Vec<_> = then_info.var_overwrites.into_iter().collect();
+        if codegen.config.stabilize {
+            // Sort by circom variable names to ensure a stable order.
+            overwrites_sorted.sort_by(|(name_a, _), (name_b, _)| name_a.cmp(name_b));
+        }
+        let (overwrite_names, then_values): (Vec<_>, Vec<_>) =
+            overwrites_sorted.into_iter().unzip();
+
+        // Create list of values to yield from the `else` block in the same order
+        // as `overwrite_names`, again using current-scope values for missing keys.
+        let else_values = overwrite_names
+            .iter()
+            .map(|name| {
+                else_info
+                    .var_overwrites
+                    .get(name)
+                    .map_or_else(|| self.block_ctx.get_named_value(name).cloned(), |v| Ok(*v))
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        // Insert `scf.yield` at the end of each block.
+        Self::append_multi_operand_yield_to_block(
+            codegen,
+            then_info.block,
+            &then_values,
+            &overwrite_names,
+            location,
+        )?;
+        Self::append_multi_operand_yield_to_block(
+            codegen,
+            else_info.block,
+            &else_values,
+            &overwrite_names,
+            location,
+        )?;
+
+        // Use `overwrite_names` and the current block context to get the types of
+        // the named values to define the result types of the `scf.if` op.
+        let result_types = overwrite_names
+            .iter()
+            .map(|name| {
+                self.block_ctx
+                    .get_named_value(name)
+                    .inspect_err(|e| eprintln!("\nERROR: {e:?}"))
+                    .map(|v| v.r#type())
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        // Cast condition value to bool type if needed.
+        let condition = self.cast_to_bool_if_needed(codegen, location, condition)?;
+        // Generate the `scf.if` op for the circom `IfThenElse` statement.
+        let scf_if_op = self.append_op(scf::r#if(
+            condition,
+            &result_types,
+            then_info.region,
+            else_info.region,
+            location,
+        ));
+
+        // Update the current block context with results from the `scf.if` op.
+        overwrite_names
+            .into_iter()
+            .zip(scf_if_op.results())
+            .try_for_each(|(name, result)| self.block_ctx.set_named_value(name, result.into()))?;
+        Ok(())
+    }
+
+    /// Generate one region for either the then-arm or else-arm of a simple scf.if operation.
+    /// Used by [Self::generate_simple_scf_if].
+    /// The `value_gen` function is called to generate the value to be yielded from the arm.
+    fn generate_simple_scf_if_arm<F>(
+        &mut self,
+        location: Location<'ctx>,
+        value_gen: F,
+    ) -> Result<(Region<'ctx>, Value<'ctx, 'val>)>
+    where
+        F: FnOnce(&mut Self) -> Result<Value<'ctx, 'val>>,
+    {
+        let region = Region::new();
+        let block = region.append_block(Block::new(&[]));
+        self.block_ctx.push(block);
+        let arm_val = value_gen(self)?;
+        self.block_ctx.pop();
+        no_results(block.append_operation(scf::r#yield(&[arm_val], location)))?;
+        Ok((region, arm_val))
+    }
+
+    /// Generate a simple scf.if operation that yields the given `then_value` or `else_value`
+    /// depending on the `condition` value. Unlike [Self::gen_scf_if], this assumes that the
+    /// then and else arms do not modify the current block context and only produce values.
+    pub fn generate_simple_scf_if<F1, F2>(
+        &mut self,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+        meta: &Meta,
+        condition: Value<'ctx, 'val>,
+        then_value_gen: F1,
+        else_value_gen: F2,
+    ) -> Result<Operation<'ctx>>
+    where
+        F1: FnOnce(&mut Self) -> Result<Value<'ctx, 'val>>,
+        F2: FnOnce(&mut Self) -> Result<Value<'ctx, 'val>>,
+    {
+        let location = codegen.location_from_meta(meta);
+
+        let (then_region, then_value) =
+            self.generate_simple_scf_if_arm(location, then_value_gen)?;
+        let (else_region, else_value) =
+            self.generate_simple_scf_if_arm(location, else_value_gen)?;
+
+        // Ensure then_value and else_value have the same types
+        assert_eq!(
+            then_value.r#type(),
+            else_value.r#type(),
+            "then and else branches of scf.if must have matching value types"
+        );
+
+        Ok(scf::r#if(condition, &[then_value.r#type()], then_region, else_region, location))
+    }
+
+    /// Generate a simple `scf.for` op that doesn't need to override variables
+    /// in the block context.
+    /// The body function (`body_fn`) accepts a `Block` with a single argument representing
+    /// the for-loop induction variable and is used to fill in the `scf.for` op.
+    pub fn gen_simple_scf_for(
+        &mut self,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+        location: Location<'ctx>,
+        start: Value<'ctx, 'val>,
+        step: Value<'ctx, 'val>,
+        end: Value<'ctx, 'val>,
+        body_fn: impl FnOnce(&mut Block<'ctx>) -> Result<()>,
+    ) -> Result<()> {
+        let block_arg = (codegen.index_type(), location);
+        let mut block = Block::new(&[block_arg]);
+        body_fn(&mut block)?;
+        let region = Region::new();
+        region.append_block(block);
+        let scf_op = scf::r#for(start, end, step, region, location);
+        self.append_op_no_result(scf_op)
+    }
+
+    /// Generate a simple `scf.for` op with normalized start=0 and step=1.
+    #[inline]
+    pub fn gen_normalized_scf_for(
+        &mut self,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+        location: Location<'ctx>,
+        end: Value<'ctx, 'val>,
+        body_fn: impl FnOnce(&mut Block<'ctx>) -> Result<()>,
+    ) -> Result<()> {
+        let start = self.append_op_unnamed_result(codegen.new_index_const_op(0, location))?;
+        let step = self.append_op_unnamed_result(codegen.new_index_const_op(1, location))?;
+        self.gen_simple_scf_for(codegen, location, start, step, end, body_fn)
+    }
+
+    /// Generates IR for decreasing the counter of a subcomponent.
+    ///
+    /// Returns a [`Value`] with the updated counter.
+    pub fn gen_subcmp_decrease_counter(
+        &mut self,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+        location: Location<'ctx>,
+        subcmp_memory: Value<'ctx, 'val>,
+        amount: u32,
+    ) -> Result<Value<'ctx, 'val>> {
+        let counter = self.append_op_unnamed_result(codegen.new_pod_read_op(
+            subcmp_memory,
+            COUNT,
+            location,
+        )?)?;
+        let one = self.append_op_unnamed_result(codegen.new_index_const_op(amount, location))?;
+        let counter = self.append_op_unnamed_result(arith::subi(counter, one, location))?;
+        self.append_op_no_result(codegen.new_pod_write_op(
+            location,
+            subcmp_memory,
+            COUNT,
+            counter,
+        ))?;
+        Ok(counter)
+    }
+
+    /// Decomposes the given value of [`PodType`] into a sequence of values in declaration order.
+    pub fn gen_decompose_pod(
+        &mut self,
+        pod: Value<'ctx, 'val>,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+        location: Location<'ctx>,
+    ) -> Result<Vec<Value<'ctx, 'val>>> {
+        PodType::try_from(pod.r#type())?
+            .get_records()
+            .into_iter()
+            .map(|record| {
+                let record_name = codegen.flat_sym(record.name().as_string_ref().as_str()?);
+                self.append_op_unnamed_result(pod::read(
+                    location,
+                    pod,
+                    record_name,
+                    record.r#type(),
+                ))
+            })
+            .collect()
+    }
+
+    /// Generates a call to `@compute` for the given struct type.
+    ///
+    /// The arguments for the call are given as a value of [`PodType`] representing the inputs of
+    /// the subcomponent.
+    ///
+    /// # TODO
+    ///
+    /// Map operands are missing.
+    pub fn gen_compute_call(
+        &mut self,
+        struct_type: StructType<'ctx>,
+        inputs: Value<'ctx, 'val>,
+        location: Location<'ctx>,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+    ) -> Result<Value<'ctx, 'val>> {
+        let input_values = self.gen_decompose_pod(inputs, codegen, location)?;
+        let func_name = append_tail(&struct_type.name(), FUNC_NAME_COMPUTE.as_ref());
+        self.append_op_unnamed_result(
+            function::call(
+                codegen.op_builder(),
+                location,
+                func_name,
+                &input_values,
+                &[struct_type],
+            )?
+            .into(),
+        )
+    }
+
+    /// Generates a call to `@constrain` for the given struct type.
+    ///
+    /// The arguments for the call are given as a value of [`PodType`] representing the inputs of
+    /// the subcomponent.
+    pub fn gen_constrain_call(
+        &mut self,
+        subcmp: Value<'ctx, 'val>,
+        inputs: Value<'ctx, 'val>,
+        location: Location<'ctx>,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+    ) -> Result<()> {
+        let mut call_args = vec![subcmp];
+        call_args.extend(self.gen_decompose_pod(inputs, codegen, location)?);
+        let func_name = append_tail(
+            &StructType::try_from(subcmp.r#type())?.name(),
+            FUNC_NAME_CONSTRAIN.as_ref(),
+        );
+        let return_types: [Type; 0] = [];
+        self.append_op_no_result(
+            function::call(codegen.op_builder(), location, func_name, &call_args, &return_types)?
+                .into(),
+        )
+    }
+
+    /// Convert a dimension [Attribute] from an [ArrayType] into a [`Value`] of index type,
+    /// generating the necessary IR if the attribute is a symbol reference to a struct param.
+    pub fn array_dim_attr_to_idx_val(
+        &mut self,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+        location: Location<'ctx>,
+        dim: Attribute<'ctx>,
+    ) -> Result<Value<'ctx, 'val>> {
+        if IntegerAttribute::try_from(dim).is_ok() {
+            if !dim.r#type().is_index() {
+                anyhow::bail!(
+                    "expected index type for array dimension attribute, got '{}'",
+                    dim.r#type()
+                );
+            }
+            return self.append_op_unnamed_result(arith::constant(codegen.context, dim, location));
+        }
+        if let Ok(sym_ref) = FlatSymbolRefAttribute::try_from(dim) {
+            return self.append_op_unnamed_result(poly::read_const(
+                location,
+                sym_ref.value(),
+                codegen.index_type(),
+            ));
+        }
+        unreachable!("Unhandled attribute in array dimensions {}", dim)
+    }
+
+    /// Creates a loop nest from a list of array dimension attributes.
+    ///
+    /// The body of the inner-most loop is defined by the given closure, which accepts a list of
+    /// values representing the current value of each loop's induction variable.
+    pub fn gen_loop_nest_from_attrs(
+        &mut self,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+        location: Location<'ctx>,
+        dims: &[Attribute<'ctx>],
+        body: impl FnOnce(&mut Self, &[Value<'ctx, 'val>]) -> Result<()>,
+    ) -> Result<()>
+    where
+        'val: 'blk,
+    {
+        // Create values from the dimensions
+        let dim_values = dims
+            .iter()
+            .map(|dim| self.array_dim_attr_to_idx_val(codegen, location, *dim))
+            .collect::<Result<Vec<_>>>()?;
+
+        self.gen_loop_nest(codegen, location, &dim_values, body)
+    }
+
+    /// Creates a loop nest from a list of array dimension values.
+    ///
+    /// The body of the inner-most loop is defined by the given closure, which accepts a list of
+    /// values representing the current value of each loop's induction variable.
+    pub fn gen_loop_nest(
+        &mut self,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+        location: Location<'ctx>,
+        dim_values: &[Value<'ctx, 'val>],
+        body: impl FnOnce(&mut Self, &[Value<'ctx, 'val>]) -> Result<()>,
+    ) -> Result<()>
+    where
+        'val: 'blk,
+    {
+        let zero = self.append_op_unnamed_result(codegen.new_index_const_op(0, location))?;
+        let one = self.append_op_unnamed_result(codegen.new_index_const_op(1, location))?;
+
+        let loop_block_args = [(codegen.index_type(), location)];
+        let top_block = *self.block_ctx.top_block();
+        let mut loop_vars: Vec<Value> = vec![];
+        // Create the loop nest
+        let mut block: Option<BlockRef<'_, '_>> = None;
+        for dim in dim_values {
+            let op = scf::r#for(zero, *dim, one, region_with_block(&loop_block_args), location);
+            let loop_op = match &block {
+                Some(block_ref) => block_ref.append_operation(op),
+                None => self.append_op(op),
+            };
+            block = Some(
+                loop_op
+                    .region(0)?
+                    .first_block()
+                    .ok_or_else(|| anyhow::anyhow!("region is missing first block"))?,
+            );
+            // Accumulate the induction variables for later giving all of them to the callback.
+            loop_vars.push(block.unwrap().argument(0)?.into());
+        }
+
+        // Unwrap the block after creating the loop nest.
+        let mut block = block.ok_or_else(|| anyhow::anyhow!("no loops created"))?;
+        // Push the block of the inner-most loop s.t. the user can use `self` and ops will get added
+        // to the right block.
+        self.block_ctx.push(block);
+        body(self, &loop_vars)?;
+        self.block_ctx.pop();
+
+        // Traverse the stack of blocks until we reach the block where we inserted the whole nest.
+        // For each block traversed this way add the scf terminator op.
+        while block != top_block {
+            block.append_operation(scf::r#yield(&[], location));
+            block = block
+                .parent_operation()
+                .and_then(|op| op.block())
+                .ok_or_else(|| anyhow::anyhow!("detached block while creating loop nest"))?;
+        }
+
+        Ok(())
+    }
+
+    /// Implementation for [Expression::UniformArray] after conversion of dimension
+    /// expression. Useful because dimension generation differs between function
+    /// and template contexts due to template parameters, but the actual array generation
+    /// is otherwise the same.
+    pub fn generate_uniform_array(
+        &mut self,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+        location: Location<'ctx>,
+        value: Value<'ctx, 'val>,
+        dimension: &ArrayDimension<'ctx, 'val>,
+    ) -> Result<Value<'ctx, 'val>> {
+        // Ensure all symbols are of index type
+        let dimension = &self.transform_symbols_to_index(location, dimension)?;
+        let const_dim = IntegerAttribute::try_from(dimension);
+        if let Ok(subarr_ty) = ArrayType::try_from(value.r#type()) {
+            let arr_ty = dimension.new_array_type(&subarr_ty.into());
+            let mut symbols_sto = vec![];
+            // The array.new constructor doesn't accept arrays as initializer values,
+            // so we instead create the array empty and use array.insert to insert values.
+            let ctor = if let Some(symbols) = dimension.value_range()? {
+                symbols_sto.push(symbols);
+                ArrayCtor::MapDimSlice(&symbols_sto, &[0])
+            } else {
+                ArrayCtor::Empty
+            };
+            let new_arr =
+                self.append_op_unnamed_result(codegen.new_array_new_op(location, arr_ty, ctor))?;
+            if let Ok(const_dim) = const_dim {
+                for idx in 0..const_dim.value() {
+                    let idx_val =
+                        self.append_op_unnamed_result(codegen.new_index_const_op(idx, location))?;
+                    self.append_op_no_result(array::insert(location, new_arr, &[idx_val], value))?;
+                }
+            } else {
+                let dim = self.append_op_unnamed_result(codegen.new_index_const_op(0, location))?;
+                let array_len =
+                    self.append_op_unnamed_result(array::len(location, new_arr, dim))?;
+                self.gen_normalized_scf_for(codegen, location, array_len, |b| {
+                    let induction_var = b.argument(0)?;
+                    b.append_operation(array::insert(
+                        location,
+                        new_arr,
+                        &[induction_var.into()],
+                        value,
+                    ));
+                    b.append_operation(scf::r#yield(&[], location));
+                    Ok(())
+                })?;
+            };
+            // Output value is still the newly created array
+            Ok(new_arr)
+        } else {
+            let arr_ty = dimension.new_array_type(&value.r#type());
+            if let Ok(const_dim) = const_dim {
+                let values = vec![value; usize::try_from(const_dim.value())?];
+                self.append_op_unnamed_result(codegen.new_array_new_op(
+                    location,
+                    arr_ty,
+                    ArrayCtor::Values(&values),
+                ))
+            } else {
+                let mut v_sto = vec![];
+                let ctor = if let Ok(Some(v)) = dimension.value_range() {
+                    v_sto.push(v);
+                    ArrayCtor::MapDimSlice(&v_sto, &[0])
+                } else {
+                    ArrayCtor::Empty
+                };
+                let array_ref = self
+                    .append_op_unnamed_result(codegen.new_array_new_op(location, arr_ty, ctor))?;
+                let dim = self.append_op_unnamed_result(codegen.new_index_const_op(0, location))?;
+                let array_len =
+                    self.append_op_unnamed_result(array::len(location, array_ref, dim))?;
+                self.gen_normalized_scf_for(codegen, location, array_len, |b| {
+                    let induction_var = b.argument(0)?;
+                    b.append_operation(array::write(
+                        location,
+                        array_ref,
+                        &[induction_var.into()],
+                        value,
+                    ));
+                    b.append_operation(scf::r#yield(&[], location));
+                    Ok(())
+                })?;
+                Ok(array_ref)
+            }
+        }
+    }
+
+    /// Generate an `scf.while` op based on the given [NestedBlockInfo] and update the
+    /// block context with the results of the `scf.while` op mapped to the given names.
+    pub fn gen_scf_while(
+        &mut self,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+        location: Location<'ctx>,
+        condition: Value<'ctx, 'val>,
+        loop_cond_info: NestedBlockInfo<'ctx, 'blk, 'val>,
+        loop_body_info: NestedBlockInfo<'ctx, 'blk, 'val>,
+        loop_bounds: Option<LoopBoundsAttribute<'ctx>>,
+    ) -> Result<bool> {
+        // ASSERT: loop condition was a single Expression so there are no variable overwrites.
+        assert!(loop_cond_info.var_overwrites.is_empty());
+
+        // Split `loop_body_info.var_overwrites` into ordered lists of names and values. The
+        // ordering of names here defines the ordering of the loop-carried variables for the
+        // `scf.while` op and thus the ordering of operands for `scf.yield` and `scf.condition`.
+        let mut overwrites_sorted: Vec<_> = loop_body_info.var_overwrites.into_iter().collect();
+        if codegen.config.stabilize {
+            // Sort by circom variable names to ensure a stable order.
+            overwrites_sorted.sort_by(|(name_a, _), (name_b, _)| name_a.cmp(name_b));
+        }
+        let (loop_carried_var_names, body_yield_values): (Vec<_>, Vec<_>) =
+            overwrites_sorted.into_iter().unzip();
+
+        // Append the loop body block with an `scf.yield`
+        Self::append_multi_operand_yield_to_block(
+            codegen,
+            loop_body_info.block,
+            &body_yield_values,
+            &loop_carried_var_names,
+            location,
+        )?;
+
+        // Use `loop_carried_var_names` and the current block context to build a list of types of
+        // the loop-carried variables, add BlockArguments of those types in both blocks, and
+        // replace uses of the overwritten variables in both blocks with references to the new
+        // BlockArguments Values.
+        let mut loop_carried_types = Vec::new();
+        // Additionally, track if `VAR_NAME_HAD_RETURN` is among the loop-carried variables
+        // (indicating there was a return somewhere within the loop body) to later update the
+        // loop condition to ensure iteration stops when a return occurs.
+        let mut return_flag: Option<Value> = None;
+        for name in loop_carried_var_names.iter() {
+            let orig_val = self.block_ctx.get_named_value(name).unwrap();
+            loop_carried_types.push(orig_val.r#type());
+            replace_uses_with_new_block_argument(loop_body_info.block, orig_val, location);
+            let f = replace_uses_with_new_block_argument(loop_cond_info.block, orig_val, location);
+            if name == VAR_NAME_HAD_RETURN {
+                return_flag = Some(f);
+            }
+        }
+
+        // In the loop condition block, ensure the condition has bool type and generate an
+        // `scf.condition` op with the condition value and the loop-carried variables.
+        {
+            let mut condition = self.cast_to_bool_if_needed(codegen, location, condition)?;
+            // If there is a return within the loop, add prefix "!<VAR_NAME_HAD_RETURN> &&" to the
+            // loop condition to ensure the loop terminates when the return occurs.
+            if let Some(flag) = return_flag {
+                let not_return_flag = single_result_as_value(
+                    loop_cond_info.block.append_operation(bool::r#not(location, flag)?.into()),
+                )?;
+                condition =
+                    single_result_as_value(loop_cond_info.block.append_operation(
+                        bool::and(location, not_return_flag, condition)?.into(),
+                    ))?;
+            }
+            // Pass the block arguments as the initial values to the condition op.
+            let block_arg_values = (0..loop_cond_info.block.argument_count())
+                .map(|i| loop_cond_info.block.argument(i).map_err(Into::into).map(Value::from))
+                .collect::<Result<Vec<Value>>>()?;
+            no_results(loop_cond_info.block.append_operation(scf::condition(
+                condition,
+                &block_arg_values,
+                location,
+            )))?;
+        }
+
+        // Create list of initial values of the loop-carried variables (i.e. the overwritten
+        // variables, in the order of `loop_carried_var_names`) to pass into the `scf.while`.
+        let initial_values = loop_carried_var_names
+            .iter()
+            .map(|name| self.block_ctx.get_named_value(name).cloned())
+            .collect::<Result<Vec<_>>>()?;
+
+        // Generate the `scf.while` op for the circom `While` statement, adding `loopbounds`
+        // attribute if given, and append it to the current block.
+        let mut scf_op = scf::r#while(
+            &initial_values,
+            &loop_carried_types,
+            loop_cond_info.region,
+            loop_body_info.region,
+            location,
+        );
+        if let Some(loop_bounds) = loop_bounds {
+            scf_op.set_attribute("llzk.loopbounds", loop_bounds.into());
+        }
+        let scf_op = self.append_op(scf_op);
+
+        // Update the current block context with results from the `scf.while` op.
+        loop_carried_var_names
+            .into_iter()
+            .zip(scf_op.results())
+            .try_for_each(|(name, result)| self.block_ctx.set_named_value(name, result.into()))?;
+
+        Ok(return_flag.is_some())
+    }
+
+    /// Cast all symbols passed to affine_maps into index types, which is required
+    /// for affine_map usage.
+    #[inline]
+    fn transform_symbols_to_index(
+        &mut self,
+        location: Location<'ctx>,
+        dimension: &ArrayDimension<'ctx, 'val>,
+    ) -> Result<ArrayDimension<'ctx, 'val>> {
+        dimension.transform(|val| self.cast_to_index_if_needed(location, val))
+    }
+
+    /// Handle a [Statement::Declaration] by generating a nondet felt value with the given
+    /// dimensions and declaring it in the current block context.
+    pub fn gen_declaration(
+        &mut self,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+        meta: &Meta,
+        name: &str,
+        dimensions: &[Expression],
+    ) -> Result<()> {
+        if self.block_ctx.is_name_present(name) {
+            return Ok(());
+        }
+        // If generating from VCP, there are cases where the `sugar_cleaner` added new
+        // declarations that only have `MemoryKnowledge` but not `dimensions` in the AST. So
+        // check `MemoryKnowledge` first (if not generating from VCP, this will always be
+        // empty so `dimensions` will be used).
+        let mk = meta.get_memory_knowledge();
+        let dims = if mk.has_concrete_dimensions() {
+            (mk.get_concrete_dimensions(), codegen).try_into()?
+        } else {
+            self.get_dim_exprs(codegen, dimensions)?
+        };
+        if codegen.config.verbose {
+            println!("Declaring variable '{name}' with dimensions {dims:?}");
+        }
+        let op = dims.new_nondet_felt_of_dimensions(codegen, meta)?;
+        self.block_ctx.declare_name_ensure_not_present(name, op)
+    }
+}
+
+impl<'ctx, 'blk, 'val> DimExprConverter<'ctx, 'val> for BlockGenContext<'ctx, 'blk, 'val>
+where
+    'ctx: 'blk,
+    'blk: 'val,
+{
+    fn get_dim_expr(
+        &self,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+        expr: &Expression,
+    ) -> Result<ArrayDimensionResult<'ctx, 'val>> {
+        // First try to compute statically, falling back to literal computation if all values are
+        // not compile-time constants or if the final result does not properly convert to i64.
+        if let Some(integer) = shared::try_compute_as_i64(expr, codegen.prime())? {
+            ArrayDimensionResult::new(codegen.index_attr(integer).into(), &[])
+        } else {
+            #[allow(unused_variables)] // TODO: TEMP
+            match expr {
+                Expression::Number(_, _) => {
+                    unreachable!("handled by try_compute_as_i64")
+                }
+                Expression::Variable { meta, name, access } => match access.as_slice() {
+                    [] => {
+                        if let Ok(v) = self.block_ctx.get_named_value(name) {
+                            let id_map = codegen.identity_affine_map_attr()?;
+                            ArrayDimensionResult::new(id_map, &[*v])
+                        } else {
+                            todo!("Handle Variable expression in dimension for non-integer, non-template parameter attributes in BlockGenContext")
+                        }
+                    }
+                    a => {
+                        todo!("Handle Variable expression with accesses in BlockGenContext")
+                    }
+                },
+                Expression::InfixOp { meta, lhe, infix_op, rhe } => {
+                    todo!("Handle Infix expression in dimension for non-integer attributes")
+                }
+                Expression::PrefixOp { meta, prefix_op, rhe } => {
+                    todo!("Handle Prefix expression in dimension for non-integer attributes")
+                }
+                Expression::InlineSwitchOp { meta, cond, if_true, if_false } => {
+                    todo!(
+                        "Handle InlineSwitchOp expression in dimension for non-integer attributes"
+                    )
+                }
+                Expression::Call { meta, id, args } => {
+                    todo!("Handle Call expression in dimension")
+                }
+                // The remaining cases do not produce a scalar value.
+                // i.e. ParallelOp, ArrayInLine, UniformArray, BusCall, AnonymousComp, Tuple
+                // Give the same error that the circom type checker gives. The type checker ran
+                // earlier so this should technically be unreachable.
+                _ => {
+                    unreachable!("Array indexes and lengths must be single arithmetic expressions")
+                }
+            }
+        }
+    }
+}
+
+/// A trait to generate LLZK IR to an arbitrary LLZK block.
+///
+/// 'ctx: lifetime of the `LlzkContext` and generated `Module`
+/// 'blk: lifetime of the generated `Block` instances within functions
+/// 'val: lifetime of the generated `Value` or `Operation` instances within blocks
+pub trait GenerateLLZKInAnyBlock<'ctx, 'blk, 'val>
+where
+    'ctx: 'blk,
+    'blk: 'val,
+{
+    /// Generates LLZK IR in the given block context.
+    fn gen_llzk_in_block<'info>(
+        &self,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+        block_gen: &mut BlockGenContext<'ctx, 'blk, 'val>,
+        info: InfoProviders<'info>,
+    ) -> Result<Value<'ctx, 'val>>;
+}
+
+/// This handles translation of circom [Expression] nodes within functions and templates (i.e.
+/// [crate::template::GenerateLLZKInTemplate] implementation for [Expression] directly calls this)
+/// and code generation to LLZK `poly.expr` blocks. Therefore, it must handle things that are not
+/// legal in functions such as [Expression::BusCall] and [Access::ComponentAccess] but are legal in
+/// other contexts such as circom templates. The `type_analysis_user::analyse_project()` pass that
+/// runs before the LLZK translation pass ensures that these illegal constructs do not appear in
+/// pure functions.
+impl<'ctx, 'blk, 'val> GenerateLLZKInAnyBlock<'ctx, 'blk, 'val> for Expression
+where
+    'ctx: 'blk,
+    'blk: 'val,
+{
+    fn gen_llzk_in_block<'info>(
+        &self,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+        block_gen: &mut BlockGenContext<'ctx, 'blk, 'val>,
+        info: InfoProviders<'info>,
+    ) -> Result<Value<'ctx, 'val>> {
+        match self {
+            Expression::Number(meta, big_int) => {
+                // Convert the BigInt to an LLZK `felt.const` op. The user of the Expression is
+                // responsible for converting this `felt.type` value to another type if needed.
+                block_gen.append_op_unnamed_result(
+                    codegen.new_felt_const_op(big_int, codegen.location_from_meta(meta))?,
+                )
+            }
+            Expression::Variable { meta, name, access } => {
+                let lvalue = Lvalue::new(
+                    name,
+                    if info.subcmp_info.is_subcmp(name) { Root::Signal } else { Root::Var },
+                    access,
+                );
+                lvalue.get_value(
+                    codegen,
+                    block_gen,
+                    info.subcmp_info,
+                    codegen.location_from_meta(meta),
+                    None,
+                )
+            }
+            Expression::InfixOp { meta, lhe, infix_op, rhe } => {
+                let lhs = lhe.gen_llzk_in_block(codegen, block_gen, info)?;
+                let rhs = rhe.gen_llzk_in_block(codegen, block_gen, info)?;
+                block_gen.gen_infix_op(codegen, meta, infix_op, lhs, rhs)
+            }
+            Expression::PrefixOp { meta, prefix_op, rhe } => {
+                let rhs = rhe.gen_llzk_in_block(codegen, block_gen, info)?;
+                block_gen.gen_prefix_op(codegen, meta, prefix_op, rhs)
+            }
+            Expression::InlineSwitchOp { meta, cond, if_true, if_false } => {
+                let location = codegen.location_from_meta(meta);
+                // Ensure the condition is a bool type.
+                let cond_val = cond.gen_llzk_in_block(codegen, block_gen, info)?;
+                let condition = block_gen.cast_to_bool_if_needed(codegen, location, cond_val)?;
+
+                // Then arm: generate in a nested block so `gen_llzk_in_block` can use `block_gen`
+                let then_region = Region::new();
+                let then_block = then_region.append_block(Block::new(&[]));
+                block_gen.block_ctx.push(then_block);
+                let then_value = if_true.gen_llzk_in_block(codegen, block_gen, info)?;
+                block_gen.block_ctx.pop();
+                no_results(then_block.append_operation(scf::r#yield(&[then_value], location)))?;
+
+                // Else arm
+                let else_region = Region::new();
+                let else_block = else_region.append_block(Block::new(&[]));
+                block_gen.block_ctx.push(else_block);
+                let else_value = if_false.gen_llzk_in_block(codegen, block_gen, info)?;
+                block_gen.block_ctx.pop();
+                no_results(else_block.append_operation(scf::r#yield(&[else_value], location)))?;
+
+                assert_eq!(
+                    then_value.r#type(),
+                    else_value.r#type(),
+                    "then and else branches of scf.if must have matching value types"
+                );
+                block_gen.append_op_unnamed_result(scf::r#if(
+                    condition,
+                    &[then_value.r#type()],
+                    then_region,
+                    else_region,
+                    location,
+                ))
+            }
+            Expression::ArrayInLine { meta, values } => {
+                let location = codegen.location_from_meta(meta);
+                // Multi-dimensional arrays are made up of array values as their elements
+                let values = values
+                    .iter()
+                    .map(|val_expr| val_expr.gen_llzk_in_block(codegen, block_gen, info))
+                    .collect::<Result<Vec<Value>>>()?;
+                let value_ty =
+                    values.first().expect("Array must have at least one element").r#type();
+                assert!(
+                    values.iter().all(|&v| v.r#type() == value_ty),
+                    "All array elements must have the same type"
+                );
+                if let Ok(subarr_ty) = ArrayType::try_from(value_ty) {
+                    // For subarrays, we need to create a new array then insert the values
+                    let dim = codegen.index_attr(i64::try_from(values.len())?);
+                    let arr_ty = new_array_type(dim.into(), &subarr_ty);
+                    let new_arr = block_gen.append_op_unnamed_result(codegen.new_array_new_op(
+                        location,
+                        arr_ty,
+                        ArrayCtor::Empty,
+                    ))?;
+                    for (idx, val) in values.iter().enumerate() {
+                        let idx_val = block_gen.append_op_unnamed_result(
+                            codegen.new_index_const_op(i64::try_from(idx)?, location),
+                        )?;
+                        block_gen.append_op_no_result(array::insert(
+                            location,
+                            new_arr,
+                            &[idx_val],
+                            *val,
+                        ))?;
+                    }
+
+                    // Output value is still the newly created array
+                    Ok(new_arr)
+                } else {
+                    let dim = codegen.index_attr(i64::try_from(values.len())?);
+                    let arr_ty = ArrayType::new(value_ty.into(), &[dim.into()]);
+                    block_gen.append_op_unnamed_result(codegen.new_array_new_op(
+                        location,
+                        arr_ty,
+                        ArrayCtor::Values(&values),
+                    ))
+                }
+            }
+            Expression::UniformArray { meta, value, dimension } => {
+                let location = codegen.location_from_meta(meta);
+                // Multi-dimensional arrays are made up of array values as their elements
+                let value = value.gen_llzk_in_block(codegen, block_gen, info)?;
+                let dim = block_gen
+                    .get_dim_expr(codegen, dimension)
+                    .and_then(ArrayDimension::try_from)?;
+                block_gen.generate_uniform_array(codegen, location, value, &dim)
+            }
+            Expression::Call { meta, id, args } => {
+                let location = codegen.location_from_meta(meta);
+                let target_function_data = codegen.program.get_function_data(id);
+                // Visit each argument and collect the resulting LLZK Values for both functions.
+                let param_types = target_function_data.get_type_of_params(codegen);
+                assert_eq!(param_types.len(), args.len(), "Argument-parameter count mismatch");
+                let call_operands = args
+                    .iter()
+                    .zip(param_types)
+                    .map(|(arg, expected_type)| {
+                        let operand_val = arg.gen_llzk_in_block(codegen, block_gen, info)?;
+                        block_gen.cast_to_expected_type_if_needed(
+                            codegen,
+                            location,
+                            operand_val,
+                            expected_type,
+                        )
+                    })
+                    .collect::<Result<Vec<Value>>>()?;
+                // Create the CallOp in each function using the collected args.
+                block_gen.append_op_unnamed_result(
+                    function::call(
+                        codegen.op_builder(),
+                        location,
+                        codegen.flat_sym(id),
+                        &call_operands,
+                        &[target_function_data.get_type_of_return(codegen)],
+                    )?
+                    .into(),
+                )
+            }
+            #[allow(unused_variables)] // TODO: TEMP
+            Expression::BusCall { meta, id, args } => {
+                todo!("Handle BusCall expression")
+            }
+            Expression::AnonymousComp { .. } => unreachable!("removed by 'syntax_sugar_remover'"),
+            Expression::Tuple { .. } => unreachable!("removed by 'syntax_sugar_remover'"),
+            Expression::ParallelOp { .. } => {
+                unreachable!("handled in templates, illegal in pure functions")
+            }
+        }
+    }
 }

--- a/llzk_backend/src/gen_context.rs
+++ b/llzk_backend/src/gen_context.rs
@@ -55,6 +55,7 @@ use llzk::prelude::PodType;
 use llzk::prelude::Region;
 use llzk::prelude::RegionLike as _;
 use llzk::prelude::StructType;
+use llzk::prelude::TemplateExprOp;
 use llzk::prelude::Type;
 use llzk::prelude::Value;
 use llzk::prelude::ValueLike as _;
@@ -65,12 +66,15 @@ use melior::ir::AttributeLike as _;
 use melior::ir::TypeLike as _;
 use num_bigint_dig::BigInt;
 use num_traits::Zero;
+use program_structure::ast::Access;
+use program_structure::ast::AssignOp;
 use program_structure::ast::Expression;
 use program_structure::ast::ExpressionInfixOpcode;
 use program_structure::ast::ExpressionPrefixOpcode;
 use program_structure::ast::Meta;
 use program_structure::error_code::ReportCode;
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::convert::TryFrom;
 use std::convert::TryInto;
 use std::iter::zip;
@@ -583,6 +587,8 @@ where
 {
     /// Nested block context within the root block.
     pub(crate) block_ctx: BlockContextStack<'ctx, 'blk, 'val>,
+    /// Names of `poly.param` and `poly.expr` defs visible in the current context.
+    poly_template_binding_names: HashSet<String>,
 }
 
 impl<'ctx, 'blk, 'val> BlockGenContext<'ctx, 'blk, 'val>
@@ -590,9 +596,37 @@ where
     'ctx: 'blk,
     'blk: 'val,
 {
-    /// Create a new [BlockGenContext] with the given block context stack.
-    pub fn new(block_ctx: BlockContextStack<'ctx, 'blk, 'val>) -> Self {
-        Self { block_ctx }
+    /// Create a new [BlockGenContext] with the given block context stack and set of visible
+    /// `poly.param` and `poly.expr` names.
+    pub fn new<'n>(
+        block_ctx: BlockContextStack<'ctx, 'blk, 'val>,
+        poly_template_binding_names: impl IntoIterator<Item = &'n String>,
+    ) -> Self {
+        Self {
+            block_ctx,
+            poly_template_binding_names: poly_template_binding_names.into_iter().cloned().collect(),
+        }
+    }
+
+    /// For each name in `self.poly_template_binding_names`, generate and append a `read_const`
+    /// operation and store the resulting Value in the block context under that name. This ensures
+    /// that template parameters are available as SSA Values in the block context.
+    pub fn with_poly_template_binding_locals(
+        mut self,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+        location: Location<'ctx>,
+    ) -> Result<Self> {
+        let mut sorted: Vec<_> = self.poly_template_binding_names.iter().collect();
+        if codegen.config.stabilize {
+            sorted.sort();
+        }
+        for name in sorted {
+            self.block_ctx.declare_name_ensure_not_present(
+                name,
+                poly::read_const(location, name, codegen.felt_type().into()),
+            )?;
+        }
+        Ok(self)
     }
 
     /// Append an operation.
@@ -621,21 +655,6 @@ where
         let v = self.append_op_unnamed_result(op)?;
         self.block_ctx.set_named_value(name, v)?;
         Ok(v)
-    }
-
-    /// Generate and append a `read_const` operation for the given template binding name and store
-    /// the mapping in the block context so all references to that binding name can reuse the Value.
-    #[inline]
-    pub fn append_initial_read_const(
-        &mut self,
-        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        location: Location<'ctx>,
-        name: &str,
-    ) -> Result<()> {
-        self.block_ctx.declare_name_ensure_not_present(
-            name,
-            poly::read_const(location, name, codegen.felt_type().into()),
-        )
     }
 
     /// Insert cast operations as needed to make `lhs` and `rhs` have compatible types for equality
@@ -745,6 +764,18 @@ where
         self.append_op_unnamed_result(array_get_op)
     }
 
+    /// Cast `val` to bool and emit a `bool.assert` op.
+    pub fn append_assert(
+        &mut self,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+        location: Location<'ctx>,
+        val: Value<'ctx, 'val>,
+    ) -> Result<()> {
+        let cond = self.cast_to_bool_if_needed(codegen, location, val)?;
+        let msg = Some("assertion failed");
+        self.append_op_no_result(bool::assert(location, cond, msg)?.into())
+    }
+
     /// Create a cast to felt (field element) type.
     #[inline]
     pub fn cast_to_felt(
@@ -832,6 +863,9 @@ where
         } else if is_bool(expected) {
             self.cast_to_bool_if_needed(codegen, location, val)
         } else {
+            // TODO: Must support array types by adding a unifiable cast.
+            // Alternatively, add LLZK type unification check to `llzk-rs` API and use that above
+            // instead of full equality.
             anyhow::bail!(
                 "Unsupported 'expected' type '{expected}' with value type {}",
                 val.r#type()
@@ -944,6 +978,48 @@ where
             rvalue.r#type(),
             existing.r#type()
         )
+    }
+
+    /// Handle [program_structure::ast::Statement::Substitution] when the operator is not a signal
+    /// operator. Note: Do not use directly from `GenerateLLZKInTemplate`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn handle_substitution_stmt_nonsignal<'info>(
+        &mut self,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+        info: InfoProviders<'info>,
+        meta: &Meta,
+        var: &String,
+        access: &[Access],
+        op: &AssignOp,
+        rhe: &Expression,
+    ) -> Result<()>
+    where
+        'val: 'blk,
+    {
+        assert!(!op.is_signal_operator()); // pre-condition
+
+        let rvalue = rhe.gen_llzk_in_block(codegen, self, info)?;
+        if access.is_empty() {
+            self.handle_simple_assignment(codegen, meta, var, rvalue)
+        } else {
+            let location = codegen.location_from_meta(meta);
+            let indices = &access
+                .iter()
+                .map(|access| {
+                    let idx = match access {
+                        Access::ArrayAccess(index_expr) => {
+                            index_expr.gen_llzk_in_block(codegen, self, info)
+                        }
+                        Access::ComponentAccess(_) => {
+                            todo!("Handle Substitution component access in BlockGenContext")
+                        }
+                    }?;
+                    self.cast_to_index_if_needed(location, idx)
+                })
+                .collect::<Result<Vec<Value<'_, '_>>>>()?;
+            let arr_ref = *self.block_ctx.get_named_value(var)?;
+            self.append_array_write(codegen, arr_ref, indices, location, rvalue, Some(var))
+        }
     }
 
     /// Creates LLZK ops for array indexing from the collection of elements.
@@ -1319,7 +1395,7 @@ where
     /// Generate one region for either the then-arm or else-arm of a simple scf.if operation.
     /// Used by [Self::generate_simple_scf_if].
     /// The `value_gen` function is called to generate the value to be yielded from the arm.
-    fn generate_simple_scf_if_arm<F>(
+    pub fn generate_simple_scf_if_arm<F>(
         &mut self,
         location: Location<'ctx>,
         value_gen: F,
@@ -1823,8 +1899,8 @@ where
         dimension.transform(|val| self.cast_to_index_if_needed(location, val))
     }
 
-    /// Handle a [Statement::Declaration] by generating a nondet felt value with the given
-    /// dimensions and declaring it in the current block context.
+    /// Handle a [program_structure::ast::Statement::Declaration] by generating a nondet felt value
+    /// with the given dimensions and declaring it in the current block context.
     pub fn gen_declaration(
         &mut self,
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
@@ -1858,6 +1934,10 @@ where
     'ctx: 'blk,
     'blk: 'val,
 {
+    fn callback_store_poly_expr(&self, name: String, op: TemplateExprOp<'ctx>) {
+        todo!("BlockGenContext::store_template_poly_expr: {name} -> {op:?}");
+    }
+
     fn get_dim_expr(
         &self,
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
@@ -1875,9 +1955,10 @@ where
                 }
                 Expression::Variable { meta, name, access } => match access.as_slice() {
                     [] => {
-                        if let Ok(v) = self.block_ctx.get_named_value(name) {
-                            let id_map = codegen.identity_affine_map_attr()?;
-                            ArrayDimensionResult::new(id_map, &[*v])
+                        if self.poly_template_binding_names.contains(name) {
+                            ArrayDimensionResult::new(codegen.flat_sym(name).into(), &[])
+                        } else if let Ok(v) = self.block_ctx.get_named_value(name) {
+                            ArrayDimensionResult::new(codegen.identity_affine_map_attr()?, &[*v])
                         } else {
                             todo!("Handle Variable expression in dimension for non-integer, non-template parameter attributes in BlockGenContext")
                         }

--- a/llzk_backend/src/lvalue.rs
+++ b/llzk_backend/src/lvalue.rs
@@ -1,7 +1,7 @@
 //! Types for handling location values (a.k.a. lvalues).
 
-use crate::function::FunctionContext;
 use crate::function::InfoProviders;
+use crate::gen_context::BlockGenContext;
 use crate::program_ext::ProgramLike;
 use crate::shared;
 use crate::shared::LlzkCodegen;
@@ -107,12 +107,12 @@ impl<'ast> Lvalue<'ast> {
     fn get_root_signal<'ctx, 'val>(
         &self,
         var: &str,
-        fc: &mut FunctionContext<'ctx, '_, '_, 'val>,
+        block_gen: &mut BlockGenContext<'ctx, '_, 'val>,
     ) -> Result<Value<'ctx, 'val>> {
         // Both compute and constrain functions should have the `var` defined:
         // compute from an existing assignment, or constrain from pre-generation
         // of the `readm` in `gen_template_llzk`.
-        fc.block_ctx.get_named_value(var).copied()
+        block_gen.block_ctx.get_named_value(var).copied()
     }
 
     /// Handle [Lvalue::Root] case of [`Lvalue::get_value`] other than
@@ -120,9 +120,9 @@ impl<'ast> Lvalue<'ast> {
     fn get_root_value<'ctx, 'val>(
         &self,
         var: &str,
-        fc: &mut FunctionContext<'ctx, '_, '_, 'val>,
+        block_gen: &mut BlockGenContext<'ctx, '_, 'val>,
     ) -> Result<Value<'ctx, 'val>> {
-        fc.block_ctx.get_named_value(var).copied()
+        block_gen.block_ctx.get_named_value(var).copied()
     }
 
     /// Handle [Lvalue::Array] case of [`Lvalue::get_value`].
@@ -131,12 +131,12 @@ impl<'ast> Lvalue<'ast> {
         indices: &[&Expression],
         prev: Value<'ctx, 'val>,
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        fc: &mut FunctionContext<'ctx, '_, '_, 'val>,
+        block_gen: &mut BlockGenContext<'ctx, '_, 'val>,
         location: Location<'ctx>,
         info: InfoProviders<'_>,
     ) -> Result<Value<'ctx, 'val>> {
-        let indices = fc.gen_index_ops(indices.iter().copied(), codegen, location, info)?;
-        fc.append_array_read(prev, &indices, location, None)
+        let indices = block_gen.gen_index_ops(indices.iter().copied(), codegen, location, info)?;
+        block_gen.append_array_read(prev, &indices, location, None)
     }
 
     /// Handle [Lvalue::Subcmp]  in [`Lvalue::get_value`] when the signal is an output of the
@@ -146,12 +146,12 @@ impl<'ast> Lvalue<'ast> {
         signal_name: &str,
         subcmp_value: Value<'ctx, 'val>,
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        fc: &mut FunctionContext<'ctx, '_, '_, 'val>,
+        block_gen: &mut BlockGenContext<'ctx, '_, 'val>,
         location: Location<'ctx>,
     ) -> Result<Value<'ctx, 'val>> {
         let comp_value = type_switch! { let ty = subcmp_value.r#type();
             PodType => {
-                fc.append_op_unnamed_result(pod::read(
+                block_gen.append_op_unnamed_result(pod::read(
                     location,
                     subcmp_value,
                     codegen.flat_sym(COMP),
@@ -170,7 +170,7 @@ impl<'ast> Lvalue<'ast> {
         let field_ty = codegen
             .get_output_signal_type(shared::get_name_tail(&comp_value_type)?, signal_name)?;
 
-        fc.append_op_unnamed_result(r#struct::readm(
+        block_gen.append_op_unnamed_result(r#struct::readm(
             codegen.op_builder(),
             location,
             field_ty,
@@ -186,10 +186,10 @@ impl<'ast> Lvalue<'ast> {
         signal_name: &str,
         subcmp_value: Value<'ctx, 'val>,
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        fc: &mut FunctionContext<'ctx, '_, '_, 'val>,
+        block_gen: &mut BlockGenContext<'ctx, '_, 'val>,
         location: Location<'ctx>,
     ) -> Result<Value<'ctx, 'val>> {
-        fc.append_op_unnamed_result(pod::read(
+        block_gen.append_op_unnamed_result(pod::read(
             location,
             subcmp_value,
             codegen.flat_sym(signal_name),
@@ -210,7 +210,7 @@ impl<'ast> Lvalue<'ast> {
     pub fn get_value<'ctx, 'val>(
         &self,
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        fc: &mut FunctionContext<'ctx, '_, '_, 'val>,
+        block_gen: &mut BlockGenContext<'ctx, '_, 'val>,
         subcmp_info: &dyn SubcmpInfo,
         location: Location<'ctx>,
         ov: Option<&dyn OverrideVar>,
@@ -226,16 +226,16 @@ impl<'ast> Lvalue<'ast> {
 
         match self {
             Lvalue::Root { var, op: Root::Signal } => {
-                self.get_root_signal(var_name!(ov, var, Root::Signal), fc)
+                self.get_root_signal(var_name!(ov, var, Root::Signal), block_gen)
             }
             Lvalue::Root { var, op: Root::Var } => {
-                self.get_root_value(var_name!(ov, var, Root::Var), fc)
+                self.get_root_value(var_name!(ov, var, Root::Var), block_gen)
             }
             Lvalue::Array { indices, prev } => self.get_array_value(
                 indices,
-                prev.get_value(codegen, fc, subcmp_info, location, ov)?,
+                prev.get_value(codegen, block_gen, subcmp_info, location, ov)?,
                 codegen,
-                fc,
+                block_gen,
                 location,
                 InfoProviders { subcmp_info, ..Default::default() },
             ),
@@ -265,12 +265,12 @@ impl<'ast> Lvalue<'ast> {
                 let ovii = OverrideIfInput { do_override: is_input };
 
                 let subcmp_value =
-                    prev.get_value(codegen, fc, subcmp_info, location, ov.or(Some(&ovii)))?;
+                    prev.get_value(codegen, block_gen, subcmp_info, location, ov.or(Some(&ovii)))?;
 
                 if is_input {
-                    self.get_subcmp_input(signal_name, subcmp_value, codegen, fc, location)
+                    self.get_subcmp_input(signal_name, subcmp_value, codegen, block_gen, location)
                 } else {
-                    self.get_subcmp_output(signal_name, subcmp_value, codegen, fc, location)
+                    self.get_subcmp_output(signal_name, subcmp_value, codegen, block_gen, location)
                 }
             }
         }

--- a/llzk_backend/src/module.rs
+++ b/llzk_backend/src/module.rs
@@ -882,13 +882,16 @@ pub trait GenerateLLZKInModule<'ctx, P: ProgramLike> {
 impl<'ctx, P: ProgramLike> GenerateLLZKInModule<'ctx, P> for P {
     fn gen_llzk<'ast>(&'ast self, codegen: &LlzkCodegen<'ast, 'ctx, P>) -> Result<()> {
         for f in self.get_functions(codegen.config.stabilize) {
+            codegen.set_current_body(f.get_body());
             gen_function_llzk(f, codegen)?;
         }
         // Collect declaration information for all templates first to avoid duplicating work.
         for t in self.get_templates(false) {
+            codegen.set_current_body(t.get_body());
             codegen.put_template_decl(t.get_name(), t.get_declarations(codegen)?);
         }
         for t in self.get_templates(codegen.config.stabilize) {
+            codegen.set_current_body(t.get_body());
             gen_template_llzk(t, codegen)?;
         }
         Ok(())

--- a/llzk_backend/src/module.rs
+++ b/llzk_backend/src/module.rs
@@ -6,6 +6,7 @@ use crate::function::GenerateLLZKInFunction as _;
 use crate::function_ext::FunctionLike;
 use crate::program_ext::ProgramLike;
 use crate::shared;
+use crate::shared::dim_expr_name;
 use crate::shared::map_array_inner_type;
 use crate::shared::map_name_to_arg_value;
 use crate::shared::ArrayDimensionResult;
@@ -55,15 +56,16 @@ use llzk::prelude::StringRef;
 use llzk::prelude::StructDefOpLike as _;
 use llzk::prelude::StructDefOpRef;
 use llzk::prelude::StructType;
+use llzk::prelude::TemplateExprOp;
 use llzk::prelude::TemplateOpLike;
 use llzk::prelude::Type;
-use llzk::prelude::Value;
 use program_structure::ast::AssignOp;
 use program_structure::ast::Expression;
 use program_structure::ast::Meta;
 use program_structure::ast::SignalType;
 use program_structure::ast::Statement;
 use program_structure::ast::VariableType;
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::convert::TryFrom;
@@ -121,7 +123,10 @@ pub struct DeclarationInfo<'ctx> {
     /// Map `component` name to its declaration information.
     subcmp_decls: HashMap<String, SubcmpDeclInfo<'ctx>>,
     /// The template params that may be used to instantiate array dimensions.
+    /// Note: this is set on construction and not modified.
     template_params: HashSet<String>,
+    /// Dimension expressions mapped to generated `poly.expr` op to be inserted into the template.
+    poly_exprs: RefCell<HashMap<String, TemplateExprOp<'ctx>>>,
 }
 
 impl<'ctx> DeclarationInfo<'ctx> {
@@ -256,6 +261,7 @@ impl<'ctx> DeclarationInfo<'ctx> {
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
         stmt: &Statement,
     ) -> Result<()> {
+        let _guard = codegen.trace_statement(stmt);
         match stmt {
             Statement::Block { stmts, .. } => {
                 // TemplateInstance (in concrete programs) has Declaration in Block (but only for
@@ -461,6 +467,14 @@ impl<'ctx, 'val> DimExprConverter<'ctx, 'val> for DeclarationInfo<'ctx>
 where
     'ctx: 'val,
 {
+    fn poly_template_binding_names(&self) -> impl IntoIterator<Item = &String> {
+        &self.template_params
+    }
+
+    fn callback_store_poly_expr(&self, name: String, op: TemplateExprOp<'ctx>) {
+        self.poly_exprs.borrow_mut().insert(name, op);
+    }
+
     fn get_dim_expr(
         &self,
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
@@ -471,42 +485,33 @@ where
         if let Some(integer) = shared::try_compute_as_i64(expr, codegen.prime())? {
             ArrayDimensionResult::new(codegen.index_attr(integer).into(), &[])
         } else {
-            #[allow(unused_variables)] // TODO: TEMP
             match expr {
                 Expression::Number(_, _) => {
                     unreachable!("handled by try_compute_as_i64")
                 }
-                Expression::Variable { meta, name, access } => match access.as_slice() {
-                    [] => {
-                        if self.template_params.contains(name) {
-                            let template_param_attr = codegen.flat_sym(name);
-                            ArrayDimensionResult::new(template_param_attr.into(), &[])
-                        } else if let Some(op) = self.decl_inits.get(name) {
-                            let id_map = codegen.identity_affine_map_attr()?;
-                            let value_range: Vec<Value<'ctx, 'val>> =
-                                op.results().map(Into::into).collect();
-                            ArrayDimensionResult::new(id_map, &value_range)
-                        } else {
-                            todo!("Handle Variable expression in dimension for non-integer, non-template parameter attributes in DeclarationInfo")
-                        }
+                Expression::Variable { name, access, .. } if access.is_empty() => {
+                    if self.template_params.contains(name) {
+                        ArrayDimensionResult::new(codegen.flat_sym(name).into(), &[])
+                    } else if self.poly_exprs.borrow().contains_key(name) {
+                        // This is a `Statement::Declaration` with `VariableType::Var` that was
+                        // previously encountered and converted into a `poly.expr`.
+                        ArrayDimensionResult::new(codegen.flat_sym(name).into(), &[])
+                    } else if self.decl_inits.contains_key(name) {
+                        // This is a `Statement::Declaration` with `VariableType::Var` that is
+                        // encountered for the first time and must have a `poly.expr` generated.
+                        self.gen_template_poly_expr(codegen, name.clone(), expr)
+                    } else {
+                        // TODO: this happens in `circom/tests/circom_doc_examples/04.circom`
+                        // and I think it's related to the "TODO" on `DeclarationInfo::visit`.
+                        todo!("not a known circom template parameter or var declaration: {}", name)
                     }
-                    a => {
-                        todo!("Handle Variable expression with accesses in DeclarationInfo")
-                    }
-                },
-                Expression::InfixOp { meta, lhe, infix_op, rhe } => {
-                    todo!("Handle Infix expression in dimension for non-integer attributes in DeclarationInfo")
                 }
-                Expression::PrefixOp { meta, prefix_op, rhe } => {
-                    todo!("Handle Prefix expression in dimension for non-integer attributes in DeclarationInfo")
-                }
-                Expression::InlineSwitchOp { meta, cond, if_true, if_false } => {
-                    todo!(
-                        "Handle InlineSwitchOp expression in dimension for non-integer attributes in DeclarationInfo"
-                    )
-                }
-                Expression::Call { meta, id, args } => {
-                    todo!("Handle Call expression in dimension")
+                Expression::Variable { .. } /* with non-empty `access` */
+                | Expression::InlineSwitchOp { .. }
+                | Expression::PrefixOp { .. }
+                | Expression::InfixOp { .. }
+                | Expression::Call { .. } => {
+                    self.gen_template_poly_expr(codegen, dim_expr_name(expr), expr)
                 }
                 // The remaining cases do not produce a scalar value.
                 // i.e. ParallelOp, ArrayInLine, UniformArray, BusCall, AnonymousComp, Tuple
@@ -547,7 +552,7 @@ fn gen_function_llzk<'ast, 'ctx, F: FunctionLike>(
     let name_to_value = map_name_to_arg_value(func, func_like.get_name_of_params())?;
 
     // Visit the body of the function and generate LLZK IR for it.
-    let mut func_context = FunctionContext::new::<true>(codegen, func, name_to_value)?;
+    let mut func_context = FunctionContext::new::<true>(codegen, func, name_to_value, &[])?;
     func_like.get_body().gen_llzk_in_function(codegen, &mut func_context, Default::default())?;
     func_context.finalize(codegen)
 }
@@ -561,7 +566,8 @@ fn gen_template_llzk<'ast, 'ctx, T: TemplateLike>(
         println!("Generating LLZK for template {}", template_like.get_name());
     }
     // Collect declarations first to determine struct fields and function parameters.
-    let mut declarations = codegen.take_template_decl(template_like.get_name())?;
+    let mut declarations: DeclarationInfo<'ctx> =
+        codegen.take_template_decl(template_like.get_name())?;
     let subcmps = declarations.complete(codegen)?;
     let location = template_like.get_location(codegen);
 
@@ -574,6 +580,16 @@ fn gen_template_llzk<'ast, 'ctx, T: TemplateLike>(
     let llzk_template_def =
         poly::template(location, template_like.get_name(), template_region_ops)?;
     let new_template = codegen.add_template(llzk_template_def)?;
+
+    // Insert the declarations from `declarations.poly_exprs`.
+    let mut poly_exprs = declarations.poly_exprs.into_inner();
+    let mut poly_expr_names: Vec<_> = poly_exprs.keys().cloned().collect();
+    if codegen.config.stabilize {
+        poly_expr_names.sort();
+    }
+    for name in &poly_expr_names {
+        new_template.body().append_operation(poly_exprs.remove(name).unwrap().into());
+    }
 
     // Add the struct definition, prepopulated with fields, to the template body.
     let new_struct = StructDefOpRef::try_from(
@@ -616,6 +632,8 @@ fn gen_template_llzk<'ast, 'ctx, T: TemplateLike>(
         codegen,
         compute_func,
         map_name_to_arg_value(compute_func, arg_names.clone())?,
+        // concatenate circom template parameter names with `poly_expr_names`
+        template_like.get_name_of_params().iter().chain(poly_expr_names.iter()),
     )?;
     let mut arg_names = arg_names;
     arg_names.insert(0, "**self**".to_string());
@@ -623,14 +641,9 @@ fn gen_template_llzk<'ast, 'ctx, T: TemplateLike>(
         codegen,
         constrain_func,
         map_name_to_arg_value(constrain_func, arg_names)?,
+        // concatenate circom template parameter names with `poly_expr_names`
+        template_like.get_name_of_params().iter().chain(poly_expr_names.iter()),
     )?;
-
-    // Insert Operations to read templated struct parameters into an SSA Value in each function.
-    // This ensures the struct parameter is available as a Value in the block context.
-    for name in template_like.get_name_of_params() {
-        compute_ctx.append_initial_read_const(codegen, location, name)?;
-        constrain_ctx.append_initial_read_const(codegen, location, name)?;
-    }
 
     // Insert read operations for struct fields into constrain functions.
     let location = codegen.location_unknown();

--- a/llzk_backend/src/shared.rs
+++ b/llzk_backend/src/shared.rs
@@ -75,11 +75,13 @@ use program_structure::ast::Expression;
 use program_structure::ast::ExpressionInfixOpcode;
 use program_structure::ast::ExpressionPrefixOpcode;
 use program_structure::ast::Meta;
+use program_structure::ast::Statement;
 use program_structure::error_code::ReportCode;
 use program_structure::error_definition::Report;
 use program_structure::file_definition::FileID;
 use program_structure::file_definition::FileLocation;
 use program_structure::wire_data::WireType;
+use std::cell::Cell;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::convert::TryFrom;
@@ -257,6 +259,8 @@ pub struct LlzkCodegen<'ast, 'ctx, P: ProgramLike> {
     pub config: LlzkConfig,
     /// Declaration info pre-computed for all templates.
     template_decls: RefCell<HashMap<String, DeclInfo<'ctx>>>,
+    /// Body of the function or template currently being processed.
+    current_body: Cell<Option<&'ast [Statement]>>,
     /// Operation builder
     builder: OpBuilder<'ctx>,
 }
@@ -520,6 +524,7 @@ impl<'ast, 'ctx, P: ProgramLike> LlzkCodegen<'ast, 'ctx, P> {
             module,
             config,
             template_decls: RefCell::new(Default::default()),
+            current_body: Cell::new(None),
             builder: OpBuilder::new(context),
         }
     }
@@ -527,6 +532,16 @@ impl<'ast, 'ctx, P: ProgramLike> LlzkCodegen<'ast, 'ctx, P> {
     /// Returns a reference to the operation builder.
     pub fn op_builder(&self) -> &OpBuilder<'ctx> {
         &self.builder
+    }
+
+    /// Set the body of the function or template currently being processed.
+    pub fn set_current_body(&self, body: &'ast [Statement]) {
+        self.current_body.set(Some(body));
+    }
+
+    /// Get the body of the function or template currently being processed.
+    pub fn current_body(&self) -> Option<&'ast [Statement]> {
+        self.current_body.get()
     }
 
     /// Store the full [DeclarationInfo] for the template with the given name.

--- a/llzk_backend/src/shared.rs
+++ b/llzk_backend/src/shared.rs
@@ -1,6 +1,12 @@
 //! Shared code generation utilities.
 
+use crate::function::InfoProviders;
+use crate::gen_context::BlockContextStack;
 use crate::gen_context::BlockGenContext;
+use crate::gen_context::GenerateLLZKInAnyBlock;
+use crate::gen_context::NestedBlockInfo;
+use crate::lvalue::Lvalue;
+use crate::lvalue::Root;
 use crate::module::DeclarationInfo;
 use crate::program_ext::ProgramLike;
 use crate::subcmp::names::COMP;
@@ -19,8 +25,10 @@ use llzk::dialect::array;
 use llzk::dialect::array::ArrayCtor;
 use llzk::dialect::felt;
 use llzk::dialect::pod;
+use llzk::dialect::poly;
 use llzk::prelude::is_felt_type;
 use llzk::prelude::melior_dialects::arith;
+use llzk::prelude::melior_dialects::scf;
 use llzk::prelude::verify_operation_with_diags;
 use llzk::prelude::ArrayType;
 use llzk::prelude::Attribute;
@@ -53,6 +61,8 @@ use llzk::prelude::RegionLike as _;
 use llzk::prelude::StringAttribute;
 use llzk::prelude::StructType;
 use llzk::prelude::SymbolRefAttribute;
+use llzk::prelude::TemplateExprOp;
+use llzk::prelude::TemplateExprOpLike;
 use llzk::prelude::TemplateOp;
 use llzk::prelude::TemplateOpRef;
 use llzk::prelude::TemplateOpRefMut;
@@ -76,6 +86,7 @@ use program_structure::ast::ExpressionInfixOpcode;
 use program_structure::ast::ExpressionPrefixOpcode;
 use program_structure::ast::Meta;
 use program_structure::ast::Statement;
+use program_structure::ast::VariableType;
 use program_structure::error_code::ReportCode;
 use program_structure::error_definition::Report;
 use program_structure::file_definition::FileID;
@@ -261,8 +272,28 @@ pub struct LlzkCodegen<'ast, 'ctx, P: ProgramLike> {
     template_decls: RefCell<HashMap<String, DeclInfo<'ctx>>>,
     /// Body of the function or template currently being processed.
     current_body: Cell<Option<&'ast [Statement]>>,
+    /// Current [Statement] (or stack thereof when within an `IfThenElse` or `While`) being visited
+    /// and/or translated. Used by [`DimExprConverter::gen_template_poly_expr`] to replicate the
+    /// body into the `poly.expr` initializer up to the current position so all variable
+    /// assignments that contribute to the target expression will be computed.
+    statement_trace: RefCell<Vec<*const Statement>>,
     /// Operation builder
     builder: OpBuilder<'ctx>,
+}
+
+/// RAII guard that pops one entry from the statement trace on drop.
+///
+/// Returned by [`LlzkCodegen::trace_statement`] to keep [`LlzkCodegen::statement_trace`] updated.
+#[derive(Debug)]
+pub struct StatementTraceGuard<'a> {
+    /// Reference to the statement trace managed by this guard.
+    trace: &'a RefCell<Vec<*const Statement>>,
+}
+
+impl Drop for StatementTraceGuard<'_> {
+    fn drop(&mut self) {
+        self.trace.borrow_mut().pop();
+    }
 }
 
 /// Maps parameter symbols to the attributes assigned to a concrete instances of a template.
@@ -525,6 +556,7 @@ impl<'ast, 'ctx, P: ProgramLike> LlzkCodegen<'ast, 'ctx, P> {
             config,
             template_decls: RefCell::new(Default::default()),
             current_body: Cell::new(None),
+            statement_trace: RefCell::new(Vec::new()),
             builder: OpBuilder::new(context),
         }
     }
@@ -542,6 +574,25 @@ impl<'ast, 'ctx, P: ProgramLike> LlzkCodegen<'ast, 'ctx, P> {
     /// Get the body of the function or template currently being processed.
     pub fn current_body(&self) -> Option<&'ast [Statement]> {
         self.current_body.get()
+    }
+
+    /// Push `stmt` onto the statement trace and return a guard that pops it on drop.
+    ///
+    /// Call this at the top of every `gen_llzk_in_template`, `gen_llzk_in_function`, etc.
+    /// that traverses all body [Statement] and may end up calling the [`DimExprConverter`] so
+    /// that its [`DimExprConverter::gen_template_poly_expr`] can observe the exact path of
+    /// statements surrounding the target expression.
+    pub fn trace_statement<'a>(&'a self, stmt: &Statement) -> StatementTraceGuard<'a> {
+        self.statement_trace.borrow_mut().push(stmt as *const Statement);
+        StatementTraceGuard { trace: &self.statement_trace }
+    }
+
+    /// Snapshot the current statement trace (outermost statement first) as raw pointers.
+    ///
+    /// The pointers are valid for the duration of the AST (`'ast` lifetime of the codegen).
+    /// Use pointer equality (`std::ptr::eq`) when comparing against slice elements.
+    pub fn snapshot_statement_trace(&self) -> Vec<*const Statement> {
+        self.statement_trace.borrow().clone()
     }
 
     /// Store the full [DeclarationInfo] for the template with the given name.
@@ -1553,7 +1604,10 @@ impl<'ctx, 'val, P: ProgramLike> TryFrom<(&[usize], &LlzkCodegen<'_, 'ctx, P>)>
 }
 
 /// A trait to generate array dimensions from the given dimension expressions.
-pub trait DimExprConverter<'ctx, 'val> {
+pub trait DimExprConverter<'ctx, 'val>
+where
+    'ctx: 'val,
+{
     /// Convert a circom [Expression] used as an array dimension to an LLZK Attribute.
     ///
     /// Returns an error if there was an error converting a dimension that should be convertible.
@@ -1561,12 +1615,6 @@ pub trait DimExprConverter<'ctx, 'val> {
     /// lack of information in the implementer. Users can then attempt to resolve the dimension in a
     /// different context, or throw an error if all available contexts are unable to convert the
     /// dimension.
-    ///
-    /// Note: The LLZK ArrayType can only use the following Attribute types for dimensions:
-    /// IntegerAttr (`index` or `i1`) or AffineMapAttr (with single result).
-    /// To simplify the implementation, template parameters are read using `poly.read_const`
-    /// and passed to an affine map rather than trying to use a symbol attribute as the
-    /// dimension (which would only work for bare template parameters without computation anyways).
     fn get_dim_expr(
         &self,
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
@@ -1601,6 +1649,265 @@ pub trait DimExprConverter<'ctx, 'val> {
             anyhow!("unexpected lack of data needed to convert dimension expressions")
         })
     }
+
+    /// Names of `poly.param` and `poly.expr` defs visible in the current context.
+    fn poly_template_binding_names(&self) -> impl IntoIterator<Item = &String> {
+        std::iter::empty()
+    }
+
+    /// Callback to store a `poly.expr` operation generated on the fly for an array dimension.
+    fn callback_store_poly_expr(&self, name: String, op: TemplateExprOp<'ctx>);
+
+    /// Generate a new `poly.expr` operation for the given array dimension [Expression].
+    fn gen_template_poly_expr(
+        &self,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+        name: String,
+        target_expr: &Expression, // the result that should yield from the `poly.expr`
+    ) -> Result<ArrayDimensionResult<'ctx, 'val>> {
+        /// Fully generate LLZK for a single [Statement] in a `poly.expr` initializer without
+        /// truncating at any target expression.
+        fn gen_stmt_fully<'ctx, 'blk, 'val>(
+            stmt: &Statement,
+            codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+            gen_ctx: &mut BlockGenContext<'ctx, 'blk, 'val>,
+        ) -> Result<()>
+        where
+            'ctx: 'blk,
+            'blk: 'val,
+            'val: 'blk,
+        {
+            match stmt {
+                Statement::Block { stmts, .. } => {
+                    for s in stmts {
+                        gen_stmt_fully(s, codegen, gen_ctx)?;
+                    }
+                }
+                Statement::InitializationBlock { initializations, .. } => {
+                    for s in initializations {
+                        gen_stmt_fully(s, codegen, gen_ctx)?;
+                    }
+                }
+                Statement::Declaration { meta, xtype, name, dimensions, .. } => {
+                    if VariableType::Var == *xtype {
+                        gen_ctx.gen_declaration(codegen, meta, name, dimensions)?;
+                    }
+                }
+                Statement::Substitution { meta, var, access, op, rhe } => {
+                    // Signal assignments don't affect var values so skip those.
+                    if !op.is_signal_operator() {
+                        gen_ctx.handle_substitution_stmt_nonsignal(
+                            codegen,
+                            InfoProviders::default(),
+                            meta,
+                            var,
+                            access,
+                            op,
+                            rhe,
+                        )?;
+                    }
+                }
+                Statement::IfThenElse { meta, cond, if_case, else_case } => {
+                    let location = codegen.location_from_meta(meta);
+                    let cond_val = cond.gen_llzk_in_block(codegen, gen_ctx, Default::default())?;
+                    let cond_bool = gen_ctx.cast_to_bool_if_needed(codegen, location, cond_val)?;
+                    // Build then-branch NestedBlockInfo.
+                    let mut then_info = NestedBlockInfo::default();
+                    gen_ctx.block_ctx.push(then_info.block);
+                    gen_stmt_fully(if_case, codegen, gen_ctx)?;
+                    then_info.var_overwrites = gen_ctx.block_ctx.pop();
+                    // Build else-branch NestedBlockInfo.
+                    let mut else_info = NestedBlockInfo::default();
+                    gen_ctx.block_ctx.push(else_info.block);
+                    if let Some(ec) = else_case {
+                        gen_stmt_fully(ec, codegen, gen_ctx)?;
+                    }
+                    else_info.var_overwrites = gen_ctx.block_ctx.pop();
+                    gen_ctx.gen_scf_if(codegen, location, cond_bool, then_info, else_info)?;
+                }
+                Statement::While { .. } => {
+                    anyhow::bail!("poly.expr depending on a while loop is not yet supported")
+                }
+                Statement::Assert { meta, arg } => {
+                    let val = arg.gen_llzk_in_block(codegen, gen_ctx, Default::default())?;
+                    gen_ctx.append_assert(codegen, codegen.location_from_meta(meta), val)?
+                }
+                Statement::LogCall { meta, .. } => {
+                    codegen.emit_circom_warning(
+                        meta,
+                        "log calls are not currently supported in LLZK",
+                        ReportCode::NotAllowedOperation,
+                    );
+                }
+                Statement::Return { .. } => {
+                    unreachable!("encountered return statement while computing array dimension")
+                }
+                _ => {}
+            }
+            Ok(())
+        }
+
+        /// Generate the `scf.if` for a [Statement::IfThenElse] boundary encountered while
+        /// walking toward `target_expr`. The branch containing the target recursively calls
+        /// `gen_up_to_target`; the other branch yields a `nondet` placeholder of the same type.
+        #[allow(clippy::too_many_arguments)]
+        fn gen_if_then_else_up_to_target<'ctx, 'blk, 'val>(
+            codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+            gen_ctx: &mut BlockGenContext<'ctx, 'blk, 'val>,
+            target_expr: &Expression,
+            trace: &[*const Statement],
+            meta: &Meta,
+            cond: &Expression,
+            if_case: &Statement,
+            else_case: &Option<Box<Statement>>,
+        ) -> Result<Value<'ctx, 'val>>
+        where
+            'ctx: 'blk,
+            'blk: 'val,
+            'val: 'blk,
+        {
+            ensure!(
+                !trace.is_empty(),
+                "trace ended at IfThenElse; expected continuation into a branch"
+            );
+            let boundary_ptr: *const Statement = trace[0];
+
+            let location = codegen.location_from_meta(meta);
+            let cond_val = cond.gen_llzk_in_block(codegen, gen_ctx, Default::default())?;
+            let cond_bool = gen_ctx.cast_to_bool_if_needed(codegen, location, cond_val)?;
+
+            // Determine which branch contains the target by pointer identity.
+            let target_in_then = std::ptr::eq(if_case, boundary_ptr);
+            let containing_stmt = if target_in_then {
+                if_case
+            } else {
+                let opt = else_case.as_deref();
+                ensure!(
+                    opt.is_some_and(|ec| std::ptr::eq(ec, boundary_ptr)),
+                    "trace does not point to either branch of IfThenElse"
+                );
+                opt.expect("checked above")
+            };
+
+            // Generate the branch that contains the target, then a nondet placeholder for the
+            // other branch (using the result type from the containing branch).
+            let (containing_region, target_val) =
+                gen_ctx.generate_simple_scf_if_arm(location, |gc| {
+                    gen_up_to_target(
+                        codegen,
+                        gc,
+                        target_expr,
+                        std::slice::from_ref(containing_stmt),
+                        trace,
+                    )
+                })?;
+            let result_type = target_val.r#type();
+            let (other_region, _) = gen_ctx.generate_simple_scf_if_arm(location, |gc| {
+                gc.append_op_unnamed_result(codegen.new_nondet_at_location(location, result_type)?)
+            })?;
+
+            // Assemble the scf.if with regions in the correct order.
+            let (then_region, else_region) = if target_in_then {
+                (containing_region, other_region)
+            } else {
+                (other_region, containing_region)
+            };
+            gen_ctx.append_op_unnamed_result(scf::r#if(
+                cond_bool,
+                &[result_type],
+                then_region,
+                else_region,
+                location,
+            ))
+        }
+
+        /// Generate LLZK for all of `stmts` up to the first [Statement] in the `trace` (i.e. the
+        /// boundary). Then, pop the first [Statement] from the `trace` and, if applicable, descend
+        /// into its nested body following the same proceedure. When the trace is exhausted,
+        /// generate LLZK for the `target_expr` and return its result [Value].
+        fn gen_up_to_target<'ctx, 'blk, 'val>(
+            codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+            gen_ctx: &mut BlockGenContext<'ctx, 'blk, 'val>,
+            target_expr: &Expression,
+            stmts: &[Statement],
+            trace: &[*const Statement],
+        ) -> Result<Value<'ctx, 'val>>
+        where
+            'ctx: 'blk,
+            'blk: 'val,
+            'val: 'blk,
+        {
+            assert!(!trace.is_empty(), "trace must not be empty in gen_up_to_target");
+            let boundary_ptr: *const Statement = trace[0];
+            let inner_trace = &trace[1..];
+
+            // Generate all statements that precede the boundary, then find the boundary itself.
+            let mut boundary_stmt: Option<&Statement> = None;
+            for stmt in stmts {
+                if std::ptr::eq(stmt as *const Statement, boundary_ptr) {
+                    boundary_stmt = Some(stmt);
+                    break;
+                }
+                gen_stmt_fully(stmt, codegen, gen_ctx)?;
+            }
+            let boundary_stmt = boundary_stmt.ok_or_else(|| {
+                anyhow!("statement trace boundary not found in current stmts slice")
+            })?;
+
+            // Process the boundary statement (the one on the trace path).
+            match boundary_stmt {
+                Statement::Block { stmts, .. } => {
+                    // Target is somewhere within this block's statements; recurse.
+                    gen_up_to_target(codegen, gen_ctx, target_expr, stmts, inner_trace)
+                }
+                Statement::InitializationBlock { initializations, .. } => {
+                    gen_up_to_target(codegen, gen_ctx, target_expr, initializations, inner_trace)
+                }
+                Statement::IfThenElse { meta, cond, if_case, else_case } => {
+                    gen_if_then_else_up_to_target(
+                        codegen,
+                        gen_ctx,
+                        target_expr,
+                        inner_trace,
+                        meta,
+                        cond,
+                        if_case,
+                        else_case,
+                    )
+                }
+                Statement::While { .. } => {
+                    anyhow::bail!("poly.expr depending on a while loop is not yet supported")
+                }
+                _ => {
+                    assert!(inner_trace.is_empty(), "trace should end at a leaf statement");
+                    // Leaf: this boundary statement directly contains `target_expr` in its
+                    // dimensions. Generate the target expression in the current block context.
+                    target_expr.gen_llzk_in_block(codegen, gen_ctx, Default::default())
+                }
+            }
+        }
+
+        //////////////////////////////////////////////////////////////////////////////////////////
+        // Generate `poly.expr` and fill its initializer region.
+        let location = codegen.location_from_meta(target_expr.get_meta());
+        let expr_op = poly::expr(location, &name, std::iter::empty())?;
+        let mut gen_ctx = BlockGenContext::new(
+            BlockContextStack::new(
+                expr_op.initializer_region().first_block().expect("block should have been added"),
+            ),
+            self.poly_template_binding_names(),
+        )
+        .with_poly_template_binding_locals(codegen, location)?;
+        let body_opt = codegen.current_body();
+        assert!(body_opt.is_some(), "should have been set at top level");
+        let trace = codegen.snapshot_statement_trace();
+        let val = gen_up_to_target(codegen, &mut gen_ctx, target_expr, body_opt.unwrap(), &trace)?;
+        gen_ctx.append_op_no_result(poly::r#yield(location, val)?.into())?;
+
+        let name_sym = codegen.flat_sym(&name);
+        self.callback_store_poly_expr(name, expr_op);
+        ArrayDimensionResult::new(name_sym.into(), &[])
+    }
 }
 
 /// Maps the inner type of the given type if it is an [`ArrayType`]. Returns the new type
@@ -1625,4 +1932,43 @@ pub fn region_with_block<'ctx>(arguments: &[(Type<'ctx>, Location<'ctx>)]) -> Re
 pub fn comp_type<'ctx>(pod: PodType<'ctx>) -> Result<Type<'ctx>> {
     pod.get_type_of_record(COMP)
         .ok_or_else(|| anyhow::anyhow!("missing {COMP} record in memory struct: {pod:?}"))
+}
+
+/// Generate a stable name for a dimension expression, suitable for use as a `poly.expr` name.
+///
+/// The generated name uniquely represents the expression structure so that the same expression
+/// always maps to the same name, enabling deduplication of `poly.expr` ops.
+pub fn dim_expr_name(expr: &Expression) -> String {
+    match expr {
+        Expression::Number(_, n) => n.to_string(),
+        Expression::Variable { name, access, .. } => {
+            if access.is_empty() {
+                name.clone()
+            } else {
+                // Reuse `Lvalue` string format but drop the "Var:" prefix.
+                Lvalue::new(name, Root::Var, access)
+                    .to_string()
+                    .trim_start_matches("Var:")
+                    .to_string()
+            }
+        }
+        Expression::InfixOp { lhe, infix_op, rhe, .. } => {
+            format!("{}_{infix_op:?}_{}", dim_expr_name(lhe), dim_expr_name(rhe))
+        }
+        Expression::PrefixOp { prefix_op, rhe, .. } => {
+            format!("{prefix_op:?}_{}", dim_expr_name(rhe))
+        }
+        Expression::InlineSwitchOp { cond, if_true, if_false, .. } => {
+            format!(
+                "{}?{}:{}",
+                dim_expr_name(cond),
+                dim_expr_name(if_true),
+                dim_expr_name(if_false)
+            )
+        }
+        Expression::Call { id, args, .. } => {
+            format!("{id}({})", args.iter().map(dim_expr_name).collect::<Vec<_>>().join(","))
+        }
+        _ => unreachable!("dimension expression must produce a scalar value"),
+    }
 }

--- a/llzk_backend/src/shared.rs
+++ b/llzk_backend/src/shared.rs
@@ -1,6 +1,6 @@
 //! Shared code generation utilities.
 
-use crate::function::FunctionContext;
+use crate::gen_context::BlockGenContext;
 use crate::module::DeclarationInfo;
 use crate::program_ext::ProgramLike;
 use crate::subcmp::names::COMP;
@@ -441,10 +441,10 @@ impl<'ctx> TypeSizeExpr<'ctx> {
     }
 
     /// Generate code for the expression as an index value in LLZK IR.
-    pub fn to_index_value<'ast, 'func, 'blk, 'val>(
+    pub fn to_index_value<'ast, 'blk, 'val>(
         &self,
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        fc: &mut FunctionContext<'ctx, 'func, 'blk, 'val>,
+        fc: &mut BlockGenContext<'ctx, 'blk, 'val>,
         location: Location<'ctx>,
         env: Option<&TmplParamsInstance<'ast, 'ctx>>,
     ) -> Result<Value<'ctx, 'val>> {

--- a/llzk_backend/src/shared.rs
+++ b/llzk_backend/src/shared.rs
@@ -275,7 +275,9 @@ pub struct LlzkCodegen<'ast, 'ctx, P: ProgramLike> {
     /// Current [Statement] (or stack thereof when within an `IfThenElse` or `While`) being visited
     /// and/or translated. Used by [`DimExprConverter::gen_template_poly_expr`] to replicate the
     /// body into the `poly.expr` initializer up to the current position so all variable
-    /// assignments that contribute to the target expression will be computed.
+    /// assignments that contribute to the target expression will be computed. Raw pointers are
+    /// used to avoid a lifetime issue from synthetic Statements created on-the-fly and translated.
+    /// They pointers must only be used for pointer equality comparisons to avoid unsafe behavior.
     statement_trace: RefCell<Vec<*const Statement>>,
     /// Operation builder
     builder: OpBuilder<'ctx>,

--- a/llzk_backend/src/template.rs
+++ b/llzk_backend/src/template.rs
@@ -767,18 +767,16 @@ where
                     }
                 },
                 Expression::InfixOp { meta, lhe, infix_op, rhe } => {
-                    todo!("Handle Infix expression in dimension for non-integer attributes")
+                    todo!("Handle InfixOp in dimension for non-integer attributes: {:?}", expr)
                 }
                 Expression::PrefixOp { meta, prefix_op, rhe } => {
-                    todo!("Handle Prefix expression in dimension for non-integer attributes")
+                    todo!("Handle PrefixOp in dimension for non-integer attributes: {:?}", expr)
                 }
                 Expression::InlineSwitchOp { meta, cond, if_true, if_false } => {
-                    todo!(
-                        "Handle InlineSwitchOp expression in dimension for non-integer attributes"
-                    )
+                    todo!("Handle InlineSwitch in dimension for non-integer attributes: {:?}", expr)
                 }
                 Expression::Call { meta, id, args } => {
-                    todo!("Handle Call expression in dimension")
+                    todo!("Handle Call in dimension for non-integer attributes: {:?}", expr)
                 }
                 // The remaining cases do not produce a scalar value.
                 // i.e. ParallelOp, ArrayInLine, UniformArray, BusCall, AnonymousComp, Tuple

--- a/llzk_backend/src/template.rs
+++ b/llzk_backend/src/template.rs
@@ -1,10 +1,10 @@
 //! Handles template-level LLZK code generation. The [TemplateContext] carries information about the
 //! current LLZK struct being generated and some helpers related to generating code within the
 //! struct. The [GenerateLLZKInTemplate] trait provides the visitor to generate LLZK IR for all
-//! circom [Expression](program_structure::abstract_syntax_tree::ast::Expression) and
-//! [Statement](program_structure::abstract_syntax_tree::ast::Statement) nodes. There are also a few
-//! helper traits like [GenResult] and [Chainable] that implement some boilerplate to make the
-//! actual code generation within [GenerateLLZKInTemplate] a lot simpler.
+//! circom [Expression](program_structure::ast::Expression) and
+//! [Statement](program_structure::ast::Statement) nodes. There are also a few helper traits like
+//! [GenResult] and [Chainable] that implement some boilerplate to make the actual code generation
+//! within [GenerateLLZKInTemplate] a lot simpler.
 
 use crate::function::FunctionContext;
 use crate::gen_context::BlockGenContext;
@@ -47,6 +47,7 @@ use llzk::prelude::RecordValue;
 use llzk::prelude::StringRef;
 use llzk::prelude::StructDefOpLike as _;
 use llzk::prelude::StructDefOpRefMut;
+use llzk::prelude::TemplateExprOp;
 use llzk::prelude::TemplateOpLike;
 use llzk::prelude::TemplateOpRefMut;
 use llzk::prelude::Type;
@@ -732,6 +733,10 @@ where
     'func: 'blk,
     'blk: 'val,
 {
+    fn callback_store_poly_expr(&self, name: String, op: TemplateExprOp<'ctx>) {
+        todo!("TemplateContext::store_template_poly_expr: {name} -> {op:?}");
+    }
+
     fn get_dim_expr(
         &self,
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
@@ -1020,6 +1025,7 @@ where
     where
         'val: 'r,
     {
+        let _guard = codegen.trace_statement(self);
         match self {
             Statement::InitializationBlock { initializations, .. } => {
                 gen_init_block(codegen, template, initializations)
@@ -1213,10 +1219,7 @@ where
             }
             Statement::Assert { meta, arg } => {
                 arg.gen_llzk_in_template(codegen, template)?.and_then_same(|fc, val| {
-                    let location = codegen.location_from_meta(meta);
-                    let cond = fc.cast_to_bool_if_needed(codegen, location, val)?;
-                    let msg = Some("assertion failed");
-                    fc.append_op_no_result(llzk::dialect::bool::assert(location, cond, msg)?.into())
+                    fc.append_assert(codegen, codegen.location_from_meta(meta), val)
                 })
             }
             Statement::LogCall { meta, .. } => {

--- a/llzk_backend/src/template.rs
+++ b/llzk_backend/src/template.rs
@@ -430,7 +430,7 @@ where
             let mut fc = rc.borrow_mut();
             let popped = fc.block_ctx.pop();
             overwrite_handler(
-                &mut fc.base,
+                &mut fc,
                 overwrite_data.compute.get_or_insert_with(NestedBlockInfo::default),
                 popped,
             )?;
@@ -439,7 +439,7 @@ where
             let mut fc = rc.borrow_mut();
             let popped = fc.block_ctx.pop();
             overwrite_handler(
-                &mut fc.base,
+                &mut fc,
                 overwrite_data.constrain.get_or_insert_with(NestedBlockInfo::default),
                 popped,
             )?;

--- a/llzk_backend/src/template.rs
+++ b/llzk_backend/src/template.rs
@@ -7,7 +7,9 @@
 //! actual code generation within [GenerateLLZKInTemplate] a lot simpler.
 
 use crate::function::FunctionContext;
+use crate::gen_context::BlockGenContext;
 use crate::gen_context::GenWithCircomScopeHandling;
+use crate::gen_context::GenerateLLZKInAnyBlock;
 use crate::gen_context::NestedBlockInfo;
 use crate::lvalue::Lvalue;
 use crate::lvalue::Root;
@@ -414,7 +416,7 @@ where
     ) -> Result<()>
     where
         H: Fn(
-            &mut FunctionContext<'ctx, 'func, 'blk, 'val>,
+            &mut BlockGenContext<'ctx, 'blk, 'val>,
             &mut NestedBlockInfo<'ctx, 'blk, 'val>,
             HashMap<String, Value<'ctx, 'val>>,
         ) -> Result<()>,
@@ -427,7 +429,7 @@ where
             let mut fc = rc.borrow_mut();
             let popped = fc.block_ctx.pop();
             overwrite_handler(
-                &mut fc,
+                &mut fc.base,
                 overwrite_data.compute.get_or_insert_with(NestedBlockInfo::default),
                 popped,
             )?;
@@ -436,7 +438,7 @@ where
             let mut fc = rc.borrow_mut();
             let popped = fc.block_ctx.pop();
             overwrite_handler(
-                &mut fc,
+                &mut fc.base,
                 overwrite_data.constrain.get_or_insert_with(NestedBlockInfo::default),
                 popped,
             )?;
@@ -1097,14 +1099,10 @@ where
                                             signal_type,
                                         )?;
                                         // Write value to field of "self" struct.
+                                        let self_val = fc.func.self_value_of_compute()?;
                                         fc.append_op_no_result(
-                                            r#struct::writem(
-                                                location,
-                                                fc.func.self_value_of_compute()?,
-                                                var,
-                                                value,
-                                            )?
-                                            .into(),
+                                            r#struct::writem(location, self_val, var, value)?
+                                                .into(),
                                         )?;
                                         fc.block_ctx.set_named_value(var.clone(), value)
                                     })
@@ -1139,14 +1137,10 @@ where
                                             signal_type,
                                         )?;
                                         // Write value to field of "self" struct.
+                                        let self_val = fc.func.self_value_of_compute()?;
                                         fc.append_op_no_result(
-                                            r#struct::writem(
-                                                location,
-                                                fc.func.self_value_of_compute()?,
-                                                var,
-                                                value,
-                                            )?
-                                            .into(),
+                                            r#struct::writem(location, self_val, var, value)?
+                                                .into(),
                                         )?;
                                         fc.block_ctx.set_named_value(var.clone(), value)
                                     },
@@ -1155,11 +1149,11 @@ where
                                         // at the beginning of the constrain function, see
                                         // `gen_template_llzk`) and generate equality constraint
                                         // with 'val'.
-                                        let signal_val = fc.block_ctx.get_named_value(var)?;
+                                        let signal_val = *fc.block_ctx.get_named_value(var)?;
                                         fc.append_constrain_eq(
                                             codegen,
                                             codegen.location_from_meta(meta),
-                                            *signal_val,
+                                            signal_val,
                                             val,
                                         )
                                     },
@@ -1354,12 +1348,7 @@ where
             }
             // Delegate any other kind of expression to the implementation in `function.rs`.
             expr => {
-                template.and_then_same(|fc, _| {
-                    // The import is here rather than top level because it is very important that
-                    // `gen_llzk_in_function()` is not used while translating statements.
-                    use crate::function::GenerateLLZKInFunction;
-                    expr.gen_llzk_in_function(codegen, fc, template.into())
-                })
+                template.and_then_same(|fc, _| expr.gen_llzk_in_block(codegen, fc, template.into()))
             }
         }
     }


### PR DESCRIPTION
- Create `BlockGenContext` and rehome parts of `FunctionContext` that does not specifically require a `FuncDefOp` instance into it. This allows the common functionality to be reused by `DimExprConverter` which does not require a `FuncDefOp` instance.
- Refactor several other blocks of code into a `BlockGenContext` function for reuse.
- Make `LlzkCodegen` track the current body (list of statements) and the current statement (or stack of statements for nested control-flow ops) being translated/visited. This enables creation of a `poly.expr` body containing all content up to a certain point to ensure all values needed for a dimension expression are available.
- Generate `poly.expr` for "easier" cases (`var`, infix, prefix, ternary, etc.) of `DeclarationInfo` (see `circom/tests/arrays/array_dimensions_11.circom` for some examples)