### PR TITLE
Avoid `poly.expr` name conflicts

### DIFF
--- a/circom/tests/arrays/array_dimensions_06.circom
+++ b/circom/tests/arrays/array_dimensions_06.circom
@@ -13,22 +13,22 @@ component main = ArrayDims(7);
 // CHECK-LABEL: module attributes {llzk.lang, llzk.main = !struct.type<@ArrayDims::@ArrayDims<[7]>>} {
 // CHECK-NEXT:    poly.template @ArrayDims {
 // CHECK-NEXT:      poly.param @N
-// CHECK-NEXT:      poly.expr @N_Add_1 {
+// CHECK-NEXT:      poly.expr @"N_Add_1@279" {
 // CHECK-NEXT:        %[[VAL_0:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
 // CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
 // CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_0]], %[[VAL_1]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:        poly.yield %[[VAL_2]] : !felt.type<"bn128">
 // CHECK-NEXT:      }
 // CHECK-NEXT:      struct.def @ArrayDims {
-// CHECK-NEXT:        function.def @compute(%[[VAL_3:[0-9a-zA-Z_\.]+]]: !array.type<@N_Add_1 x !felt.type<"bn128">>) -> !struct.type<@ArrayDims::@ArrayDims<[@N]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
+// CHECK-NEXT:        function.def @compute(%[[VAL_3:[0-9a-zA-Z_\.]+]]: !array.type<@"N_Add_1@279" x !felt.type<"bn128">>) -> !struct.type<@ArrayDims::@ArrayDims<[@N]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
 // CHECK-NEXT:          %[[VAL_4:[0-9a-zA-Z_\.]+]] = struct.new : <@ArrayDims::@ArrayDims<[@N]>>
 // CHECK-NEXT:          %[[VAL_5:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_6:[0-9a-zA-Z_\.]+]] = poly.read_const @N_Add_1 : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_6:[0-9a-zA-Z_\.]+]] = poly.read_const @"N_Add_1@279" : !felt.type<"bn128">
 // CHECK-NEXT:          function.return %[[VAL_4]] : !struct.type<@ArrayDims::@ArrayDims<[@N]>>
 // CHECK-NEXT:        }
-// CHECK-NEXT:        function.def @constrain(%[[VAL_7:[0-9a-zA-Z_\.]+]]: !struct.type<@ArrayDims::@ArrayDims<[@N]>>, %[[VAL_8:[0-9a-zA-Z_\.]+]]: !array.type<@N_Add_1 x !felt.type<"bn128">>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        function.def @constrain(%[[VAL_7:[0-9a-zA-Z_\.]+]]: !struct.type<@ArrayDims::@ArrayDims<[@N]>>, %[[VAL_8:[0-9a-zA-Z_\.]+]]: !array.type<@"N_Add_1@279" x !felt.type<"bn128">>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:          %[[VAL_9:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_10:[0-9a-zA-Z_\.]+]] = poly.read_const @N_Add_1 : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_10:[0-9a-zA-Z_\.]+]] = poly.read_const @"N_Add_1@279" : !felt.type<"bn128">
 // CHECK-NEXT:          function.return
 // CHECK-NEXT:        }
 // CHECK-NEXT:      }

--- a/circom/tests/arrays/array_dimensions_10.circom
+++ b/circom/tests/arrays/array_dimensions_10.circom
@@ -13,7 +13,7 @@ component main = ArrayDims();
 
 // CHECK-LABEL: module attributes {llzk.lang, llzk.main = !struct.type<@ArrayDims::@ArrayDims<[]>>} {
 // CHECK-NEXT:    poly.template @ArrayDims {
-// CHECK-NEXT:      poly.expr @"a[1]" {
+// CHECK-NEXT:      poly.expr @"a[1]@307" {
 // CHECK-NEXT:        %[[VAL_0:[0-9a-zA-Z_\.]+]] = llzk.nondet : !array.type<2 x !felt.type<"bn128">>
 // CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
 // CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_1]], %[[VAL_1]] : <2 x !felt.type<"bn128">>
@@ -26,10 +26,10 @@ component main = ArrayDims();
 // CHECK-NEXT:        poly.yield %[[VAL_8]] : !felt.type<"bn128">
 // CHECK-NEXT:      }
 // CHECK-NEXT:      struct.def @ArrayDims {
-// CHECK-NEXT:        struct.member @outp : !array.type<@"a[1]" x !felt.type<"bn128">> {llzk.pub}
+// CHECK-NEXT:        struct.member @outp : !array.type<@"a[1]@307" x !felt.type<"bn128">> {llzk.pub}
 // CHECK-NEXT:        function.def @compute() -> !struct.type<@ArrayDims::@ArrayDims<[]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
 // CHECK-NEXT:          %[[VAL_9:[0-9a-zA-Z_\.]+]] = struct.new : <@ArrayDims::@ArrayDims<[]>>
-// CHECK-NEXT:          %[[VAL_10:[0-9a-zA-Z_\.]+]] = poly.read_const @"a[1]" : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_10:[0-9a-zA-Z_\.]+]] = poly.read_const @"a[1]@307" : !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_11:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
 // CHECK-NEXT:          %[[VAL_12:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_11]], %[[VAL_11]] : <2 x !felt.type<"bn128">>
 // CHECK-NEXT:          %[[VAL_13:[0-9a-zA-Z_\.]+]] = felt.const  123 : <"bn128">
@@ -38,8 +38,8 @@ component main = ArrayDims();
 // CHECK-NEXT:          function.return %[[VAL_9]] : !struct.type<@ArrayDims::@ArrayDims<[]>>
 // CHECK-NEXT:        }
 // CHECK-NEXT:        function.def @constrain(%[[VAL_16:[0-9a-zA-Z_\.]+]]: !struct.type<@ArrayDims::@ArrayDims<[]>>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:          %[[VAL_17:[0-9a-zA-Z_\.]+]] = poly.read_const @"a[1]" : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_18:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_16]][@outp] : <@ArrayDims::@ArrayDims<[]>>, !array.type<@"a[1]" x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_17:[0-9a-zA-Z_\.]+]] = poly.read_const @"a[1]@307" : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_18:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_16]][@outp] : <@ArrayDims::@ArrayDims<[]>>, !array.type<@"a[1]@307" x !felt.type<"bn128">>
 // CHECK-NEXT:          %[[VAL_19:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
 // CHECK-NEXT:          %[[VAL_20:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_19]], %[[VAL_19]] : <2 x !felt.type<"bn128">>
 // CHECK-NEXT:          %[[VAL_21:[0-9a-zA-Z_\.]+]] = felt.const  123 : <"bn128">

--- a/circom/tests/arrays/array_dimensions_11.circom
+++ b/circom/tests/arrays/array_dimensions_11.circom
@@ -19,7 +19,7 @@ component main = EvilArrayDims(7);
 // CHECK-LABEL: module attributes {llzk.lang, llzk.main = !struct.type<@EvilArrayDims::@EvilArrayDims<[7]>>} {
 // CHECK-NEXT:    poly.template @EvilArrayDims {
 // CHECK-NEXT:      poly.param @N
-// CHECK-NEXT:      poly.expr @"N_Greater_12?a[0]_Add_a[1]:0" {
+// CHECK-NEXT:      poly.expr @"N_Greater_12?a[0]_Add_a[1]:0@411" {
 // CHECK-NEXT:        %[[VAL_0:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
 // CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = llzk.nondet : !felt.type<"bn128">
 // CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = felt.const  12 : <"bn128">
@@ -51,7 +51,7 @@ component main = EvilArrayDims(7);
 // CHECK-NEXT:        }
 // CHECK-NEXT:        poly.yield %[[VAL_15]] : !felt.type<"bn128">
 // CHECK-NEXT:      }
-// CHECK-NEXT:      poly.expr @"a[1]" {
+// CHECK-NEXT:      poly.expr @"a[1]@381" {
 // CHECK-NEXT:        %[[VAL_24:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
 // CHECK-NEXT:        %[[VAL_25:[0-9a-zA-Z_\.]+]] = llzk.nondet : !felt.type<"bn128">
 // CHECK-NEXT:        %[[VAL_26:[0-9a-zA-Z_\.]+]] = felt.const  12 : <"bn128">
@@ -85,13 +85,13 @@ component main = EvilArrayDims(7);
 // CHECK-NEXT:        poly.yield %[[VAL_49]] : !felt.type<"bn128">
 // CHECK-NEXT:      }
 // CHECK-NEXT:      struct.def @EvilArrayDims {
-// CHECK-NEXT:        struct.member @out1 : !array.type<@"a[1]" x !felt.type<"bn128">> {llzk.pub}
-// CHECK-NEXT:        struct.member @out2 : !array.type<@"N_Greater_12?a[0]_Add_a[1]:0" x !felt.type<"bn128">> {llzk.pub}
+// CHECK-NEXT:        struct.member @out1 : !array.type<@"a[1]@381" x !felt.type<"bn128">> {llzk.pub}
+// CHECK-NEXT:        struct.member @out2 : !array.type<@"N_Greater_12?a[0]_Add_a[1]:0@411" x !felt.type<"bn128">> {llzk.pub}
 // CHECK-NEXT:        function.def @compute(%[[VAL_50:[0-9a-zA-Z_\.]+]]: !array.type<@x x !felt.type<"bn128">>) -> !struct.type<@EvilArrayDims::@EvilArrayDims<[@N]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
 // CHECK-NEXT:          %[[VAL_51:[0-9a-zA-Z_\.]+]] = struct.new : <@EvilArrayDims::@EvilArrayDims<[@N]>>
 // CHECK-NEXT:          %[[VAL_52:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_53:[0-9a-zA-Z_\.]+]] = poly.read_const @"N_Greater_12?a[0]_Add_a[1]:0" : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_54:[0-9a-zA-Z_\.]+]] = poly.read_const @"a[1]" : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_53:[0-9a-zA-Z_\.]+]] = poly.read_const @"N_Greater_12?a[0]_Add_a[1]:0@411" : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_54:[0-9a-zA-Z_\.]+]] = poly.read_const @"a[1]@381" : !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_55:[0-9a-zA-Z_\.]+]] = poly.read_const @x : !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_56:[0-9a-zA-Z_\.]+]] = felt.const  12 : <"bn128">
 // CHECK-NEXT:          %[[VAL_57:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
@@ -108,11 +108,11 @@ component main = EvilArrayDims(7);
 // CHECK-NEXT:        }
 // CHECK-NEXT:        function.def @constrain(%[[VAL_66:[0-9a-zA-Z_\.]+]]: !struct.type<@EvilArrayDims::@EvilArrayDims<[@N]>>, %[[VAL_67:[0-9a-zA-Z_\.]+]]: !array.type<@x x !felt.type<"bn128">>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:          %[[VAL_68:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_69:[0-9a-zA-Z_\.]+]] = poly.read_const @"N_Greater_12?a[0]_Add_a[1]:0" : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_70:[0-9a-zA-Z_\.]+]] = poly.read_const @"a[1]" : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_69:[0-9a-zA-Z_\.]+]] = poly.read_const @"N_Greater_12?a[0]_Add_a[1]:0@411" : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_70:[0-9a-zA-Z_\.]+]] = poly.read_const @"a[1]@381" : !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_71:[0-9a-zA-Z_\.]+]] = poly.read_const @x : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_72:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_66]][@out1] : <@EvilArrayDims::@EvilArrayDims<[@N]>>, !array.type<@"a[1]" x !felt.type<"bn128">>
-// CHECK-NEXT:          %[[VAL_73:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_66]][@out2] : <@EvilArrayDims::@EvilArrayDims<[@N]>>, !array.type<@"N_Greater_12?a[0]_Add_a[1]:0" x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_72:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_66]][@out1] : <@EvilArrayDims::@EvilArrayDims<[@N]>>, !array.type<@"a[1]@381" x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_73:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_66]][@out2] : <@EvilArrayDims::@EvilArrayDims<[@N]>>, !array.type<@"N_Greater_12?a[0]_Add_a[1]:0@411" x !felt.type<"bn128">>
 // CHECK-NEXT:          %[[VAL_74:[0-9a-zA-Z_\.]+]] = felt.const  12 : <"bn128">
 // CHECK-NEXT:          %[[VAL_75:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
 // CHECK-NEXT:          %[[VAL_76:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_75]], %[[VAL_75]] : <2 x !felt.type<"bn128">>

--- a/circom/tests/arrays/unknown_index_constrained.circom
+++ b/circom/tests/arrays/unknown_index_constrained.circom
@@ -329,7 +329,7 @@ component main = ForUnknownIndex(252);
 // CHECK-NEXT:    }
 // CHECK-NEXT:    poly.template @LessThan {
 // CHECK-NEXT:      poly.param @n
-// CHECK-NEXT:      poly.expr @n_Add_1 {
+// CHECK-NEXT:      poly.expr @"n_Add_1@633" {
 // CHECK-NEXT:        %[[VAL_174:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
 // CHECK-NEXT:        %[[VAL_175:[0-9a-zA-Z_\.]+]] = felt.const  252 : <"bn128">
 // CHECK-NEXT:        %[[VAL_176:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_174]], %[[VAL_175]]) : !felt.type<"bn128">, !felt.type<"bn128">
@@ -340,14 +340,14 @@ component main = ForUnknownIndex(252);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      struct.def @LessThan {
 // CHECK-NEXT:        struct.member @out : !felt.type<"bn128"> {llzk.pub}
-// CHECK-NEXT:        struct.member @n2b : !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>
+// CHECK-NEXT:        struct.member @n2b : !struct.type<@Num2Bits::@Num2Bits<[@"n_Add_1@633"]>>
 // CHECK-NEXT:        struct.member @n2b$inputs : !pod.type<[@in: !felt.type<"bn128">]>
 // CHECK-NEXT:        function.def @compute(%[[VAL_179:[0-9a-zA-Z_\.]+]]: !array.type<2 x !felt.type<"bn128">>) -> !struct.type<@LessThan::@LessThan<[@n]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
 // CHECK-NEXT:          %[[VAL_180:[0-9a-zA-Z_\.]+]] = struct.new : <@LessThan::@LessThan<[@n]>>
 // CHECK-NEXT:          %[[VAL_181:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_182:[0-9a-zA-Z_\.]+]] = poly.read_const @n_Add_1 : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_182:[0-9a-zA-Z_\.]+]] = poly.read_const @"n_Add_1@633" : !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_183:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:          %[[VAL_184:[0-9a-zA-Z_\.]+]] = pod.new { @count = %[[VAL_183]] }  : <[@count: index, @comp: !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:          %[[VAL_184:[0-9a-zA-Z_\.]+]] = pod.new { @count = %[[VAL_183]] }  : <[@count: index, @comp: !struct.type<@Num2Bits::@Num2Bits<[@"n_Add_1@633"]>>, @params: !pod.type<[]>]>
 // CHECK-NEXT:          %[[VAL_185:[0-9a-zA-Z_\.]+]] = pod.new : <[@in: !felt.type<"bn128">]>
 // CHECK-NEXT:          %[[VAL_186:[0-9a-zA-Z_\.]+]] = felt.const  252 : <"bn128">
 // CHECK-NEXT:          %[[VAL_187:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_181]], %[[VAL_186]]) : !felt.type<"bn128">, !felt.type<"bn128">
@@ -363,35 +363,35 @@ component main = ForUnknownIndex(252);
 // CHECK-NEXT:          %[[VAL_196:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_179]]{{\[}}%[[VAL_195]]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_197:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_193]], %[[VAL_196]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:          pod.write %[[VAL_185]][@in] = %[[VAL_197]] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_198:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_184]][@count] : <[@count: index, @comp: !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:          %[[VAL_198:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_184]][@count] : <[@count: index, @comp: !struct.type<@Num2Bits::@Num2Bits<[@"n_Add_1@633"]>>, @params: !pod.type<[]>]>, index
 // CHECK-NEXT:          %[[VAL_199:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
 // CHECK-NEXT:          %[[VAL_200:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_198]], %[[VAL_199]] : index
-// CHECK-NEXT:          pod.write %[[VAL_184]][@count] = %[[VAL_200]] : <[@count: index, @comp: !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:          pod.write %[[VAL_184]][@count] = %[[VAL_200]] : <[@count: index, @comp: !struct.type<@Num2Bits::@Num2Bits<[@"n_Add_1@633"]>>, @params: !pod.type<[]>]>, index
 // CHECK-NEXT:          %[[VAL_201:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
 // CHECK-NEXT:          %[[VAL_202:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_200]], %[[VAL_201]] : index
 // CHECK-NEXT:          scf.if %[[VAL_202]] {
 // CHECK-NEXT:            %[[VAL_203:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_185]][@in] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_204:[0-9a-zA-Z_\.]+]] = function.call @Num2Bits::@Num2Bits::@compute(%[[VAL_203]]) : (!felt.type<"bn128">) -> !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>
-// CHECK-NEXT:            pod.write %[[VAL_184]][@comp] = %[[VAL_204]] : <[@count: index, @comp: !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>, @params: !pod.type<[]>]>, !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>
+// CHECK-NEXT:            %[[VAL_204:[0-9a-zA-Z_\.]+]] = function.call @Num2Bits::@Num2Bits::@compute(%[[VAL_203]]) : (!felt.type<"bn128">) -> !struct.type<@Num2Bits::@Num2Bits<[@"n_Add_1@633"]>>
+// CHECK-NEXT:            pod.write %[[VAL_184]][@comp] = %[[VAL_204]] : <[@count: index, @comp: !struct.type<@Num2Bits::@Num2Bits<[@"n_Add_1@633"]>>, @params: !pod.type<[]>]>, !struct.type<@Num2Bits::@Num2Bits<[@"n_Add_1@633"]>>
 // CHECK-NEXT:          } else {
 // CHECK-NEXT:          }
 // CHECK-NEXT:          %[[VAL_205:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:          %[[VAL_206:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_184]][@comp] : <[@count: index, @comp: !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>, @params: !pod.type<[]>]>, !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>
-// CHECK-NEXT:          %[[VAL_207:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_206]][@out] : <@Num2Bits::@Num2Bits<[@n_Add_1]>>, !array.type<@n x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_206:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_184]][@comp] : <[@count: index, @comp: !struct.type<@Num2Bits::@Num2Bits<[@"n_Add_1@633"]>>, @params: !pod.type<[]>]>, !struct.type<@Num2Bits::@Num2Bits<[@"n_Add_1@633"]>>
+// CHECK-NEXT:          %[[VAL_207:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_206]][@out] : <@Num2Bits::@Num2Bits<[@"n_Add_1@633"]>>, !array.type<@n x !felt.type<"bn128">>
 // CHECK-NEXT:          %[[VAL_208:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_181]] : !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_209:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_207]]{{\[}}%[[VAL_208]]] : <@n x !felt.type<"bn128">>, !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_210:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_205]], %[[VAL_209]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:          struct.writem %[[VAL_180]][@out] = %[[VAL_210]] : <@LessThan::@LessThan<[@n]>>, !felt.type<"bn128">
 // CHECK-NEXT:          struct.writem %[[VAL_180]][@n2b$inputs] = %[[VAL_185]] : <@LessThan::@LessThan<[@n]>>, !pod.type<[@in: !felt.type<"bn128">]>
-// CHECK-NEXT:          %[[VAL_211:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_184]][@comp] : <[@count: index, @comp: !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>, @params: !pod.type<[]>]>, !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>
-// CHECK-NEXT:          struct.writem %[[VAL_180]][@n2b] = %[[VAL_211]] : <@LessThan::@LessThan<[@n]>>, !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>
+// CHECK-NEXT:          %[[VAL_211:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_184]][@comp] : <[@count: index, @comp: !struct.type<@Num2Bits::@Num2Bits<[@"n_Add_1@633"]>>, @params: !pod.type<[]>]>, !struct.type<@Num2Bits::@Num2Bits<[@"n_Add_1@633"]>>
+// CHECK-NEXT:          struct.writem %[[VAL_180]][@n2b] = %[[VAL_211]] : <@LessThan::@LessThan<[@n]>>, !struct.type<@Num2Bits::@Num2Bits<[@"n_Add_1@633"]>>
 // CHECK-NEXT:          function.return %[[VAL_180]] : !struct.type<@LessThan::@LessThan<[@n]>>
 // CHECK-NEXT:        }
 // CHECK-NEXT:        function.def @constrain(%[[VAL_212:[0-9a-zA-Z_\.]+]]: !struct.type<@LessThan::@LessThan<[@n]>>, %[[VAL_213:[0-9a-zA-Z_\.]+]]: !array.type<2 x !felt.type<"bn128">>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:          %[[VAL_214:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_215:[0-9a-zA-Z_\.]+]] = poly.read_const @n_Add_1 : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_215:[0-9a-zA-Z_\.]+]] = poly.read_const @"n_Add_1@633" : !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_216:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_212]][@out] : <@LessThan::@LessThan<[@n]>>, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_217:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_212]][@n2b] : <@LessThan::@LessThan<[@n]>>, !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>
+// CHECK-NEXT:          %[[VAL_217:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_212]][@n2b] : <@LessThan::@LessThan<[@n]>>, !struct.type<@Num2Bits::@Num2Bits<[@"n_Add_1@633"]>>
 // CHECK-NEXT:          %[[VAL_218:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_212]][@n2b$inputs] : <@LessThan::@LessThan<[@n]>>, !pod.type<[@in: !felt.type<"bn128">]>
 // CHECK-NEXT:          %[[VAL_219:[0-9a-zA-Z_\.]+]] = felt.const  252 : <"bn128">
 // CHECK-NEXT:          %[[VAL_220:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_214]], %[[VAL_219]]) : !felt.type<"bn128">, !felt.type<"bn128">
@@ -409,13 +409,13 @@ component main = ForUnknownIndex(252);
 // CHECK-NEXT:          %[[VAL_231:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_218]][@in] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
 // CHECK-NEXT:          constrain.eq %[[VAL_231]], %[[VAL_230]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_232:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:          %[[VAL_233:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_217]][@out] : <@Num2Bits::@Num2Bits<[@n_Add_1]>>, !array.type<@n x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_233:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_217]][@out] : <@Num2Bits::@Num2Bits<[@"n_Add_1@633"]>>, !array.type<@n x !felt.type<"bn128">>
 // CHECK-NEXT:          %[[VAL_234:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_214]] : !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_235:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_233]]{{\[}}%[[VAL_234]]] : <@n x !felt.type<"bn128">>, !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_236:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_232]], %[[VAL_235]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:          constrain.eq %[[VAL_216]], %[[VAL_236]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_237:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_218]][@in] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:          function.call @Num2Bits::@Num2Bits::@constrain(%[[VAL_217]], %[[VAL_237]]) : (!struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>, !felt.type<"bn128">) -> ()
+// CHECK-NEXT:          function.call @Num2Bits::@Num2Bits::@constrain(%[[VAL_217]], %[[VAL_237]]) : (!struct.type<@Num2Bits::@Num2Bits<[@"n_Add_1@633"]>>, !felt.type<"bn128">) -> ()
 // CHECK-NEXT:          function.return
 // CHECK-NEXT:        }
 // CHECK-NEXT:      }

--- a/circom/tests/loops/inner_loop_05.circom
+++ b/circom/tests/loops/inner_loop_05.circom
@@ -20,18 +20,18 @@ component main = Num2Bits(2);
 // CHECK-LABEL: module attributes {llzk.lang, llzk.main = !struct.type<@Num2Bits::@Num2Bits<[2]>>} {
 // CHECK-NEXT:    poly.template @Num2Bits {
 // CHECK-NEXT:      poly.param @n
-// CHECK-NEXT:      poly.expr @n_Mul_n {
+// CHECK-NEXT:      poly.expr @"n_Mul_n@300" {
 // CHECK-NEXT:        %[[VAL_0:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
 // CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_0]], %[[VAL_0]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:        poly.yield %[[VAL_1]] : !felt.type<"bn128">
 // CHECK-NEXT:      }
 // CHECK-NEXT:      struct.def @Num2Bits {
-// CHECK-NEXT:        struct.member @out : !array.type<@n_Mul_n x !felt.type<"bn128">> {llzk.pub}
+// CHECK-NEXT:        struct.member @out : !array.type<@"n_Mul_n@300" x !felt.type<"bn128">> {llzk.pub}
 // CHECK-NEXT:        function.def @compute(%[[VAL_2:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) -> !struct.type<@Num2Bits::@Num2Bits<[@n]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
 // CHECK-NEXT:          %[[VAL_3:[0-9a-zA-Z_\.]+]] = struct.new : <@Num2Bits::@Num2Bits<[@n]>>
 // CHECK-NEXT:          %[[VAL_4:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_5:[0-9a-zA-Z_\.]+]] = poly.read_const @n_Mul_n : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_6:[0-9a-zA-Z_\.]+]] = llzk.nondet : !array.type<@n_Mul_n x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_5:[0-9a-zA-Z_\.]+]] = poly.read_const @"n_Mul_n@300" : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_6:[0-9a-zA-Z_\.]+]] = llzk.nondet : !array.type<@"n_Mul_n@300" x !felt.type<"bn128">>
 // CHECK-NEXT:          %[[VAL_7:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
 // CHECK-NEXT:          %[[VAL_8:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_9:[0-9a-zA-Z_\.]+]] = %[[VAL_7]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
 // CHECK-NEXT:            %[[VAL_10:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_9]], %[[VAL_4]]) : !felt.type<"bn128">, !felt.type<"bn128">
@@ -47,7 +47,7 @@ component main = Num2Bits(2);
 // CHECK-NEXT:              %[[VAL_17:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_11]], %[[VAL_4]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:              %[[VAL_18:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_17]], %[[VAL_16]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:              %[[VAL_19:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_18]] : !felt.type<"bn128">
-// CHECK-NEXT:              array.write %[[VAL_6]]{{\[}}%[[VAL_19]]] = %[[VAL_2]] : <@n_Mul_n x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:              array.write %[[VAL_6]]{{\[}}%[[VAL_19]]] = %[[VAL_2]] : <@"n_Mul_n@300" x !felt.type<"bn128">>, !felt.type<"bn128">
 // CHECK-NEXT:              %[[VAL_20:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
 // CHECK-NEXT:              %[[VAL_21:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_16]], %[[VAL_20]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:              scf.yield %[[VAL_21]] : !felt.type<"bn128">
@@ -56,13 +56,13 @@ component main = Num2Bits(2);
 // CHECK-NEXT:            %[[VAL_23:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_11]], %[[VAL_22]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:            scf.yield %[[VAL_23]] : !felt.type<"bn128">
 // CHECK-NEXT:          }
-// CHECK-NEXT:          struct.writem %[[VAL_3]][@out] = %[[VAL_6]] : <@Num2Bits::@Num2Bits<[@n]>>, !array.type<@n_Mul_n x !felt.type<"bn128">>
+// CHECK-NEXT:          struct.writem %[[VAL_3]][@out] = %[[VAL_6]] : <@Num2Bits::@Num2Bits<[@n]>>, !array.type<@"n_Mul_n@300" x !felt.type<"bn128">>
 // CHECK-NEXT:          function.return %[[VAL_3]] : !struct.type<@Num2Bits::@Num2Bits<[@n]>>
 // CHECK-NEXT:        }
 // CHECK-NEXT:        function.def @constrain(%[[VAL_24:[0-9a-zA-Z_\.]+]]: !struct.type<@Num2Bits::@Num2Bits<[@n]>>, %[[VAL_25:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:          %[[VAL_26:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_27:[0-9a-zA-Z_\.]+]] = poly.read_const @n_Mul_n : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_28:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_24]][@out] : <@Num2Bits::@Num2Bits<[@n]>>, !array.type<@n_Mul_n x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_27:[0-9a-zA-Z_\.]+]] = poly.read_const @"n_Mul_n@300" : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_28:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_24]][@out] : <@Num2Bits::@Num2Bits<[@n]>>, !array.type<@"n_Mul_n@300" x !felt.type<"bn128">>
 // CHECK-NEXT:          %[[VAL_29:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
 // CHECK-NEXT:          %[[VAL_30:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_31:[0-9a-zA-Z_\.]+]] = %[[VAL_29]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
 // CHECK-NEXT:            %[[VAL_32:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_31]], %[[VAL_26]]) : !felt.type<"bn128">, !felt.type<"bn128">

--- a/circom/tests/loops/unknown_loop_index.circom
+++ b/circom/tests/loops/unknown_loop_index.circom
@@ -111,7 +111,7 @@ component main = UnknownLoopIndex(100);
 // CHECK-NEXT:    }
 // CHECK-NEXT:    poly.template @LessThan {
 // CHECK-NEXT:      poly.param @n
-// CHECK-NEXT:      poly.expr @n_Add_1 {
+// CHECK-NEXT:      poly.expr @"n_Add_1@633" {
 // CHECK-NEXT:        %[[VAL_23:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
 // CHECK-NEXT:        %[[VAL_24:[0-9a-zA-Z_\.]+]] = felt.const  252 : <"bn128">
 // CHECK-NEXT:        %[[VAL_25:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_23]], %[[VAL_24]]) : !felt.type<"bn128">, !felt.type<"bn128">
@@ -122,14 +122,14 @@ component main = UnknownLoopIndex(100);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      struct.def @LessThan {
 // CHECK-NEXT:        struct.member @out : !felt.type<"bn128"> {llzk.pub}
-// CHECK-NEXT:        struct.member @n2b : !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>
+// CHECK-NEXT:        struct.member @n2b : !struct.type<@Num2Bits::@Num2Bits<[@"n_Add_1@633"]>>
 // CHECK-NEXT:        struct.member @n2b$inputs : !pod.type<[@in: !felt.type<"bn128">]>
 // CHECK-NEXT:        function.def @compute(%[[VAL_28:[0-9a-zA-Z_\.]+]]: !array.type<2 x !felt.type<"bn128">>) -> !struct.type<@LessThan::@LessThan<[@n]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
 // CHECK-NEXT:          %[[VAL_29:[0-9a-zA-Z_\.]+]] = struct.new : <@LessThan::@LessThan<[@n]>>
 // CHECK-NEXT:          %[[VAL_30:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_31:[0-9a-zA-Z_\.]+]] = poly.read_const @n_Add_1 : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_31:[0-9a-zA-Z_\.]+]] = poly.read_const @"n_Add_1@633" : !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_32:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:          %[[VAL_33:[0-9a-zA-Z_\.]+]] = pod.new { @count = %[[VAL_32]] }  : <[@count: index, @comp: !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:          %[[VAL_33:[0-9a-zA-Z_\.]+]] = pod.new { @count = %[[VAL_32]] }  : <[@count: index, @comp: !struct.type<@Num2Bits::@Num2Bits<[@"n_Add_1@633"]>>, @params: !pod.type<[]>]>
 // CHECK-NEXT:          %[[VAL_34:[0-9a-zA-Z_\.]+]] = pod.new : <[@in: !felt.type<"bn128">]>
 // CHECK-NEXT:          %[[VAL_35:[0-9a-zA-Z_\.]+]] = felt.const  252 : <"bn128">
 // CHECK-NEXT:          %[[VAL_36:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_30]], %[[VAL_35]]) : !felt.type<"bn128">, !felt.type<"bn128">
@@ -145,35 +145,35 @@ component main = UnknownLoopIndex(100);
 // CHECK-NEXT:          %[[VAL_45:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_28]]{{\[}}%[[VAL_44]]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_46:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_42]], %[[VAL_45]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:          pod.write %[[VAL_34]][@in] = %[[VAL_46]] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_47:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_33]][@count] : <[@count: index, @comp: !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:          %[[VAL_47:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_33]][@count] : <[@count: index, @comp: !struct.type<@Num2Bits::@Num2Bits<[@"n_Add_1@633"]>>, @params: !pod.type<[]>]>, index
 // CHECK-NEXT:          %[[VAL_48:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
 // CHECK-NEXT:          %[[VAL_49:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_47]], %[[VAL_48]] : index
-// CHECK-NEXT:          pod.write %[[VAL_33]][@count] = %[[VAL_49]] : <[@count: index, @comp: !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:          pod.write %[[VAL_33]][@count] = %[[VAL_49]] : <[@count: index, @comp: !struct.type<@Num2Bits::@Num2Bits<[@"n_Add_1@633"]>>, @params: !pod.type<[]>]>, index
 // CHECK-NEXT:          %[[VAL_50:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
 // CHECK-NEXT:          %[[VAL_51:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_49]], %[[VAL_50]] : index
 // CHECK-NEXT:          scf.if %[[VAL_51]] {
 // CHECK-NEXT:            %[[VAL_52:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_34]][@in] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_53:[0-9a-zA-Z_\.]+]] = function.call @Num2Bits::@Num2Bits::@compute(%[[VAL_52]]) : (!felt.type<"bn128">) -> !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>
-// CHECK-NEXT:            pod.write %[[VAL_33]][@comp] = %[[VAL_53]] : <[@count: index, @comp: !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>, @params: !pod.type<[]>]>, !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>
+// CHECK-NEXT:            %[[VAL_53:[0-9a-zA-Z_\.]+]] = function.call @Num2Bits::@Num2Bits::@compute(%[[VAL_52]]) : (!felt.type<"bn128">) -> !struct.type<@Num2Bits::@Num2Bits<[@"n_Add_1@633"]>>
+// CHECK-NEXT:            pod.write %[[VAL_33]][@comp] = %[[VAL_53]] : <[@count: index, @comp: !struct.type<@Num2Bits::@Num2Bits<[@"n_Add_1@633"]>>, @params: !pod.type<[]>]>, !struct.type<@Num2Bits::@Num2Bits<[@"n_Add_1@633"]>>
 // CHECK-NEXT:          } else {
 // CHECK-NEXT:          }
 // CHECK-NEXT:          %[[VAL_54:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:          %[[VAL_55:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_33]][@comp] : <[@count: index, @comp: !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>, @params: !pod.type<[]>]>, !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>
-// CHECK-NEXT:          %[[VAL_56:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_55]][@out] : <@Num2Bits::@Num2Bits<[@n_Add_1]>>, !array.type<@n x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_55:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_33]][@comp] : <[@count: index, @comp: !struct.type<@Num2Bits::@Num2Bits<[@"n_Add_1@633"]>>, @params: !pod.type<[]>]>, !struct.type<@Num2Bits::@Num2Bits<[@"n_Add_1@633"]>>
+// CHECK-NEXT:          %[[VAL_56:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_55]][@out] : <@Num2Bits::@Num2Bits<[@"n_Add_1@633"]>>, !array.type<@n x !felt.type<"bn128">>
 // CHECK-NEXT:          %[[VAL_57:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_30]] : !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_58:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_56]]{{\[}}%[[VAL_57]]] : <@n x !felt.type<"bn128">>, !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_59:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_54]], %[[VAL_58]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:          struct.writem %[[VAL_29]][@out] = %[[VAL_59]] : <@LessThan::@LessThan<[@n]>>, !felt.type<"bn128">
 // CHECK-NEXT:          struct.writem %[[VAL_29]][@n2b$inputs] = %[[VAL_34]] : <@LessThan::@LessThan<[@n]>>, !pod.type<[@in: !felt.type<"bn128">]>
-// CHECK-NEXT:          %[[VAL_60:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_33]][@comp] : <[@count: index, @comp: !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>, @params: !pod.type<[]>]>, !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>
-// CHECK-NEXT:          struct.writem %[[VAL_29]][@n2b] = %[[VAL_60]] : <@LessThan::@LessThan<[@n]>>, !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>
+// CHECK-NEXT:          %[[VAL_60:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_33]][@comp] : <[@count: index, @comp: !struct.type<@Num2Bits::@Num2Bits<[@"n_Add_1@633"]>>, @params: !pod.type<[]>]>, !struct.type<@Num2Bits::@Num2Bits<[@"n_Add_1@633"]>>
+// CHECK-NEXT:          struct.writem %[[VAL_29]][@n2b] = %[[VAL_60]] : <@LessThan::@LessThan<[@n]>>, !struct.type<@Num2Bits::@Num2Bits<[@"n_Add_1@633"]>>
 // CHECK-NEXT:          function.return %[[VAL_29]] : !struct.type<@LessThan::@LessThan<[@n]>>
 // CHECK-NEXT:        }
 // CHECK-NEXT:        function.def @constrain(%[[VAL_61:[0-9a-zA-Z_\.]+]]: !struct.type<@LessThan::@LessThan<[@n]>>, %[[VAL_62:[0-9a-zA-Z_\.]+]]: !array.type<2 x !felt.type<"bn128">>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:          %[[VAL_63:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_64:[0-9a-zA-Z_\.]+]] = poly.read_const @n_Add_1 : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_64:[0-9a-zA-Z_\.]+]] = poly.read_const @"n_Add_1@633" : !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_65:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_61]][@out] : <@LessThan::@LessThan<[@n]>>, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_66:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_61]][@n2b] : <@LessThan::@LessThan<[@n]>>, !struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>
+// CHECK-NEXT:          %[[VAL_66:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_61]][@n2b] : <@LessThan::@LessThan<[@n]>>, !struct.type<@Num2Bits::@Num2Bits<[@"n_Add_1@633"]>>
 // CHECK-NEXT:          %[[VAL_67:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_61]][@n2b$inputs] : <@LessThan::@LessThan<[@n]>>, !pod.type<[@in: !felt.type<"bn128">]>
 // CHECK-NEXT:          %[[VAL_68:[0-9a-zA-Z_\.]+]] = felt.const  252 : <"bn128">
 // CHECK-NEXT:          %[[VAL_69:[0-9a-zA-Z_\.]+]] = bool.cmp le(%[[VAL_63]], %[[VAL_68]]) : !felt.type<"bn128">, !felt.type<"bn128">
@@ -191,13 +191,13 @@ component main = UnknownLoopIndex(100);
 // CHECK-NEXT:          %[[VAL_80:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_67]][@in] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
 // CHECK-NEXT:          constrain.eq %[[VAL_80]], %[[VAL_79]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_81:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:          %[[VAL_82:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_66]][@out] : <@Num2Bits::@Num2Bits<[@n_Add_1]>>, !array.type<@n x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_82:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_66]][@out] : <@Num2Bits::@Num2Bits<[@"n_Add_1@633"]>>, !array.type<@n x !felt.type<"bn128">>
 // CHECK-NEXT:          %[[VAL_83:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_63]] : !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_84:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_82]]{{\[}}%[[VAL_83]]] : <@n x !felt.type<"bn128">>, !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_85:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_81]], %[[VAL_84]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:          constrain.eq %[[VAL_65]], %[[VAL_85]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_86:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_67]][@in] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:          function.call @Num2Bits::@Num2Bits::@constrain(%[[VAL_66]], %[[VAL_86]]) : (!struct.type<@Num2Bits::@Num2Bits<[@n_Add_1]>>, !felt.type<"bn128">) -> ()
+// CHECK-NEXT:          function.call @Num2Bits::@Num2Bits::@constrain(%[[VAL_66]], %[[VAL_86]]) : (!struct.type<@Num2Bits::@Num2Bits<[@"n_Add_1@633"]>>, !felt.type<"bn128">) -> ()
 // CHECK-NEXT:          function.return
 // CHECK-NEXT:        }
 // CHECK-NEXT:      }

--- a/circom/tests/loops/variant_idx_in_loop_03.circom
+++ b/circom/tests/loops/variant_idx_in_loop_03.circom
@@ -20,18 +20,18 @@ component main = VariantIndex(2);
 // CHECK-LABEL: module attributes {llzk.lang, llzk.main = !struct.type<@VariantIndex::@VariantIndex<[2]>>} {
 // CHECK-NEXT:    poly.template @VariantIndex {
 // CHECK-NEXT:      poly.param @n
-// CHECK-NEXT:      poly.expr @n_Mul_n {
+// CHECK-NEXT:      poly.expr @"n_Mul_n@304" {
 // CHECK-NEXT:        %[[VAL_0:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
 // CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_0]], %[[VAL_0]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:        poly.yield %[[VAL_1]] : !felt.type<"bn128">
 // CHECK-NEXT:      }
 // CHECK-NEXT:      struct.def @VariantIndex {
-// CHECK-NEXT:        struct.member @out : !array.type<@n_Mul_n x !felt.type<"bn128">> {llzk.pub}
+// CHECK-NEXT:        struct.member @out : !array.type<@"n_Mul_n@304" x !felt.type<"bn128">> {llzk.pub}
 // CHECK-NEXT:        function.def @compute(%[[VAL_2:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) -> !struct.type<@VariantIndex::@VariantIndex<[@n]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
 // CHECK-NEXT:          %[[VAL_3:[0-9a-zA-Z_\.]+]] = struct.new : <@VariantIndex::@VariantIndex<[@n]>>
 // CHECK-NEXT:          %[[VAL_4:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_5:[0-9a-zA-Z_\.]+]] = poly.read_const @n_Mul_n : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_6:[0-9a-zA-Z_\.]+]] = llzk.nondet : !array.type<@n_Mul_n x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_5:[0-9a-zA-Z_\.]+]] = poly.read_const @"n_Mul_n@304" : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_6:[0-9a-zA-Z_\.]+]] = llzk.nondet : !array.type<@"n_Mul_n@304" x !felt.type<"bn128">>
 // CHECK-NEXT:          %[[VAL_7:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
 // CHECK-NEXT:          %[[VAL_8:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
 // CHECK-NEXT:          %[[VAL_9:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_10:[0-9a-zA-Z_\.]+]] = %[[VAL_8]], %[[VAL_11:[0-9a-zA-Z_\.]+]] = %[[VAL_7]]) : (!felt.type<"bn128">, !felt.type<"bn128">) -> (!felt.type<"bn128">, !felt.type<"bn128">) {
@@ -42,18 +42,18 @@ component main = VariantIndex(2);
 // CHECK-NEXT:            %[[VAL_15:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_14]], %[[VAL_13]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:            %[[VAL_16:[0-9a-zA-Z_\.]+]] = felt.shr %[[VAL_2]], %[[VAL_13]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:            %[[VAL_17:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_15]] : !felt.type<"bn128">
-// CHECK-NEXT:            array.write %[[VAL_6]]{{\[}}%[[VAL_17]]] = %[[VAL_16]] : <@n_Mul_n x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            array.write %[[VAL_6]]{{\[}}%[[VAL_17]]] = %[[VAL_16]] : <@"n_Mul_n@304" x !felt.type<"bn128">>, !felt.type<"bn128">
 // CHECK-NEXT:            %[[VAL_18:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
 // CHECK-NEXT:            %[[VAL_19:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_13]], %[[VAL_18]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:            scf.yield %[[VAL_19]], %[[VAL_15]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:          }
-// CHECK-NEXT:          struct.writem %[[VAL_3]][@out] = %[[VAL_6]] : <@VariantIndex::@VariantIndex<[@n]>>, !array.type<@n_Mul_n x !felt.type<"bn128">>
+// CHECK-NEXT:          struct.writem %[[VAL_3]][@out] = %[[VAL_6]] : <@VariantIndex::@VariantIndex<[@n]>>, !array.type<@"n_Mul_n@304" x !felt.type<"bn128">>
 // CHECK-NEXT:          function.return %[[VAL_3]] : !struct.type<@VariantIndex::@VariantIndex<[@n]>>
 // CHECK-NEXT:        }
 // CHECK-NEXT:        function.def @constrain(%[[VAL_20:[0-9a-zA-Z_\.]+]]: !struct.type<@VariantIndex::@VariantIndex<[@n]>>, %[[VAL_21:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:          %[[VAL_22:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_23:[0-9a-zA-Z_\.]+]] = poly.read_const @n_Mul_n : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_24:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_20]][@out] : <@VariantIndex::@VariantIndex<[@n]>>, !array.type<@n_Mul_n x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_23:[0-9a-zA-Z_\.]+]] = poly.read_const @"n_Mul_n@304" : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_24:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_20]][@out] : <@VariantIndex::@VariantIndex<[@n]>>, !array.type<@"n_Mul_n@304" x !felt.type<"bn128">>
 // CHECK-NEXT:          %[[VAL_25:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
 // CHECK-NEXT:          %[[VAL_26:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
 // CHECK-NEXT:          %[[VAL_27:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_28:[0-9a-zA-Z_\.]+]] = %[[VAL_26]], %[[VAL_29:[0-9a-zA-Z_\.]+]] = %[[VAL_25]]) : (!felt.type<"bn128">, !felt.type<"bn128">) -> (!felt.type<"bn128">, !felt.type<"bn128">) {

--- a/circom/tests/simple/create_component.circom
+++ b/circom/tests/simple/create_component.circom
@@ -19,46 +19,46 @@ component main = A(5);
 // CHECK-LABEL: module attributes {llzk.lang, llzk.main = !struct.type<@A::@A<[5]>>} {
 // CHECK-NEXT:    poly.template @A {
 // CHECK-NEXT:      poly.param @n
-// CHECK-NEXT:      poly.expr @n_Mul_n {
+// CHECK-NEXT:      poly.expr @"n_Mul_n@327" {
 // CHECK-NEXT:        %[[VAL_0:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
 // CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_0]], %[[VAL_0]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:        poly.yield %[[VAL_1]] : !felt.type<"bn128">
 // CHECK-NEXT:      }
 // CHECK-NEXT:      struct.def @A {
-// CHECK-NEXT:        struct.member @x : !struct.type<@B::@B<[@n_Mul_n]>>
+// CHECK-NEXT:        struct.member @x : !struct.type<@B::@B<[@"n_Mul_n@327"]>>
 // CHECK-NEXT:        struct.member @x$inputs : !pod.type<[@inB: !felt.type<"bn128">]>
 // CHECK-NEXT:        function.def @compute(%[[VAL_2:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) -> !struct.type<@A::@A<[@n]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
 // CHECK-NEXT:          %[[VAL_3:[0-9a-zA-Z_\.]+]] = struct.new : <@A::@A<[@n]>>
 // CHECK-NEXT:          %[[VAL_4:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_5:[0-9a-zA-Z_\.]+]] = poly.read_const @n_Mul_n : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_5:[0-9a-zA-Z_\.]+]] = poly.read_const @"n_Mul_n@327" : !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_6:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:          %[[VAL_7:[0-9a-zA-Z_\.]+]] = pod.new { @count = %[[VAL_6]] }  : <[@count: index, @comp: !struct.type<@B::@B<[@n_Mul_n]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:          %[[VAL_7:[0-9a-zA-Z_\.]+]] = pod.new { @count = %[[VAL_6]] }  : <[@count: index, @comp: !struct.type<@B::@B<[@"n_Mul_n@327"]>>, @params: !pod.type<[]>]>
 // CHECK-NEXT:          %[[VAL_8:[0-9a-zA-Z_\.]+]] = pod.new : <[@inB: !felt.type<"bn128">]>
 // CHECK-NEXT:          pod.write %[[VAL_8]][@inB] = %[[VAL_2]] : <[@inB: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_9:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_7]][@count] : <[@count: index, @comp: !struct.type<@B::@B<[@n_Mul_n]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:          %[[VAL_9:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_7]][@count] : <[@count: index, @comp: !struct.type<@B::@B<[@"n_Mul_n@327"]>>, @params: !pod.type<[]>]>, index
 // CHECK-NEXT:          %[[VAL_10:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
 // CHECK-NEXT:          %[[VAL_11:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_9]], %[[VAL_10]] : index
-// CHECK-NEXT:          pod.write %[[VAL_7]][@count] = %[[VAL_11]] : <[@count: index, @comp: !struct.type<@B::@B<[@n_Mul_n]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:          pod.write %[[VAL_7]][@count] = %[[VAL_11]] : <[@count: index, @comp: !struct.type<@B::@B<[@"n_Mul_n@327"]>>, @params: !pod.type<[]>]>, index
 // CHECK-NEXT:          %[[VAL_12:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
 // CHECK-NEXT:          %[[VAL_13:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_11]], %[[VAL_12]] : index
 // CHECK-NEXT:          scf.if %[[VAL_13]] {
 // CHECK-NEXT:            %[[VAL_14:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_8]][@inB] : <[@inB: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_15:[0-9a-zA-Z_\.]+]] = function.call @B::@B::@compute(%[[VAL_14]]) : (!felt.type<"bn128">) -> !struct.type<@B::@B<[@n_Mul_n]>>
-// CHECK-NEXT:            pod.write %[[VAL_7]][@comp] = %[[VAL_15]] : <[@count: index, @comp: !struct.type<@B::@B<[@n_Mul_n]>>, @params: !pod.type<[]>]>, !struct.type<@B::@B<[@n_Mul_n]>>
+// CHECK-NEXT:            %[[VAL_15:[0-9a-zA-Z_\.]+]] = function.call @B::@B::@compute(%[[VAL_14]]) : (!felt.type<"bn128">) -> !struct.type<@B::@B<[@"n_Mul_n@327"]>>
+// CHECK-NEXT:            pod.write %[[VAL_7]][@comp] = %[[VAL_15]] : <[@count: index, @comp: !struct.type<@B::@B<[@"n_Mul_n@327"]>>, @params: !pod.type<[]>]>, !struct.type<@B::@B<[@"n_Mul_n@327"]>>
 // CHECK-NEXT:          } else {
 // CHECK-NEXT:          }
 // CHECK-NEXT:          struct.writem %[[VAL_3]][@x$inputs] = %[[VAL_8]] : <@A::@A<[@n]>>, !pod.type<[@inB: !felt.type<"bn128">]>
-// CHECK-NEXT:          %[[VAL_16:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_7]][@comp] : <[@count: index, @comp: !struct.type<@B::@B<[@n_Mul_n]>>, @params: !pod.type<[]>]>, !struct.type<@B::@B<[@n_Mul_n]>>
-// CHECK-NEXT:          struct.writem %[[VAL_3]][@x] = %[[VAL_16]] : <@A::@A<[@n]>>, !struct.type<@B::@B<[@n_Mul_n]>>
+// CHECK-NEXT:          %[[VAL_16:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_7]][@comp] : <[@count: index, @comp: !struct.type<@B::@B<[@"n_Mul_n@327"]>>, @params: !pod.type<[]>]>, !struct.type<@B::@B<[@"n_Mul_n@327"]>>
+// CHECK-NEXT:          struct.writem %[[VAL_3]][@x] = %[[VAL_16]] : <@A::@A<[@n]>>, !struct.type<@B::@B<[@"n_Mul_n@327"]>>
 // CHECK-NEXT:          function.return %[[VAL_3]] : !struct.type<@A::@A<[@n]>>
 // CHECK-NEXT:        }
 // CHECK-NEXT:        function.def @constrain(%[[VAL_17:[0-9a-zA-Z_\.]+]]: !struct.type<@A::@A<[@n]>>, %[[VAL_18:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:          %[[VAL_19:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_20:[0-9a-zA-Z_\.]+]] = poly.read_const @n_Mul_n : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_21:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_17]][@x] : <@A::@A<[@n]>>, !struct.type<@B::@B<[@n_Mul_n]>>
+// CHECK-NEXT:          %[[VAL_20:[0-9a-zA-Z_\.]+]] = poly.read_const @"n_Mul_n@327" : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_21:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_17]][@x] : <@A::@A<[@n]>>, !struct.type<@B::@B<[@"n_Mul_n@327"]>>
 // CHECK-NEXT:          %[[VAL_22:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_17]][@x$inputs] : <@A::@A<[@n]>>, !pod.type<[@inB: !felt.type<"bn128">]>
 // CHECK-NEXT:          %[[VAL_23:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_22]][@inB] : <[@inB: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:          function.call @B::@B::@constrain(%[[VAL_21]], %[[VAL_23]]) : (!struct.type<@B::@B<[@n_Mul_n]>>, !felt.type<"bn128">) -> ()
+// CHECK-NEXT:          function.call @B::@B::@constrain(%[[VAL_21]], %[[VAL_23]]) : (!struct.type<@B::@B<[@"n_Mul_n@327"]>>, !felt.type<"bn128">) -> ()
 // CHECK-NEXT:          function.return
 // CHECK-NEXT:        }
 // CHECK-NEXT:      }

--- a/circom/tests/subcmps/subcmps4.circom
+++ b/circom/tests/subcmps/subcmps4.circom
@@ -40,7 +40,7 @@ component main = SubCmps4(3);
 // CHECK-LABEL: module attributes {llzk.lang, llzk.main = !struct.type<@SubCmps4::@SubCmps4<[3]>>} {
 // CHECK-NEXT:    poly.template @SubCmps4 {
 // CHECK-NEXT:      poly.param @n
-// CHECK-NEXT:      poly.expr @n_Mul_2 {
+// CHECK-NEXT:      poly.expr @"n_Mul_2@443" {
 // CHECK-NEXT:        %[[VAL_0:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
 // CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
 // CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_0]], %[[VAL_1]] : !felt.type<"bn128">, !felt.type<"bn128">
@@ -52,10 +52,10 @@ component main = SubCmps4(3);
 // CHECK-NEXT:        struct.member @a$inputs : !pod.type<[@inp: !array.type<@n x !felt.type<"bn128">>]>
 // CHECK-NEXT:        struct.member @b : !struct.type<@Sum::@Sum<[@n]>>
 // CHECK-NEXT:        struct.member @b$inputs : !pod.type<[@inp: !array.type<@n x !felt.type<"bn128">>]>
-// CHECK-NEXT:        function.def @compute(%[[VAL_3:[0-9a-zA-Z_\.]+]]: !array.type<@n_Mul_2 x !felt.type<"bn128">>) -> !struct.type<@SubCmps4::@SubCmps4<[@n]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
+// CHECK-NEXT:        function.def @compute(%[[VAL_3:[0-9a-zA-Z_\.]+]]: !array.type<@"n_Mul_2@443" x !felt.type<"bn128">>) -> !struct.type<@SubCmps4::@SubCmps4<[@n]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
 // CHECK-NEXT:          %[[VAL_4:[0-9a-zA-Z_\.]+]] = struct.new : <@SubCmps4::@SubCmps4<[@n]>>
 // CHECK-NEXT:          %[[VAL_5:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_6:[0-9a-zA-Z_\.]+]] = poly.read_const @n_Mul_2 : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_6:[0-9a-zA-Z_\.]+]] = poly.read_const @"n_Mul_2@443" : !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_7:[0-9a-zA-Z_\.]+]] = llzk.nondet : !array.type<2 x !felt.type<"bn128">>
 // CHECK-NEXT:          %[[VAL_8:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_5]] : !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_9:[0-9a-zA-Z_\.]+]] = pod.new { @count = %[[VAL_8]] }  : <[@count: index, @comp: !struct.type<@Sum::@Sum<[@n]>>, @params: !pod.type<[]>]>
@@ -77,7 +77,7 @@ component main = SubCmps4(3);
 // CHECK-NEXT:            %[[VAL_28:[0-9a-zA-Z_\.]+]] = bool.cmp eq(%[[VAL_26]], %[[VAL_27]]) : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:            %[[VAL_29:[0-9a-zA-Z_\.]+]]:2 = scf.if %[[VAL_28]] -> (!pod.type<[@inp: !array.type<@n x !felt.type<"bn128">>]>, !pod.type<[@inp: !array.type<@n x !felt.type<"bn128">>]>) {
 // CHECK-NEXT:              %[[VAL_30:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_24]] : !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_31:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_3]]{{\[}}%[[VAL_30]]] : <@n_Mul_2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_31:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_3]]{{\[}}%[[VAL_30]]] : <@"n_Mul_2@443" x !felt.type<"bn128">>, !felt.type<"bn128">
 // CHECK-NEXT:              %[[VAL_32:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_22]][@inp] : <[@inp: !array.type<@n x !felt.type<"bn128">>]>, !array.type<@n x !felt.type<"bn128">>
 // CHECK-NEXT:              %[[VAL_33:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
 // CHECK-NEXT:              %[[VAL_34:[0-9a-zA-Z_\.]+]] = felt.uintdiv %[[VAL_24]], %[[VAL_33]] : !felt.type<"bn128">, !felt.type<"bn128">
@@ -99,7 +99,7 @@ component main = SubCmps4(3);
 // CHECK-NEXT:              scf.yield %[[VAL_22]], %[[VAL_23]] : !pod.type<[@inp: !array.type<@n x !felt.type<"bn128">>]>, !pod.type<[@inp: !array.type<@n x !felt.type<"bn128">>]>
 // CHECK-NEXT:            } else {
 // CHECK-NEXT:              %[[VAL_43:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_24]] : !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_44:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_3]]{{\[}}%[[VAL_43]]] : <@n_Mul_2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_44:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_3]]{{\[}}%[[VAL_43]]] : <@"n_Mul_2@443" x !felt.type<"bn128">>, !felt.type<"bn128">
 // CHECK-NEXT:              %[[VAL_45:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_23]][@inp] : <[@inp: !array.type<@n x !felt.type<"bn128">>]>, !array.type<@n x !felt.type<"bn128">>
 // CHECK-NEXT:              %[[VAL_46:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
 // CHECK-NEXT:              %[[VAL_47:[0-9a-zA-Z_\.]+]] = felt.uintdiv %[[VAL_24]], %[[VAL_46]] : !felt.type<"bn128">, !felt.type<"bn128">
@@ -143,9 +143,9 @@ component main = SubCmps4(3);
 // CHECK-NEXT:          struct.writem %[[VAL_4]][@outp] = %[[VAL_7]] : <@SubCmps4::@SubCmps4<[@n]>>, !array.type<2 x !felt.type<"bn128">>
 // CHECK-NEXT:          function.return %[[VAL_4]] : !struct.type<@SubCmps4::@SubCmps4<[@n]>>
 // CHECK-NEXT:        }
-// CHECK-NEXT:        function.def @constrain(%[[VAL_68:[0-9a-zA-Z_\.]+]]: !struct.type<@SubCmps4::@SubCmps4<[@n]>>, %[[VAL_69:[0-9a-zA-Z_\.]+]]: !array.type<@n_Mul_2 x !felt.type<"bn128">>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        function.def @constrain(%[[VAL_68:[0-9a-zA-Z_\.]+]]: !struct.type<@SubCmps4::@SubCmps4<[@n]>>, %[[VAL_69:[0-9a-zA-Z_\.]+]]: !array.type<@"n_Mul_2@443" x !felt.type<"bn128">>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:          %[[VAL_70:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_71:[0-9a-zA-Z_\.]+]] = poly.read_const @n_Mul_2 : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_71:[0-9a-zA-Z_\.]+]] = poly.read_const @"n_Mul_2@443" : !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_72:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_68]][@outp] : <@SubCmps4::@SubCmps4<[@n]>>, !array.type<2 x !felt.type<"bn128">>
 // CHECK-NEXT:          %[[VAL_73:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_68]][@a] : <@SubCmps4::@SubCmps4<[@n]>>, !struct.type<@Sum::@Sum<[@n]>>
 // CHECK-NEXT:          %[[VAL_74:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_68]][@a$inputs] : <@SubCmps4::@SubCmps4<[@n]>>, !pod.type<[@inp: !array.type<@n x !felt.type<"bn128">>]>
@@ -165,7 +165,7 @@ component main = SubCmps4(3);
 // CHECK-NEXT:            %[[VAL_87:[0-9a-zA-Z_\.]+]] = bool.cmp eq(%[[VAL_85]], %[[VAL_86]]) : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:            scf.if %[[VAL_87]] {
 // CHECK-NEXT:              %[[VAL_88:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_83]] : !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_89:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_69]]{{\[}}%[[VAL_88]]] : <@n_Mul_2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_89:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_69]]{{\[}}%[[VAL_88]]] : <@"n_Mul_2@443" x !felt.type<"bn128">>, !felt.type<"bn128">
 // CHECK-NEXT:              %[[VAL_90:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_74]][@inp] : <[@inp: !array.type<@n x !felt.type<"bn128">>]>, !array.type<@n x !felt.type<"bn128">>
 // CHECK-NEXT:              %[[VAL_91:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
 // CHECK-NEXT:              %[[VAL_92:[0-9a-zA-Z_\.]+]] = felt.uintdiv %[[VAL_83]], %[[VAL_91]] : !felt.type<"bn128">, !felt.type<"bn128">
@@ -174,7 +174,7 @@ component main = SubCmps4(3);
 // CHECK-NEXT:              constrain.eq %[[VAL_94]], %[[VAL_89]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:            } else {
 // CHECK-NEXT:              %[[VAL_95:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_83]] : !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_96:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_69]]{{\[}}%[[VAL_95]]] : <@n_Mul_2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_96:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_69]]{{\[}}%[[VAL_95]]] : <@"n_Mul_2@443" x !felt.type<"bn128">>, !felt.type<"bn128">
 // CHECK-NEXT:              %[[VAL_97:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_76]][@inp] : <[@inp: !array.type<@n x !felt.type<"bn128">>]>, !array.type<@n x !felt.type<"bn128">>
 // CHECK-NEXT:              %[[VAL_98:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
 // CHECK-NEXT:              %[[VAL_99:[0-9a-zA-Z_\.]+]] = felt.uintdiv %[[VAL_83]], %[[VAL_98]] : !felt.type<"bn128">, !felt.type<"bn128">

--- a/llzk_backend/src/gen_context.rs
+++ b/llzk_backend/src/gen_context.rs
@@ -55,6 +55,7 @@ use llzk::prelude::OperationRef;
 use llzk::prelude::PodType;
 use llzk::prelude::Region;
 use llzk::prelude::RegionLike as _;
+use llzk::prelude::StringAttribute;
 use llzk::prelude::StructType;
 use llzk::prelude::TemplateExprOp;
 use llzk::prelude::Type;
@@ -1938,7 +1939,11 @@ where
         self.var_decl_types
     }
 
-    fn callback_store_poly_expr(&self, name: String, op: TemplateExprOp<'ctx>) {
+    fn callback_store_poly_expr(
+        &self,
+        name: String,
+        op: TemplateExprOp<'ctx>,
+    ) -> StringAttribute<'ctx> {
         todo!("BlockGenContext::store_template_poly_expr: {name} -> {op:?}");
     }
 

--- a/llzk_backend/src/module.rs
+++ b/llzk_backend/src/module.rs
@@ -7,6 +7,7 @@ use crate::function_ext::FunctionLike;
 use crate::program_ext::ProgramLike;
 use crate::shared;
 use crate::shared::dim_expr_name;
+use crate::shared::get_poly_expr_name;
 use crate::shared::map_array_inner_type;
 use crate::shared::map_name_to_arg_value;
 use crate::shared::ArrayDimensionResult;
@@ -52,6 +53,7 @@ use llzk::prelude::PodType;
 use llzk::prelude::PublicAttribute;
 use llzk::prelude::RecordValue;
 use llzk::prelude::RegionLike as _;
+use llzk::prelude::StringAttribute;
 use llzk::prelude::StringRef;
 use llzk::prelude::StructDefOpLike as _;
 use llzk::prelude::StructDefOpRef;
@@ -484,8 +486,18 @@ where
         &self.template_params
     }
 
-    fn callback_store_poly_expr(&self, name: String, op: TemplateExprOp<'ctx>) {
-        self.poly_exprs.borrow_mut().insert(name, op);
+    fn callback_store_poly_expr(
+        &self,
+        name: String,
+        op: TemplateExprOp<'ctx>,
+    ) -> StringAttribute<'ctx> {
+        let uniqued_name = get_poly_expr_name(&op);
+        let old = self.poly_exprs.borrow_mut().insert(name, op);
+        // ASSERT: In general, `DimExprConverter` has to account for non-unique names but in this
+        // `DeclarationInfo` implementation, names will always be unique (assuming the `Meta::start`
+        // from the circom AST that `dim_expr_name()` appends to the names is accurate).
+        assert!(old.is_none(), "multiple poly.expr generated for the same dimension expression");
+        uniqued_name
     }
 
     fn get_dim_expr(
@@ -603,6 +615,8 @@ fn gen_template_llzk<'ast, 'ctx, T: TemplateLike>(
         poly_expr_names.sort();
     }
     for name in &poly_expr_names {
+        // Here the template is empty and the names are unique per storage in HashMap so they
+        // can be directly appended without using `symbol_table::insert` to unique names.
         new_template.body().append_operation(poly_exprs.remove(name).unwrap().into());
     }
 

--- a/llzk_backend/src/shared.rs
+++ b/llzk_backend/src/shared.rs
@@ -1658,7 +1658,11 @@ where
     }
 
     /// Callback to store a `poly.expr` operation generated on the fly for an array dimension.
-    fn callback_store_poly_expr(&self, name: String, op: TemplateExprOp<'ctx>);
+    fn callback_store_poly_expr(
+        &self,
+        name: String,
+        op: TemplateExprOp<'ctx>,
+    ) -> StringAttribute<'ctx>;
 
     /// Get the mapping of `var` name to declared LLZK type.
     fn get_var_decl_types(&self) -> &HashMap<String, Type<'ctx>>;
@@ -1919,9 +1923,9 @@ where
             gen_up_to_target(codegen, &mut expr_gen_ctx, target_expr, body_opt.unwrap(), &trace)?;
         expr_gen_ctx.append_op_no_result(poly::r#yield(location, val)?.into())?;
 
-        let name_sym = codegen.flat_sym(&name);
-        self.callback_store_poly_expr(name, expr_op);
-        ArrayDimensionResult::new(name_sym.into(), &[])
+        let uniqued_name = self.callback_store_poly_expr(name, expr_op);
+        // Have to convert the StringAttribute to FlatSymbolRefAttribute before returning it.
+        ArrayDimensionResult::new(codegen.flat_sym(uniqued_name.value()).into(), &[])
     }
 }
 
@@ -1954,36 +1958,44 @@ pub fn comp_type<'ctx>(pod: PodType<'ctx>) -> Result<Type<'ctx>> {
 /// The generated name uniquely represents the expression structure so that the same expression
 /// always maps to the same name, enabling deduplication of `poly.expr` ops.
 pub fn dim_expr_name(expr: &Expression) -> String {
-    match expr {
-        Expression::Number(_, n) => n.to_string(),
-        Expression::Variable { name, access, .. } => {
-            if access.is_empty() {
-                name.clone()
-            } else {
-                // Reuse `Lvalue` string format but drop the "Var:" prefix.
-                Lvalue::new(name, Root::Var, access)
-                    .to_string()
-                    .trim_start_matches("Var:")
-                    .to_string()
+    fn visit(expr: &Expression) -> String {
+        match expr {
+            Expression::Number(_, n) => n.to_string(),
+            Expression::Variable { name, access, .. } => {
+                if access.is_empty() {
+                    name.clone()
+                } else {
+                    // Reuse `Lvalue` string format but drop the "Var:" prefix.
+                    Lvalue::new(name, Root::Var, access)
+                        .to_string()
+                        .trim_start_matches("Var:")
+                        .to_string()
+                }
             }
+            Expression::InfixOp { lhe, infix_op, rhe, .. } => {
+                format!("{}_{infix_op:?}_{}", visit(lhe), visit(rhe))
+            }
+            Expression::PrefixOp { prefix_op, rhe, .. } => {
+                format!("{prefix_op:?}_{}", visit(rhe))
+            }
+            Expression::InlineSwitchOp { cond, if_true, if_false, .. } => {
+                format!("{}?{}:{}", visit(cond), visit(if_true), visit(if_false))
+            }
+            Expression::Call { id, args, .. } => {
+                format!("{id}({})", args.iter().map(visit).collect::<Vec<_>>().join(","))
+            }
+            _ => unreachable!("dimension expression must produce a scalar value"),
         }
-        Expression::InfixOp { lhe, infix_op, rhe, .. } => {
-            format!("{}_{infix_op:?}_{}", dim_expr_name(lhe), dim_expr_name(rhe))
-        }
-        Expression::PrefixOp { prefix_op, rhe, .. } => {
-            format!("{prefix_op:?}_{}", dim_expr_name(rhe))
-        }
-        Expression::InlineSwitchOp { cond, if_true, if_false, .. } => {
-            format!(
-                "{}?{}:{}",
-                dim_expr_name(cond),
-                dim_expr_name(if_true),
-                dim_expr_name(if_false)
-            )
-        }
-        Expression::Call { id, args, .. } => {
-            format!("{id}({})", args.iter().map(dim_expr_name).collect::<Vec<_>>().join(","))
-        }
-        _ => unreachable!("dimension expression must produce a scalar value"),
     }
+    // Add starting location of the expression to the name to ensure (**assuming Meta information
+    // is accurate**) context sensitivity (i.e. expressions at different code locations may have a
+    // different value store and thus should be treated as different values).
+    format!("{}@{}", visit(expr), expr.get_meta().start)
+}
+
+/// Get the `sym_name` attribute from a `poly.expr` operation.
+pub fn get_poly_expr_name<'c: 'a, 'a>(op: &impl OperationLike<'c, 'a>) -> StringAttribute<'c> {
+    assert!(poly::is_expr_op(op), "expected a poly.expr operation");
+    let a = op.attribute("sym_name").expect("`poly.expr` op has `sym_name` attribute per ODS");
+    StringAttribute::try_from(a).expect("`sym_name` attribute is StringAttr per ODS")
 }

--- a/llzk_backend/src/template.rs
+++ b/llzk_backend/src/template.rs
@@ -18,6 +18,7 @@ use crate::program_ext::ProgramLike;
 use crate::shared;
 use crate::shared::comp_type;
 use crate::shared::dim_expr_name;
+use crate::shared::get_poly_expr_name;
 use crate::shared::map_array_inner_type;
 use crate::shared::ArrayDimension;
 use crate::shared::ArrayDimensionResult;
@@ -39,13 +40,13 @@ use llzk::dialect::constrain;
 use llzk::dialect::pod;
 use llzk::dialect::r#struct;
 use llzk::prelude::ArrayType;
-use llzk::prelude::BlockLike;
 use llzk::prelude::BlockRef;
 use llzk::prelude::FuncDefOpLike as _;
 use llzk::prelude::LoopBoundsAttribute;
 use llzk::prelude::MemberDefOpLike as _;
 use llzk::prelude::PodType;
 use llzk::prelude::RecordValue;
+use llzk::prelude::StringAttribute;
 use llzk::prelude::StringRef;
 use llzk::prelude::StructDefOpLike as _;
 use llzk::prelude::StructDefOpRefMut;
@@ -55,6 +56,7 @@ use llzk::prelude::TemplateOpRefMut;
 use llzk::prelude::Type;
 use llzk::prelude::Value;
 use llzk::prelude::ValueLike as _;
+use llzk::symbol_table;
 use program_structure::ast::AssignOp;
 use program_structure::ast::Expression;
 use program_structure::ast::Meta;
@@ -754,8 +756,13 @@ where
         self.var_decl_types
     }
 
-    fn callback_store_poly_expr(&self, _: String, op: TemplateExprOp<'ctx>) {
-        self.template_def.body().append_operation(op.into());
+    fn callback_store_poly_expr(
+        &self,
+        _: String,
+        op: TemplateExprOp<'ctx>,
+    ) -> StringAttribute<'ctx> {
+        // Use `symbol_table::insert` instead of direct insertion to rename duplicates
+        get_poly_expr_name(&symbol_table::insert(&self.template_def, op.into()))
     }
 
     fn get_dim_expr(


### PR DESCRIPTION
- Add `Expression` start location to the name for context-sensitive naming
- Use `SymbolTable::insert(..)` to rename in case of duplicate names