### PR TITLE
Handle more `DimExprConverter` cases

### DIFF
--- a/circom/tests/declaration_in_template/array_dim_expr_prefix_B.circom
+++ b/circom/tests/declaration_in_template/array_dim_expr_prefix_B.circom
@@ -1,0 +1,17 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --stabilize --llzk --llzk_plaintext -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
+// XFAIL:.*
+
+pragma circom 2.0.0;
+
+template A() {
+  var s = -6;
+  signal input in[-s];
+  s = -12;
+  var x[-s] = in;
+}
+
+component main = A();
+
+// CHECK-LABEL: module attributes {

--- a/circom/tests/declaration_in_template/array_dim_expr_prefix_C.circom
+++ b/circom/tests/declaration_in_template/array_dim_expr_prefix_C.circom
@@ -1,0 +1,14 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --stabilize --llzk --llzk_plaintext -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
+// XFAIL:.*
+
+pragma circom 2.0.0;
+
+template A() {
+  var x[-12];
+}
+
+component main = A();
+
+// CHECK-LABEL: module attributes {

--- a/llzk_backend/src/function.rs
+++ b/llzk_backend/src/function.rs
@@ -104,9 +104,9 @@ impl Default for InfoProviders<'_> {
 }
 
 impl<'tmpl, 'ctx, 'str, 'func, 'blk, 'val>
-    From<&'tmpl TemplateContext<'ctx, 'str, 'func, 'blk, 'val>> for InfoProviders<'tmpl>
+    From<&'tmpl TemplateContext<'_, 'ctx, 'str, 'func, 'blk, 'val>> for InfoProviders<'tmpl>
 {
-    fn from(template: &'tmpl TemplateContext<'ctx, 'str, 'func, 'blk, 'val>) -> Self {
+    fn from(template: &'tmpl TemplateContext<'_, 'ctx, 'str, 'func, 'blk, 'val>) -> Self {
         Self { subcmp_info: template, signal_write_info: template }
     }
 }
@@ -118,7 +118,7 @@ impl<'tmpl, 'ctx, 'str, 'func, 'blk, 'val>
 /// 'blk: lifetime of the generated `Block` instances within functions
 /// 'val: lifetime of the generated `Value` or `Operation` instances within blocks
 #[derive(Debug)]
-pub struct FunctionContext<'ctx, 'func, 'blk, 'val>
+pub struct FunctionContext<'decls, 'ctx, 'func, 'blk, 'val>
 where
     'ctx: 'func,
     'func: 'blk,
@@ -127,23 +127,23 @@ where
     /// The function reference.
     pub(crate) func: FuncDefOpRefMut<'ctx, 'func>,
     /// Base block generation context.
-    pub(crate) base: BlockGenContext<'ctx, 'blk, 'val>,
+    pub(crate) base: BlockGenContext<'decls, 'ctx, 'blk, 'val>,
 }
 
 /// Allows calling through to functions on the [`BlockGenContext`].
-impl<'ctx, 'blk, 'val> std::ops::Deref for FunctionContext<'ctx, '_, 'blk, 'val>
+impl<'decls, 'ctx, 'blk, 'val> std::ops::Deref for FunctionContext<'decls, 'ctx, '_, 'blk, 'val>
 where
     'ctx: 'blk,
     'blk: 'val,
 {
-    type Target = BlockGenContext<'ctx, 'blk, 'val>;
+    type Target = BlockGenContext<'decls, 'ctx, 'blk, 'val>;
 
     fn deref(&self) -> &Self::Target {
         &self.base
     }
 }
 
-impl<'ctx, 'blk, 'val> std::ops::DerefMut for FunctionContext<'ctx, '_, 'blk, 'val>
+impl<'ctx, 'blk, 'val> std::ops::DerefMut for FunctionContext<'_, 'ctx, '_, 'blk, 'val>
 where
     'ctx: 'blk,
     'blk: 'val,
@@ -198,19 +198,21 @@ impl<'ctx> RefactoringBlockResultType<'ctx> {
     }
 }
 
-impl<'ctx, 'func, 'blk, 'val> FunctionContext<'ctx, 'func, 'blk, 'val>
+impl<'decls, 'ctx, 'func, 'blk, 'val> FunctionContext<'decls, 'ctx, 'func, 'blk, 'val>
 where
     'ctx: 'func,
     'func: 'blk,
     'blk: 'val,
 {
-    /// Create a new [FunctionContext] for the given function with an initial name-to-value mapping
-    /// and set of visible `poly.param` and `poly.expr` names.
-    pub fn new<'n, const FREE_FUNC: bool>(
+    /// Create a new [FunctionContext] for the given function with an initial name-to-value mapping,
+    /// mapping of `var` declaration names to their declared LLZK types, and set of visible
+    /// `poly.param` and `poly.expr` names.
+    pub fn new<'names, const FREE_FUNC: bool>(
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
         func: FuncDefOpRefMut<'ctx, 'func>,
         param_name_to_value: HashMap<String, Value<'ctx, 'val>>,
-        poly_template_binding_names: impl IntoIterator<Item = &'n String>,
+        var_decl_types: &'decls HashMap<String, Type<'ctx>>,
+        poly_template_binding_names: impl IntoIterator<Item = &'names String>,
     ) -> Result<Self> {
         let mut block_ctx = BlockContextStack::from_function(func.deref(), param_name_to_value)?;
         if FREE_FUNC {
@@ -228,7 +230,7 @@ where
         }
         Ok(Self {
             func,
-            base: BlockGenContext::new(block_ctx, poly_template_binding_names)
+            base: BlockGenContext::new(block_ctx, var_decl_types, poly_template_binding_names)
                 .with_poly_template_binding_locals(codegen, codegen.location_unknown())?,
         })
     }
@@ -475,7 +477,7 @@ where
 
 /// The [FunctionContext] directly accesses a single [BlockContextStack] for circom scope handling.
 impl<'ctx, 'func, 'blk, 'val> GenWithCircomScopeHandling<'ctx, 'func, 'blk, 'val>
-    for FunctionContext<'ctx, 'func, 'blk, 'val>
+    for FunctionContext<'_, 'ctx, 'func, 'blk, 'val>
 where
     'ctx: 'func,
     'func: 'blk,
@@ -499,7 +501,7 @@ where
     ) -> Result<()>
     where
         H: Fn(
-            &mut BlockGenContext<'ctx, 'blk, 'val>,
+            &mut BlockGenContext<'_, 'ctx, 'blk, 'val>,
             &mut NestedBlockInfo<'ctx, 'blk, 'val>,
             HashMap<String, Value<'ctx, 'val>>,
         ) -> Result<()>,
@@ -528,7 +530,7 @@ where
     fn gen_llzk_in_function<'info>(
         &self,
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        function: &mut FunctionContext<'ctx, 'func, 'blk, 'val>,
+        function: &mut FunctionContext<'_, 'ctx, 'func, 'blk, 'val>,
         info: InfoProviders<'info>,
     ) -> Result<Self::Output>;
 }
@@ -572,7 +574,7 @@ where
 #[allow(clippy::too_many_arguments)]
 fn handle_unbalanced_return<'ctx, 'func, 'blk, 'val>(
     codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-    function: &mut FunctionContext<'ctx, 'func, 'blk, 'val>,
+    function: &mut FunctionContext<'_, 'ctx, 'func, 'blk, 'val>,
     location: Location<'ctx>,
     return_val: Value<'ctx, 'val>,
     returning_block: BlockRef<'ctx, 'blk>,
@@ -624,7 +626,7 @@ where
 /// ```
 fn gen_unbalanced_return_extra<'ctx, 'func, 'blk, 'val>(
     codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-    function: &mut FunctionContext<'ctx, 'func, 'blk, 'val>,
+    function: &mut FunctionContext<'_, 'ctx, 'func, 'blk, 'val>,
     location: Location<'ctx>,
 ) -> Result<()>
 where
@@ -649,7 +651,7 @@ where
 /// Generate LLZK code for a circom [Statement::IfThenElse].
 fn gen_if_then_else<'ctx, 'func, 'blk, 'val, 'info>(
     codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-    function: &mut FunctionContext<'ctx, 'func, 'blk, 'val>,
+    function: &mut FunctionContext<'_, 'ctx, 'func, 'blk, 'val>,
     info: InfoProviders<'info>,
     meta: &Meta,
     cond: &Expression,
@@ -740,7 +742,7 @@ where
 /// Generate LLZK code for a circom [Statement::While].
 fn gen_while<'ctx, 'func, 'blk, 'val, 'info>(
     codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-    function: &mut FunctionContext<'ctx, 'func, 'blk, 'val>,
+    function: &mut FunctionContext<'_, 'ctx, 'func, 'blk, 'val>,
     info: InfoProviders<'info>,
     meta: &Meta,
     cond: &Expression,
@@ -824,7 +826,7 @@ where
 #[inline]
 fn gen_init_block<'ctx, 'func, 'blk, 'val>(
     codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-    function: &mut FunctionContext<'ctx, 'func, 'blk, 'val>,
+    function: &mut FunctionContext<'_, 'ctx, 'func, 'blk, 'val>,
     info: InfoProviders<'_>,
     initializations: &[Statement],
 ) -> Result<()>
@@ -849,7 +851,7 @@ where
     fn gen_llzk_in_function<'info>(
         &self,
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        function: &mut FunctionContext<'ctx, 'func, 'blk, 'val>,
+        function: &mut FunctionContext<'_, 'ctx, 'func, 'blk, 'val>,
         info: InfoProviders<'info>,
     ) -> Result<Self::Output> {
         let _guard = codegen.trace_statement(self);
@@ -952,7 +954,7 @@ where
     fn gen_llzk_in_function<'info>(
         &self,
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        function: &mut FunctionContext<'ctx, 'func, 'blk, 'val>,
+        function: &mut FunctionContext<'_, 'ctx, 'func, 'blk, 'val>,
         info: InfoProviders<'info>,
     ) -> Result<Self::Output> {
         for s in self {

--- a/llzk_backend/src/gen_context.rs
+++ b/llzk_backend/src/gen_context.rs
@@ -124,7 +124,7 @@ where
 {
     /// Create a new empty [BlockContext] for the given block.
     fn new(block: BlockRef<'ctx, 'blk>) -> Self {
-        BlockContext {
+        Self {
             block,
             scope_local_name_to_value: Default::default(),
             overwriting_name_to_value: Default::default(),
@@ -132,18 +132,10 @@ where
         }
     }
 
-    /// Create a new [BlockContext] for the given block, initializing the scope local
-    /// declarations with the mapping of parameter names to values.
-    fn new_with_params(
-        block: BlockRef<'ctx, 'blk>,
-        param_name_to_value: HashMap<String, Value<'ctx, 'val>>,
-    ) -> Self {
-        BlockContext {
-            block,
-            scope_local_name_to_value: param_name_to_value,
-            overwriting_name_to_value: Default::default(),
-            op_queue: Default::default(),
-        }
+    /// Set the scope local declarations with the mapping of parameter names to values.
+    fn with_params(mut self, param_name_to_value: HashMap<String, Value<'ctx, 'val>>) -> Self {
+        self.scope_local_name_to_value = param_name_to_value;
+        self
     }
 
     /// Get the LLZK IR SSA Value for the given circom var name. Check the local scope first since
@@ -202,7 +194,8 @@ where
     }
 
     /// Create a new [BlockContextStack] for the given function with an initial name-to-value
-    /// mapping containing function parameters.
+    /// mapping containing function parameters and a mapping of `var` declaration names to their
+    /// declared LLZK types.
     pub fn from_function(
         func: &FuncDefOp<'ctx>,
         param_name_to_value: HashMap<String, Value<'ctx, 'val>>,
@@ -210,7 +203,7 @@ where
         let root_block =
             func.region(0)?.first_block().ok_or_else(|| anyhow!("missing function entry block"))?;
         Ok(Self {
-            root: BlockContext::new_with_params(root_block, param_name_to_value),
+            root: BlockContext::new(root_block).with_params(param_name_to_value),
             other_blocks: Default::default(),
         })
     }
@@ -442,7 +435,7 @@ where
     pub fn add_missing_values(
         &mut self,
         other: &NestedBlockInfo<'ctx, 'blk, 'val>,
-        fc: &BlockGenContext<'ctx, 'blk, 'val>,
+        fc: &BlockGenContext<'_, 'ctx, 'blk, 'val>,
     ) -> Result<()> {
         for name in other.var_overwrites.keys() {
             if !self.var_overwrites.contains_key(name) {
@@ -482,7 +475,7 @@ where
     ) -> Result<()>
     where
         H: Fn(
-            &mut BlockGenContext<'ctx, 'blk, 'val>,
+            &mut BlockGenContext<'_, 'ctx, 'blk, 'val>,
             &mut NestedBlockInfo<'ctx, 'blk, 'val>,
             HashMap<String, Value<'ctx, 'val>>,
         ) -> Result<()>;
@@ -500,7 +493,7 @@ where
     ) -> Result<R>
     where
         H: Fn(
-            &mut BlockGenContext<'ctx, 'blk, 'val>,
+            &mut BlockGenContext<'_, 'ctx, 'blk, 'val>,
             &mut NestedBlockInfo<'ctx, 'blk, 'val>,
             HashMap<String, Value<'ctx, 'val>>,
         ) -> Result<()>,
@@ -581,30 +574,36 @@ fn block_not_in_stack(block: BlockRef) -> anyhow::Error {
 /// 'blk: lifetime of the generated `Block` instances within functions
 /// 'val: lifetime of the generated `Value` or `Operation` instances within blocks
 #[derive(Debug)]
-pub struct BlockGenContext<'ctx, 'blk, 'val>
+pub struct BlockGenContext<'decls, 'ctx, 'blk, 'val>
 where
     'ctx: 'blk,
     'blk: 'val,
 {
     /// Nested block context within the root block.
     pub(crate) block_ctx: BlockContextStack<'ctx, 'blk, 'val>,
+    /// Pre-computed LLZK types for circom `var` declarations, keyed by var name. Populated from
+    /// [crate::module::DeclarationInfo] when generating `poly.expr` bodies for templates so that
+    /// dimension expressions referencing other vars do not trigger recursive code generation.
+    pub(crate) var_decl_types: &'decls HashMap<String, Type<'ctx>>,
     /// Names of `poly.param` and `poly.expr` defs visible in the current context.
     poly_template_binding_names: HashSet<String>,
 }
 
-impl<'ctx, 'blk, 'val> BlockGenContext<'ctx, 'blk, 'val>
+impl<'decls, 'ctx, 'blk, 'val> BlockGenContext<'decls, 'ctx, 'blk, 'val>
 where
     'ctx: 'blk,
     'blk: 'val,
 {
-    /// Create a new [BlockGenContext] with the given block context stack and set of visible
-    /// `poly.param` and `poly.expr` names.
-    pub fn new<'n>(
+    /// Create a new [BlockGenContext] with the given block context stack, mapping of `var` name to
+    /// declared LLZK type, and set of visible `poly.param` and `poly.expr` names.
+    pub fn new<'names>(
         block_ctx: BlockContextStack<'ctx, 'blk, 'val>,
-        poly_template_binding_names: impl IntoIterator<Item = &'n String>,
+        var_decl_types: &'decls HashMap<String, Type<'ctx>>,
+        poly_template_binding_names: impl IntoIterator<Item = &'names String>,
     ) -> Self {
         Self {
             block_ctx,
+            var_decl_types,
             poly_template_binding_names: poly_template_binding_names.into_iter().cloned().collect(),
         }
     }
@@ -1930,11 +1929,15 @@ where
     }
 }
 
-impl<'ctx, 'blk, 'val> DimExprConverter<'ctx, 'val> for BlockGenContext<'ctx, 'blk, 'val>
+impl<'ctx, 'blk, 'val> DimExprConverter<'ctx, 'val> for BlockGenContext<'_, 'ctx, 'blk, 'val>
 where
     'ctx: 'blk,
     'blk: 'val,
 {
+    fn get_var_decl_types(&self) -> &HashMap<String, Type<'ctx>> {
+        self.var_decl_types
+    }
+
     fn callback_store_poly_expr(&self, name: String, op: TemplateExprOp<'ctx>) {
         todo!("BlockGenContext::store_template_poly_expr: {name} -> {op:?}");
     }
@@ -1996,7 +1999,7 @@ where
     fn gen_llzk_in_block<'info>(
         &self,
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        block_gen: &mut BlockGenContext<'ctx, 'blk, 'val>,
+        block_gen: &mut BlockGenContext<'_, 'ctx, 'blk, 'val>,
         info: InfoProviders<'info>,
     ) -> Result<Value<'ctx, 'val>>;
 }
@@ -2016,7 +2019,7 @@ where
     fn gen_llzk_in_block<'info>(
         &self,
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        block_gen: &mut BlockGenContext<'ctx, 'blk, 'val>,
+        block_gen: &mut BlockGenContext<'_, 'ctx, 'blk, 'val>,
         info: InfoProviders<'info>,
     ) -> Result<Value<'ctx, 'val>> {
         match self {

--- a/llzk_backend/src/gen_context.rs
+++ b/llzk_backend/src/gen_context.rs
@@ -7,6 +7,7 @@ use crate::lvalue::Root;
 use crate::program_ext::ProgramLike;
 use crate::shared;
 use crate::shared::append_tail;
+use crate::shared::dim_expr_name;
 use crate::shared::is_bool;
 use crate::shared::is_index;
 use crate::shared::new_array_type;
@@ -1953,33 +1954,21 @@ where
                 Expression::Number(_, _) => {
                     unreachable!("handled by try_compute_as_i64")
                 }
-                Expression::Variable { meta, name, access } => match access.as_slice() {
-                    [] => {
-                        if self.poly_template_binding_names.contains(name) {
-                            ArrayDimensionResult::new(codegen.flat_sym(name).into(), &[])
-                        } else if let Ok(v) = self.block_ctx.get_named_value(name) {
-                            ArrayDimensionResult::new(codegen.identity_affine_map_attr()?, &[*v])
-                        } else {
-                            todo!("Handle Variable expression in dimension for non-integer, non-template parameter attributes in BlockGenContext")
-                        }
-                    }
-                    a => {
-                        todo!("Handle Variable expression with accesses in BlockGenContext")
+                Expression::Variable { meta, name, access } if access.is_empty()=> {
+                    if self.poly_template_binding_names.contains(name) {
+                        ArrayDimensionResult::new(codegen.flat_sym(name).into(), &[])
+                    } else if let Ok(v) = self.block_ctx.get_named_value(name) {
+                        ArrayDimensionResult::new(codegen.identity_affine_map_attr()?, &[*v])
+                    } else {
+                        todo!("Handle Variable expression in dimension for non-integer, non-template parameter attributes in BlockGenContext")
                     }
                 },
-                Expression::InfixOp { meta, lhe, infix_op, rhe } => {
-                    todo!("Handle Infix expression in dimension for non-integer attributes")
-                }
-                Expression::PrefixOp { meta, prefix_op, rhe } => {
-                    todo!("Handle Prefix expression in dimension for non-integer attributes")
-                }
-                Expression::InlineSwitchOp { meta, cond, if_true, if_false } => {
-                    todo!(
-                        "Handle InlineSwitchOp expression in dimension for non-integer attributes"
-                    )
-                }
-                Expression::Call { meta, id, args } => {
-                    todo!("Handle Call expression in dimension")
+                Expression::Variable { .. } /* with non-empty `access` */
+                | Expression::InlineSwitchOp { .. }
+                | Expression::PrefixOp { .. }
+                | Expression::InfixOp { .. }
+                | Expression::Call { .. } => {
+                    self.gen_template_poly_expr(codegen, dim_expr_name(expr), expr)
                 }
                 // The remaining cases do not produce a scalar value.
                 // i.e. ParallelOp, ArrayInLine, UniformArray, BusCall, AnonymousComp, Tuple

--- a/llzk_backend/src/lvalue.rs
+++ b/llzk_backend/src/lvalue.rs
@@ -107,7 +107,7 @@ impl<'ast> Lvalue<'ast> {
     fn get_root_signal<'ctx, 'val>(
         &self,
         var: &str,
-        block_gen: &mut BlockGenContext<'ctx, '_, 'val>,
+        block_gen: &mut BlockGenContext<'_, 'ctx, '_, 'val>,
     ) -> Result<Value<'ctx, 'val>> {
         // Both compute and constrain functions should have the `var` defined:
         // compute from an existing assignment, or constrain from pre-generation
@@ -120,7 +120,7 @@ impl<'ast> Lvalue<'ast> {
     fn get_root_value<'ctx, 'val>(
         &self,
         var: &str,
-        block_gen: &mut BlockGenContext<'ctx, '_, 'val>,
+        block_gen: &mut BlockGenContext<'_, 'ctx, '_, 'val>,
     ) -> Result<Value<'ctx, 'val>> {
         block_gen.block_ctx.get_named_value(var).copied()
     }
@@ -131,7 +131,7 @@ impl<'ast> Lvalue<'ast> {
         indices: &[&Expression],
         prev: Value<'ctx, 'val>,
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        block_gen: &mut BlockGenContext<'ctx, '_, 'val>,
+        block_gen: &mut BlockGenContext<'_, 'ctx, '_, 'val>,
         location: Location<'ctx>,
         info: InfoProviders<'_>,
     ) -> Result<Value<'ctx, 'val>> {
@@ -146,7 +146,7 @@ impl<'ast> Lvalue<'ast> {
         signal_name: &str,
         subcmp_value: Value<'ctx, 'val>,
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        block_gen: &mut BlockGenContext<'ctx, '_, 'val>,
+        block_gen: &mut BlockGenContext<'_, 'ctx, '_, 'val>,
         location: Location<'ctx>,
     ) -> Result<Value<'ctx, 'val>> {
         let comp_value = type_switch! { let ty = subcmp_value.r#type();
@@ -186,7 +186,7 @@ impl<'ast> Lvalue<'ast> {
         signal_name: &str,
         subcmp_value: Value<'ctx, 'val>,
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        block_gen: &mut BlockGenContext<'ctx, '_, 'val>,
+        block_gen: &mut BlockGenContext<'_, 'ctx, '_, 'val>,
         location: Location<'ctx>,
     ) -> Result<Value<'ctx, 'val>> {
         block_gen.append_op_unnamed_result(pod::read(
@@ -210,7 +210,7 @@ impl<'ast> Lvalue<'ast> {
     pub fn get_value<'ctx, 'val>(
         &self,
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        block_gen: &mut BlockGenContext<'ctx, '_, 'val>,
+        block_gen: &mut BlockGenContext<'_, 'ctx, '_, 'val>,
         subcmp_info: &dyn SubcmpInfo,
         location: Location<'ctx>,
         ov: Option<&dyn OverrideVar>,

--- a/llzk_backend/src/module.rs
+++ b/llzk_backend/src/module.rs
@@ -127,6 +127,9 @@ pub struct DeclarationInfo<'ctx> {
     template_params: HashSet<String>,
     /// Dimension expressions mapped to generated `poly.expr` op to be inserted into the template.
     poly_exprs: RefCell<HashMap<String, TemplateExprOp<'ctx>>>,
+    /// Pre-computed LLZK types for `var` declarations, keyed by var name. Used by
+    /// `poly.expr` body generation to avoid recursive dimension-expression recomputation.
+    var_decl_types: HashMap<String, Type<'ctx>>,
 }
 
 impl<'ctx> DeclarationInfo<'ctx> {
@@ -307,9 +310,15 @@ impl<'ctx> DeclarationInfo<'ctx> {
                         // Create `llzk.nondet` of the appropriate type. When the actual assignment
                         // is processed later, this is replaced with the appropriate value.
                         let dimensions = self.get_dim_exprs(codegen, dimensions)?;
+                        let var_type =
+                            dimensions.type_from_dimension_exprs(codegen.felt_type().into());
+                        self.var_decl_types.insert(name.clone(), var_type);
                         self.decl_inits.insert(
                             name.clone(),
-                            dimensions.new_nondet_felt_of_dimensions(codegen, meta)?,
+                            codegen.new_nondet_at_location(
+                                codegen.location_from_meta(meta),
+                                var_type,
+                            )?,
                         );
                         Ok(())
                     }
@@ -467,6 +476,10 @@ impl<'ctx, 'val> DimExprConverter<'ctx, 'val> for DeclarationInfo<'ctx>
 where
     'ctx: 'val,
 {
+    fn get_var_decl_types(&self) -> &HashMap<String, Type<'ctx>> {
+        &self.var_decl_types
+    }
+
     fn poly_template_binding_names(&self) -> impl IntoIterator<Item = &String> {
         &self.template_params
     }
@@ -552,7 +565,9 @@ fn gen_function_llzk<'ast, 'ctx, F: FunctionLike>(
     let name_to_value = map_name_to_arg_value(func, func_like.get_name_of_params())?;
 
     // Visit the body of the function and generate LLZK IR for it.
-    let mut func_context = FunctionContext::new::<true>(codegen, func, name_to_value, &[])?;
+    let var_decl_types = HashMap::new();
+    let mut func_context =
+        FunctionContext::new::<true>(codegen, func, name_to_value, &var_decl_types, &[])?;
     func_like.get_body().gen_llzk_in_function(codegen, &mut func_context, Default::default())?;
     func_context.finalize(codegen)
 }
@@ -632,6 +647,7 @@ fn gen_template_llzk<'ast, 'ctx, T: TemplateLike>(
         codegen,
         compute_func,
         map_name_to_arg_value(compute_func, arg_names.clone())?,
+        &declarations.var_decl_types,
         // concatenate circom template parameter names with `poly_expr_names`
         template_like.get_name_of_params().iter().chain(poly_expr_names.iter()),
     )?;
@@ -641,6 +657,7 @@ fn gen_template_llzk<'ast, 'ctx, T: TemplateLike>(
         codegen,
         constrain_func,
         map_name_to_arg_value(constrain_func, arg_names)?,
+        &declarations.var_decl_types,
         // concatenate circom template parameter names with `poly_expr_names`
         template_like.get_name_of_params().iter().chain(poly_expr_names.iter()),
     )?;
@@ -698,6 +715,7 @@ fn gen_template_llzk<'ast, 'ctx, T: TemplateLike>(
         compute_ctx,
         constrain_ctx,
         &subcmp_names,
+        &declarations.var_decl_types,
     );
     template_like.gen_preamble(codegen, &template_context)?;
     template_like.get_body().gen_llzk_in_template(codegen, &template_context)?;
@@ -712,8 +730,8 @@ fn scalar_or_inner<'ctx>(t: Type<'ctx>) -> Type<'ctx> {
 /// Generates the prologue related to subcomponents in a template body.
 fn gen_subcmps_prologue_in_template<'ast, 'ctx, 'func, 'blk, 'val>(
     subcmps: impl IntoIterator<Item = SubcmpPrologueData<'ast, 'ctx>>,
-    compute_ctx: &mut FunctionContext<'ctx, 'func, 'blk, 'val>,
-    constrain_ctx: &mut FunctionContext<'ctx, '_, '_, '_>,
+    compute_ctx: &mut FunctionContext<'_, 'ctx, 'func, 'blk, 'val>,
+    constrain_ctx: &mut FunctionContext<'_, 'ctx, '_, '_, '_>,
     codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
     subcmp_decls: &HashMap<String, SubcmpDeclInfo<'ctx>>,
 ) -> Result<()>

--- a/llzk_backend/src/shared.rs
+++ b/llzk_backend/src/shared.rs
@@ -481,7 +481,7 @@ impl<'ctx> TypeSizeExpr<'ctx> {
     pub fn to_index_value<'ast, 'blk, 'val>(
         &self,
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        fc: &mut BlockGenContext<'ctx, 'blk, 'val>,
+        fc: &mut BlockGenContext<'_, 'ctx, 'blk, 'val>,
         location: Location<'ctx>,
         env: Option<&TmplParamsInstance<'ast, 'ctx>>,
     ) -> Result<Value<'ctx, 'val>> {
@@ -1660,6 +1660,9 @@ where
     /// Callback to store a `poly.expr` operation generated on the fly for an array dimension.
     fn callback_store_poly_expr(&self, name: String, op: TemplateExprOp<'ctx>);
 
+    /// Get the mapping of `var` name to declared LLZK type.
+    fn get_var_decl_types(&self) -> &HashMap<String, Type<'ctx>>;
+
     /// Generate a new `poly.expr` operation for the given array dimension [Expression].
     fn gen_template_poly_expr(
         &self,
@@ -1672,7 +1675,7 @@ where
         fn gen_stmt_fully<'ctx, 'blk, 'val>(
             stmt: &Statement,
             codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-            gen_ctx: &mut BlockGenContext<'ctx, 'blk, 'val>,
+            gen_ctx: &mut BlockGenContext<'_, 'ctx, 'blk, 'val>,
         ) -> Result<()>
         where
             'ctx: 'blk,
@@ -1692,7 +1695,16 @@ where
                 }
                 Statement::Declaration { meta, xtype, name, dimensions, .. } => {
                     if VariableType::Var == *xtype {
-                        gen_ctx.gen_declaration(codegen, meta, name, dimensions)?;
+                        // Use the pre-computed type from DeclarationInfo (seeded into the
+                        // BlockContextStack root) to avoid triggering recursive
+                        // gen_template_poly_expr calls for non-constant dimension expressions.
+                        if let Some(ty) = gen_ctx.var_decl_types.get(name) {
+                            let op = codegen
+                                .new_nondet_at_location(codegen.location_from_meta(meta), *ty)?;
+                            gen_ctx.block_ctx.declare_name_ensure_not_present(name, op)?;
+                        } else {
+                            gen_ctx.gen_declaration(codegen, meta, name, dimensions)?;
+                        }
                     }
                 }
                 Statement::Substitution { meta, var, access, op, rhe } => {
@@ -1755,7 +1767,7 @@ where
         #[allow(clippy::too_many_arguments)]
         fn gen_if_then_else_up_to_target<'ctx, 'blk, 'val>(
             codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-            gen_ctx: &mut BlockGenContext<'ctx, 'blk, 'val>,
+            gen_ctx: &mut BlockGenContext<'_, 'ctx, 'blk, 'val>,
             target_expr: &Expression,
             trace: &[*const Statement],
             meta: &Meta,
@@ -1829,7 +1841,7 @@ where
         /// generate LLZK for the `target_expr` and return its result [Value].
         fn gen_up_to_target<'ctx, 'blk, 'val>(
             codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-            gen_ctx: &mut BlockGenContext<'ctx, 'blk, 'val>,
+            gen_ctx: &mut BlockGenContext<'_, 'ctx, 'blk, 'val>,
             target_expr: &Expression,
             stmts: &[Statement],
             trace: &[*const Statement],
@@ -1859,7 +1871,6 @@ where
             // Process the boundary statement (the one on the trace path).
             match boundary_stmt {
                 Statement::Block { stmts, .. } => {
-                    // Target is somewhere within this block's statements; recurse.
                     gen_up_to_target(codegen, gen_ctx, target_expr, stmts, inner_trace)
                 }
                 Statement::InitializationBlock { initializations, .. } => {
@@ -1893,18 +1904,20 @@ where
         // Generate `poly.expr` and fill its initializer region.
         let location = codegen.location_from_meta(target_expr.get_meta());
         let expr_op = poly::expr(location, &name, std::iter::empty())?;
-        let mut gen_ctx = BlockGenContext::new(
+        let mut expr_gen_ctx = BlockGenContext::new(
             BlockContextStack::new(
                 expr_op.initializer_region().first_block().expect("block should have been added"),
             ),
+            self.get_var_decl_types(),
             self.poly_template_binding_names(),
         )
         .with_poly_template_binding_locals(codegen, location)?;
         let body_opt = codegen.current_body();
         assert!(body_opt.is_some(), "should have been set at top level");
         let trace = codegen.snapshot_statement_trace();
-        let val = gen_up_to_target(codegen, &mut gen_ctx, target_expr, body_opt.unwrap(), &trace)?;
-        gen_ctx.append_op_no_result(poly::r#yield(location, val)?.into())?;
+        let val =
+            gen_up_to_target(codegen, &mut expr_gen_ctx, target_expr, body_opt.unwrap(), &trace)?;
+        expr_gen_ctx.append_op_no_result(poly::r#yield(location, val)?.into())?;
 
         let name_sym = codegen.flat_sym(&name);
         self.callback_store_poly_expr(name, expr_op);

--- a/llzk_backend/src/template.rs
+++ b/llzk_backend/src/template.rs
@@ -17,6 +17,7 @@ use crate::program_ext::ProgramInfo;
 use crate::program_ext::ProgramLike;
 use crate::shared;
 use crate::shared::comp_type;
+use crate::shared::dim_expr_name;
 use crate::shared::map_array_inner_type;
 use crate::shared::ArrayDimension;
 use crate::shared::ArrayDimensionResult;
@@ -752,31 +753,21 @@ where
                 Expression::Number(_, _) => {
                     unreachable!("handled by try_compute_as_i64")
                 }
-                Expression::Variable { meta, name, access } => match access.as_slice() {
-                    [] => {
-                        // Grab the parameter name if it exists, else, defer to function generation.
-                        if self.template_def.has_const_param_named(name) {
-                            ArrayDimensionResult::new(codegen.flat_sym(name).into(), &[])
-                        } else {
-                            // Other variables are unsupported, defer to function context
-                            ArrayDimensionResult::insufficient_data_result()
-                        }
+                Expression::Variable { meta, name, access } if access.is_empty() => {
+                    // Grab the parameter name if it exists, else, defer to `BlockGenContext`.
+                    if self.template_def.has_const_param_named(name) {
+                        ArrayDimensionResult::new(codegen.flat_sym(name).into(), &[])
+                    } else {
+                        // Other variables are unsupported, defer to `BlockGenContext`
+                        ArrayDimensionResult::insufficient_data_result()
                     }
-                    a => {
-                        todo!("Handle Variable expression in dimension for non-integer attributes")
-                    }
-                },
-                Expression::InfixOp { meta, lhe, infix_op, rhe } => {
-                    todo!("Handle InfixOp in dimension for non-integer attributes: {:?}", expr)
                 }
-                Expression::PrefixOp { meta, prefix_op, rhe } => {
-                    todo!("Handle PrefixOp in dimension for non-integer attributes: {:?}", expr)
-                }
-                Expression::InlineSwitchOp { meta, cond, if_true, if_false } => {
-                    todo!("Handle InlineSwitch in dimension for non-integer attributes: {:?}", expr)
-                }
-                Expression::Call { meta, id, args } => {
-                    todo!("Handle Call in dimension for non-integer attributes: {:?}", expr)
+                Expression::Variable { .. } /* with non-empty `access` */
+                | Expression::InlineSwitchOp { .. }
+                | Expression::PrefixOp { .. }
+                | Expression::InfixOp { .. }
+                | Expression::Call { .. } => {
+                    self.gen_template_poly_expr(codegen, dim_expr_name(expr), expr)
                 }
                 // The remaining cases do not produce a scalar value.
                 // i.e. ParallelOp, ArrayInLine, UniformArray, BusCall, AnonymousComp, Tuple

--- a/llzk_backend/src/template.rs
+++ b/llzk_backend/src/template.rs
@@ -39,6 +39,7 @@ use llzk::dialect::constrain;
 use llzk::dialect::pod;
 use llzk::dialect::r#struct;
 use llzk::prelude::ArrayType;
+use llzk::prelude::BlockLike;
 use llzk::prelude::BlockRef;
 use llzk::prelude::FuncDefOpLike as _;
 use llzk::prelude::LoopBoundsAttribute;
@@ -86,7 +87,7 @@ where
 {
     /// Returns a [TemplateFuncPair] with a default [NestedBlockInfo] for `compute`/`constrain`
     /// according to the respective [ShouldGenerate] value in the given [TemplateContext].
-    pub fn new(template: &TemplateContext<'_, '_, '_, '_, '_>) -> Self {
+    pub fn new(template: &TemplateContext<'_, '_, '_, '_, '_, '_>) -> Self {
         Self {
             compute: template.compute.is_some().then(NestedBlockInfo::default),
             constrain: template.constrain.is_some().then(NestedBlockInfo::default),
@@ -112,7 +113,7 @@ where
 /// 'blk: lifetime of the generated `Block` instances within functions
 /// 'val: lifetime of the generated `Value` or `Operation` instances within blocks
 #[derive(Debug)]
-pub struct TemplateContext<'ctx, 'str, 'func, 'blk, 'val>
+pub struct TemplateContext<'decls, 'ctx, 'str, 'func, 'blk, 'val>
 where
     'ctx: 'str,
     'str: 'func,
@@ -125,25 +126,33 @@ where
     /// Current LLZK `StructDefOp` within the `TemplateOp`
     struct_def: StructDefOpRefMut<'ctx, 'str>,
     /// Codegen refs for the "@compute" function within `struct_def`
-    compute: ShouldGenerate<Rc<RefCell<FunctionContext<'ctx, 'func, 'blk, 'val>>>>,
+    compute: ShouldGenerate<Rc<RefCell<FunctionContext<'decls, 'ctx, 'func, 'blk, 'val>>>>,
     /// Codegen refs for the "@constrain" function within `struct_def`
-    constrain: ShouldGenerate<Rc<RefCell<FunctionContext<'ctx, 'func, 'blk, 'val>>>>,
+    constrain: ShouldGenerate<Rc<RefCell<FunctionContext<'decls, 'ctx, 'func, 'blk, 'val>>>>,
     /// Map of subcomponent names to their types.
     subcmps: &'str HashMap<String, String>,
     /// Tracks for what component signals we have created their `struct.writem` op already.
     written_signals: Rc<RefCell<HashSet<String>>>,
+    /// Pre-computed LLZK types for circom `var` declarations, keyed by var name. Populated from
+    /// [crate::module::DeclarationInfo] when generating `poly.expr` bodies for templates so that
+    /// dimension expressions referencing other vars do not trigger recursive code generation.
+    ///
+    /// Note: this is also stored in `compute` and/or `constrain` but it made several things more
+    /// straightforward to just store it here as well since it's just a reference.
+    var_decl_types: &'decls HashMap<String, Type<'ctx>>,
 }
 
-impl<'ctx, 'str, 'func, 'blk, 'val> TemplateContext<'ctx, 'str, 'func, 'blk, 'val> {
+impl<'decls, 'ctx, 'str, 'func, 'blk, 'val> TemplateContext<'decls, 'ctx, 'str, 'func, 'blk, 'val> {
     /// Creates a new [TemplateContext].
     #[inline]
     pub fn new(
         template_def: TemplateOpRefMut<'ctx, 'str>,
         struct_def: StructDefOpRefMut<'ctx, 'str>,
-        compute: FunctionContext<'ctx, 'func, 'blk, 'val>,
-        constrain: FunctionContext<'ctx, 'func, 'blk, 'val>,
+        compute: FunctionContext<'decls, 'ctx, 'func, 'blk, 'val>,
+        constrain: FunctionContext<'decls, 'ctx, 'func, 'blk, 'val>,
         subcmps: &'str HashMap<String, String>,
-    ) -> TemplateContext<'ctx, 'str, 'func, 'blk, 'val> {
+        var_decl_types: &'decls HashMap<String, Type<'ctx>>,
+    ) -> TemplateContext<'decls, 'ctx, 'str, 'func, 'blk, 'val> {
         Self {
             template_def,
             struct_def,
@@ -151,12 +160,13 @@ impl<'ctx, 'str, 'func, 'blk, 'val> TemplateContext<'ctx, 'str, 'func, 'blk, 'va
             constrain: Some(Rc::new(RefCell::new(constrain))),
             subcmps,
             written_signals: Default::default(),
+            var_decl_types,
         }
     }
 
     /// Creates a new [TemplateContext] that will only generate within the "@compute" function.
     #[inline]
-    pub fn compute_only(&self) -> TemplateContext<'ctx, 'str, 'func, 'blk, 'val> {
+    pub fn compute_only(&self) -> TemplateContext<'decls, 'ctx, 'str, 'func, 'blk, 'val> {
         Self {
             template_def: self.template_def,
             struct_def: self.struct_def,
@@ -164,12 +174,13 @@ impl<'ctx, 'str, 'func, 'blk, 'val> TemplateContext<'ctx, 'str, 'func, 'blk, 'va
             constrain: None,
             subcmps: self.subcmps,
             written_signals: self.written_signals.clone(),
+            var_decl_types: self.var_decl_types,
         }
     }
 
     /// Creates a new [TemplateContext] that will only generate within the "@constrain" function.
     #[inline]
-    pub fn constrain_only(&self) -> TemplateContext<'ctx, 'str, 'func, 'blk, 'val> {
+    pub fn constrain_only(&self) -> TemplateContext<'decls, 'ctx, 'str, 'func, 'blk, 'val> {
         Self {
             template_def: self.template_def,
             struct_def: self.struct_def,
@@ -177,6 +188,7 @@ impl<'ctx, 'str, 'func, 'blk, 'val> TemplateContext<'ctx, 'str, 'func, 'blk, 'va
             constrain: self.constrain.as_ref().map(Rc::clone),
             subcmps: self.subcmps,
             written_signals: self.written_signals.clone(),
+            var_decl_types: self.var_decl_types,
         }
     }
 
@@ -359,7 +371,7 @@ impl<'ctx, 'str, 'func, 'blk, 'val> TemplateContext<'ctx, 'str, 'func, 'blk, 'va
     }
 }
 
-impl SubcmpInfo for TemplateContext<'_, '_, '_, '_, '_> {
+impl SubcmpInfo for TemplateContext<'_, '_, '_, '_, '_, '_> {
     fn is_subcmp(&self, var: &str) -> bool {
         self.subcmps.contains_key(var)
     }
@@ -385,7 +397,7 @@ impl SubcmpInfo for TemplateContext<'_, '_, '_, '_, '_> {
 /// `TemplateContext` and is instead implemented for `&TemplateContext` which means its functions
 /// must be called via a `&mut &TemplateContext` reference.
 impl<'ctx, 'str, 'func, 'blk, 'val> GenWithCircomScopeHandling<'ctx, 'func, 'blk, 'val>
-    for &TemplateContext<'ctx, 'str, 'func, 'blk, 'val>
+    for &TemplateContext<'_, 'ctx, 'str, 'func, 'blk, 'val>
 where
     'ctx: 'str,
     'str: 'func,
@@ -418,7 +430,7 @@ where
     ) -> Result<()>
     where
         H: Fn(
-            &mut BlockGenContext<'ctx, 'blk, 'val>,
+            &mut BlockGenContext<'_, 'ctx, 'blk, 'val>,
             &mut NestedBlockInfo<'ctx, 'blk, 'val>,
             HashMap<String, Value<'ctx, 'val>>,
         ) -> Result<()>,
@@ -453,7 +465,7 @@ where
 /// per the type aliases below) that comes from generating LLZK for a circom Expression within a
 /// template.
 #[derive(Debug)]
-pub struct GenResult<'ctx, 'str, 'func, 'blk, 'val, 'r, ResultType>
+pub struct GenResult<'decls, 'ctx, 'str, 'func, 'blk, 'val, 'r, ResultType>
 where
     'ctx: 'str,
     'str: 'func,
@@ -462,7 +474,7 @@ where
     'val: 'r,
 {
     /// Reference to the template context in which the expression was generated.
-    template: &'r TemplateContext<'ctx, 'str, 'func, 'blk, 'val>,
+    template: &'r TemplateContext<'decls, 'ctx, 'str, 'func, 'blk, 'val>,
     /// Result for the "@compute" function.
     compute_res: ShouldGenerate<ResultType>,
     /// Result for the "@constrain" function.
@@ -470,28 +482,28 @@ where
 }
 
 /// Alias for [GenResult] containing a single SSA Value result.
-type GenResultSingleVal<'ctx, 'str, 'func, 'blk, 'val, 'r> =
-    GenResult<'ctx, 'str, 'func, 'blk, 'val, 'r, Value<'ctx, 'val>>;
+type GenResultSingleVal<'decls, 'ctx, 'str, 'func, 'blk, 'val, 'r> =
+    GenResult<'decls, 'ctx, 'str, 'func, 'blk, 'val, 'r, Value<'ctx, 'val>>;
 
 /// Alias for [GenResult] containing a list of SSA Value results.
-type GenResultMultiVal<'ctx, 'str, 'func, 'blk, 'val, 'r> =
-    GenResult<'ctx, 'str, 'func, 'blk, 'val, 'r, Vec<Value<'ctx, 'val>>>;
+type GenResultMultiVal<'decls, 'ctx, 'str, 'func, 'blk, 'val, 'r> =
+    GenResult<'decls, 'ctx, 'str, 'func, 'blk, 'val, 'r, Vec<Value<'ctx, 'val>>>;
 
 /// Alias for [GenResult] containing the unit type (i.e. nothing).
-type GenResultUnit<'ctx, 'str, 'func, 'blk, 'val, 'r> =
-    GenResult<'ctx, 'str, 'func, 'blk, 'val, 'r, ()>;
+type GenResultUnit<'decls, 'ctx, 'str, 'func, 'blk, 'val, 'r> =
+    GenResult<'decls, 'ctx, 'str, 'func, 'blk, 'val, 'r, ()>;
 
 /// This trait abstracts over the output type of [Chainable::and_then] to allow a single
 /// implementation of that function to produce different result types depending on the callback
 /// function type provided.
-trait ChainResult<'ctx, 'str, 'func, 'blk, 'val, 'r> {
+trait ChainResult<'decls, 'ctx, 'str, 'func, 'blk, 'val, 'r> {
     /// Output type of the generator callback functions.
     type HandlerOutput;
 
     /// Combines results from the "@compute" and "@constrain" generator functions into the final
     /// result of [Chainable::and_then].
     fn produce(
-        template: &'r TemplateContext<'ctx, 'str, 'func, 'blk, 'val>,
+        template: &'r TemplateContext<'decls, 'ctx, 'str, 'func, 'blk, 'val>,
         compute_res: ShouldGenerate<Self::HandlerOutput>,
         constrain_res: ShouldGenerate<Self::HandlerOutput>,
     ) -> Self;
@@ -499,8 +511,9 @@ trait ChainResult<'ctx, 'str, 'func, 'blk, 'val, 'r> {
 
 /// Support [Chainable::and_then] producing a [GenResult]. This allows for chaining another
 /// generator function on this result whose input is `ResultType`.
-impl<'ctx, 'str, 'func, 'blk, 'val, 'r, ResultType> ChainResult<'ctx, 'str, 'func, 'blk, 'val, 'r>
-    for GenResult<'ctx, 'str, 'func, 'blk, 'val, 'r, ResultType>
+impl<'decls, 'ctx, 'str, 'func, 'blk, 'val, 'r, ResultType>
+    ChainResult<'decls, 'ctx, 'str, 'func, 'blk, 'val, 'r>
+    for GenResult<'decls, 'ctx, 'str, 'func, 'blk, 'val, 'r, ResultType>
 where
     'ctx: 'str,
     'str: 'func,
@@ -511,11 +524,11 @@ where
     type HandlerOutput = ResultType;
 
     fn produce(
-        template: &'r TemplateContext<'ctx, 'str, 'func, 'blk, 'val>,
+        template: &'r TemplateContext<'decls, 'ctx, 'str, 'func, 'blk, 'val>,
         compute_res: ShouldGenerate<Self::HandlerOutput>,
         constrain_res: ShouldGenerate<Self::HandlerOutput>,
     ) -> Self {
-        GenResult::<'ctx, 'str, 'func, 'blk, 'val, 'r, ResultType> {
+        GenResult::<'decls, 'ctx, 'str, 'func, 'blk, 'val, 'r, ResultType> {
             template,
             compute_res,
             constrain_res,
@@ -525,7 +538,8 @@ where
 
 /// Support [Chainable::and_then] producing `()` which can be used when nothing further is generated
 /// from the result and there is no [Value] available to return within the generator function.
-impl<'ctx, 'str, 'func, 'blk, 'val, 'r> ChainResult<'ctx, 'str, 'func, 'blk, 'val, 'r> for ()
+impl<'decls, 'ctx, 'str, 'func, 'blk, 'val, 'r>
+    ChainResult<'decls, 'ctx, 'str, 'func, 'blk, 'val, 'r> for ()
 where
     'ctx: 'str,
     'str: 'func,
@@ -536,7 +550,7 @@ where
     type HandlerOutput = ();
 
     fn produce(
-        _: &'r TemplateContext<'ctx, 'str, 'func, 'blk, 'val>,
+        _: &'r TemplateContext<'decls, 'ctx, 'str, 'func, 'blk, 'val>,
         _: ShouldGenerate<Self::HandlerOutput>,
         _: ShouldGenerate<Self::HandlerOutput>,
     ) -> Self {
@@ -546,7 +560,7 @@ where
 /// This trait provides a clean interface for chaining multiple code generation steps. It abstracts
 /// away most of the complexity (unwrapping, is_some assertions, etc.) that result from
 /// [GenResult] containing optional results for both "@compute" and "@constrain" functions.
-trait Chainable<'ctx, 'str, 'func, 'blk, 'val, 'r>
+trait Chainable<'decls, 'ctx, 'str, 'func, 'blk, 'val, 'r>
 where
     'ctx: 'str,
     'str: 'func,
@@ -559,31 +573,31 @@ where
 
     /// Applies the compute and constrain generator functions to the current result, producing
     /// a new [ChainResult].
-    fn and_then<F1, F2, CR: ChainResult<'ctx, 'str, 'func, 'blk, 'val, 'r>>(
+    fn and_then<F1, F2, CR: ChainResult<'decls, 'ctx, 'str, 'func, 'blk, 'val, 'r>>(
         self,
         gen_compute: F1,
         gen_constrain: F2,
     ) -> Result<CR>
     where
         F1: FnOnce(
-            &mut FunctionContext<'ctx, 'func, 'blk, 'val>,
+            &mut FunctionContext<'decls, 'ctx, 'func, 'blk, 'val>,
             Self::HandlerInput,
         ) -> Result<CR::HandlerOutput>,
         F2: FnOnce(
-            &mut FunctionContext<'ctx, 'func, 'blk, 'val>,
+            &mut FunctionContext<'decls, 'ctx, 'func, 'blk, 'val>,
             Self::HandlerInput,
         ) -> Result<CR::HandlerOutput>;
 
     /// Delegates to [Self::and_then] with the same handler for both compute and constrain.
     #[inline]
-    fn and_then_same<F, CR: ChainResult<'ctx, 'str, 'func, 'blk, 'val, 'r>>(
+    fn and_then_same<F, CR: ChainResult<'decls, 'ctx, 'str, 'func, 'blk, 'val, 'r>>(
         self,
         handle: F,
     ) -> Result<CR>
     where
         Self: Sized,
         F: Fn(
-            &mut FunctionContext<'ctx, 'func, 'blk, 'val>,
+            &mut FunctionContext<'decls, 'ctx, 'func, 'blk, 'val>,
             Self::HandlerInput,
         ) -> Result<CR::HandlerOutput>,
     {
@@ -591,7 +605,8 @@ where
     }
 }
 
-impl<'ctx, 'str, 'func, 'blk, 'val, 'r> GenResultMultiVal<'ctx, 'str, 'func, 'blk, 'val, 'r>
+impl<'decls, 'ctx, 'str, 'func, 'blk, 'val, 'r>
+    GenResultMultiVal<'decls, 'ctx, 'str, 'func, 'blk, 'val, 'r>
 where
     'ctx: 'str,
     'str: 'func,
@@ -602,7 +617,7 @@ where
     /// Create an empty [GenResultMultiVal] (i.e. an [GenResult] where the result
     /// is a vector of SSA Values).
     #[inline]
-    fn new(template: &'r TemplateContext<'ctx, 'str, 'func, 'blk, 'val>) -> Self {
+    fn new(template: &'r TemplateContext<'decls, 'ctx, 'str, 'func, 'blk, 'val>) -> Self {
         GenResult {
             template,
             // This construction ensures that the result vectors are only created
@@ -615,7 +630,7 @@ where
     /// Create an [GenResultMultiVal] populated by generating LLZK for each [Expression] given.
     #[inline]
     fn gen_exprs<'ast, I>(
-        template: &'r TemplateContext<'ctx, 'str, 'func, 'blk, 'val>,
+        template: &'r TemplateContext<'decls, 'ctx, 'str, 'func, 'blk, 'val>,
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
         exprs: I,
     ) -> Result<Self>
@@ -640,8 +655,9 @@ where
 }
 
 /// Implementation of [Chainable] for any [GenResult].
-impl<'ctx, 'str, 'func, 'blk, 'val, 'r, T> Chainable<'ctx, 'str, 'func, 'blk, 'val, 'r>
-    for GenResult<'ctx, 'str, 'func, 'blk, 'val, 'r, T>
+impl<'decls, 'ctx, 'str, 'func, 'blk, 'val, 'r, T>
+    Chainable<'decls, 'ctx, 'str, 'func, 'blk, 'val, 'r>
+    for GenResult<'decls, 'ctx, 'str, 'func, 'blk, 'val, 'r, T>
 where
     'ctx: 'str,
     'str: 'func,
@@ -651,18 +667,18 @@ where
 {
     type HandlerInput = T;
 
-    fn and_then<F1, F2, CR: ChainResult<'ctx, 'str, 'func, 'blk, 'val, 'r>>(
+    fn and_then<F1, F2, CR: ChainResult<'decls, 'ctx, 'str, 'func, 'blk, 'val, 'r>>(
         self,
         gen_compute: F1,
         gen_constrain: F2,
     ) -> Result<CR>
     where
         F1: FnOnce(
-            &mut FunctionContext<'ctx, 'func, 'blk, 'val>,
+            &mut FunctionContext<'decls, 'ctx, 'func, 'blk, 'val>,
             Self::HandlerInput,
         ) -> Result<CR::HandlerOutput>,
         F2: FnOnce(
-            &mut FunctionContext<'ctx, 'func, 'blk, 'val>,
+            &mut FunctionContext<'decls, 'ctx, 'func, 'blk, 'val>,
             Self::HandlerInput,
         ) -> Result<CR::HandlerOutput>,
     {
@@ -689,8 +705,8 @@ where
 
 /// Implementation of [Chainable] for a [TemplateContext]. Useful when there is no initial
 /// [GenResult] to chain onto.
-impl<'ctx, 'str, 'func, 'blk, 'val, 'r> Chainable<'ctx, 'str, 'func, 'blk, 'val, 'r>
-    for &'r TemplateContext<'ctx, 'str, 'func, 'blk, 'val>
+impl<'decls, 'ctx, 'str, 'func, 'blk, 'val, 'r> Chainable<'decls, 'ctx, 'str, 'func, 'blk, 'val, 'r>
+    for &'r TemplateContext<'decls, 'ctx, 'str, 'func, 'blk, 'val>
 where
     'ctx: 'str,
     'str: 'func,
@@ -700,18 +716,18 @@ where
 {
     type HandlerInput = ();
 
-    fn and_then<F1, F2, CR: ChainResult<'ctx, 'str, 'func, 'blk, 'val, 'r>>(
+    fn and_then<F1, F2, CR: ChainResult<'decls, 'ctx, 'str, 'func, 'blk, 'val, 'r>>(
         self,
         gen_compute: F1,
         gen_constrain: F2,
     ) -> Result<CR>
     where
         F1: FnOnce(
-            &mut FunctionContext<'ctx, 'func, 'blk, 'val>,
+            &mut FunctionContext<'decls, 'ctx, 'func, 'blk, 'val>,
             Self::HandlerInput,
         ) -> Result<CR::HandlerOutput>,
         F2: FnOnce(
-            &mut FunctionContext<'ctx, 'func, 'blk, 'val>,
+            &mut FunctionContext<'decls, 'ctx, 'func, 'blk, 'val>,
             Self::HandlerInput,
         ) -> Result<CR::HandlerOutput>,
     {
@@ -726,16 +742,20 @@ where
     }
 }
 
-impl<'ctx, 'func, 'blk, 'val, 'str> DimExprConverter<'ctx, 'val>
-    for TemplateContext<'ctx, 'str, 'func, 'blk, 'val>
+impl<'decls, 'ctx, 'func, 'blk, 'val, 'str> DimExprConverter<'ctx, 'val>
+    for TemplateContext<'decls, 'ctx, 'str, 'func, 'blk, 'val>
 where
     'ctx: 'str,
     'str: 'func,
     'func: 'blk,
     'blk: 'val,
 {
-    fn callback_store_poly_expr(&self, name: String, op: TemplateExprOp<'ctx>) {
-        todo!("TemplateContext::store_template_poly_expr: {name} -> {op:?}");
+    fn get_var_decl_types(&self) -> &HashMap<String, Type<'ctx>> {
+        self.var_decl_types
+    }
+
+    fn callback_store_poly_expr(&self, _: String, op: TemplateExprOp<'ctx>) {
+        self.template_def.body().append_operation(op.into());
     }
 
     fn get_dim_expr(
@@ -788,8 +808,9 @@ where
 /// 'func: lifetime of the generated `FuncDefOp` instances within the struct
 /// 'blk: lifetime of the generated `Block` instances within functions
 /// 'val: lifetime of the generated `Value` or `Operation` instances within blocks
-pub trait GenerateLLZKInTemplate<'ctx, 'str, 'func, 'blk, 'val>
+pub trait GenerateLLZKInTemplate<'decls, 'ctx, 'str, 'func, 'blk, 'val>
 where
+    'ctx: 'decls,
     'ctx: 'str,
     'str: 'func,
     'func: 'blk,
@@ -799,6 +820,7 @@ where
     /// should be the unit type whereas [Expression] nodes produce a Value.
     type Output<'r>
     where
+        'decls: 'r,
         'val: 'r,
         'val: 'blk;
 
@@ -806,15 +828,16 @@ where
     fn gen_llzk_in_template<'r>(
         &self,
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        template: &'r TemplateContext<'ctx, 'str, 'func, 'blk, 'val>,
+        template: &'r TemplateContext<'decls, 'ctx, 'str, 'func, 'blk, 'val>,
     ) -> Result<Self::Output<'r>>
     where
         'val: 'r;
 }
 
-impl<'ctx, 'str, 'func, 'blk, 'val> GenerateLLZKInTemplate<'ctx, 'str, 'func, 'blk, 'val>
-    for [Statement]
+impl<'decls, 'ctx, 'str, 'func, 'blk, 'val>
+    GenerateLLZKInTemplate<'decls, 'ctx, 'str, 'func, 'blk, 'val> for [Statement]
 where
+    'ctx: 'decls,
     'ctx: 'str,
     'str: 'func,
     'func: 'blk,
@@ -824,12 +847,13 @@ where
     type Output<'r>
         = ()
     where
+        'decls: 'r,
         'val: 'r;
 
     fn gen_llzk_in_template<'r>(
         &self,
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        template: &'r TemplateContext<'ctx, 'str, 'func, 'blk, 'val>,
+        template: &'r TemplateContext<'decls, 'ctx, 'str, 'func, 'blk, 'val>,
     ) -> Result<Self::Output<'r>>
     where
         'val: 'r,
@@ -851,7 +875,7 @@ where
 /// Generate LLZK code for a circom [Statement::IfThenElse].
 fn gen_if_then_else<'ctx, 'str, 'func, 'blk, 'val, 'r>(
     codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-    template: &'r TemplateContext<'ctx, 'str, 'func, 'blk, 'val>,
+    template: &'r TemplateContext<'_, 'ctx, 'str, 'func, 'blk, 'val>,
     meta: &Meta,
     cond: &Expression,
     if_case: &Statement,
@@ -911,7 +935,7 @@ where
 /// Generate LLZK code for a circom [Statement::While].
 fn gen_while<'ctx, 'str, 'func, 'blk, 'val, 'r>(
     codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-    template: &'r TemplateContext<'ctx, 'str, 'func, 'blk, 'val>,
+    template: &'r TemplateContext<'_, 'ctx, 'str, 'func, 'blk, 'val>,
     meta: &Meta,
     cond: &Expression,
     body_stmt: &Statement,
@@ -981,7 +1005,7 @@ where
 #[inline]
 fn gen_init_block<'ctx, 'str, 'func, 'blk, 'val, 'r>(
     codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-    template: &'r TemplateContext<'ctx, 'str, 'func, 'blk, 'val>,
+    template: &'r TemplateContext<'_, 'ctx, 'str, 'func, 'blk, 'val>,
     initializations: &[Statement],
 ) -> Result<()>
 where
@@ -992,9 +1016,10 @@ where
     initializations.gen_llzk_in_template(codegen, template)
 }
 
-impl<'ctx, 'str, 'func, 'blk, 'val> GenerateLLZKInTemplate<'ctx, 'str, 'func, 'blk, 'val>
-    for Statement
+impl<'decls, 'ctx, 'str, 'func, 'blk, 'val>
+    GenerateLLZKInTemplate<'decls, 'ctx, 'str, 'func, 'blk, 'val> for Statement
 where
+    'ctx: 'decls,
     'ctx: 'str,
     'str: 'func,
     'func: 'blk,
@@ -1004,12 +1029,13 @@ where
     type Output<'r>
         = ()
     where
+        'decls: 'r,
         'val: 'r;
 
     fn gen_llzk_in_template<'r>(
         &self,
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        template: &'r TemplateContext<'ctx, 'str, 'func, 'blk, 'val>,
+        template: &'r TemplateContext<'decls, 'ctx, 'str, 'func, 'blk, 'val>,
     ) -> Result<Self::Output<'r>>
     where
         'val: 'r,
@@ -1230,9 +1256,10 @@ where
     }
 }
 
-impl<'ctx, 'str, 'func, 'blk, 'val> GenerateLLZKInTemplate<'ctx, 'str, 'func, 'blk, 'val>
-    for Expression
+impl<'decls, 'ctx, 'str, 'func, 'blk, 'val>
+    GenerateLLZKInTemplate<'decls, 'ctx, 'str, 'func, 'blk, 'val> for Expression
 where
+    'ctx: 'decls,
     'ctx: 'str,
     'str: 'func,
     'func: 'blk,
@@ -1240,14 +1267,15 @@ where
     'val: 'blk,
 {
     type Output<'r>
-        = GenResultSingleVal<'ctx, 'str, 'func, 'blk, 'val, 'r>
+        = GenResultSingleVal<'decls, 'ctx, 'str, 'func, 'blk, 'val, 'r>
     where
+        'decls: 'r,
         'val: 'r;
 
     fn gen_llzk_in_template<'r>(
         &self,
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        template: &'r TemplateContext<'ctx, 'str, 'func, 'blk, 'val>,
+        template: &'r TemplateContext<'decls, 'ctx, 'str, 'func, 'blk, 'val>,
     ) -> Result<Self::Output<'r>>
     where
         'val: 'r,

--- a/llzk_backend/src/template_ext.rs
+++ b/llzk_backend/src/template_ext.rs
@@ -118,7 +118,7 @@ pub trait TemplateLike: std::fmt::Debug {
     fn gen_preamble<'ctx>(
         &self,
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        template: &TemplateContext<'ctx, '_, '_, '_, '_>,
+        template: &TemplateContext<'_, 'ctx, '_, '_, '_, '_>,
     ) -> Result<()>;
 }
 
@@ -177,7 +177,7 @@ impl TemplateLike for TemplateData {
     fn gen_preamble<'ctx>(
         &self,
         _codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        _template: &TemplateContext<'ctx, '_, '_, '_, '_>,
+        _template: &TemplateContext<'_, 'ctx, '_, '_, '_, '_>,
     ) -> Result<()> {
         Ok(())
     }
@@ -310,7 +310,7 @@ impl TemplateLike for TemplateInstance {
     fn gen_preamble<'ctx>(
         &self,
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        template: &TemplateContext<'ctx, '_, '_, '_, '_>,
+        template: &TemplateContext<'_, 'ctx, '_, '_, '_, '_>,
     ) -> Result<()> {
         fn build_nested(
             meta: &Meta,

--- a/llzk_backend/src/write_chain.rs
+++ b/llzk_backend/src/write_chain.rs
@@ -33,7 +33,7 @@ pub trait SignalWriteInfo: std::fmt::Debug {
     fn mark_signal_as_written(&self, name: String);
 }
 
-impl SignalWriteInfo for TemplateContext<'_, '_, '_, '_, '_> {
+impl SignalWriteInfo for TemplateContext<'_, '_, '_, '_, '_, '_> {
     fn signal_already_written(&self, name: &str) -> bool {
         self.signal_already_written(name)
     }
@@ -131,7 +131,7 @@ impl<'ast> WriteChain<'ast> {
         val: Value<'ctx, 'val>,
         target: WriteTarget,
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        fc: &mut FunctionContext<'ctx, '_, '_, 'val>,
+        fc: &mut FunctionContext<'_, 'ctx, '_, '_, 'val>,
         location: Location<'ctx>,
         signal_write_info: &dyn SignalWriteInfo,
         subcmp_info: &dyn SubcmpInfo,
@@ -161,7 +161,7 @@ impl<'ast> WriteChain<'ast> {
         val: Value<'ctx, 'val>,
         target: WriteTarget,
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        fc: &mut FunctionContext<'ctx, '_, '_, 'val>,
+        fc: &mut FunctionContext<'_, 'ctx, '_, '_, 'val>,
         location: Location<'ctx>,
         signal_write_info: &dyn SignalWriteInfo,
         subcmp_info: &dyn SubcmpInfo,
@@ -224,7 +224,7 @@ impl<'ast> WriteChain<'ast> {
         val: Value<'ctx, 'val>,
         target: WriteTarget,
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        fc: &mut FunctionContext<'ctx, '_, '_, 'val>,
+        fc: &mut FunctionContext<'_, 'ctx, '_, '_, 'val>,
         location: Location<'ctx>,
         signal_write_info: &dyn SignalWriteInfo,
         subcmp_info: &dyn SubcmpInfo,
@@ -234,7 +234,7 @@ impl<'ast> WriteChain<'ast> {
             var: String,
             val: Value<'ctx, 'val>,
             target: WriteTarget,
-            fc: &mut FunctionContext<'ctx, '_, '_, 'val>,
+            fc: &mut FunctionContext<'_, 'ctx, '_, '_, 'val>,
             location: Location<'ctx>,
             signal_write_info: &dyn SignalWriteInfo,
         ) -> Result<()> {


### PR DESCRIPTION
- Implement most of the remaining `get_dim_expr()` cases. 
- Cache circom `var` declaration types in the context so they can be reused in `poly.expr` to avoid infinite recursion in `get_dim_expr()`. This unfortunately required a mass propagation of an additional lifetime parameter (to avoid cloning the map repeatedly).

There are currently no new passing tests because of naming conflicts between `poly.expr` which will be resolved once I add the API to `llzk-rs`. Since these changes are widespread, I think it best to merge them without waiting on that Rust API so @0xddom does not end up with annoying merge conflicts.