### PR TITLE
Relax type equality to "unifies with" and add unifiable cast

### DIFF
--- a/circom/tests/circom_doc_examples/21.circom
+++ b/circom/tests/circom_doc_examples/21.circom
@@ -1,8 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --stabilize --llzk --llzk_plaintext -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL:.*
-// related to the "TODO" in `cast_to_expected_type_if_needed()`
 
 pragma circom 2.1.0;
 
@@ -14,4 +12,27 @@ template Ex(n,m){
 
 component main = Ex(3,3);
 
-// CHECK-LABEL: module attributes {
+// CHECK-LABEL: module attributes {llzk.lang, llzk.main = !struct.type<@Ex::@Ex<[3, 3]>>} {
+// CHECK-NEXT:    poly.template @Ex {
+// CHECK-NEXT:      poly.param @n
+// CHECK-NEXT:      poly.param @m
+// CHECK-NEXT:      struct.def @Ex {
+// CHECK-NEXT:        struct.member @out : !array.type<@m x !felt.type<"bn128">> {llzk.pub}
+// CHECK-NEXT:        function.def @compute(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type<"bn128">>) -> !struct.type<@Ex::@Ex<[@n, @m]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
+// CHECK-NEXT:          %[[VAL_1:[0-9a-zA-Z_\.]+]] = struct.new : <@Ex::@Ex<[@n, @m]>>
+// CHECK-NEXT:          %[[VAL_2:[0-9a-zA-Z_\.]+]] = poly.read_const @m : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_3:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_4:[0-9a-zA-Z_\.]+]] = poly.unifiable_cast %[[VAL_0]] : (!array.type<@n x !felt.type<"bn128">>) -> !array.type<@m x !felt.type<"bn128">>
+// CHECK-NEXT:          struct.writem %[[VAL_1]][@out] = %[[VAL_4]] : <@Ex::@Ex<[@n, @m]>>, !array.type<@m x !felt.type<"bn128">>
+// CHECK-NEXT:          function.return %[[VAL_1]] : !struct.type<@Ex::@Ex<[@n, @m]>>
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.def @constrain(%[[VAL_5:[0-9a-zA-Z_\.]+]]: !struct.type<@Ex::@Ex<[@n, @m]>>, %[[VAL_6:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type<"bn128">>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_7:[0-9a-zA-Z_\.]+]] = poly.read_const @m : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_8:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_9:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_5]][@out] : <@Ex::@Ex<[@n, @m]>>, !array.type<@m x !felt.type<"bn128">>
+// CHECK-NEXT:          constrain.eq %[[VAL_9]], %[[VAL_6]] : !array.type<@m x !felt.type<"bn128">>, !array.type<@n x !felt.type<"bn128">>
+// CHECK-NEXT:          function.return
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/circom_doc_examples/23.circom
+++ b/circom/tests/circom_doc_examples/23.circom
@@ -2,7 +2,6 @@
 // RUN: rm -rf %t && mkdir %t && %circom --stabilize --llzk --llzk_plaintext -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
 // XFAIL:.*
-// related to the "TODO" in `cast_to_expected_type_if_needed()`
 
 pragma circom 2.1.0;
 

--- a/llzk_backend/src/gen_context.rs
+++ b/llzk_backend/src/gen_context.rs
@@ -63,6 +63,7 @@ use llzk::prelude::Value;
 use llzk::prelude::ValueLike as _;
 use llzk::prelude::FUNC_NAME_COMPUTE;
 use llzk::prelude::FUNC_NAME_CONSTRAIN;
+use llzk::typing::is_unifiable_with;
 use melior::dialect::ods::math;
 use melior::ir::AttributeLike as _;
 use melior::ir::TypeLike as _;
@@ -857,6 +858,8 @@ where
     ) -> Result<Value<'ctx, 'val>> {
         if expected == val.r#type() {
             Ok(val)
+        } else if is_unifiable_with(expected, val.r#type()) {
+            self.append_op_unnamed_result(poly::unifiable_cast(location, val, expected))
         } else if is_felt_type(expected) {
             self.cast_to_felt_if_needed(codegen, location, val)
         } else if is_index(expected) {
@@ -864,9 +867,6 @@ where
         } else if is_bool(expected) {
             self.cast_to_bool_if_needed(codegen, location, val)
         } else {
-            // TODO: Must support array types by adding a unifiable cast.
-            // Alternatively, add LLZK type unification check to `llzk-rs` API and use that above
-            // instead of full equality.
             anyhow::bail!(
                 "Unsupported 'expected' type '{expected}' with value type {}",
                 val.r#type()


### PR DESCRIPTION
removed the comment from `circom/tests/circom_doc_examples/23.circom` because it now fails for a different reason