### PR TITLE
Fix conflicting array types in mixed subcmps

### DIFF
--- a/circom/tests/arrays/array_write3_loop.circom
+++ b/circom/tests/arrays/array_write3_loop.circom
@@ -54,79 +54,81 @@ component main = Array1();
 // CHECK-NEXT:            array.write %[[VAL_10]]{{\[}}%[[VAL_18]]] = %[[VAL_17]] : <5 x !pod.type<[@a: !felt.type<"bn128">]>>, !pod.type<[@a: !felt.type<"bn128">]>
 // CHECK-NEXT:            %[[VAL_19:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_11]] : !felt.type<"bn128">
 // CHECK-NEXT:            %[[VAL_20:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_2]]{{\[}}%[[VAL_19]]] : <5 x !pod.type<[@count: index, @comp: !struct.type<@Foo::@Foo<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Foo::@Foo<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:            %[[VAL_21:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_20]][@count] : <[@count: index, @comp: !struct.type<@Foo::@Foo<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:            %[[VAL_22:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:            %[[VAL_23:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_21]], %[[VAL_22]] : index
-// CHECK-NEXT:            pod.write %[[VAL_20]][@count] = %[[VAL_23]] : <[@count: index, @comp: !struct.type<@Foo::@Foo<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:            %[[VAL_24:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:            %[[VAL_25:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_23]], %[[VAL_24]] : index
-// CHECK-NEXT:            scf.if %[[VAL_25]] {
-// CHECK-NEXT:              %[[VAL_26:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_20]][@params] : <[@count: index, @comp: !struct.type<@Foo::@Foo<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
-// CHECK-NEXT:              %[[VAL_27:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_17]][@a] : <[@a: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_28:[0-9a-zA-Z_\.]+]] = function.call @Foo::@Foo::@compute(%[[VAL_27]]) : (!felt.type<"bn128">) -> !struct.type<@Foo::@Foo<[]>>
-// CHECK-NEXT:              pod.write %[[VAL_20]][@comp] = %[[VAL_28]] : <[@count: index, @comp: !struct.type<@Foo::@Foo<[]>>, @params: !pod.type<[]>]>, !struct.type<@Foo::@Foo<[]>>
-// CHECK-NEXT:              %[[VAL_29:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_11]] : !felt.type<"bn128">
-// CHECK-NEXT:              array.write %[[VAL_2]]{{\[}}%[[VAL_29]]] = %[[VAL_20]] : <5 x !pod.type<[@count: index, @comp: !struct.type<@Foo::@Foo<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Foo::@Foo<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:            %[[VAL_21:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_11]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_22:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_10]]{{\[}}%[[VAL_21]]] : <5 x !pod.type<[@a: !felt.type<"bn128">]>>, !pod.type<[@a: !felt.type<"bn128">]>
+// CHECK-NEXT:            %[[VAL_23:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_20]][@count] : <[@count: index, @comp: !struct.type<@Foo::@Foo<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:            %[[VAL_24:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:            %[[VAL_25:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_23]], %[[VAL_24]] : index
+// CHECK-NEXT:            pod.write %[[VAL_20]][@count] = %[[VAL_25]] : <[@count: index, @comp: !struct.type<@Foo::@Foo<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:            %[[VAL_26:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:            %[[VAL_27:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_25]], %[[VAL_26]] : index
+// CHECK-NEXT:            scf.if %[[VAL_27]] {
+// CHECK-NEXT:              %[[VAL_28:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_20]][@params] : <[@count: index, @comp: !struct.type<@Foo::@Foo<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
+// CHECK-NEXT:              %[[VAL_29:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_22]][@a] : <[@a: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_30:[0-9a-zA-Z_\.]+]] = function.call @Foo::@Foo::@compute(%[[VAL_29]]) : (!felt.type<"bn128">) -> !struct.type<@Foo::@Foo<[]>>
+// CHECK-NEXT:              pod.write %[[VAL_20]][@comp] = %[[VAL_30]] : <[@count: index, @comp: !struct.type<@Foo::@Foo<[]>>, @params: !pod.type<[]>]>, !struct.type<@Foo::@Foo<[]>>
+// CHECK-NEXT:              %[[VAL_31:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_11]] : !felt.type<"bn128">
+// CHECK-NEXT:              array.write %[[VAL_2]]{{\[}}%[[VAL_31]]] = %[[VAL_20]] : <5 x !pod.type<[@count: index, @comp: !struct.type<@Foo::@Foo<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Foo::@Foo<[]>>, @params: !pod.type<[]>]>
 // CHECK-NEXT:            }
-// CHECK-NEXT:            %[[VAL_30:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_11]] : !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_31:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_2]]{{\[}}%[[VAL_30]]] : <5 x !pod.type<[@count: index, @comp: !struct.type<@Foo::@Foo<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Foo::@Foo<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:            %[[VAL_32:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_31]][@comp] : <[@count: index, @comp: !struct.type<@Foo::@Foo<[]>>, @params: !pod.type<[]>]>, !struct.type<@Foo::@Foo<[]>>
-// CHECK-NEXT:            %[[VAL_33:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_32]][@b] : <@Foo::@Foo<[]>>, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_34:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_11]] : !felt.type<"bn128">
-// CHECK-NEXT:            array.write %[[VAL_1]]{{\[}}%[[VAL_34]]] = %[[VAL_33]] : <5 x !felt.type<"bn128">>, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_35:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_36:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_11]], %[[VAL_35]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            scf.yield %[[VAL_10]], %[[VAL_36]] : !array.type<5 x !pod.type<[@a: !felt.type<"bn128">]>>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_32:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_11]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_33:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_2]]{{\[}}%[[VAL_32]]] : <5 x !pod.type<[@count: index, @comp: !struct.type<@Foo::@Foo<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Foo::@Foo<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:            %[[VAL_34:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_33]][@comp] : <[@count: index, @comp: !struct.type<@Foo::@Foo<[]>>, @params: !pod.type<[]>]>, !struct.type<@Foo::@Foo<[]>>
+// CHECK-NEXT:            %[[VAL_35:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_34]][@b] : <@Foo::@Foo<[]>>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_36:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_11]] : !felt.type<"bn128">
+// CHECK-NEXT:            array.write %[[VAL_1]]{{\[}}%[[VAL_36]]] = %[[VAL_35]] : <5 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_37:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_38:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_11]], %[[VAL_37]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_10]], %[[VAL_38]] : !array.type<5 x !pod.type<[@a: !felt.type<"bn128">]>>, !felt.type<"bn128">
 // CHECK-NEXT:          }
 // CHECK-NEXT:          struct.writem %[[VAL_0]][@foo$inputs] = %[[VAL_5]]#0 : <@Array1::@Array1<[]>>, !array.type<5 x !pod.type<[@a: !felt.type<"bn128">]>>
-// CHECK-NEXT:          %[[VAL_37:[0-9a-zA-Z_\.]+]] = array.new  : <5 x !struct.type<@Foo::@Foo<[]>>>
-// CHECK-NEXT:          %[[VAL_38:[0-9a-zA-Z_\.]+]] = arith.constant 5 : index
-// CHECK-NEXT:          %[[VAL_39:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[VAL_40:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:          scf.for %[[VAL_41:[0-9a-zA-Z_\.]+]] = %[[VAL_39]] to %[[VAL_38]] step %[[VAL_40]] {
-// CHECK-NEXT:            %[[VAL_42:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_2]]{{\[}}%[[VAL_41]]] : <5 x !pod.type<[@count: index, @comp: !struct.type<@Foo::@Foo<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Foo::@Foo<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:            %[[VAL_43:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_42]][@comp] : <[@count: index, @comp: !struct.type<@Foo::@Foo<[]>>, @params: !pod.type<[]>]>, !struct.type<@Foo::@Foo<[]>>
-// CHECK-NEXT:            array.write %[[VAL_37]]{{\[}}%[[VAL_41]]] = %[[VAL_43]] : <5 x !struct.type<@Foo::@Foo<[]>>>, !struct.type<@Foo::@Foo<[]>>
+// CHECK-NEXT:          %[[VAL_39:[0-9a-zA-Z_\.]+]] = array.new  : <5 x !struct.type<@Foo::@Foo<[]>>>
+// CHECK-NEXT:          %[[VAL_40:[0-9a-zA-Z_\.]+]] = arith.constant 5 : index
+// CHECK-NEXT:          %[[VAL_41:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_42:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          scf.for %[[VAL_43:[0-9a-zA-Z_\.]+]] = %[[VAL_41]] to %[[VAL_40]] step %[[VAL_42]] {
+// CHECK-NEXT:            %[[VAL_44:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_2]]{{\[}}%[[VAL_43]]] : <5 x !pod.type<[@count: index, @comp: !struct.type<@Foo::@Foo<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Foo::@Foo<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:            %[[VAL_45:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_44]][@comp] : <[@count: index, @comp: !struct.type<@Foo::@Foo<[]>>, @params: !pod.type<[]>]>, !struct.type<@Foo::@Foo<[]>>
+// CHECK-NEXT:            array.write %[[VAL_39]]{{\[}}%[[VAL_43]]] = %[[VAL_45]] : <5 x !struct.type<@Foo::@Foo<[]>>>, !struct.type<@Foo::@Foo<[]>>
 // CHECK-NEXT:          }
-// CHECK-NEXT:          struct.writem %[[VAL_0]][@foo] = %[[VAL_37]] : <@Array1::@Array1<[]>>, !array.type<5 x !struct.type<@Foo::@Foo<[]>>>
+// CHECK-NEXT:          struct.writem %[[VAL_0]][@foo] = %[[VAL_39]] : <@Array1::@Array1<[]>>, !array.type<5 x !struct.type<@Foo::@Foo<[]>>>
 // CHECK-NEXT:          struct.writem %[[VAL_0]][@out] = %[[VAL_1]] : <@Array1::@Array1<[]>>, !array.type<5 x !felt.type<"bn128">>
 // CHECK-NEXT:          function.return %[[VAL_0]] : !struct.type<@Array1::@Array1<[]>>
 // CHECK-NEXT:        }
-// CHECK-NEXT:        function.def @constrain(%[[VAL_44:[0-9a-zA-Z_\.]+]]: !struct.type<@Array1::@Array1<[]>>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:          %[[VAL_45:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_44]][@out] : <@Array1::@Array1<[]>>, !array.type<5 x !felt.type<"bn128">>
-// CHECK-NEXT:          %[[VAL_46:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_44]][@foo] : <@Array1::@Array1<[]>>, !array.type<5 x !struct.type<@Foo::@Foo<[]>>>
-// CHECK-NEXT:          %[[VAL_47:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_44]][@foo$inputs] : <@Array1::@Array1<[]>>, !array.type<5 x !pod.type<[@a: !felt.type<"bn128">]>>
-// CHECK-NEXT:          %[[VAL_48:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:          %[[VAL_49:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_50:[0-9a-zA-Z_\.]+]] = %[[VAL_48]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
-// CHECK-NEXT:            %[[VAL_51:[0-9a-zA-Z_\.]+]] = felt.const  5 : <"bn128">
-// CHECK-NEXT:            %[[VAL_52:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_50]], %[[VAL_51]]) : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            scf.condition(%[[VAL_52]]) %[[VAL_50]] : !felt.type<"bn128">
+// CHECK-NEXT:        function.def @constrain(%[[VAL_46:[0-9a-zA-Z_\.]+]]: !struct.type<@Array1::@Array1<[]>>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_47:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_46]][@out] : <@Array1::@Array1<[]>>, !array.type<5 x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_48:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_46]][@foo] : <@Array1::@Array1<[]>>, !array.type<5 x !struct.type<@Foo::@Foo<[]>>>
+// CHECK-NEXT:          %[[VAL_49:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_46]][@foo$inputs] : <@Array1::@Array1<[]>>, !array.type<5 x !pod.type<[@a: !felt.type<"bn128">]>>
+// CHECK-NEXT:          %[[VAL_50:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_51:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_52:[0-9a-zA-Z_\.]+]] = %[[VAL_50]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
+// CHECK-NEXT:            %[[VAL_53:[0-9a-zA-Z_\.]+]] = felt.const  5 : <"bn128">
+// CHECK-NEXT:            %[[VAL_54:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_52]], %[[VAL_53]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.condition(%[[VAL_54]]) %[[VAL_52]] : !felt.type<"bn128">
 // CHECK-NEXT:          } do {
-// CHECK-NEXT:          ^bb0(%[[VAL_53:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
-// CHECK-NEXT:            %[[VAL_54:[0-9a-zA-Z_\.]+]] = pod.new : <[]>
-// CHECK-NEXT:            %[[VAL_55:[0-9a-zA-Z_\.]+]] = pod.new : <[@count: index, @comp: !struct.type<@Foo::@Foo<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:            %[[VAL_56:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_53]] : !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_57:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_47]]{{\[}}%[[VAL_56]]] : <5 x !pod.type<[@a: !felt.type<"bn128">]>>, !pod.type<[@a: !felt.type<"bn128">]>
-// CHECK-NEXT:            %[[VAL_58:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_57]][@a] : <[@a: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:            constrain.eq %[[VAL_58]], %[[VAL_53]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_59:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_53]] : !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_60:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_46]]{{\[}}%[[VAL_59]]] : <5 x !struct.type<@Foo::@Foo<[]>>>, !struct.type<@Foo::@Foo<[]>>
-// CHECK-NEXT:            %[[VAL_61:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_60]][@b] : <@Foo::@Foo<[]>>, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_62:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_53]] : !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_63:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_45]]{{\[}}%[[VAL_62]]] : <5 x !felt.type<"bn128">>, !felt.type<"bn128">
-// CHECK-NEXT:            constrain.eq %[[VAL_63]], %[[VAL_61]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_64:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_65:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_53]], %[[VAL_64]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            scf.yield %[[VAL_65]] : !felt.type<"bn128">
+// CHECK-NEXT:          ^bb0(%[[VAL_55:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
+// CHECK-NEXT:            %[[VAL_56:[0-9a-zA-Z_\.]+]] = pod.new : <[]>
+// CHECK-NEXT:            %[[VAL_57:[0-9a-zA-Z_\.]+]] = pod.new : <[@count: index, @comp: !struct.type<@Foo::@Foo<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:            %[[VAL_58:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_55]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_59:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_49]]{{\[}}%[[VAL_58]]] : <5 x !pod.type<[@a: !felt.type<"bn128">]>>, !pod.type<[@a: !felt.type<"bn128">]>
+// CHECK-NEXT:            %[[VAL_60:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_59]][@a] : <[@a: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:            constrain.eq %[[VAL_60]], %[[VAL_55]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_61:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_55]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_62:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_48]]{{\[}}%[[VAL_61]]] : <5 x !struct.type<@Foo::@Foo<[]>>>, !struct.type<@Foo::@Foo<[]>>
+// CHECK-NEXT:            %[[VAL_63:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_62]][@b] : <@Foo::@Foo<[]>>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_64:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_55]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_65:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_47]]{{\[}}%[[VAL_64]]] : <5 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            constrain.eq %[[VAL_65]], %[[VAL_63]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_66:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_67:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_55]], %[[VAL_66]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_67]] : !felt.type<"bn128">
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[VAL_66:[0-9a-zA-Z_\.]+]] = arith.constant 5 : index
-// CHECK-NEXT:          %[[VAL_67:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[VAL_68:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:          scf.for %[[VAL_69:[0-9a-zA-Z_\.]+]] = %[[VAL_67]] to %[[VAL_66]] step %[[VAL_68]] {
-// CHECK-NEXT:            %[[VAL_70:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_46]]{{\[}}%[[VAL_69]]] : <5 x !struct.type<@Foo::@Foo<[]>>>, !struct.type<@Foo::@Foo<[]>>
-// CHECK-NEXT:            %[[VAL_71:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_47]]{{\[}}%[[VAL_69]]] : <5 x !pod.type<[@a: !felt.type<"bn128">]>>, !pod.type<[@a: !felt.type<"bn128">]>
-// CHECK-NEXT:            %[[VAL_72:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_71]][@a] : <[@a: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:            function.call @Foo::@Foo::@constrain(%[[VAL_70]], %[[VAL_72]]) : (!struct.type<@Foo::@Foo<[]>>, !felt.type<"bn128">) -> ()
+// CHECK-NEXT:          %[[VAL_68:[0-9a-zA-Z_\.]+]] = arith.constant 5 : index
+// CHECK-NEXT:          %[[VAL_69:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_70:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          scf.for %[[VAL_71:[0-9a-zA-Z_\.]+]] = %[[VAL_69]] to %[[VAL_68]] step %[[VAL_70]] {
+// CHECK-NEXT:            %[[VAL_72:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_48]]{{\[}}%[[VAL_71]]] : <5 x !struct.type<@Foo::@Foo<[]>>>, !struct.type<@Foo::@Foo<[]>>
+// CHECK-NEXT:            %[[VAL_73:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_49]]{{\[}}%[[VAL_71]]] : <5 x !pod.type<[@a: !felt.type<"bn128">]>>, !pod.type<[@a: !felt.type<"bn128">]>
+// CHECK-NEXT:            %[[VAL_74:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_73]][@a] : <[@a: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:            function.call @Foo::@Foo::@constrain(%[[VAL_72]], %[[VAL_74]]) : (!struct.type<@Foo::@Foo<[]>>, !felt.type<"bn128">) -> ()
 // CHECK-NEXT:          }
 // CHECK-NEXT:          function.return
 // CHECK-NEXT:        }
@@ -135,14 +137,14 @@ component main = Array1();
 // CHECK-NEXT:    poly.template @Foo {
 // CHECK-NEXT:      struct.def @Foo {
 // CHECK-NEXT:        struct.member @b : !felt.type<"bn128"> {llzk.pub}
-// CHECK-NEXT:        function.def @compute(%[[VAL_73:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) -> !struct.type<@Foo::@Foo<[]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
-// CHECK-NEXT:          %[[VAL_74:[0-9a-zA-Z_\.]+]] = struct.new : <@Foo::@Foo<[]>>
-// CHECK-NEXT:          struct.writem %[[VAL_74]][@b] = %[[VAL_73]] : <@Foo::@Foo<[]>>, !felt.type<"bn128">
-// CHECK-NEXT:          function.return %[[VAL_74]] : !struct.type<@Foo::@Foo<[]>>
+// CHECK-NEXT:        function.def @compute(%[[VAL_75:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) -> !struct.type<@Foo::@Foo<[]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
+// CHECK-NEXT:          %[[VAL_76:[0-9a-zA-Z_\.]+]] = struct.new : <@Foo::@Foo<[]>>
+// CHECK-NEXT:          struct.writem %[[VAL_76]][@b] = %[[VAL_75]] : <@Foo::@Foo<[]>>, !felt.type<"bn128">
+// CHECK-NEXT:          function.return %[[VAL_76]] : !struct.type<@Foo::@Foo<[]>>
 // CHECK-NEXT:        }
-// CHECK-NEXT:        function.def @constrain(%[[VAL_75:[0-9a-zA-Z_\.]+]]: !struct.type<@Foo::@Foo<[]>>, %[[VAL_76:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:          %[[VAL_77:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_75]][@b] : <@Foo::@Foo<[]>>, !felt.type<"bn128">
-// CHECK-NEXT:          constrain.eq %[[VAL_77]], %[[VAL_76]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:        function.def @constrain(%[[VAL_77:[0-9a-zA-Z_\.]+]]: !struct.type<@Foo::@Foo<[]>>, %[[VAL_78:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_79:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_77]][@b] : <@Foo::@Foo<[]>>, !felt.type<"bn128">
+// CHECK-NEXT:          constrain.eq %[[VAL_79]], %[[VAL_78]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:          function.return
 // CHECK-NEXT:        }
 // CHECK-NEXT:      }

--- a/circom/tests/arrays/basic_array_02.circom
+++ b/circom/tests/arrays/basic_array_02.circom
@@ -72,192 +72,201 @@ component main = A();
 // CHECK-NEXT:          %[[VAL_18:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
 // CHECK-NEXT:          %[[VAL_19:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_18]] : !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_20:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_2]]{{\[}}%[[VAL_19]]] : <3 x !pod.type<[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:          %[[VAL_21:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_20]][@count] : <[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:          %[[VAL_22:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:          %[[VAL_23:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_21]], %[[VAL_22]] : index
-// CHECK-NEXT:          pod.write %[[VAL_20]][@count] = %[[VAL_23]] : <[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:          %[[VAL_24:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[VAL_25:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_23]], %[[VAL_24]] : index
-// CHECK-NEXT:          scf.if %[[VAL_25]] {
-// CHECK-NEXT:            %[[VAL_26:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_20]][@params] : <[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
-// CHECK-NEXT:            %[[VAL_27:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_15]][@x] : <[@x: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_28:[0-9a-zA-Z_\.]+]] = function.call @B::@B::@compute(%[[VAL_27]]) : (!felt.type<"bn128">) -> !struct.type<@B::@B<[]>>
-// CHECK-NEXT:            pod.write %[[VAL_20]][@comp] = %[[VAL_28]] : <[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>, !struct.type<@B::@B<[]>>
-// CHECK-NEXT:            %[[VAL_29:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:            %[[VAL_30:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_29]] : !felt.type<"bn128">
-// CHECK-NEXT:            array.write %[[VAL_2]]{{\[}}%[[VAL_30]]] = %[[VAL_20]] : <3 x !pod.type<[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:          %[[VAL_21:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_22:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_21]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_23:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_3]]{{\[}}%[[VAL_22]]] : <3 x !pod.type<[@x: !felt.type<"bn128">]>>, !pod.type<[@x: !felt.type<"bn128">]>
+// CHECK-NEXT:          %[[VAL_24:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_20]][@count] : <[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:          %[[VAL_25:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          %[[VAL_26:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_24]], %[[VAL_25]] : index
+// CHECK-NEXT:          pod.write %[[VAL_20]][@count] = %[[VAL_26]] : <[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:          %[[VAL_27:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_28:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_26]], %[[VAL_27]] : index
+// CHECK-NEXT:          scf.if %[[VAL_28]] {
+// CHECK-NEXT:            %[[VAL_29:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_20]][@params] : <[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
+// CHECK-NEXT:            %[[VAL_30:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_23]][@x] : <[@x: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_31:[0-9a-zA-Z_\.]+]] = function.call @B::@B::@compute(%[[VAL_30]]) : (!felt.type<"bn128">) -> !struct.type<@B::@B<[]>>
+// CHECK-NEXT:            pod.write %[[VAL_20]][@comp] = %[[VAL_31]] : <[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>, !struct.type<@B::@B<[]>>
+// CHECK-NEXT:            %[[VAL_32:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:            %[[VAL_33:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_32]] : !felt.type<"bn128">
+// CHECK-NEXT:            array.write %[[VAL_2]]{{\[}}%[[VAL_33]]] = %[[VAL_20]] : <3 x !pod.type<[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[VAL_31:[0-9a-zA-Z_\.]+]] = pod.new : <[]>
-// CHECK-NEXT:          %[[VAL_32:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:          %[[VAL_33:[0-9a-zA-Z_\.]+]] = pod.new { @count = %[[VAL_32]], @params = %[[VAL_31]] }  : <[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:          %[[VAL_34:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:          %[[VAL_35:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_34]] : !felt.type<"bn128">
-// CHECK-NEXT:          array.write %[[VAL_2]]{{\[}}%[[VAL_35]]] = %[[VAL_33]] : <3 x !pod.type<[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:          %[[VAL_36:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:          %[[VAL_37:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_36]] : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_38:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_3]]{{\[}}%[[VAL_37]]] : <3 x !pod.type<[@x: !felt.type<"bn128">]>>, !pod.type<[@x: !felt.type<"bn128">]>
-// CHECK-NEXT:          pod.write %[[VAL_38]][@x] = %[[VAL_0]] : <[@x: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_34:[0-9a-zA-Z_\.]+]] = pod.new : <[]>
+// CHECK-NEXT:          %[[VAL_35:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          %[[VAL_36:[0-9a-zA-Z_\.]+]] = pod.new { @count = %[[VAL_35]], @params = %[[VAL_34]] }  : <[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:          %[[VAL_37:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_38:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_37]] : !felt.type<"bn128">
+// CHECK-NEXT:          array.write %[[VAL_2]]{{\[}}%[[VAL_38]]] = %[[VAL_36]] : <3 x !pod.type<[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>
 // CHECK-NEXT:          %[[VAL_39:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
 // CHECK-NEXT:          %[[VAL_40:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_39]] : !felt.type<"bn128">
-// CHECK-NEXT:          array.write %[[VAL_3]]{{\[}}%[[VAL_40]]] = %[[VAL_38]] : <3 x !pod.type<[@x: !felt.type<"bn128">]>>, !pod.type<[@x: !felt.type<"bn128">]>
-// CHECK-NEXT:          %[[VAL_41:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:          %[[VAL_42:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_41]] : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_43:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_2]]{{\[}}%[[VAL_42]]] : <3 x !pod.type<[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:          %[[VAL_44:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_43]][@count] : <[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:          %[[VAL_45:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:          %[[VAL_46:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_44]], %[[VAL_45]] : index
-// CHECK-NEXT:          pod.write %[[VAL_43]][@count] = %[[VAL_46]] : <[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:          %[[VAL_47:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[VAL_48:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_46]], %[[VAL_47]] : index
-// CHECK-NEXT:          scf.if %[[VAL_48]] {
-// CHECK-NEXT:            %[[VAL_49:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_43]][@params] : <[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
-// CHECK-NEXT:            %[[VAL_50:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_38]][@x] : <[@x: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_51:[0-9a-zA-Z_\.]+]] = function.call @B::@B::@compute(%[[VAL_50]]) : (!felt.type<"bn128">) -> !struct.type<@B::@B<[]>>
-// CHECK-NEXT:            pod.write %[[VAL_43]][@comp] = %[[VAL_51]] : <[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>, !struct.type<@B::@B<[]>>
-// CHECK-NEXT:            %[[VAL_52:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_53:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_52]] : !felt.type<"bn128">
-// CHECK-NEXT:            array.write %[[VAL_2]]{{\[}}%[[VAL_53]]] = %[[VAL_43]] : <3 x !pod.type<[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:          %[[VAL_41:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_3]]{{\[}}%[[VAL_40]]] : <3 x !pod.type<[@x: !felt.type<"bn128">]>>, !pod.type<[@x: !felt.type<"bn128">]>
+// CHECK-NEXT:          pod.write %[[VAL_41]][@x] = %[[VAL_0]] : <[@x: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_42:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_43:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_42]] : !felt.type<"bn128">
+// CHECK-NEXT:          array.write %[[VAL_3]]{{\[}}%[[VAL_43]]] = %[[VAL_41]] : <3 x !pod.type<[@x: !felt.type<"bn128">]>>, !pod.type<[@x: !felt.type<"bn128">]>
+// CHECK-NEXT:          %[[VAL_44:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_45:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_44]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_46:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_2]]{{\[}}%[[VAL_45]]] : <3 x !pod.type<[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:          %[[VAL_47:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_48:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_47]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_49:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_3]]{{\[}}%[[VAL_48]]] : <3 x !pod.type<[@x: !felt.type<"bn128">]>>, !pod.type<[@x: !felt.type<"bn128">]>
+// CHECK-NEXT:          %[[VAL_50:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_46]][@count] : <[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:          %[[VAL_51:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          %[[VAL_52:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_50]], %[[VAL_51]] : index
+// CHECK-NEXT:          pod.write %[[VAL_46]][@count] = %[[VAL_52]] : <[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:          %[[VAL_53:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_54:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_52]], %[[VAL_53]] : index
+// CHECK-NEXT:          scf.if %[[VAL_54]] {
+// CHECK-NEXT:            %[[VAL_55:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_46]][@params] : <[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
+// CHECK-NEXT:            %[[VAL_56:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_49]][@x] : <[@x: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_57:[0-9a-zA-Z_\.]+]] = function.call @B::@B::@compute(%[[VAL_56]]) : (!felt.type<"bn128">) -> !struct.type<@B::@B<[]>>
+// CHECK-NEXT:            pod.write %[[VAL_46]][@comp] = %[[VAL_57]] : <[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>, !struct.type<@B::@B<[]>>
+// CHECK-NEXT:            %[[VAL_58:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_59:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_58]] : !felt.type<"bn128">
+// CHECK-NEXT:            array.write %[[VAL_2]]{{\[}}%[[VAL_59]]] = %[[VAL_46]] : <3 x !pod.type<[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[VAL_54:[0-9a-zA-Z_\.]+]] = pod.new : <[]>
-// CHECK-NEXT:          %[[VAL_55:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:          %[[VAL_56:[0-9a-zA-Z_\.]+]] = pod.new { @count = %[[VAL_55]], @params = %[[VAL_54]] }  : <[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:          %[[VAL_57:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
-// CHECK-NEXT:          %[[VAL_58:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_57]] : !felt.type<"bn128">
-// CHECK-NEXT:          array.write %[[VAL_2]]{{\[}}%[[VAL_58]]] = %[[VAL_56]] : <3 x !pod.type<[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:          %[[VAL_59:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
-// CHECK-NEXT:          %[[VAL_60:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_59]] : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_61:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_3]]{{\[}}%[[VAL_60]]] : <3 x !pod.type<[@x: !felt.type<"bn128">]>>, !pod.type<[@x: !felt.type<"bn128">]>
-// CHECK-NEXT:          pod.write %[[VAL_61]][@x] = %[[VAL_0]] : <[@x: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_62:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
-// CHECK-NEXT:          %[[VAL_63:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_62]] : !felt.type<"bn128">
-// CHECK-NEXT:          array.write %[[VAL_3]]{{\[}}%[[VAL_63]]] = %[[VAL_61]] : <3 x !pod.type<[@x: !felt.type<"bn128">]>>, !pod.type<[@x: !felt.type<"bn128">]>
-// CHECK-NEXT:          %[[VAL_64:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
-// CHECK-NEXT:          %[[VAL_65:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_64]] : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_66:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_2]]{{\[}}%[[VAL_65]]] : <3 x !pod.type<[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:          %[[VAL_67:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_66]][@count] : <[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:          %[[VAL_68:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:          %[[VAL_69:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_67]], %[[VAL_68]] : index
-// CHECK-NEXT:          pod.write %[[VAL_66]][@count] = %[[VAL_69]] : <[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:          %[[VAL_70:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[VAL_71:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_69]], %[[VAL_70]] : index
-// CHECK-NEXT:          scf.if %[[VAL_71]] {
-// CHECK-NEXT:            %[[VAL_72:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_66]][@params] : <[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
-// CHECK-NEXT:            %[[VAL_73:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_61]][@x] : <[@x: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_74:[0-9a-zA-Z_\.]+]] = function.call @B::@B::@compute(%[[VAL_73]]) : (!felt.type<"bn128">) -> !struct.type<@B::@B<[]>>
-// CHECK-NEXT:            pod.write %[[VAL_66]][@comp] = %[[VAL_74]] : <[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>, !struct.type<@B::@B<[]>>
-// CHECK-NEXT:            %[[VAL_75:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
-// CHECK-NEXT:            %[[VAL_76:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_75]] : !felt.type<"bn128">
-// CHECK-NEXT:            array.write %[[VAL_2]]{{\[}}%[[VAL_76]]] = %[[VAL_66]] : <3 x !pod.type<[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:          %[[VAL_60:[0-9a-zA-Z_\.]+]] = pod.new : <[]>
+// CHECK-NEXT:          %[[VAL_61:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          %[[VAL_62:[0-9a-zA-Z_\.]+]] = pod.new { @count = %[[VAL_61]], @params = %[[VAL_60]] }  : <[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:          %[[VAL_63:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
+// CHECK-NEXT:          %[[VAL_64:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_63]] : !felt.type<"bn128">
+// CHECK-NEXT:          array.write %[[VAL_2]]{{\[}}%[[VAL_64]]] = %[[VAL_62]] : <3 x !pod.type<[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:          %[[VAL_65:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
+// CHECK-NEXT:          %[[VAL_66:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_65]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_67:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_3]]{{\[}}%[[VAL_66]]] : <3 x !pod.type<[@x: !felt.type<"bn128">]>>, !pod.type<[@x: !felt.type<"bn128">]>
+// CHECK-NEXT:          pod.write %[[VAL_67]][@x] = %[[VAL_0]] : <[@x: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_68:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
+// CHECK-NEXT:          %[[VAL_69:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_68]] : !felt.type<"bn128">
+// CHECK-NEXT:          array.write %[[VAL_3]]{{\[}}%[[VAL_69]]] = %[[VAL_67]] : <3 x !pod.type<[@x: !felt.type<"bn128">]>>, !pod.type<[@x: !felt.type<"bn128">]>
+// CHECK-NEXT:          %[[VAL_70:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
+// CHECK-NEXT:          %[[VAL_71:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_70]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_72:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_2]]{{\[}}%[[VAL_71]]] : <3 x !pod.type<[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:          %[[VAL_73:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
+// CHECK-NEXT:          %[[VAL_74:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_73]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_75:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_3]]{{\[}}%[[VAL_74]]] : <3 x !pod.type<[@x: !felt.type<"bn128">]>>, !pod.type<[@x: !felt.type<"bn128">]>
+// CHECK-NEXT:          %[[VAL_76:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_72]][@count] : <[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:          %[[VAL_77:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          %[[VAL_78:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_76]], %[[VAL_77]] : index
+// CHECK-NEXT:          pod.write %[[VAL_72]][@count] = %[[VAL_78]] : <[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:          %[[VAL_79:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_80:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_78]], %[[VAL_79]] : index
+// CHECK-NEXT:          scf.if %[[VAL_80]] {
+// CHECK-NEXT:            %[[VAL_81:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_72]][@params] : <[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
+// CHECK-NEXT:            %[[VAL_82:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_75]][@x] : <[@x: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_83:[0-9a-zA-Z_\.]+]] = function.call @B::@B::@compute(%[[VAL_82]]) : (!felt.type<"bn128">) -> !struct.type<@B::@B<[]>>
+// CHECK-NEXT:            pod.write %[[VAL_72]][@comp] = %[[VAL_83]] : <[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>, !struct.type<@B::@B<[]>>
+// CHECK-NEXT:            %[[VAL_84:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
+// CHECK-NEXT:            %[[VAL_85:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_84]] : !felt.type<"bn128">
+// CHECK-NEXT:            array.write %[[VAL_2]]{{\[}}%[[VAL_85]]] = %[[VAL_72]] : <3 x !pod.type<[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>
 // CHECK-NEXT:          }
 // CHECK-NEXT:          pod.write %[[VAL_4]][@x] = %[[VAL_0]] : <[@x: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_77:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_7]][@count] : <[@count: index, @comp: !struct.type<@C::@C<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:          %[[VAL_78:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:          %[[VAL_79:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_77]], %[[VAL_78]] : index
-// CHECK-NEXT:          pod.write %[[VAL_7]][@count] = %[[VAL_79]] : <[@count: index, @comp: !struct.type<@C::@C<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:          %[[VAL_80:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[VAL_81:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_79]], %[[VAL_80]] : index
-// CHECK-NEXT:          scf.if %[[VAL_81]] {
-// CHECK-NEXT:            %[[VAL_82:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_7]][@params] : <[@count: index, @comp: !struct.type<@C::@C<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
-// CHECK-NEXT:            %[[VAL_83:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_4]][@x] : <[@x: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_84:[0-9a-zA-Z_\.]+]] = function.call @C::@C::@compute(%[[VAL_83]]) : (!felt.type<"bn128">) -> !struct.type<@C::@C<[]>>
-// CHECK-NEXT:            pod.write %[[VAL_7]][@comp] = %[[VAL_84]] : <[@count: index, @comp: !struct.type<@C::@C<[]>>, @params: !pod.type<[]>]>, !struct.type<@C::@C<[]>>
+// CHECK-NEXT:          %[[VAL_86:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_7]][@count] : <[@count: index, @comp: !struct.type<@C::@C<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:          %[[VAL_87:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          %[[VAL_88:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_86]], %[[VAL_87]] : index
+// CHECK-NEXT:          pod.write %[[VAL_7]][@count] = %[[VAL_88]] : <[@count: index, @comp: !struct.type<@C::@C<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:          %[[VAL_89:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_90:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_88]], %[[VAL_89]] : index
+// CHECK-NEXT:          scf.if %[[VAL_90]] {
+// CHECK-NEXT:            %[[VAL_91:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_7]][@params] : <[@count: index, @comp: !struct.type<@C::@C<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
+// CHECK-NEXT:            %[[VAL_92:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_4]][@x] : <[@x: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_93:[0-9a-zA-Z_\.]+]] = function.call @C::@C::@compute(%[[VAL_92]]) : (!felt.type<"bn128">) -> !struct.type<@C::@C<[]>>
+// CHECK-NEXT:            pod.write %[[VAL_7]][@comp] = %[[VAL_93]] : <[@count: index, @comp: !struct.type<@C::@C<[]>>, @params: !pod.type<[]>]>, !struct.type<@C::@C<[]>>
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[VAL_85:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:          %[[VAL_86:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_85]] : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_87:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_2]]{{\[}}%[[VAL_86]]] : <3 x !pod.type<[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:          %[[VAL_88:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_87]][@comp] : <[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>, !struct.type<@B::@B<[]>>
-// CHECK-NEXT:          %[[VAL_89:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_88]][@y] : <@B::@B<[]>>, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_90:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:          %[[VAL_91:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_90]] : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_92:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_2]]{{\[}}%[[VAL_91]]] : <3 x !pod.type<[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:          %[[VAL_93:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_92]][@comp] : <[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>, !struct.type<@B::@B<[]>>
-// CHECK-NEXT:          %[[VAL_94:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_93]][@y] : <@B::@B<[]>>, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_95:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_89]], %[[VAL_94]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_96:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
-// CHECK-NEXT:          %[[VAL_97:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_96]] : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_98:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_2]]{{\[}}%[[VAL_97]]] : <3 x !pod.type<[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:          %[[VAL_99:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_98]][@comp] : <[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>, !struct.type<@B::@B<[]>>
-// CHECK-NEXT:          %[[VAL_100:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_99]][@y] : <@B::@B<[]>>, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_101:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_95]], %[[VAL_100]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_102:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_7]][@comp] : <[@count: index, @comp: !struct.type<@C::@C<[]>>, @params: !pod.type<[]>]>, !struct.type<@C::@C<[]>>
-// CHECK-NEXT:          %[[VAL_103:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_102]][@y] : <@C::@C<[]>>, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_104:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_101]], %[[VAL_103]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:          struct.writem %[[VAL_1]][@y] = %[[VAL_104]] : <@A::@A<[]>>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_94:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_95:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_94]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_96:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_2]]{{\[}}%[[VAL_95]]] : <3 x !pod.type<[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:          %[[VAL_97:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_96]][@comp] : <[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>, !struct.type<@B::@B<[]>>
+// CHECK-NEXT:          %[[VAL_98:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_97]][@y] : <@B::@B<[]>>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_99:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_100:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_99]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_101:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_2]]{{\[}}%[[VAL_100]]] : <3 x !pod.type<[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:          %[[VAL_102:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_101]][@comp] : <[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>, !struct.type<@B::@B<[]>>
+// CHECK-NEXT:          %[[VAL_103:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_102]][@y] : <@B::@B<[]>>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_104:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_98]], %[[VAL_103]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_105:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
+// CHECK-NEXT:          %[[VAL_106:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_105]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_107:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_2]]{{\[}}%[[VAL_106]]] : <3 x !pod.type<[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:          %[[VAL_108:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_107]][@comp] : <[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>, !struct.type<@B::@B<[]>>
+// CHECK-NEXT:          %[[VAL_109:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_108]][@y] : <@B::@B<[]>>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_110:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_104]], %[[VAL_109]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_111:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_7]][@comp] : <[@count: index, @comp: !struct.type<@C::@C<[]>>, @params: !pod.type<[]>]>, !struct.type<@C::@C<[]>>
+// CHECK-NEXT:          %[[VAL_112:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_111]][@y] : <@C::@C<[]>>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_113:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_110]], %[[VAL_112]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          struct.writem %[[VAL_1]][@y] = %[[VAL_113]] : <@A::@A<[]>>, !felt.type<"bn128">
 // CHECK-NEXT:          struct.writem %[[VAL_1]][@bs$inputs] = %[[VAL_3]] : <@A::@A<[]>>, !array.type<3 x !pod.type<[@x: !felt.type<"bn128">]>>
-// CHECK-NEXT:          %[[VAL_105:[0-9a-zA-Z_\.]+]] = array.new  : <3 x !struct.type<@B::@B<[]>>>
-// CHECK-NEXT:          %[[VAL_106:[0-9a-zA-Z_\.]+]] = arith.constant 3 : index
-// CHECK-NEXT:          %[[VAL_107:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[VAL_108:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:          scf.for %[[VAL_109:[0-9a-zA-Z_\.]+]] = %[[VAL_107]] to %[[VAL_106]] step %[[VAL_108]] {
-// CHECK-NEXT:            %[[VAL_110:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_2]]{{\[}}%[[VAL_109]]] : <3 x !pod.type<[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:            %[[VAL_111:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_110]][@comp] : <[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>, !struct.type<@B::@B<[]>>
-// CHECK-NEXT:            array.write %[[VAL_105]]{{\[}}%[[VAL_109]]] = %[[VAL_111]] : <3 x !struct.type<@B::@B<[]>>>, !struct.type<@B::@B<[]>>
+// CHECK-NEXT:          %[[VAL_114:[0-9a-zA-Z_\.]+]] = array.new  : <3 x !struct.type<@B::@B<[]>>>
+// CHECK-NEXT:          %[[VAL_115:[0-9a-zA-Z_\.]+]] = arith.constant 3 : index
+// CHECK-NEXT:          %[[VAL_116:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_117:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          scf.for %[[VAL_118:[0-9a-zA-Z_\.]+]] = %[[VAL_116]] to %[[VAL_115]] step %[[VAL_117]] {
+// CHECK-NEXT:            %[[VAL_119:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_2]]{{\[}}%[[VAL_118]]] : <3 x !pod.type<[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:            %[[VAL_120:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_119]][@comp] : <[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>, !struct.type<@B::@B<[]>>
+// CHECK-NEXT:            array.write %[[VAL_114]]{{\[}}%[[VAL_118]]] = %[[VAL_120]] : <3 x !struct.type<@B::@B<[]>>>, !struct.type<@B::@B<[]>>
 // CHECK-NEXT:          }
-// CHECK-NEXT:          struct.writem %[[VAL_1]][@bs] = %[[VAL_105]] : <@A::@A<[]>>, !array.type<3 x !struct.type<@B::@B<[]>>>
+// CHECK-NEXT:          struct.writem %[[VAL_1]][@bs] = %[[VAL_114]] : <@A::@A<[]>>, !array.type<3 x !struct.type<@B::@B<[]>>>
 // CHECK-NEXT:          struct.writem %[[VAL_1]][@c$inputs] = %[[VAL_4]] : <@A::@A<[]>>, !pod.type<[@x: !felt.type<"bn128">]>
-// CHECK-NEXT:          %[[VAL_112:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_7]][@comp] : <[@count: index, @comp: !struct.type<@C::@C<[]>>, @params: !pod.type<[]>]>, !struct.type<@C::@C<[]>>
-// CHECK-NEXT:          struct.writem %[[VAL_1]][@c] = %[[VAL_112]] : <@A::@A<[]>>, !struct.type<@C::@C<[]>>
+// CHECK-NEXT:          %[[VAL_121:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_7]][@comp] : <[@count: index, @comp: !struct.type<@C::@C<[]>>, @params: !pod.type<[]>]>, !struct.type<@C::@C<[]>>
+// CHECK-NEXT:          struct.writem %[[VAL_1]][@c] = %[[VAL_121]] : <@A::@A<[]>>, !struct.type<@C::@C<[]>>
 // CHECK-NEXT:          function.return %[[VAL_1]] : !struct.type<@A::@A<[]>>
 // CHECK-NEXT:        }
-// CHECK-NEXT:        function.def @constrain(%[[VAL_113:[0-9a-zA-Z_\.]+]]: !struct.type<@A::@A<[]>>, %[[VAL_114:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:          %[[VAL_115:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_113]][@y] : <@A::@A<[]>>, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_116:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_113]][@bs] : <@A::@A<[]>>, !array.type<3 x !struct.type<@B::@B<[]>>>
-// CHECK-NEXT:          %[[VAL_117:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_113]][@bs$inputs] : <@A::@A<[]>>, !array.type<3 x !pod.type<[@x: !felt.type<"bn128">]>>
-// CHECK-NEXT:          %[[VAL_118:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_113]][@c] : <@A::@A<[]>>, !struct.type<@C::@C<[]>>
-// CHECK-NEXT:          %[[VAL_119:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_113]][@c$inputs] : <@A::@A<[]>>, !pod.type<[@x: !felt.type<"bn128">]>
-// CHECK-NEXT:          %[[VAL_120:[0-9a-zA-Z_\.]+]] = pod.new : <[]>
-// CHECK-NEXT:          %[[VAL_121:[0-9a-zA-Z_\.]+]] = pod.new : <[@count: index, @comp: !struct.type<@C::@C<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:          %[[VAL_122:[0-9a-zA-Z_\.]+]] = pod.new : <[]>
-// CHECK-NEXT:          %[[VAL_123:[0-9a-zA-Z_\.]+]] = pod.new : <[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:          %[[VAL_124:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:          %[[VAL_125:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_124]] : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_126:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_117]]{{\[}}%[[VAL_125]]] : <3 x !pod.type<[@x: !felt.type<"bn128">]>>, !pod.type<[@x: !felt.type<"bn128">]>
-// CHECK-NEXT:          %[[VAL_127:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_126]][@x] : <[@x: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:          constrain.eq %[[VAL_127]], %[[VAL_114]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_128:[0-9a-zA-Z_\.]+]] = pod.new : <[]>
-// CHECK-NEXT:          %[[VAL_129:[0-9a-zA-Z_\.]+]] = pod.new : <[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:          %[[VAL_130:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:          %[[VAL_131:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_130]] : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_132:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_117]]{{\[}}%[[VAL_131]]] : <3 x !pod.type<[@x: !felt.type<"bn128">]>>, !pod.type<[@x: !felt.type<"bn128">]>
-// CHECK-NEXT:          %[[VAL_133:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_132]][@x] : <[@x: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:          constrain.eq %[[VAL_133]], %[[VAL_114]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_134:[0-9a-zA-Z_\.]+]] = pod.new : <[]>
-// CHECK-NEXT:          %[[VAL_135:[0-9a-zA-Z_\.]+]] = pod.new : <[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:          %[[VAL_136:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
-// CHECK-NEXT:          %[[VAL_137:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_136]] : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_138:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_117]]{{\[}}%[[VAL_137]]] : <3 x !pod.type<[@x: !felt.type<"bn128">]>>, !pod.type<[@x: !felt.type<"bn128">]>
-// CHECK-NEXT:          %[[VAL_139:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_138]][@x] : <[@x: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:          constrain.eq %[[VAL_139]], %[[VAL_114]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_140:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_119]][@x] : <[@x: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:          constrain.eq %[[VAL_140]], %[[VAL_114]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_141:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:          %[[VAL_142:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_141]] : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_143:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_116]]{{\[}}%[[VAL_142]]] : <3 x !struct.type<@B::@B<[]>>>, !struct.type<@B::@B<[]>>
-// CHECK-NEXT:          %[[VAL_144:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_143]][@y] : <@B::@B<[]>>, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_145:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:        function.def @constrain(%[[VAL_122:[0-9a-zA-Z_\.]+]]: !struct.type<@A::@A<[]>>, %[[VAL_123:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_124:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_122]][@y] : <@A::@A<[]>>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_125:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_122]][@bs] : <@A::@A<[]>>, !array.type<3 x !struct.type<@B::@B<[]>>>
+// CHECK-NEXT:          %[[VAL_126:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_122]][@bs$inputs] : <@A::@A<[]>>, !array.type<3 x !pod.type<[@x: !felt.type<"bn128">]>>
+// CHECK-NEXT:          %[[VAL_127:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_122]][@c] : <@A::@A<[]>>, !struct.type<@C::@C<[]>>
+// CHECK-NEXT:          %[[VAL_128:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_122]][@c$inputs] : <@A::@A<[]>>, !pod.type<[@x: !felt.type<"bn128">]>
+// CHECK-NEXT:          %[[VAL_129:[0-9a-zA-Z_\.]+]] = pod.new : <[]>
+// CHECK-NEXT:          %[[VAL_130:[0-9a-zA-Z_\.]+]] = pod.new : <[@count: index, @comp: !struct.type<@C::@C<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:          %[[VAL_131:[0-9a-zA-Z_\.]+]] = pod.new : <[]>
+// CHECK-NEXT:          %[[VAL_132:[0-9a-zA-Z_\.]+]] = pod.new : <[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:          %[[VAL_133:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_134:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_133]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_135:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_126]]{{\[}}%[[VAL_134]]] : <3 x !pod.type<[@x: !felt.type<"bn128">]>>, !pod.type<[@x: !felt.type<"bn128">]>
+// CHECK-NEXT:          %[[VAL_136:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_135]][@x] : <[@x: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:          constrain.eq %[[VAL_136]], %[[VAL_123]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_137:[0-9a-zA-Z_\.]+]] = pod.new : <[]>
+// CHECK-NEXT:          %[[VAL_138:[0-9a-zA-Z_\.]+]] = pod.new : <[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:          %[[VAL_139:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_140:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_139]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_141:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_126]]{{\[}}%[[VAL_140]]] : <3 x !pod.type<[@x: !felt.type<"bn128">]>>, !pod.type<[@x: !felt.type<"bn128">]>
+// CHECK-NEXT:          %[[VAL_142:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_141]][@x] : <[@x: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:          constrain.eq %[[VAL_142]], %[[VAL_123]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_143:[0-9a-zA-Z_\.]+]] = pod.new : <[]>
+// CHECK-NEXT:          %[[VAL_144:[0-9a-zA-Z_\.]+]] = pod.new : <[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:          %[[VAL_145:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
 // CHECK-NEXT:          %[[VAL_146:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_145]] : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_147:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_116]]{{\[}}%[[VAL_146]]] : <3 x !struct.type<@B::@B<[]>>>, !struct.type<@B::@B<[]>>
-// CHECK-NEXT:          %[[VAL_148:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_147]][@y] : <@B::@B<[]>>, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_149:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_144]], %[[VAL_148]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_150:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
+// CHECK-NEXT:          %[[VAL_147:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_126]]{{\[}}%[[VAL_146]]] : <3 x !pod.type<[@x: !felt.type<"bn128">]>>, !pod.type<[@x: !felt.type<"bn128">]>
+// CHECK-NEXT:          %[[VAL_148:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_147]][@x] : <[@x: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:          constrain.eq %[[VAL_148]], %[[VAL_123]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_149:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_128]][@x] : <[@x: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:          constrain.eq %[[VAL_149]], %[[VAL_123]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_150:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
 // CHECK-NEXT:          %[[VAL_151:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_150]] : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_152:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_116]]{{\[}}%[[VAL_151]]] : <3 x !struct.type<@B::@B<[]>>>, !struct.type<@B::@B<[]>>
+// CHECK-NEXT:          %[[VAL_152:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_125]]{{\[}}%[[VAL_151]]] : <3 x !struct.type<@B::@B<[]>>>, !struct.type<@B::@B<[]>>
 // CHECK-NEXT:          %[[VAL_153:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_152]][@y] : <@B::@B<[]>>, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_154:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_149]], %[[VAL_153]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_155:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_118]][@y] : <@C::@C<[]>>, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_156:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_154]], %[[VAL_155]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:          constrain.eq %[[VAL_115]], %[[VAL_156]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_157:[0-9a-zA-Z_\.]+]] = arith.constant 3 : index
-// CHECK-NEXT:          %[[VAL_158:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[VAL_159:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:          scf.for %[[VAL_160:[0-9a-zA-Z_\.]+]] = %[[VAL_158]] to %[[VAL_157]] step %[[VAL_159]] {
-// CHECK-NEXT:            %[[VAL_161:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_116]]{{\[}}%[[VAL_160]]] : <3 x !struct.type<@B::@B<[]>>>, !struct.type<@B::@B<[]>>
-// CHECK-NEXT:            %[[VAL_162:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_117]]{{\[}}%[[VAL_160]]] : <3 x !pod.type<[@x: !felt.type<"bn128">]>>, !pod.type<[@x: !felt.type<"bn128">]>
-// CHECK-NEXT:            %[[VAL_163:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_162]][@x] : <[@x: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:            function.call @B::@B::@constrain(%[[VAL_161]], %[[VAL_163]]) : (!struct.type<@B::@B<[]>>, !felt.type<"bn128">) -> ()
+// CHECK-NEXT:          %[[VAL_154:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_155:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_154]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_156:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_125]]{{\[}}%[[VAL_155]]] : <3 x !struct.type<@B::@B<[]>>>, !struct.type<@B::@B<[]>>
+// CHECK-NEXT:          %[[VAL_157:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_156]][@y] : <@B::@B<[]>>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_158:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_153]], %[[VAL_157]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_159:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
+// CHECK-NEXT:          %[[VAL_160:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_159]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_161:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_125]]{{\[}}%[[VAL_160]]] : <3 x !struct.type<@B::@B<[]>>>, !struct.type<@B::@B<[]>>
+// CHECK-NEXT:          %[[VAL_162:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_161]][@y] : <@B::@B<[]>>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_163:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_158]], %[[VAL_162]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_164:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_127]][@y] : <@C::@C<[]>>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_165:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_163]], %[[VAL_164]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          constrain.eq %[[VAL_124]], %[[VAL_165]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_166:[0-9a-zA-Z_\.]+]] = arith.constant 3 : index
+// CHECK-NEXT:          %[[VAL_167:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_168:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          scf.for %[[VAL_169:[0-9a-zA-Z_\.]+]] = %[[VAL_167]] to %[[VAL_166]] step %[[VAL_168]] {
+// CHECK-NEXT:            %[[VAL_170:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_125]]{{\[}}%[[VAL_169]]] : <3 x !struct.type<@B::@B<[]>>>, !struct.type<@B::@B<[]>>
+// CHECK-NEXT:            %[[VAL_171:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_126]]{{\[}}%[[VAL_169]]] : <3 x !pod.type<[@x: !felt.type<"bn128">]>>, !pod.type<[@x: !felt.type<"bn128">]>
+// CHECK-NEXT:            %[[VAL_172:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_171]][@x] : <[@x: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:            function.call @B::@B::@constrain(%[[VAL_170]], %[[VAL_172]]) : (!struct.type<@B::@B<[]>>, !felt.type<"bn128">) -> ()
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[VAL_164:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_119]][@x] : <[@x: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:          function.call @C::@C::@constrain(%[[VAL_118]], %[[VAL_164]]) : (!struct.type<@C::@C<[]>>, !felt.type<"bn128">) -> ()
+// CHECK-NEXT:          %[[VAL_173:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_128]][@x] : <[@x: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:          function.call @C::@C::@constrain(%[[VAL_127]], %[[VAL_173]]) : (!struct.type<@C::@C<[]>>, !felt.type<"bn128">) -> ()
 // CHECK-NEXT:          function.return
 // CHECK-NEXT:        }
 // CHECK-NEXT:      }
@@ -265,16 +274,16 @@ component main = A();
 // CHECK-NEXT:    poly.template @B {
 // CHECK-NEXT:      struct.def @B {
 // CHECK-NEXT:        struct.member @y : !felt.type<"bn128"> {llzk.pub}
-// CHECK-NEXT:        function.def @compute(%[[VAL_165:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) -> !struct.type<@B::@B<[]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
-// CHECK-NEXT:          %[[VAL_166:[0-9a-zA-Z_\.]+]] = struct.new : <@B::@B<[]>>
-// CHECK-NEXT:          %[[VAL_167:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_165]], %[[VAL_165]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:          struct.writem %[[VAL_166]][@y] = %[[VAL_167]] : <@B::@B<[]>>, !felt.type<"bn128">
-// CHECK-NEXT:          function.return %[[VAL_166]] : !struct.type<@B::@B<[]>>
+// CHECK-NEXT:        function.def @compute(%[[VAL_174:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) -> !struct.type<@B::@B<[]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
+// CHECK-NEXT:          %[[VAL_175:[0-9a-zA-Z_\.]+]] = struct.new : <@B::@B<[]>>
+// CHECK-NEXT:          %[[VAL_176:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_174]], %[[VAL_174]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          struct.writem %[[VAL_175]][@y] = %[[VAL_176]] : <@B::@B<[]>>, !felt.type<"bn128">
+// CHECK-NEXT:          function.return %[[VAL_175]] : !struct.type<@B::@B<[]>>
 // CHECK-NEXT:        }
-// CHECK-NEXT:        function.def @constrain(%[[VAL_168:[0-9a-zA-Z_\.]+]]: !struct.type<@B::@B<[]>>, %[[VAL_169:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:          %[[VAL_170:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_168]][@y] : <@B::@B<[]>>, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_171:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_169]], %[[VAL_169]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:          constrain.eq %[[VAL_170]], %[[VAL_171]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:        function.def @constrain(%[[VAL_177:[0-9a-zA-Z_\.]+]]: !struct.type<@B::@B<[]>>, %[[VAL_178:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_179:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_177]][@y] : <@B::@B<[]>>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_180:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_178]], %[[VAL_178]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          constrain.eq %[[VAL_179]], %[[VAL_180]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:          function.return
 // CHECK-NEXT:        }
 // CHECK-NEXT:      }
@@ -282,16 +291,16 @@ component main = A();
 // CHECK-NEXT:    poly.template @C {
 // CHECK-NEXT:      struct.def @C {
 // CHECK-NEXT:        struct.member @y : !felt.type<"bn128"> {llzk.pub}
-// CHECK-NEXT:        function.def @compute(%[[VAL_172:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) -> !struct.type<@C::@C<[]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
-// CHECK-NEXT:          %[[VAL_173:[0-9a-zA-Z_\.]+]] = struct.new : <@C::@C<[]>>
-// CHECK-NEXT:          %[[VAL_174:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_172]], %[[VAL_172]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:          struct.writem %[[VAL_173]][@y] = %[[VAL_174]] : <@C::@C<[]>>, !felt.type<"bn128">
-// CHECK-NEXT:          function.return %[[VAL_173]] : !struct.type<@C::@C<[]>>
+// CHECK-NEXT:        function.def @compute(%[[VAL_181:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) -> !struct.type<@C::@C<[]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
+// CHECK-NEXT:          %[[VAL_182:[0-9a-zA-Z_\.]+]] = struct.new : <@C::@C<[]>>
+// CHECK-NEXT:          %[[VAL_183:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_181]], %[[VAL_181]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          struct.writem %[[VAL_182]][@y] = %[[VAL_183]] : <@C::@C<[]>>, !felt.type<"bn128">
+// CHECK-NEXT:          function.return %[[VAL_182]] : !struct.type<@C::@C<[]>>
 // CHECK-NEXT:        }
-// CHECK-NEXT:        function.def @constrain(%[[VAL_175:[0-9a-zA-Z_\.]+]]: !struct.type<@C::@C<[]>>, %[[VAL_176:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:          %[[VAL_177:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_175]][@y] : <@C::@C<[]>>, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_178:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_176]], %[[VAL_176]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:          constrain.eq %[[VAL_177]], %[[VAL_178]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:        function.def @constrain(%[[VAL_184:[0-9a-zA-Z_\.]+]]: !struct.type<@C::@C<[]>>, %[[VAL_185:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_186:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_184]][@y] : <@C::@C<[]>>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_187:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_185]], %[[VAL_185]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          constrain.eq %[[VAL_186]], %[[VAL_187]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:          function.return
 // CHECK-NEXT:        }
 // CHECK-NEXT:      }

--- a/circom/tests/circom_doc_examples/03-arr.circom
+++ b/circom/tests/circom_doc_examples/03-arr.circom
@@ -28,7 +28,7 @@ template B(N){
 
 component main = B(1);
 
-// CHECK:       #[[$ATTR_0:[0-9a-zA-Z_\.]+]] = affine_map<(d0) -> (d0)>
+// CHECK: #[[$ATTR_0:[0-9a-zA-Z_\.]+]] = affine_map<(d0) -> (d0)>
 // CHECK-LABEL: module attributes {llzk.lang, llzk.main = !struct.type<@B::@B<[1]>>} {
 // CHECK-NEXT:    poly.template @A {
 // CHECK-NEXT:      poly.param @N
@@ -96,79 +96,82 @@ component main = B(1);
 // CHECK-NEXT:          %[[VAL_37:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
 // CHECK-NEXT:          %[[VAL_38:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_37]] : !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_39:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_11]]{{\[}}%[[VAL_38]]] : <1 x !pod.type<[@count: index, @comp: !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>, @params: !pod.type<[@N: !felt.type<"bn128">, @M: !felt.type<"bn128">]>]>>, !pod.type<[@count: index, @comp: !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>, @params: !pod.type<[@N: !felt.type<"bn128">, @M: !felt.type<"bn128">]>]>
-// CHECK-NEXT:          %[[VAL_40:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_39]][@count] : <[@count: index, @comp: !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>, @params: !pod.type<[@N: !felt.type<"bn128">, @M: !felt.type<"bn128">]>]>, index
-// CHECK-NEXT:          %[[VAL_41:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:          %[[VAL_42:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_40]], %[[VAL_41]] : index
-// CHECK-NEXT:          pod.write %[[VAL_39]][@count] = %[[VAL_42]] : <[@count: index, @comp: !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>, @params: !pod.type<[@N: !felt.type<"bn128">, @M: !felt.type<"bn128">]>]>, index
-// CHECK-NEXT:          %[[VAL_43:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[VAL_44:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_42]], %[[VAL_43]] : index
-// CHECK-NEXT:          scf.if %[[VAL_44]] {
-// CHECK-NEXT:            %[[VAL_45:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_39]][@params] : <[@count: index, @comp: !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>, @params: !pod.type<[@N: !felt.type<"bn128">, @M: !felt.type<"bn128">]>]>, !pod.type<[@N: !felt.type<"bn128">, @M: !felt.type<"bn128">]>
-// CHECK-NEXT:            %[[VAL_46:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_34]][@in] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_47:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_45]][@N] : <[@N: !felt.type<"bn128">, @M: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_48:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_47]] : !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_49:[0-9a-zA-Z_\.]+]] = function.call @A::@A::@compute(%[[VAL_46]]) {(%[[VAL_48]])} : (!felt.type<"bn128">) -> !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>
-// CHECK-NEXT:            pod.write %[[VAL_39]][@comp] = %[[VAL_49]] : <[@count: index, @comp: !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>, @params: !pod.type<[@N: !felt.type<"bn128">, @M: !felt.type<"bn128">]>]>, !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>
-// CHECK-NEXT:            %[[VAL_50:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_40:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_41:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_40]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_42:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_12]]{{\[}}%[[VAL_41]]] : <1 x !pod.type<[@in: !felt.type<"bn128">]>>, !pod.type<[@in: !felt.type<"bn128">]>
+// CHECK-NEXT:          %[[VAL_43:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_39]][@count] : <[@count: index, @comp: !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>, @params: !pod.type<[@N: !felt.type<"bn128">, @M: !felt.type<"bn128">]>]>, index
+// CHECK-NEXT:          %[[VAL_44:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          %[[VAL_45:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_43]], %[[VAL_44]] : index
+// CHECK-NEXT:          pod.write %[[VAL_39]][@count] = %[[VAL_45]] : <[@count: index, @comp: !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>, @params: !pod.type<[@N: !felt.type<"bn128">, @M: !felt.type<"bn128">]>]>, index
+// CHECK-NEXT:          %[[VAL_46:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_47:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_45]], %[[VAL_46]] : index
+// CHECK-NEXT:          scf.if %[[VAL_47]] {
+// CHECK-NEXT:            %[[VAL_48:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_39]][@params] : <[@count: index, @comp: !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>, @params: !pod.type<[@N: !felt.type<"bn128">, @M: !felt.type<"bn128">]>]>, !pod.type<[@N: !felt.type<"bn128">, @M: !felt.type<"bn128">]>
+// CHECK-NEXT:            %[[VAL_49:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_42]][@in] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_50:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_48]][@N] : <[@N: !felt.type<"bn128">, @M: !felt.type<"bn128">]>, !felt.type<"bn128">
 // CHECK-NEXT:            %[[VAL_51:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_50]] : !felt.type<"bn128">
-// CHECK-NEXT:            array.write %[[VAL_11]]{{\[}}%[[VAL_51]]] = %[[VAL_39]] : <1 x !pod.type<[@count: index, @comp: !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>, @params: !pod.type<[@N: !felt.type<"bn128">, @M: !felt.type<"bn128">]>]>>, !pod.type<[@count: index, @comp: !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>, @params: !pod.type<[@N: !felt.type<"bn128">, @M: !felt.type<"bn128">]>]>
+// CHECK-NEXT:            %[[VAL_52:[0-9a-zA-Z_\.]+]] = function.call @A::@A::@compute(%[[VAL_49]]) {(%[[VAL_51]])} : (!felt.type<"bn128">) -> !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>
+// CHECK-NEXT:            pod.write %[[VAL_39]][@comp] = %[[VAL_52]] : <[@count: index, @comp: !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>, @params: !pod.type<[@N: !felt.type<"bn128">, @M: !felt.type<"bn128">]>]>, !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>
+// CHECK-NEXT:            %[[VAL_53:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:            %[[VAL_54:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_53]] : !felt.type<"bn128">
+// CHECK-NEXT:            array.write %[[VAL_11]]{{\[}}%[[VAL_54]]] = %[[VAL_39]] : <1 x !pod.type<[@count: index, @comp: !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>, @params: !pod.type<[@N: !felt.type<"bn128">, @M: !felt.type<"bn128">]>]>>, !pod.type<[@count: index, @comp: !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>, @params: !pod.type<[@N: !felt.type<"bn128">, @M: !felt.type<"bn128">]>]>
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[VAL_52:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:          %[[VAL_53:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_52]] : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_54:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_11]]{{\[}}%[[VAL_53]]] : <1 x !pod.type<[@count: index, @comp: !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>, @params: !pod.type<[@N: !felt.type<"bn128">, @M: !felt.type<"bn128">]>]>>, !pod.type<[@count: index, @comp: !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>, @params: !pod.type<[@N: !felt.type<"bn128">, @M: !felt.type<"bn128">]>]>
-// CHECK-NEXT:          %[[VAL_55:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_54]][@comp] : <[@count: index, @comp: !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>, @params: !pod.type<[@N: !felt.type<"bn128">, @M: !felt.type<"bn128">]>]>, !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>
-// CHECK-NEXT:          %[[VAL_56:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_55]][@out] : <@A::@A<[#[[$ATTR_0]], 1]>>, !felt.type<"bn128">
-// CHECK-NEXT:          struct.writem %[[VAL_9]][@out] = %[[VAL_56]] : <@B::@B<[@N]>>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_55:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_56:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_55]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_57:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_11]]{{\[}}%[[VAL_56]]] : <1 x !pod.type<[@count: index, @comp: !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>, @params: !pod.type<[@N: !felt.type<"bn128">, @M: !felt.type<"bn128">]>]>>, !pod.type<[@count: index, @comp: !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>, @params: !pod.type<[@N: !felt.type<"bn128">, @M: !felt.type<"bn128">]>]>
+// CHECK-NEXT:          %[[VAL_58:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_57]][@comp] : <[@count: index, @comp: !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>, @params: !pod.type<[@N: !felt.type<"bn128">, @M: !felt.type<"bn128">]>]>, !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>
+// CHECK-NEXT:          %[[VAL_59:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_58]][@out] : <@A::@A<[#[[$ATTR_0]], 1]>>, !felt.type<"bn128">
+// CHECK-NEXT:          struct.writem %[[VAL_9]][@out] = %[[VAL_59]] : <@B::@B<[@N]>>, !felt.type<"bn128">
 // CHECK-NEXT:          struct.writem %[[VAL_9]][@a$inputs] = %[[VAL_12]] : <@B::@B<[@N]>>, !array.type<1 x !pod.type<[@in: !felt.type<"bn128">]>>
-// CHECK-NEXT:          %[[VAL_57:[0-9a-zA-Z_\.]+]] = array.new  : <1 x !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>>
-// CHECK-NEXT:          %[[VAL_58:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:          %[[VAL_59:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[VAL_60:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:          scf.for %[[VAL_61:[0-9a-zA-Z_\.]+]] = %[[VAL_59]] to %[[VAL_58]] step %[[VAL_60]] {
-// CHECK-NEXT:            %[[VAL_62:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_11]]{{\[}}%[[VAL_61]]] : <1 x !pod.type<[@count: index, @comp: !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>, @params: !pod.type<[@N: !felt.type<"bn128">, @M: !felt.type<"bn128">]>]>>, !pod.type<[@count: index, @comp: !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>, @params: !pod.type<[@N: !felt.type<"bn128">, @M: !felt.type<"bn128">]>]>
-// CHECK-NEXT:            %[[VAL_63:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_62]][@comp] : <[@count: index, @comp: !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>, @params: !pod.type<[@N: !felt.type<"bn128">, @M: !felt.type<"bn128">]>]>, !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>
-// CHECK-NEXT:            array.write %[[VAL_57]]{{\[}}%[[VAL_61]]] = %[[VAL_63]] : <1 x !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>>, !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>
+// CHECK-NEXT:          %[[VAL_60:[0-9a-zA-Z_\.]+]] = array.new  : <1 x !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>>
+// CHECK-NEXT:          %[[VAL_61:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          %[[VAL_62:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_63:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          scf.for %[[VAL_64:[0-9a-zA-Z_\.]+]] = %[[VAL_62]] to %[[VAL_61]] step %[[VAL_63]] {
+// CHECK-NEXT:            %[[VAL_65:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_11]]{{\[}}%[[VAL_64]]] : <1 x !pod.type<[@count: index, @comp: !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>, @params: !pod.type<[@N: !felt.type<"bn128">, @M: !felt.type<"bn128">]>]>>, !pod.type<[@count: index, @comp: !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>, @params: !pod.type<[@N: !felt.type<"bn128">, @M: !felt.type<"bn128">]>]>
+// CHECK-NEXT:            %[[VAL_66:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_65]][@comp] : <[@count: index, @comp: !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>, @params: !pod.type<[@N: !felt.type<"bn128">, @M: !felt.type<"bn128">]>]>, !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>
+// CHECK-NEXT:            array.write %[[VAL_60]]{{\[}}%[[VAL_64]]] = %[[VAL_66]] : <1 x !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>>, !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>
 // CHECK-NEXT:          }
-// CHECK-NEXT:          struct.writem %[[VAL_9]][@a] = %[[VAL_57]] : <@B::@B<[@N]>>, !array.type<1 x !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>>
+// CHECK-NEXT:          struct.writem %[[VAL_9]][@a] = %[[VAL_60]] : <@B::@B<[@N]>>, !array.type<1 x !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>>
 // CHECK-NEXT:          function.return %[[VAL_9]] : !struct.type<@B::@B<[@N]>>
 // CHECK-NEXT:        }
-// CHECK-NEXT:        function.def @constrain(%[[VAL_64:[0-9a-zA-Z_\.]+]]: !struct.type<@B::@B<[@N]>>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:          %[[VAL_65:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_66:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_64]][@out] : <@B::@B<[@N]>>, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_67:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_64]][@a] : <@B::@B<[@N]>>, !array.type<1 x !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>>
-// CHECK-NEXT:          %[[VAL_68:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_64]][@a$inputs] : <@B::@B<[@N]>>, !array.type<1 x !pod.type<[@in: !felt.type<"bn128">]>>
-// CHECK-NEXT:          %[[VAL_69:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:          %[[VAL_70:[0-9a-zA-Z_\.]+]] = bool.cmp gt(%[[VAL_65]], %[[VAL_69]]) : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:          scf.if %[[VAL_70]] {
-// CHECK-NEXT:            %[[VAL_71:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_72:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_73:[0-9a-zA-Z_\.]+]] = pod.new { @N = %[[VAL_71]], @M = %[[VAL_72]] }  : <[@N: !felt.type<"bn128">, @M: !felt.type<"bn128">]>
-// CHECK-NEXT:            %[[VAL_74:[0-9a-zA-Z_\.]+]] = pod.new : <[@count: index, @comp: !struct.type<@A::@A<[@N, 1]>>, @params: !pod.type<[@N: !felt.type<"bn128">, @M: !felt.type<"bn128">]>]>
+// CHECK-NEXT:        function.def @constrain(%[[VAL_67:[0-9a-zA-Z_\.]+]]: !struct.type<@B::@B<[@N]>>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_68:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_69:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_67]][@out] : <@B::@B<[@N]>>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_70:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_67]][@a] : <@B::@B<[@N]>>, !array.type<1 x !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>>
+// CHECK-NEXT:          %[[VAL_71:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_67]][@a$inputs] : <@B::@B<[@N]>>, !array.type<1 x !pod.type<[@in: !felt.type<"bn128">]>>
+// CHECK-NEXT:          %[[VAL_72:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_73:[0-9a-zA-Z_\.]+]] = bool.cmp gt(%[[VAL_68]], %[[VAL_72]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          scf.if %[[VAL_73]] {
+// CHECK-NEXT:            %[[VAL_74:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_75:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_76:[0-9a-zA-Z_\.]+]] = pod.new { @N = %[[VAL_74]], @M = %[[VAL_75]] }  : <[@N: !felt.type<"bn128">, @M: !felt.type<"bn128">]>
+// CHECK-NEXT:            %[[VAL_77:[0-9a-zA-Z_\.]+]] = pod.new : <[@count: index, @comp: !struct.type<@A::@A<[@N, 1]>>, @params: !pod.type<[@N: !felt.type<"bn128">, @M: !felt.type<"bn128">]>]>
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[VAL_75:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:            %[[VAL_76:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_77:[0-9a-zA-Z_\.]+]] = pod.new { @N = %[[VAL_75]], @M = %[[VAL_76]] }  : <[@N: !felt.type<"bn128">, @M: !felt.type<"bn128">]>
-// CHECK-NEXT:            %[[VAL_78:[0-9a-zA-Z_\.]+]] = pod.new : <[@count: index, @comp: !struct.type<@A::@A<[0, 1]>>, @params: !pod.type<[@N: !felt.type<"bn128">, @M: !felt.type<"bn128">]>]>
+// CHECK-NEXT:            %[[VAL_78:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:            %[[VAL_79:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_80:[0-9a-zA-Z_\.]+]] = pod.new { @N = %[[VAL_78]], @M = %[[VAL_79]] }  : <[@N: !felt.type<"bn128">, @M: !felt.type<"bn128">]>
+// CHECK-NEXT:            %[[VAL_81:[0-9a-zA-Z_\.]+]] = pod.new : <[@count: index, @comp: !struct.type<@A::@A<[0, 1]>>, @params: !pod.type<[@N: !felt.type<"bn128">, @M: !felt.type<"bn128">]>]>
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[VAL_79:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:          %[[VAL_80:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:          %[[VAL_81:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_80]] : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_82:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_68]]{{\[}}%[[VAL_81]]] : <1 x !pod.type<[@in: !felt.type<"bn128">]>>, !pod.type<[@in: !felt.type<"bn128">]>
-// CHECK-NEXT:          %[[VAL_83:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_82]][@in] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:          constrain.eq %[[VAL_83]], %[[VAL_79]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_84:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:          %[[VAL_85:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_84]] : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_86:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_67]]{{\[}}%[[VAL_85]]] : <1 x !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>>, !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>
-// CHECK-NEXT:          %[[VAL_87:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_86]][@out] : <@A::@A<[#[[$ATTR_0]], 1]>>, !felt.type<"bn128">
-// CHECK-NEXT:          constrain.eq %[[VAL_66]], %[[VAL_87]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_88:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:          %[[VAL_89:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[VAL_90:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:          scf.for %[[VAL_91:[0-9a-zA-Z_\.]+]] = %[[VAL_89]] to %[[VAL_88]] step %[[VAL_90]] {
-// CHECK-NEXT:            %[[VAL_92:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_67]]{{\[}}%[[VAL_91]]] : <1 x !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>>, !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>
-// CHECK-NEXT:            %[[VAL_93:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_68]]{{\[}}%[[VAL_91]]] : <1 x !pod.type<[@in: !felt.type<"bn128">]>>, !pod.type<[@in: !felt.type<"bn128">]>
-// CHECK-NEXT:            %[[VAL_94:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_93]][@in] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:            function.call @A::@A::@constrain(%[[VAL_92]], %[[VAL_94]]) : (!struct.type<@A::@A<[#[[$ATTR_0]], 1]>>, !felt.type<"bn128">) -> ()
+// CHECK-NEXT:          %[[VAL_82:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_83:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_84:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_83]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_85:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_71]]{{\[}}%[[VAL_84]]] : <1 x !pod.type<[@in: !felt.type<"bn128">]>>, !pod.type<[@in: !felt.type<"bn128">]>
+// CHECK-NEXT:          %[[VAL_86:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_85]][@in] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:          constrain.eq %[[VAL_86]], %[[VAL_82]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_87:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_88:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_87]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_89:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_70]]{{\[}}%[[VAL_88]]] : <1 x !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>>, !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>
+// CHECK-NEXT:          %[[VAL_90:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_89]][@out] : <@A::@A<[#[[$ATTR_0]], 1]>>, !felt.type<"bn128">
+// CHECK-NEXT:          constrain.eq %[[VAL_69]], %[[VAL_90]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_91:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          %[[VAL_92:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_93:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          scf.for %[[VAL_94:[0-9a-zA-Z_\.]+]] = %[[VAL_92]] to %[[VAL_91]] step %[[VAL_93]] {
+// CHECK-NEXT:            %[[VAL_95:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_70]]{{\[}}%[[VAL_94]]] : <1 x !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>>, !struct.type<@A::@A<[#[[$ATTR_0]], 1]>>
+// CHECK-NEXT:            %[[VAL_96:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_71]]{{\[}}%[[VAL_94]]] : <1 x !pod.type<[@in: !felt.type<"bn128">]>>, !pod.type<[@in: !felt.type<"bn128">]>
+// CHECK-NEXT:            %[[VAL_97:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_96]][@in] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:            function.call @A::@A::@constrain(%[[VAL_95]], %[[VAL_97]]) : (!struct.type<@A::@A<[#[[$ATTR_0]], 1]>>, !felt.type<"bn128">) -> ()
 // CHECK-NEXT:          }
 // CHECK-NEXT:          function.return
 // CHECK-NEXT:        }

--- a/circom/tests/circom_doc_examples/38.circom
+++ b/circom/tests/circom_doc_examples/38.circom
@@ -119,235 +119,249 @@ component main {public [in]} = MultiplierN(3);
 // CHECK-NEXT:          %[[VAL_39:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
 // CHECK-NEXT:          %[[VAL_40:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_39]] : !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_41:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_16]]{{\[}}%[[VAL_40]]] : <@"N_Sub_1@859" x !pod.type<[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:          %[[VAL_42:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_41]][@count] : <[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:          %[[VAL_43:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:          %[[VAL_44:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_42]], %[[VAL_43]] : index
-// CHECK-NEXT:          pod.write %[[VAL_41]][@count] = %[[VAL_44]] : <[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:          %[[VAL_45:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[VAL_46:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_44]], %[[VAL_45]] : index
-// CHECK-NEXT:          scf.if %[[VAL_46]] {
-// CHECK-NEXT:            %[[VAL_47:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_41]][@params] : <[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
-// CHECK-NEXT:            %[[VAL_48:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_36]][@in1] : <[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_49:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_36]][@in2] : <[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_50:[0-9a-zA-Z_\.]+]] = function.call @Multiplier2::@Multiplier2::@compute(%[[VAL_48]], %[[VAL_49]]) : (!felt.type<"bn128">, !felt.type<"bn128">) -> !struct.type<@Multiplier2::@Multiplier2<[]>>
-// CHECK-NEXT:            pod.write %[[VAL_41]][@comp] = %[[VAL_50]] : <[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>, !struct.type<@Multiplier2::@Multiplier2<[]>>
-// CHECK-NEXT:            %[[VAL_51:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:            %[[VAL_52:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_51]] : !felt.type<"bn128">
-// CHECK-NEXT:            array.write %[[VAL_16]]{{\[}}%[[VAL_52]]] = %[[VAL_41]] : <@"N_Sub_1@859" x !pod.type<[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:          %[[VAL_42:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_43:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_42]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_44:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_17]]{{\[}}%[[VAL_43]]] : <@"N_Sub_1@859" x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>, !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>
+// CHECK-NEXT:          %[[VAL_45:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_41]][@count] : <[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:          %[[VAL_46:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          %[[VAL_47:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_45]], %[[VAL_46]] : index
+// CHECK-NEXT:          pod.write %[[VAL_41]][@count] = %[[VAL_47]] : <[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:          %[[VAL_48:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_49:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_47]], %[[VAL_48]] : index
+// CHECK-NEXT:          scf.if %[[VAL_49]] {
+// CHECK-NEXT:            %[[VAL_50:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_41]][@params] : <[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
+// CHECK-NEXT:            %[[VAL_51:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_44]][@in1] : <[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_52:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_44]][@in2] : <[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_53:[0-9a-zA-Z_\.]+]] = function.call @Multiplier2::@Multiplier2::@compute(%[[VAL_51]], %[[VAL_52]]) : (!felt.type<"bn128">, !felt.type<"bn128">) -> !struct.type<@Multiplier2::@Multiplier2<[]>>
+// CHECK-NEXT:            pod.write %[[VAL_41]][@comp] = %[[VAL_53]] : <[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>, !struct.type<@Multiplier2::@Multiplier2<[]>>
+// CHECK-NEXT:            %[[VAL_54:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:            %[[VAL_55:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_54]] : !felt.type<"bn128">
+// CHECK-NEXT:            array.write %[[VAL_16]]{{\[}}%[[VAL_55]]] = %[[VAL_41]] : <@"N_Sub_1@859" x !pod.type<[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[VAL_53:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:          %[[VAL_54:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_53]] : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_55:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_12]]{{\[}}%[[VAL_54]]] : <@N x !felt.type<"bn128">>, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_56:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_56:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
 // CHECK-NEXT:          %[[VAL_57:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_56]] : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_58:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_17]]{{\[}}%[[VAL_57]]] : <@"N_Sub_1@859" x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>, !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>
-// CHECK-NEXT:          pod.write %[[VAL_58]][@in2] = %[[VAL_55]] : <[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_58:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_12]]{{\[}}%[[VAL_57]]] : <@N x !felt.type<"bn128">>, !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_59:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
 // CHECK-NEXT:          %[[VAL_60:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_59]] : !felt.type<"bn128">
-// CHECK-NEXT:          array.write %[[VAL_17]]{{\[}}%[[VAL_60]]] = %[[VAL_58]] : <@"N_Sub_1@859" x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>, !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>
-// CHECK-NEXT:          %[[VAL_61:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:          %[[VAL_62:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_61]] : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_63:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_16]]{{\[}}%[[VAL_62]]] : <@"N_Sub_1@859" x !pod.type<[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:          %[[VAL_64:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_63]][@count] : <[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:          %[[VAL_65:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:          %[[VAL_66:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_64]], %[[VAL_65]] : index
-// CHECK-NEXT:          pod.write %[[VAL_63]][@count] = %[[VAL_66]] : <[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:          %[[VAL_67:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[VAL_68:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_66]], %[[VAL_67]] : index
-// CHECK-NEXT:          scf.if %[[VAL_68]] {
-// CHECK-NEXT:            %[[VAL_69:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_63]][@params] : <[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
-// CHECK-NEXT:            %[[VAL_70:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_58]][@in1] : <[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_71:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_58]][@in2] : <[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_72:[0-9a-zA-Z_\.]+]] = function.call @Multiplier2::@Multiplier2::@compute(%[[VAL_70]], %[[VAL_71]]) : (!felt.type<"bn128">, !felt.type<"bn128">) -> !struct.type<@Multiplier2::@Multiplier2<[]>>
-// CHECK-NEXT:            pod.write %[[VAL_63]][@comp] = %[[VAL_72]] : <[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>, !struct.type<@Multiplier2::@Multiplier2<[]>>
-// CHECK-NEXT:            %[[VAL_73:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:            %[[VAL_74:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_73]] : !felt.type<"bn128">
-// CHECK-NEXT:            array.write %[[VAL_16]]{{\[}}%[[VAL_74]]] = %[[VAL_63]] : <@"N_Sub_1@859" x !pod.type<[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:          %[[VAL_61:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_17]]{{\[}}%[[VAL_60]]] : <@"N_Sub_1@859" x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>, !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>
+// CHECK-NEXT:          pod.write %[[VAL_61]][@in2] = %[[VAL_58]] : <[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_62:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_63:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_62]] : !felt.type<"bn128">
+// CHECK-NEXT:          array.write %[[VAL_17]]{{\[}}%[[VAL_63]]] = %[[VAL_61]] : <@"N_Sub_1@859" x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>, !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>
+// CHECK-NEXT:          %[[VAL_64:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_65:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_64]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_66:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_16]]{{\[}}%[[VAL_65]]] : <@"N_Sub_1@859" x !pod.type<[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:          %[[VAL_67:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_68:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_67]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_69:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_17]]{{\[}}%[[VAL_68]]] : <@"N_Sub_1@859" x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>, !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>
+// CHECK-NEXT:          %[[VAL_70:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_66]][@count] : <[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:          %[[VAL_71:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          %[[VAL_72:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_70]], %[[VAL_71]] : index
+// CHECK-NEXT:          pod.write %[[VAL_66]][@count] = %[[VAL_72]] : <[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:          %[[VAL_73:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_74:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_72]], %[[VAL_73]] : index
+// CHECK-NEXT:          scf.if %[[VAL_74]] {
+// CHECK-NEXT:            %[[VAL_75:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_66]][@params] : <[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
+// CHECK-NEXT:            %[[VAL_76:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_69]][@in1] : <[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_77:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_69]][@in2] : <[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_78:[0-9a-zA-Z_\.]+]] = function.call @Multiplier2::@Multiplier2::@compute(%[[VAL_76]], %[[VAL_77]]) : (!felt.type<"bn128">, !felt.type<"bn128">) -> !struct.type<@Multiplier2::@Multiplier2<[]>>
+// CHECK-NEXT:            pod.write %[[VAL_66]][@comp] = %[[VAL_78]] : <[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>, !struct.type<@Multiplier2::@Multiplier2<[]>>
+// CHECK-NEXT:            %[[VAL_79:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:            %[[VAL_80:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_79]] : !felt.type<"bn128">
+// CHECK-NEXT:            array.write %[[VAL_16]]{{\[}}%[[VAL_80]]] = %[[VAL_66]] : <@"N_Sub_1@859" x !pod.type<[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[VAL_75:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:          %[[VAL_76:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_77:[0-9a-zA-Z_\.]+]] = %[[VAL_17]], %[[VAL_78:[0-9a-zA-Z_\.]+]] = %[[VAL_75]]) : (!array.type<@"N_Sub_1@859" x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>, !felt.type<"bn128">) -> (!array.type<@"N_Sub_1@859" x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>, !felt.type<"bn128">) {
-// CHECK-NEXT:            %[[VAL_79:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
-// CHECK-NEXT:            %[[VAL_80:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_14]], %[[VAL_79]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_81:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_78]], %[[VAL_80]]) : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            scf.condition(%[[VAL_81]]) %[[VAL_77]], %[[VAL_78]] : !array.type<@"N_Sub_1@859" x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_81:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_82:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_83:[0-9a-zA-Z_\.]+]] = %[[VAL_17]], %[[VAL_84:[0-9a-zA-Z_\.]+]] = %[[VAL_81]]) : (!array.type<@"N_Sub_1@859" x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>, !felt.type<"bn128">) -> (!array.type<@"N_Sub_1@859" x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>, !felt.type<"bn128">) {
+// CHECK-NEXT:            %[[VAL_85:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
+// CHECK-NEXT:            %[[VAL_86:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_14]], %[[VAL_85]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_87:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_84]], %[[VAL_86]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.condition(%[[VAL_87]]) %[[VAL_83]], %[[VAL_84]] : !array.type<@"N_Sub_1@859" x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>, !felt.type<"bn128">
 // CHECK-NEXT:          } do {
-// CHECK-NEXT:          ^bb0(%[[VAL_82:[0-9a-zA-Z_\.]+]]: !array.type<@"N_Sub_1@859" x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>, %[[VAL_83:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
-// CHECK-NEXT:            %[[VAL_84:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_83]] : !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_85:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_16]]{{\[}}%[[VAL_84]]] : <@"N_Sub_1@859" x !pod.type<[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:            %[[VAL_86:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_85]][@comp] : <[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>, !struct.type<@Multiplier2::@Multiplier2<[]>>
-// CHECK-NEXT:            %[[VAL_87:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_86]][@out] : <@Multiplier2::@Multiplier2<[]>>, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_88:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_89:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_83]], %[[VAL_88]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          ^bb0(%[[VAL_88:[0-9a-zA-Z_\.]+]]: !array.type<@"N_Sub_1@859" x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>, %[[VAL_89:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
 // CHECK-NEXT:            %[[VAL_90:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_89]] : !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_91:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_82]]{{\[}}%[[VAL_90]]] : <@"N_Sub_1@859" x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>, !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>
-// CHECK-NEXT:            pod.write %[[VAL_91]][@in1] = %[[VAL_87]] : <[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_92:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_93:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_83]], %[[VAL_92]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_94:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_93]] : !felt.type<"bn128">
-// CHECK-NEXT:            array.write %[[VAL_82]]{{\[}}%[[VAL_94]]] = %[[VAL_91]] : <@"N_Sub_1@859" x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>, !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>
-// CHECK-NEXT:            %[[VAL_95:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_96:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_83]], %[[VAL_95]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_97:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_96]] : !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_98:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_16]]{{\[}}%[[VAL_97]]] : <@"N_Sub_1@859" x !pod.type<[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:            %[[VAL_99:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_98]][@count] : <[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:            %[[VAL_100:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:            %[[VAL_101:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_99]], %[[VAL_100]] : index
-// CHECK-NEXT:            pod.write %[[VAL_98]][@count] = %[[VAL_101]] : <[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:            %[[VAL_102:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:            %[[VAL_103:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_101]], %[[VAL_102]] : index
-// CHECK-NEXT:            scf.if %[[VAL_103]] {
-// CHECK-NEXT:              %[[VAL_104:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_98]][@params] : <[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
-// CHECK-NEXT:              %[[VAL_105:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_91]][@in1] : <[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_106:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_91]][@in2] : <[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_107:[0-9a-zA-Z_\.]+]] = function.call @Multiplier2::@Multiplier2::@compute(%[[VAL_105]], %[[VAL_106]]) : (!felt.type<"bn128">, !felt.type<"bn128">) -> !struct.type<@Multiplier2::@Multiplier2<[]>>
-// CHECK-NEXT:              pod.write %[[VAL_98]][@comp] = %[[VAL_107]] : <[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>, !struct.type<@Multiplier2::@Multiplier2<[]>>
-// CHECK-NEXT:              %[[VAL_108:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:              %[[VAL_109:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_83]], %[[VAL_108]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_110:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_109]] : !felt.type<"bn128">
-// CHECK-NEXT:              array.write %[[VAL_16]]{{\[}}%[[VAL_110]]] = %[[VAL_98]] : <@"N_Sub_1@859" x !pod.type<[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:            %[[VAL_91:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_16]]{{\[}}%[[VAL_90]]] : <@"N_Sub_1@859" x !pod.type<[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:            %[[VAL_92:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_91]][@comp] : <[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>, !struct.type<@Multiplier2::@Multiplier2<[]>>
+// CHECK-NEXT:            %[[VAL_93:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_92]][@out] : <@Multiplier2::@Multiplier2<[]>>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_94:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_95:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_89]], %[[VAL_94]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_96:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_95]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_97:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_88]]{{\[}}%[[VAL_96]]] : <@"N_Sub_1@859" x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>, !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>
+// CHECK-NEXT:            pod.write %[[VAL_97]][@in1] = %[[VAL_93]] : <[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_98:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_99:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_89]], %[[VAL_98]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_100:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_99]] : !felt.type<"bn128">
+// CHECK-NEXT:            array.write %[[VAL_88]]{{\[}}%[[VAL_100]]] = %[[VAL_97]] : <@"N_Sub_1@859" x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>, !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>
+// CHECK-NEXT:            %[[VAL_101:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_102:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_89]], %[[VAL_101]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_103:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_102]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_104:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_16]]{{\[}}%[[VAL_103]]] : <@"N_Sub_1@859" x !pod.type<[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:            %[[VAL_105:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_106:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_89]], %[[VAL_105]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_107:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_106]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_108:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_88]]{{\[}}%[[VAL_107]]] : <@"N_Sub_1@859" x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>, !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>
+// CHECK-NEXT:            %[[VAL_109:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_104]][@count] : <[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:            %[[VAL_110:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:            %[[VAL_111:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_109]], %[[VAL_110]] : index
+// CHECK-NEXT:            pod.write %[[VAL_104]][@count] = %[[VAL_111]] : <[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:            %[[VAL_112:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:            %[[VAL_113:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_111]], %[[VAL_112]] : index
+// CHECK-NEXT:            scf.if %[[VAL_113]] {
+// CHECK-NEXT:              %[[VAL_114:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_104]][@params] : <[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
+// CHECK-NEXT:              %[[VAL_115:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_108]][@in1] : <[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_116:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_108]][@in2] : <[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_117:[0-9a-zA-Z_\.]+]] = function.call @Multiplier2::@Multiplier2::@compute(%[[VAL_115]], %[[VAL_116]]) : (!felt.type<"bn128">, !felt.type<"bn128">) -> !struct.type<@Multiplier2::@Multiplier2<[]>>
+// CHECK-NEXT:              pod.write %[[VAL_104]][@comp] = %[[VAL_117]] : <[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>, !struct.type<@Multiplier2::@Multiplier2<[]>>
+// CHECK-NEXT:              %[[VAL_118:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:              %[[VAL_119:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_89]], %[[VAL_118]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_120:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_119]] : !felt.type<"bn128">
+// CHECK-NEXT:              array.write %[[VAL_16]]{{\[}}%[[VAL_120]]] = %[[VAL_104]] : <@"N_Sub_1@859" x !pod.type<[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>
 // CHECK-NEXT:            }
-// CHECK-NEXT:            %[[VAL_111:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
-// CHECK-NEXT:            %[[VAL_112:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_83]], %[[VAL_111]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_113:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_112]] : !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_114:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_12]]{{\[}}%[[VAL_113]]] : <@N x !felt.type<"bn128">>, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_115:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_116:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_83]], %[[VAL_115]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_117:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_116]] : !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_118:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_82]]{{\[}}%[[VAL_117]]] : <@"N_Sub_1@859" x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>, !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>
-// CHECK-NEXT:            pod.write %[[VAL_118]][@in2] = %[[VAL_114]] : <[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_119:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_120:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_83]], %[[VAL_119]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_121:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_120]] : !felt.type<"bn128">
-// CHECK-NEXT:            array.write %[[VAL_82]]{{\[}}%[[VAL_121]]] = %[[VAL_118]] : <@"N_Sub_1@859" x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>, !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>
-// CHECK-NEXT:            %[[VAL_122:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_123:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_83]], %[[VAL_122]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_124:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_123]] : !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_125:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_16]]{{\[}}%[[VAL_124]]] : <@"N_Sub_1@859" x !pod.type<[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:            %[[VAL_126:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_125]][@count] : <[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:            %[[VAL_127:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:            %[[VAL_128:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_126]], %[[VAL_127]] : index
-// CHECK-NEXT:            pod.write %[[VAL_125]][@count] = %[[VAL_128]] : <[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:            %[[VAL_129:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:            %[[VAL_130:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_128]], %[[VAL_129]] : index
-// CHECK-NEXT:            scf.if %[[VAL_130]] {
-// CHECK-NEXT:              %[[VAL_131:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_125]][@params] : <[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
-// CHECK-NEXT:              %[[VAL_132:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_118]][@in1] : <[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_133:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_118]][@in2] : <[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_134:[0-9a-zA-Z_\.]+]] = function.call @Multiplier2::@Multiplier2::@compute(%[[VAL_132]], %[[VAL_133]]) : (!felt.type<"bn128">, !felt.type<"bn128">) -> !struct.type<@Multiplier2::@Multiplier2<[]>>
-// CHECK-NEXT:              pod.write %[[VAL_125]][@comp] = %[[VAL_134]] : <[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>, !struct.type<@Multiplier2::@Multiplier2<[]>>
-// CHECK-NEXT:              %[[VAL_135:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:              %[[VAL_136:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_83]], %[[VAL_135]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_137:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_136]] : !felt.type<"bn128">
-// CHECK-NEXT:              array.write %[[VAL_16]]{{\[}}%[[VAL_137]]] = %[[VAL_125]] : <@"N_Sub_1@859" x !pod.type<[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:            %[[VAL_121:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
+// CHECK-NEXT:            %[[VAL_122:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_89]], %[[VAL_121]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_123:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_122]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_124:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_12]]{{\[}}%[[VAL_123]]] : <@N x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_125:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_126:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_89]], %[[VAL_125]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_127:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_126]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_128:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_88]]{{\[}}%[[VAL_127]]] : <@"N_Sub_1@859" x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>, !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>
+// CHECK-NEXT:            pod.write %[[VAL_128]][@in2] = %[[VAL_124]] : <[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_129:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_130:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_89]], %[[VAL_129]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_131:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_130]] : !felt.type<"bn128">
+// CHECK-NEXT:            array.write %[[VAL_88]]{{\[}}%[[VAL_131]]] = %[[VAL_128]] : <@"N_Sub_1@859" x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>, !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>
+// CHECK-NEXT:            %[[VAL_132:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_133:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_89]], %[[VAL_132]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_134:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_133]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_135:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_16]]{{\[}}%[[VAL_134]]] : <@"N_Sub_1@859" x !pod.type<[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:            %[[VAL_136:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_137:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_89]], %[[VAL_136]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_138:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_137]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_139:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_88]]{{\[}}%[[VAL_138]]] : <@"N_Sub_1@859" x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>, !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>
+// CHECK-NEXT:            %[[VAL_140:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_135]][@count] : <[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:            %[[VAL_141:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:            %[[VAL_142:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_140]], %[[VAL_141]] : index
+// CHECK-NEXT:            pod.write %[[VAL_135]][@count] = %[[VAL_142]] : <[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:            %[[VAL_143:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:            %[[VAL_144:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_142]], %[[VAL_143]] : index
+// CHECK-NEXT:            scf.if %[[VAL_144]] {
+// CHECK-NEXT:              %[[VAL_145:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_135]][@params] : <[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
+// CHECK-NEXT:              %[[VAL_146:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_139]][@in1] : <[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_147:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_139]][@in2] : <[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_148:[0-9a-zA-Z_\.]+]] = function.call @Multiplier2::@Multiplier2::@compute(%[[VAL_146]], %[[VAL_147]]) : (!felt.type<"bn128">, !felt.type<"bn128">) -> !struct.type<@Multiplier2::@Multiplier2<[]>>
+// CHECK-NEXT:              pod.write %[[VAL_135]][@comp] = %[[VAL_148]] : <[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>, !struct.type<@Multiplier2::@Multiplier2<[]>>
+// CHECK-NEXT:              %[[VAL_149:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:              %[[VAL_150:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_89]], %[[VAL_149]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_151:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_150]] : !felt.type<"bn128">
+// CHECK-NEXT:              array.write %[[VAL_16]]{{\[}}%[[VAL_151]]] = %[[VAL_135]] : <@"N_Sub_1@859" x !pod.type<[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>
 // CHECK-NEXT:            }
-// CHECK-NEXT:            %[[VAL_138:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_139:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_83]], %[[VAL_138]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            scf.yield %[[VAL_82]], %[[VAL_139]] : !array.type<@"N_Sub_1@859" x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_152:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_153:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_89]], %[[VAL_152]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_88]], %[[VAL_153]] : !array.type<@"N_Sub_1@859" x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>, !felt.type<"bn128">
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[VAL_140:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
-// CHECK-NEXT:          %[[VAL_141:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_14]], %[[VAL_140]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_142:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_141]] : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_143:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_16]]{{\[}}%[[VAL_142]]] : <@"N_Sub_1@859" x !pod.type<[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:          %[[VAL_144:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_143]][@comp] : <[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>, !struct.type<@Multiplier2::@Multiplier2<[]>>
-// CHECK-NEXT:          %[[VAL_145:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_144]][@out] : <@Multiplier2::@Multiplier2<[]>>, !felt.type<"bn128">
-// CHECK-NEXT:          struct.writem %[[VAL_13]][@out] = %[[VAL_145]] : <@MultiplierN::@MultiplierN<[@N]>>, !felt.type<"bn128">
-// CHECK-NEXT:          struct.writem %[[VAL_13]][@comp$inputs] = %[[VAL_76]]#0 : <@MultiplierN::@MultiplierN<[@N]>>, !array.type<@"N_Sub_1@859" x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>
-// CHECK-NEXT:          %[[VAL_146:[0-9a-zA-Z_\.]+]] = array.new  : <@"N_Sub_1@859" x !struct.type<@Multiplier2::@Multiplier2<[]>>>
-// CHECK-NEXT:          %[[VAL_147:[0-9a-zA-Z_\.]+]] = poly.read_const @"N_Sub_1@859" : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_148:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_147]] : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_149:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[VAL_150:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:          scf.for %[[VAL_151:[0-9a-zA-Z_\.]+]] = %[[VAL_149]] to %[[VAL_148]] step %[[VAL_150]] {
-// CHECK-NEXT:            %[[VAL_152:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_16]]{{\[}}%[[VAL_151]]] : <@"N_Sub_1@859" x !pod.type<[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:            %[[VAL_153:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_152]][@comp] : <[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>, !struct.type<@Multiplier2::@Multiplier2<[]>>
-// CHECK-NEXT:            array.write %[[VAL_146]]{{\[}}%[[VAL_151]]] = %[[VAL_153]] : <@"N_Sub_1@859" x !struct.type<@Multiplier2::@Multiplier2<[]>>>, !struct.type<@Multiplier2::@Multiplier2<[]>>
+// CHECK-NEXT:          %[[VAL_154:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
+// CHECK-NEXT:          %[[VAL_155:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_14]], %[[VAL_154]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_156:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_155]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_157:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_16]]{{\[}}%[[VAL_156]]] : <@"N_Sub_1@859" x !pod.type<[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:          %[[VAL_158:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_157]][@comp] : <[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>, !struct.type<@Multiplier2::@Multiplier2<[]>>
+// CHECK-NEXT:          %[[VAL_159:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_158]][@out] : <@Multiplier2::@Multiplier2<[]>>, !felt.type<"bn128">
+// CHECK-NEXT:          struct.writem %[[VAL_13]][@out] = %[[VAL_159]] : <@MultiplierN::@MultiplierN<[@N]>>, !felt.type<"bn128">
+// CHECK-NEXT:          struct.writem %[[VAL_13]][@comp$inputs] = %[[VAL_82]]#0 : <@MultiplierN::@MultiplierN<[@N]>>, !array.type<@"N_Sub_1@859" x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>
+// CHECK-NEXT:          %[[VAL_160:[0-9a-zA-Z_\.]+]] = array.new  : <@"N_Sub_1@859" x !struct.type<@Multiplier2::@Multiplier2<[]>>>
+// CHECK-NEXT:          %[[VAL_161:[0-9a-zA-Z_\.]+]] = poly.read_const @"N_Sub_1@859" : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_162:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_161]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_163:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_164:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          scf.for %[[VAL_165:[0-9a-zA-Z_\.]+]] = %[[VAL_163]] to %[[VAL_162]] step %[[VAL_164]] {
+// CHECK-NEXT:            %[[VAL_166:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_16]]{{\[}}%[[VAL_165]]] : <@"N_Sub_1@859" x !pod.type<[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:            %[[VAL_167:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_166]][@comp] : <[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>, !struct.type<@Multiplier2::@Multiplier2<[]>>
+// CHECK-NEXT:            array.write %[[VAL_160]]{{\[}}%[[VAL_165]]] = %[[VAL_167]] : <@"N_Sub_1@859" x !struct.type<@Multiplier2::@Multiplier2<[]>>>, !struct.type<@Multiplier2::@Multiplier2<[]>>
 // CHECK-NEXT:          }
-// CHECK-NEXT:          struct.writem %[[VAL_13]][@comp] = %[[VAL_146]] : <@MultiplierN::@MultiplierN<[@N]>>, !array.type<@"N_Sub_1@859" x !struct.type<@Multiplier2::@Multiplier2<[]>>>
+// CHECK-NEXT:          struct.writem %[[VAL_13]][@comp] = %[[VAL_160]] : <@MultiplierN::@MultiplierN<[@N]>>, !array.type<@"N_Sub_1@859" x !struct.type<@Multiplier2::@Multiplier2<[]>>>
 // CHECK-NEXT:          function.return %[[VAL_13]] : !struct.type<@MultiplierN::@MultiplierN<[@N]>>
 // CHECK-NEXT:        }
-// CHECK-NEXT:        function.def @constrain(%[[VAL_154:[0-9a-zA-Z_\.]+]]: !struct.type<@MultiplierN::@MultiplierN<[@N]>>, %[[VAL_155:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type<"bn128">> {llzk.pub}) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:          %[[VAL_156:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_157:[0-9a-zA-Z_\.]+]] = poly.read_const @"N_Sub_1@859" : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_158:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_154]][@out] : <@MultiplierN::@MultiplierN<[@N]>>, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_159:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_154]][@comp] : <@MultiplierN::@MultiplierN<[@N]>>, !array.type<@"N_Sub_1@859" x !struct.type<@Multiplier2::@Multiplier2<[]>>>
-// CHECK-NEXT:          %[[VAL_160:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_154]][@comp$inputs] : <@MultiplierN::@MultiplierN<[@N]>>, !array.type<@"N_Sub_1@859" x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>
-// CHECK-NEXT:          %[[VAL_161:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:          %[[VAL_162:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_163:[0-9a-zA-Z_\.]+]] = %[[VAL_161]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
-// CHECK-NEXT:            %[[VAL_164:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_165:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_156]], %[[VAL_164]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_166:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_163]], %[[VAL_165]]) : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            scf.condition(%[[VAL_166]]) %[[VAL_163]] : !felt.type<"bn128">
-// CHECK-NEXT:          } do {
-// CHECK-NEXT:          ^bb0(%[[VAL_167:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
-// CHECK-NEXT:            %[[VAL_168:[0-9a-zA-Z_\.]+]] = pod.new : <[]>
-// CHECK-NEXT:            %[[VAL_169:[0-9a-zA-Z_\.]+]] = pod.new : <[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:            %[[VAL_170:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_171:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_167]], %[[VAL_170]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            scf.yield %[[VAL_171]] : !felt.type<"bn128">
-// CHECK-NEXT:          }
-// CHECK-NEXT:          %[[VAL_172:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:          %[[VAL_173:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_172]] : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_174:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_155]]{{\[}}%[[VAL_173]]] : <@N x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:        function.def @constrain(%[[VAL_168:[0-9a-zA-Z_\.]+]]: !struct.type<@MultiplierN::@MultiplierN<[@N]>>, %[[VAL_169:[0-9a-zA-Z_\.]+]]: !array.type<@N x !felt.type<"bn128">> {llzk.pub}) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_170:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_171:[0-9a-zA-Z_\.]+]] = poly.read_const @"N_Sub_1@859" : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_172:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_168]][@out] : <@MultiplierN::@MultiplierN<[@N]>>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_173:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_168]][@comp] : <@MultiplierN::@MultiplierN<[@N]>>, !array.type<@"N_Sub_1@859" x !struct.type<@Multiplier2::@Multiplier2<[]>>>
+// CHECK-NEXT:          %[[VAL_174:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_168]][@comp$inputs] : <@MultiplierN::@MultiplierN<[@N]>>, !array.type<@"N_Sub_1@859" x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>
 // CHECK-NEXT:          %[[VAL_175:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:          %[[VAL_176:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_175]] : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_177:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_160]]{{\[}}%[[VAL_176]]] : <@"N_Sub_1@859" x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>, !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>
-// CHECK-NEXT:          %[[VAL_178:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_177]][@in1] : <[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:          constrain.eq %[[VAL_178]], %[[VAL_174]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_179:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:          %[[VAL_180:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_179]] : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_181:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_155]]{{\[}}%[[VAL_180]]] : <@N x !felt.type<"bn128">>, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_182:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:          %[[VAL_183:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_182]] : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_184:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_160]]{{\[}}%[[VAL_183]]] : <@"N_Sub_1@859" x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>, !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>
-// CHECK-NEXT:          %[[VAL_185:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_184]][@in2] : <[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:          constrain.eq %[[VAL_185]], %[[VAL_181]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_186:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:          %[[VAL_187:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_188:[0-9a-zA-Z_\.]+]] = %[[VAL_186]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
-// CHECK-NEXT:            %[[VAL_189:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
-// CHECK-NEXT:            %[[VAL_190:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_156]], %[[VAL_189]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_191:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_188]], %[[VAL_190]]) : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            scf.condition(%[[VAL_191]]) %[[VAL_188]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_176:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_177:[0-9a-zA-Z_\.]+]] = %[[VAL_175]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
+// CHECK-NEXT:            %[[VAL_178:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_179:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_170]], %[[VAL_178]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_180:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_177]], %[[VAL_179]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.condition(%[[VAL_180]]) %[[VAL_177]] : !felt.type<"bn128">
 // CHECK-NEXT:          } do {
-// CHECK-NEXT:          ^bb0(%[[VAL_192:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
-// CHECK-NEXT:            %[[VAL_193:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_192]] : !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_194:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_159]]{{\[}}%[[VAL_193]]] : <@"N_Sub_1@859" x !struct.type<@Multiplier2::@Multiplier2<[]>>>, !struct.type<@Multiplier2::@Multiplier2<[]>>
-// CHECK-NEXT:            %[[VAL_195:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_194]][@out] : <@Multiplier2::@Multiplier2<[]>>, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_196:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_197:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_192]], %[[VAL_196]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_198:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_197]] : !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_199:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_160]]{{\[}}%[[VAL_198]]] : <@"N_Sub_1@859" x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>, !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>
-// CHECK-NEXT:            %[[VAL_200:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_199]][@in1] : <[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:            constrain.eq %[[VAL_200]], %[[VAL_195]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_201:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
-// CHECK-NEXT:            %[[VAL_202:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_192]], %[[VAL_201]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_203:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_202]] : !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_204:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_155]]{{\[}}%[[VAL_203]]] : <@N x !felt.type<"bn128">>, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_205:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_206:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_192]], %[[VAL_205]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_207:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_206]] : !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_208:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_160]]{{\[}}%[[VAL_207]]] : <@"N_Sub_1@859" x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>, !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>
-// CHECK-NEXT:            %[[VAL_209:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_208]][@in2] : <[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:            constrain.eq %[[VAL_209]], %[[VAL_204]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_210:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_211:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_192]], %[[VAL_210]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            scf.yield %[[VAL_211]] : !felt.type<"bn128">
+// CHECK-NEXT:          ^bb0(%[[VAL_181:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
+// CHECK-NEXT:            %[[VAL_182:[0-9a-zA-Z_\.]+]] = pod.new : <[]>
+// CHECK-NEXT:            %[[VAL_183:[0-9a-zA-Z_\.]+]] = pod.new : <[@count: index, @comp: !struct.type<@Multiplier2::@Multiplier2<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:            %[[VAL_184:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_185:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_181]], %[[VAL_184]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_185]] : !felt.type<"bn128">
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[VAL_212:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
-// CHECK-NEXT:          %[[VAL_213:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_156]], %[[VAL_212]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_214:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_213]] : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_215:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_159]]{{\[}}%[[VAL_214]]] : <@"N_Sub_1@859" x !struct.type<@Multiplier2::@Multiplier2<[]>>>, !struct.type<@Multiplier2::@Multiplier2<[]>>
-// CHECK-NEXT:          %[[VAL_216:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_215]][@out] : <@Multiplier2::@Multiplier2<[]>>, !felt.type<"bn128">
-// CHECK-NEXT:          constrain.eq %[[VAL_158]], %[[VAL_216]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_217:[0-9a-zA-Z_\.]+]] = poly.read_const @"N_Sub_1@859" : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_218:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_217]] : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_219:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[VAL_220:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:          scf.for %[[VAL_221:[0-9a-zA-Z_\.]+]] = %[[VAL_219]] to %[[VAL_218]] step %[[VAL_220]] {
-// CHECK-NEXT:            %[[VAL_222:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_159]]{{\[}}%[[VAL_221]]] : <@"N_Sub_1@859" x !struct.type<@Multiplier2::@Multiplier2<[]>>>, !struct.type<@Multiplier2::@Multiplier2<[]>>
-// CHECK-NEXT:            %[[VAL_223:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_160]]{{\[}}%[[VAL_221]]] : <@"N_Sub_1@859" x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>, !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>
-// CHECK-NEXT:            %[[VAL_224:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_223]][@in1] : <[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_225:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_223]][@in2] : <[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:            function.call @Multiplier2::@Multiplier2::@constrain(%[[VAL_222]], %[[VAL_224]], %[[VAL_225]]) : (!struct.type<@Multiplier2::@Multiplier2<[]>>, !felt.type<"bn128">, !felt.type<"bn128">) -> ()
+// CHECK-NEXT:          %[[VAL_186:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_187:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_186]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_188:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_169]]{{\[}}%[[VAL_187]]] : <@N x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_189:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_190:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_189]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_191:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_174]]{{\[}}%[[VAL_190]]] : <@"N_Sub_1@859" x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>, !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>
+// CHECK-NEXT:          %[[VAL_192:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_191]][@in1] : <[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:          constrain.eq %[[VAL_192]], %[[VAL_188]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_193:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_194:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_193]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_195:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_169]]{{\[}}%[[VAL_194]]] : <@N x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_196:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_197:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_196]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_198:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_174]]{{\[}}%[[VAL_197]]] : <@"N_Sub_1@859" x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>, !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>
+// CHECK-NEXT:          %[[VAL_199:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_198]][@in2] : <[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:          constrain.eq %[[VAL_199]], %[[VAL_195]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_200:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_201:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_202:[0-9a-zA-Z_\.]+]] = %[[VAL_200]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
+// CHECK-NEXT:            %[[VAL_203:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
+// CHECK-NEXT:            %[[VAL_204:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_170]], %[[VAL_203]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_205:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_202]], %[[VAL_204]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.condition(%[[VAL_205]]) %[[VAL_202]] : !felt.type<"bn128">
+// CHECK-NEXT:          } do {
+// CHECK-NEXT:          ^bb0(%[[VAL_206:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
+// CHECK-NEXT:            %[[VAL_207:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_206]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_208:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_173]]{{\[}}%[[VAL_207]]] : <@"N_Sub_1@859" x !struct.type<@Multiplier2::@Multiplier2<[]>>>, !struct.type<@Multiplier2::@Multiplier2<[]>>
+// CHECK-NEXT:            %[[VAL_209:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_208]][@out] : <@Multiplier2::@Multiplier2<[]>>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_210:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_211:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_206]], %[[VAL_210]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_212:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_211]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_213:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_174]]{{\[}}%[[VAL_212]]] : <@"N_Sub_1@859" x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>, !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>
+// CHECK-NEXT:            %[[VAL_214:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_213]][@in1] : <[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:            constrain.eq %[[VAL_214]], %[[VAL_209]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_215:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
+// CHECK-NEXT:            %[[VAL_216:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_206]], %[[VAL_215]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_217:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_216]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_218:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_169]]{{\[}}%[[VAL_217]]] : <@N x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_219:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_220:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_206]], %[[VAL_219]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_221:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_220]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_222:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_174]]{{\[}}%[[VAL_221]]] : <@"N_Sub_1@859" x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>, !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>
+// CHECK-NEXT:            %[[VAL_223:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_222]][@in2] : <[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:            constrain.eq %[[VAL_223]], %[[VAL_218]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_224:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_225:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_206]], %[[VAL_224]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_225]] : !felt.type<"bn128">
+// CHECK-NEXT:          }
+// CHECK-NEXT:          %[[VAL_226:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
+// CHECK-NEXT:          %[[VAL_227:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_170]], %[[VAL_226]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_228:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_227]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_229:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_173]]{{\[}}%[[VAL_228]]] : <@"N_Sub_1@859" x !struct.type<@Multiplier2::@Multiplier2<[]>>>, !struct.type<@Multiplier2::@Multiplier2<[]>>
+// CHECK-NEXT:          %[[VAL_230:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_229]][@out] : <@Multiplier2::@Multiplier2<[]>>, !felt.type<"bn128">
+// CHECK-NEXT:          constrain.eq %[[VAL_172]], %[[VAL_230]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_231:[0-9a-zA-Z_\.]+]] = poly.read_const @"N_Sub_1@859" : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_232:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_231]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_233:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_234:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          scf.for %[[VAL_235:[0-9a-zA-Z_\.]+]] = %[[VAL_233]] to %[[VAL_232]] step %[[VAL_234]] {
+// CHECK-NEXT:            %[[VAL_236:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_173]]{{\[}}%[[VAL_235]]] : <@"N_Sub_1@859" x !struct.type<@Multiplier2::@Multiplier2<[]>>>, !struct.type<@Multiplier2::@Multiplier2<[]>>
+// CHECK-NEXT:            %[[VAL_237:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_174]]{{\[}}%[[VAL_235]]] : <@"N_Sub_1@859" x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>, !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>
+// CHECK-NEXT:            %[[VAL_238:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_237]][@in1] : <[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_239:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_237]][@in2] : <[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:            function.call @Multiplier2::@Multiplier2::@constrain(%[[VAL_236]], %[[VAL_238]], %[[VAL_239]]) : (!struct.type<@Multiplier2::@Multiplier2<[]>>, !felt.type<"bn128">, !felt.type<"bn128">) -> ()
 // CHECK-NEXT:          }
 // CHECK-NEXT:          function.return
 // CHECK-NEXT:        }

--- a/circom/tests/constraints/missed_index_simple.circom
+++ b/circom/tests/constraints/missed_index_simple.circom
@@ -69,90 +69,92 @@ component main = Good(2);
 // CHECK-NEXT:              array.write %[[VAL_22]]{{\[}}%[[VAL_33]]] = %[[VAL_32]] : <@N x !pod.type<[@in: !array.type<2 x !felt.type<"bn128">>]>>, !pod.type<[@in: !array.type<2 x !felt.type<"bn128">>]>
 // CHECK-NEXT:              %[[VAL_34:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_11]] : !felt.type<"bn128">
 // CHECK-NEXT:              %[[VAL_35:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_3]]{{\[}}%[[VAL_34]]] : <@N x !pod.type<[@count: index, @comp: !struct.type<@Mult::@Mult<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Mult::@Mult<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:              %[[VAL_36:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_35]][@count] : <[@count: index, @comp: !struct.type<@Mult::@Mult<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:              %[[VAL_37:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:              %[[VAL_38:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_36]], %[[VAL_37]] : index
-// CHECK-NEXT:              pod.write %[[VAL_35]][@count] = %[[VAL_38]] : <[@count: index, @comp: !struct.type<@Mult::@Mult<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:              %[[VAL_39:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:              %[[VAL_40:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_38]], %[[VAL_39]] : index
-// CHECK-NEXT:              scf.if %[[VAL_40]] {
-// CHECK-NEXT:                %[[VAL_41:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_35]][@params] : <[@count: index, @comp: !struct.type<@Mult::@Mult<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
-// CHECK-NEXT:                %[[VAL_42:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_32]][@in] : <[@in: !array.type<2 x !felt.type<"bn128">>]>, !array.type<2 x !felt.type<"bn128">>
-// CHECK-NEXT:                %[[VAL_43:[0-9a-zA-Z_\.]+]] = function.call @Mult::@Mult::@compute(%[[VAL_42]]) : (!array.type<2 x !felt.type<"bn128">>) -> !struct.type<@Mult::@Mult<[]>>
-// CHECK-NEXT:                pod.write %[[VAL_35]][@comp] = %[[VAL_43]] : <[@count: index, @comp: !struct.type<@Mult::@Mult<[]>>, @params: !pod.type<[]>]>, !struct.type<@Mult::@Mult<[]>>
-// CHECK-NEXT:                %[[VAL_44:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_11]] : !felt.type<"bn128">
-// CHECK-NEXT:                array.write %[[VAL_3]]{{\[}}%[[VAL_44]]] = %[[VAL_35]] : <@N x !pod.type<[@count: index, @comp: !struct.type<@Mult::@Mult<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Mult::@Mult<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:              %[[VAL_36:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_11]] : !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_37:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_22]]{{\[}}%[[VAL_36]]] : <@N x !pod.type<[@in: !array.type<2 x !felt.type<"bn128">>]>>, !pod.type<[@in: !array.type<2 x !felt.type<"bn128">>]>
+// CHECK-NEXT:              %[[VAL_38:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_35]][@count] : <[@count: index, @comp: !struct.type<@Mult::@Mult<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:              %[[VAL_39:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:              %[[VAL_40:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_38]], %[[VAL_39]] : index
+// CHECK-NEXT:              pod.write %[[VAL_35]][@count] = %[[VAL_40]] : <[@count: index, @comp: !struct.type<@Mult::@Mult<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:              %[[VAL_41:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:              %[[VAL_42:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_40]], %[[VAL_41]] : index
+// CHECK-NEXT:              scf.if %[[VAL_42]] {
+// CHECK-NEXT:                %[[VAL_43:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_35]][@params] : <[@count: index, @comp: !struct.type<@Mult::@Mult<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
+// CHECK-NEXT:                %[[VAL_44:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_37]][@in] : <[@in: !array.type<2 x !felt.type<"bn128">>]>, !array.type<2 x !felt.type<"bn128">>
+// CHECK-NEXT:                %[[VAL_45:[0-9a-zA-Z_\.]+]] = function.call @Mult::@Mult::@compute(%[[VAL_44]]) : (!array.type<2 x !felt.type<"bn128">>) -> !struct.type<@Mult::@Mult<[]>>
+// CHECK-NEXT:                pod.write %[[VAL_35]][@comp] = %[[VAL_45]] : <[@count: index, @comp: !struct.type<@Mult::@Mult<[]>>, @params: !pod.type<[]>]>, !struct.type<@Mult::@Mult<[]>>
+// CHECK-NEXT:                %[[VAL_46:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_11]] : !felt.type<"bn128">
+// CHECK-NEXT:                array.write %[[VAL_3]]{{\[}}%[[VAL_46]]] = %[[VAL_35]] : <@N x !pod.type<[@count: index, @comp: !struct.type<@Mult::@Mult<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Mult::@Mult<[]>>, @params: !pod.type<[]>]>
 // CHECK-NEXT:              }
-// CHECK-NEXT:              %[[VAL_45:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:              %[[VAL_46:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_23]], %[[VAL_45]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:              scf.yield %[[VAL_22]], %[[VAL_46]] : !array.type<@N x !pod.type<[@in: !array.type<2 x !felt.type<"bn128">>]>>, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_47:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:              %[[VAL_48:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_23]], %[[VAL_47]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:              scf.yield %[[VAL_22]], %[[VAL_48]] : !array.type<@N x !pod.type<[@in: !array.type<2 x !felt.type<"bn128">>]>>, !felt.type<"bn128">
 // CHECK-NEXT:            }
-// CHECK-NEXT:            %[[VAL_47:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_48:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_11]], %[[VAL_47]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            scf.yield %[[VAL_17]]#0, %[[VAL_48]] : !array.type<@N x !pod.type<[@in: !array.type<2 x !felt.type<"bn128">>]>>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_49:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_50:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_11]], %[[VAL_49]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_17]]#0, %[[VAL_50]] : !array.type<@N x !pod.type<[@in: !array.type<2 x !felt.type<"bn128">>]>>, !felt.type<"bn128">
 // CHECK-NEXT:          }
 // CHECK-NEXT:          struct.writem %[[VAL_1]][@c$inputs] = %[[VAL_6]]#0 : <@Good::@Good<[@N]>>, !array.type<@N x !pod.type<[@in: !array.type<2 x !felt.type<"bn128">>]>>
-// CHECK-NEXT:          %[[VAL_49:[0-9a-zA-Z_\.]+]] = array.new  : <@N x !struct.type<@Mult::@Mult<[]>>>
-// CHECK-NEXT:          %[[VAL_50:[0-9a-zA-Z_\.]+]] = poly.read_const @N : index
-// CHECK-NEXT:          %[[VAL_51:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[VAL_52:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:          scf.for %[[VAL_53:[0-9a-zA-Z_\.]+]] = %[[VAL_51]] to %[[VAL_50]] step %[[VAL_52]] {
-// CHECK-NEXT:            %[[VAL_54:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_3]]{{\[}}%[[VAL_53]]] : <@N x !pod.type<[@count: index, @comp: !struct.type<@Mult::@Mult<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Mult::@Mult<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:            %[[VAL_55:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_54]][@comp] : <[@count: index, @comp: !struct.type<@Mult::@Mult<[]>>, @params: !pod.type<[]>]>, !struct.type<@Mult::@Mult<[]>>
-// CHECK-NEXT:            array.write %[[VAL_49]]{{\[}}%[[VAL_53]]] = %[[VAL_55]] : <@N x !struct.type<@Mult::@Mult<[]>>>, !struct.type<@Mult::@Mult<[]>>
+// CHECK-NEXT:          %[[VAL_51:[0-9a-zA-Z_\.]+]] = array.new  : <@N x !struct.type<@Mult::@Mult<[]>>>
+// CHECK-NEXT:          %[[VAL_52:[0-9a-zA-Z_\.]+]] = poly.read_const @N : index
+// CHECK-NEXT:          %[[VAL_53:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_54:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          scf.for %[[VAL_55:[0-9a-zA-Z_\.]+]] = %[[VAL_53]] to %[[VAL_52]] step %[[VAL_54]] {
+// CHECK-NEXT:            %[[VAL_56:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_3]]{{\[}}%[[VAL_55]]] : <@N x !pod.type<[@count: index, @comp: !struct.type<@Mult::@Mult<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Mult::@Mult<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:            %[[VAL_57:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_56]][@comp] : <[@count: index, @comp: !struct.type<@Mult::@Mult<[]>>, @params: !pod.type<[]>]>, !struct.type<@Mult::@Mult<[]>>
+// CHECK-NEXT:            array.write %[[VAL_51]]{{\[}}%[[VAL_55]]] = %[[VAL_57]] : <@N x !struct.type<@Mult::@Mult<[]>>>, !struct.type<@Mult::@Mult<[]>>
 // CHECK-NEXT:          }
-// CHECK-NEXT:          struct.writem %[[VAL_1]][@c] = %[[VAL_49]] : <@Good::@Good<[@N]>>, !array.type<@N x !struct.type<@Mult::@Mult<[]>>>
+// CHECK-NEXT:          struct.writem %[[VAL_1]][@c] = %[[VAL_51]] : <@Good::@Good<[@N]>>, !array.type<@N x !struct.type<@Mult::@Mult<[]>>>
 // CHECK-NEXT:          function.return %[[VAL_1]] : !struct.type<@Good::@Good<[@N]>>
 // CHECK-NEXT:        }
-// CHECK-NEXT:        function.def @constrain(%[[VAL_56:[0-9a-zA-Z_\.]+]]: !struct.type<@Good::@Good<[@N]>>, %[[VAL_57:[0-9a-zA-Z_\.]+]]: !array.type<@N,2 x !felt.type<"bn128">>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:          %[[VAL_58:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_59:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_56]][@c] : <@Good::@Good<[@N]>>, !array.type<@N x !struct.type<@Mult::@Mult<[]>>>
-// CHECK-NEXT:          %[[VAL_60:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_56]][@c$inputs] : <@Good::@Good<[@N]>>, !array.type<@N x !pod.type<[@in: !array.type<2 x !felt.type<"bn128">>]>>
-// CHECK-NEXT:          %[[VAL_61:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:          %[[VAL_62:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_63:[0-9a-zA-Z_\.]+]] = %[[VAL_61]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
-// CHECK-NEXT:            %[[VAL_64:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_63]], %[[VAL_58]]) : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            scf.condition(%[[VAL_64]]) %[[VAL_63]] : !felt.type<"bn128">
+// CHECK-NEXT:        function.def @constrain(%[[VAL_58:[0-9a-zA-Z_\.]+]]: !struct.type<@Good::@Good<[@N]>>, %[[VAL_59:[0-9a-zA-Z_\.]+]]: !array.type<@N,2 x !felt.type<"bn128">>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_60:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_61:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_58]][@c] : <@Good::@Good<[@N]>>, !array.type<@N x !struct.type<@Mult::@Mult<[]>>>
+// CHECK-NEXT:          %[[VAL_62:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_58]][@c$inputs] : <@Good::@Good<[@N]>>, !array.type<@N x !pod.type<[@in: !array.type<2 x !felt.type<"bn128">>]>>
+// CHECK-NEXT:          %[[VAL_63:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_64:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_65:[0-9a-zA-Z_\.]+]] = %[[VAL_63]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
+// CHECK-NEXT:            %[[VAL_66:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_65]], %[[VAL_60]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.condition(%[[VAL_66]]) %[[VAL_65]] : !felt.type<"bn128">
 // CHECK-NEXT:          } do {
-// CHECK-NEXT:          ^bb0(%[[VAL_65:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
-// CHECK-NEXT:            %[[VAL_66:[0-9a-zA-Z_\.]+]] = pod.new : <[]>
-// CHECK-NEXT:            %[[VAL_67:[0-9a-zA-Z_\.]+]] = pod.new : <[@count: index, @comp: !struct.type<@Mult::@Mult<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:            %[[VAL_68:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:            %[[VAL_69:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_70:[0-9a-zA-Z_\.]+]] = %[[VAL_68]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
-// CHECK-NEXT:              %[[VAL_71:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
-// CHECK-NEXT:              %[[VAL_72:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_70]], %[[VAL_71]]) : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:              scf.condition(%[[VAL_72]]) %[[VAL_70]] : !felt.type<"bn128">
+// CHECK-NEXT:          ^bb0(%[[VAL_67:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
+// CHECK-NEXT:            %[[VAL_68:[0-9a-zA-Z_\.]+]] = pod.new : <[]>
+// CHECK-NEXT:            %[[VAL_69:[0-9a-zA-Z_\.]+]] = pod.new : <[@count: index, @comp: !struct.type<@Mult::@Mult<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:            %[[VAL_70:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:            %[[VAL_71:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_72:[0-9a-zA-Z_\.]+]] = %[[VAL_70]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
+// CHECK-NEXT:              %[[VAL_73:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
+// CHECK-NEXT:              %[[VAL_74:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_72]], %[[VAL_73]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:              scf.condition(%[[VAL_74]]) %[[VAL_72]] : !felt.type<"bn128">
 // CHECK-NEXT:            } do {
-// CHECK-NEXT:            ^bb0(%[[VAL_73:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
-// CHECK-NEXT:              %[[VAL_74:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_65]] : !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_75:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_73]] : !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_76:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_57]]{{\[}}%[[VAL_74]], %[[VAL_75]]] : <@N,2 x !felt.type<"bn128">>, !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_77:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_65]] : !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_78:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_60]]{{\[}}%[[VAL_77]]] : <@N x !pod.type<[@in: !array.type<2 x !felt.type<"bn128">>]>>, !pod.type<[@in: !array.type<2 x !felt.type<"bn128">>]>
-// CHECK-NEXT:              %[[VAL_79:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_78]][@in] : <[@in: !array.type<2 x !felt.type<"bn128">>]>, !array.type<2 x !felt.type<"bn128">>
-// CHECK-NEXT:              %[[VAL_80:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_73]] : !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_81:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_79]]{{\[}}%[[VAL_80]]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
-// CHECK-NEXT:              constrain.eq %[[VAL_81]], %[[VAL_76]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_82:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:              %[[VAL_83:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_73]], %[[VAL_82]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:              scf.yield %[[VAL_83]] : !felt.type<"bn128">
+// CHECK-NEXT:            ^bb0(%[[VAL_75:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
+// CHECK-NEXT:              %[[VAL_76:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_67]] : !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_77:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_75]] : !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_78:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_59]]{{\[}}%[[VAL_76]], %[[VAL_77]]] : <@N,2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_79:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_67]] : !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_80:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_62]]{{\[}}%[[VAL_79]]] : <@N x !pod.type<[@in: !array.type<2 x !felt.type<"bn128">>]>>, !pod.type<[@in: !array.type<2 x !felt.type<"bn128">>]>
+// CHECK-NEXT:              %[[VAL_81:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_80]][@in] : <[@in: !array.type<2 x !felt.type<"bn128">>]>, !array.type<2 x !felt.type<"bn128">>
+// CHECK-NEXT:              %[[VAL_82:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_75]] : !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_83:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_81]]{{\[}}%[[VAL_82]]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:              constrain.eq %[[VAL_83]], %[[VAL_78]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_84:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:              %[[VAL_85:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_75]], %[[VAL_84]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:              scf.yield %[[VAL_85]] : !felt.type<"bn128">
 // CHECK-NEXT:            }
-// CHECK-NEXT:            %[[VAL_84:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_65]] : !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_85:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_59]]{{\[}}%[[VAL_84]]] : <@N x !struct.type<@Mult::@Mult<[]>>>, !struct.type<@Mult::@Mult<[]>>
-// CHECK-NEXT:            %[[VAL_86:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_85]][@out] : <@Mult::@Mult<[]>>, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_87:[0-9a-zA-Z_\.]+]] = felt.const  77 : <"bn128">
-// CHECK-NEXT:            constrain.eq %[[VAL_86]], %[[VAL_87]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_88:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_89:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_65]], %[[VAL_88]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            scf.yield %[[VAL_89]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_86:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_67]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_87:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_61]]{{\[}}%[[VAL_86]]] : <@N x !struct.type<@Mult::@Mult<[]>>>, !struct.type<@Mult::@Mult<[]>>
+// CHECK-NEXT:            %[[VAL_88:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_87]][@out] : <@Mult::@Mult<[]>>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_89:[0-9a-zA-Z_\.]+]] = felt.const  77 : <"bn128">
+// CHECK-NEXT:            constrain.eq %[[VAL_88]], %[[VAL_89]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_90:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_91:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_67]], %[[VAL_90]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_91]] : !felt.type<"bn128">
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[VAL_90:[0-9a-zA-Z_\.]+]] = poly.read_const @N : index
-// CHECK-NEXT:          %[[VAL_91:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[VAL_92:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:          scf.for %[[VAL_93:[0-9a-zA-Z_\.]+]] = %[[VAL_91]] to %[[VAL_90]] step %[[VAL_92]] {
-// CHECK-NEXT:            %[[VAL_94:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_59]]{{\[}}%[[VAL_93]]] : <@N x !struct.type<@Mult::@Mult<[]>>>, !struct.type<@Mult::@Mult<[]>>
-// CHECK-NEXT:            %[[VAL_95:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_60]]{{\[}}%[[VAL_93]]] : <@N x !pod.type<[@in: !array.type<2 x !felt.type<"bn128">>]>>, !pod.type<[@in: !array.type<2 x !felt.type<"bn128">>]>
-// CHECK-NEXT:            %[[VAL_96:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_95]][@in] : <[@in: !array.type<2 x !felt.type<"bn128">>]>, !array.type<2 x !felt.type<"bn128">>
-// CHECK-NEXT:            function.call @Mult::@Mult::@constrain(%[[VAL_94]], %[[VAL_96]]) : (!struct.type<@Mult::@Mult<[]>>, !array.type<2 x !felt.type<"bn128">>) -> ()
+// CHECK-NEXT:          %[[VAL_92:[0-9a-zA-Z_\.]+]] = poly.read_const @N : index
+// CHECK-NEXT:          %[[VAL_93:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_94:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          scf.for %[[VAL_95:[0-9a-zA-Z_\.]+]] = %[[VAL_93]] to %[[VAL_92]] step %[[VAL_94]] {
+// CHECK-NEXT:            %[[VAL_96:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_61]]{{\[}}%[[VAL_95]]] : <@N x !struct.type<@Mult::@Mult<[]>>>, !struct.type<@Mult::@Mult<[]>>
+// CHECK-NEXT:            %[[VAL_97:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_62]]{{\[}}%[[VAL_95]]] : <@N x !pod.type<[@in: !array.type<2 x !felt.type<"bn128">>]>>, !pod.type<[@in: !array.type<2 x !felt.type<"bn128">>]>
+// CHECK-NEXT:            %[[VAL_98:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_97]][@in] : <[@in: !array.type<2 x !felt.type<"bn128">>]>, !array.type<2 x !felt.type<"bn128">>
+// CHECK-NEXT:            function.call @Mult::@Mult::@constrain(%[[VAL_96]], %[[VAL_98]]) : (!struct.type<@Mult::@Mult<[]>>, !array.type<2 x !felt.type<"bn128">>) -> ()
 // CHECK-NEXT:          }
 // CHECK-NEXT:          function.return
 // CHECK-NEXT:        }
@@ -161,12 +163,12 @@ component main = Good(2);
 // CHECK-NEXT:    poly.template @Mult {
 // CHECK-NEXT:      struct.def @Mult {
 // CHECK-NEXT:        struct.member @out : !felt.type<"bn128"> {llzk.pub}
-// CHECK-NEXT:        function.def @compute(%[[VAL_97:[0-9a-zA-Z_\.]+]]: !array.type<2 x !felt.type<"bn128">>) -> !struct.type<@Mult::@Mult<[]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
-// CHECK-NEXT:          %[[VAL_98:[0-9a-zA-Z_\.]+]] = struct.new : <@Mult::@Mult<[]>>
-// CHECK-NEXT:          function.return %[[VAL_98]] : !struct.type<@Mult::@Mult<[]>>
+// CHECK-NEXT:        function.def @compute(%[[VAL_99:[0-9a-zA-Z_\.]+]]: !array.type<2 x !felt.type<"bn128">>) -> !struct.type<@Mult::@Mult<[]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
+// CHECK-NEXT:          %[[VAL_100:[0-9a-zA-Z_\.]+]] = struct.new : <@Mult::@Mult<[]>>
+// CHECK-NEXT:          function.return %[[VAL_100]] : !struct.type<@Mult::@Mult<[]>>
 // CHECK-NEXT:        }
-// CHECK-NEXT:        function.def @constrain(%[[VAL_99:[0-9a-zA-Z_\.]+]]: !struct.type<@Mult::@Mult<[]>>, %[[VAL_100:[0-9a-zA-Z_\.]+]]: !array.type<2 x !felt.type<"bn128">>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:          %[[VAL_101:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_99]][@out] : <@Mult::@Mult<[]>>, !felt.type<"bn128">
+// CHECK-NEXT:        function.def @constrain(%[[VAL_101:[0-9a-zA-Z_\.]+]]: !struct.type<@Mult::@Mult<[]>>, %[[VAL_102:[0-9a-zA-Z_\.]+]]: !array.type<2 x !felt.type<"bn128">>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_103:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_101]][@out] : <@Mult::@Mult<[]>>, !felt.type<"bn128">
 // CHECK-NEXT:          function.return
 // CHECK-NEXT:        }
 // CHECK-NEXT:      }

--- a/circom/tests/from_concrete/bench_mat_mul.circom
+++ b/circom/tests/from_concrete/bench_mat_mul.circom
@@ -340,288 +340,297 @@ component main = matMul(2,3,2);
 // CHECK-NEXT:                %[[VAL_222:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_186]] : !felt.type<"bn128">
 // CHECK-NEXT:                %[[VAL_223:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_196]] : !felt.type<"bn128">
 // CHECK-NEXT:                %[[VAL_224:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_172]]{{\[}}%[[VAL_222]], %[[VAL_223]]] : <2,2 x !pod.type<[@count: index, @comp: !struct.type<@matElemMul_0::@matElemMul_0<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@matElemMul_0::@matElemMul_0<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:                %[[VAL_225:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_224]][@count] : <[@count: index, @comp: !struct.type<@matElemMul_0::@matElemMul_0<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:                %[[VAL_226:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:                %[[VAL_227:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_225]], %[[VAL_226]] : index
-// CHECK-NEXT:                pod.write %[[VAL_224]][@count] = %[[VAL_227]] : <[@count: index, @comp: !struct.type<@matElemMul_0::@matElemMul_0<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:                %[[VAL_228:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:                %[[VAL_229:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_227]], %[[VAL_228]] : index
-// CHECK-NEXT:                scf.if %[[VAL_229]] {
-// CHECK-NEXT:                  %[[VAL_230:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_224]][@params] : <[@count: index, @comp: !struct.type<@matElemMul_0::@matElemMul_0<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
-// CHECK-NEXT:                  %[[VAL_231:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_219]][@a] : <[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>, !array.type<1,3 x !felt.type<"bn128">>
-// CHECK-NEXT:                  %[[VAL_232:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_219]][@b] : <[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>, !array.type<1,3 x !felt.type<"bn128">>
-// CHECK-NEXT:                  %[[VAL_233:[0-9a-zA-Z_\.]+]] = function.call @matElemMul_0::@matElemMul_0::@compute(%[[VAL_231]], %[[VAL_232]]) : (!array.type<1,3 x !felt.type<"bn128">>, !array.type<1,3 x !felt.type<"bn128">>) -> !struct.type<@matElemMul_0::@matElemMul_0<[]>>
-// CHECK-NEXT:                  pod.write %[[VAL_224]][@comp] = %[[VAL_233]] : <[@count: index, @comp: !struct.type<@matElemMul_0::@matElemMul_0<[]>>, @params: !pod.type<[]>]>, !struct.type<@matElemMul_0::@matElemMul_0<[]>>
-// CHECK-NEXT:                  %[[VAL_234:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_186]] : !felt.type<"bn128">
-// CHECK-NEXT:                  %[[VAL_235:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_196]] : !felt.type<"bn128">
-// CHECK-NEXT:                  array.write %[[VAL_172]]{{\[}}%[[VAL_234]], %[[VAL_235]]] = %[[VAL_224]] : <2,2 x !pod.type<[@count: index, @comp: !struct.type<@matElemMul_0::@matElemMul_0<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@matElemMul_0::@matElemMul_0<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:                %[[VAL_225:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_186]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_226:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_196]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_227:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_206]]{{\[}}%[[VAL_225]], %[[VAL_226]]] : <2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>>, !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                %[[VAL_228:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_224]][@count] : <[@count: index, @comp: !struct.type<@matElemMul_0::@matElemMul_0<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:                %[[VAL_229:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:                %[[VAL_230:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_228]], %[[VAL_229]] : index
+// CHECK-NEXT:                pod.write %[[VAL_224]][@count] = %[[VAL_230]] : <[@count: index, @comp: !struct.type<@matElemMul_0::@matElemMul_0<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:                %[[VAL_231:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:                %[[VAL_232:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_230]], %[[VAL_231]] : index
+// CHECK-NEXT:                scf.if %[[VAL_232]] {
+// CHECK-NEXT:                  %[[VAL_233:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_224]][@params] : <[@count: index, @comp: !struct.type<@matElemMul_0::@matElemMul_0<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
+// CHECK-NEXT:                  %[[VAL_234:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_227]][@a] : <[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>, !array.type<1,3 x !felt.type<"bn128">>
+// CHECK-NEXT:                  %[[VAL_235:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_227]][@b] : <[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>, !array.type<1,3 x !felt.type<"bn128">>
+// CHECK-NEXT:                  %[[VAL_236:[0-9a-zA-Z_\.]+]] = function.call @matElemMul_0::@matElemMul_0::@compute(%[[VAL_234]], %[[VAL_235]]) : (!array.type<1,3 x !felt.type<"bn128">>, !array.type<1,3 x !felt.type<"bn128">>) -> !struct.type<@matElemMul_0::@matElemMul_0<[]>>
+// CHECK-NEXT:                  pod.write %[[VAL_224]][@comp] = %[[VAL_236]] : <[@count: index, @comp: !struct.type<@matElemMul_0::@matElemMul_0<[]>>, @params: !pod.type<[]>]>, !struct.type<@matElemMul_0::@matElemMul_0<[]>>
+// CHECK-NEXT:                  %[[VAL_237:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_186]] : !felt.type<"bn128">
+// CHECK-NEXT:                  %[[VAL_238:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_196]] : !felt.type<"bn128">
+// CHECK-NEXT:                  array.write %[[VAL_172]]{{\[}}%[[VAL_237]], %[[VAL_238]]] = %[[VAL_224]] : <2,2 x !pod.type<[@count: index, @comp: !struct.type<@matElemMul_0::@matElemMul_0<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@matElemMul_0::@matElemMul_0<[]>>, @params: !pod.type<[]>]>
 // CHECK-NEXT:                }
-// CHECK-NEXT:                %[[VAL_236:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_205]] : !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_237:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_196]] : !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_238:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_169]]{{\[}}%[[VAL_236]], %[[VAL_237]]] : <3,2 x !felt.type<"bn128">>, !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_239:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_186]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_239:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_205]] : !felt.type<"bn128">
 // CHECK-NEXT:                %[[VAL_240:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_196]] : !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_241:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_206]]{{\[}}%[[VAL_239]], %[[VAL_240]]] : <2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>>, !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>
-// CHECK-NEXT:                %[[VAL_242:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_241]][@b] : <[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>, !array.type<1,3 x !felt.type<"bn128">>
-// CHECK-NEXT:                %[[VAL_243:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:                %[[VAL_244:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_243]] : !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_245:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_205]] : !felt.type<"bn128">
-// CHECK-NEXT:                array.write %[[VAL_242]]{{\[}}%[[VAL_244]], %[[VAL_245]]] = %[[VAL_238]] : <1,3 x !felt.type<"bn128">>, !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_246:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_186]] : !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_247:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_196]] : !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_248:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_206]]{{\[}}%[[VAL_246]], %[[VAL_247]]] : <2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>>, !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>
-// CHECK-NEXT:                pod.write %[[VAL_248]][@b] = %[[VAL_242]] : <[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>, !array.type<1,3 x !felt.type<"bn128">>
+// CHECK-NEXT:                %[[VAL_241:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_169]]{{\[}}%[[VAL_239]], %[[VAL_240]]] : <3,2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_242:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_186]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_243:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_196]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_244:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_206]]{{\[}}%[[VAL_242]], %[[VAL_243]]] : <2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>>, !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                %[[VAL_245:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_244]][@b] : <[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>, !array.type<1,3 x !felt.type<"bn128">>
+// CHECK-NEXT:                %[[VAL_246:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:                %[[VAL_247:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_246]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_248:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_205]] : !felt.type<"bn128">
+// CHECK-NEXT:                array.write %[[VAL_245]]{{\[}}%[[VAL_247]], %[[VAL_248]]] = %[[VAL_241]] : <1,3 x !felt.type<"bn128">>, !felt.type<"bn128">
 // CHECK-NEXT:                %[[VAL_249:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_186]] : !felt.type<"bn128">
 // CHECK-NEXT:                %[[VAL_250:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_196]] : !felt.type<"bn128">
-// CHECK-NEXT:                array.write %[[VAL_206]]{{\[}}%[[VAL_249]], %[[VAL_250]]] = %[[VAL_248]] : <2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>>, !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>
-// CHECK-NEXT:                %[[VAL_251:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_186]] : !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_252:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_196]] : !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_253:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_172]]{{\[}}%[[VAL_251]], %[[VAL_252]]] : <2,2 x !pod.type<[@count: index, @comp: !struct.type<@matElemMul_0::@matElemMul_0<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@matElemMul_0::@matElemMul_0<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:                %[[VAL_254:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_253]][@count] : <[@count: index, @comp: !struct.type<@matElemMul_0::@matElemMul_0<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:                %[[VAL_255:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:                %[[VAL_256:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_254]], %[[VAL_255]] : index
-// CHECK-NEXT:                pod.write %[[VAL_253]][@count] = %[[VAL_256]] : <[@count: index, @comp: !struct.type<@matElemMul_0::@matElemMul_0<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:                %[[VAL_257:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:                %[[VAL_258:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_256]], %[[VAL_257]] : index
-// CHECK-NEXT:                scf.if %[[VAL_258]] {
-// CHECK-NEXT:                  %[[VAL_259:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_253]][@params] : <[@count: index, @comp: !struct.type<@matElemMul_0::@matElemMul_0<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
-// CHECK-NEXT:                  %[[VAL_260:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_248]][@a] : <[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>, !array.type<1,3 x !felt.type<"bn128">>
-// CHECK-NEXT:                  %[[VAL_261:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_248]][@b] : <[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>, !array.type<1,3 x !felt.type<"bn128">>
-// CHECK-NEXT:                  %[[VAL_262:[0-9a-zA-Z_\.]+]] = function.call @matElemMul_0::@matElemMul_0::@compute(%[[VAL_260]], %[[VAL_261]]) : (!array.type<1,3 x !felt.type<"bn128">>, !array.type<1,3 x !felt.type<"bn128">>) -> !struct.type<@matElemMul_0::@matElemMul_0<[]>>
-// CHECK-NEXT:                  pod.write %[[VAL_253]][@comp] = %[[VAL_262]] : <[@count: index, @comp: !struct.type<@matElemMul_0::@matElemMul_0<[]>>, @params: !pod.type<[]>]>, !struct.type<@matElemMul_0::@matElemMul_0<[]>>
-// CHECK-NEXT:                  %[[VAL_263:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_186]] : !felt.type<"bn128">
-// CHECK-NEXT:                  %[[VAL_264:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_196]] : !felt.type<"bn128">
-// CHECK-NEXT:                  array.write %[[VAL_172]]{{\[}}%[[VAL_263]], %[[VAL_264]]] = %[[VAL_253]] : <2,2 x !pod.type<[@count: index, @comp: !struct.type<@matElemMul_0::@matElemMul_0<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@matElemMul_0::@matElemMul_0<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:                %[[VAL_251:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_206]]{{\[}}%[[VAL_249]], %[[VAL_250]]] : <2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>>, !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                pod.write %[[VAL_251]][@b] = %[[VAL_245]] : <[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>, !array.type<1,3 x !felt.type<"bn128">>
+// CHECK-NEXT:                %[[VAL_252:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_186]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_253:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_196]] : !felt.type<"bn128">
+// CHECK-NEXT:                array.write %[[VAL_206]]{{\[}}%[[VAL_252]], %[[VAL_253]]] = %[[VAL_251]] : <2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>>, !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                %[[VAL_254:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_186]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_255:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_196]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_256:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_172]]{{\[}}%[[VAL_254]], %[[VAL_255]]] : <2,2 x !pod.type<[@count: index, @comp: !struct.type<@matElemMul_0::@matElemMul_0<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@matElemMul_0::@matElemMul_0<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:                %[[VAL_257:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_186]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_258:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_196]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_259:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_206]]{{\[}}%[[VAL_257]], %[[VAL_258]]] : <2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>>, !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                %[[VAL_260:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_256]][@count] : <[@count: index, @comp: !struct.type<@matElemMul_0::@matElemMul_0<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:                %[[VAL_261:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:                %[[VAL_262:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_260]], %[[VAL_261]] : index
+// CHECK-NEXT:                pod.write %[[VAL_256]][@count] = %[[VAL_262]] : <[@count: index, @comp: !struct.type<@matElemMul_0::@matElemMul_0<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:                %[[VAL_263:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:                %[[VAL_264:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_262]], %[[VAL_263]] : index
+// CHECK-NEXT:                scf.if %[[VAL_264]] {
+// CHECK-NEXT:                  %[[VAL_265:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_256]][@params] : <[@count: index, @comp: !struct.type<@matElemMul_0::@matElemMul_0<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
+// CHECK-NEXT:                  %[[VAL_266:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_259]][@a] : <[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>, !array.type<1,3 x !felt.type<"bn128">>
+// CHECK-NEXT:                  %[[VAL_267:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_259]][@b] : <[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>, !array.type<1,3 x !felt.type<"bn128">>
+// CHECK-NEXT:                  %[[VAL_268:[0-9a-zA-Z_\.]+]] = function.call @matElemMul_0::@matElemMul_0::@compute(%[[VAL_266]], %[[VAL_267]]) : (!array.type<1,3 x !felt.type<"bn128">>, !array.type<1,3 x !felt.type<"bn128">>) -> !struct.type<@matElemMul_0::@matElemMul_0<[]>>
+// CHECK-NEXT:                  pod.write %[[VAL_256]][@comp] = %[[VAL_268]] : <[@count: index, @comp: !struct.type<@matElemMul_0::@matElemMul_0<[]>>, @params: !pod.type<[]>]>, !struct.type<@matElemMul_0::@matElemMul_0<[]>>
+// CHECK-NEXT:                  %[[VAL_269:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_186]] : !felt.type<"bn128">
+// CHECK-NEXT:                  %[[VAL_270:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_196]] : !felt.type<"bn128">
+// CHECK-NEXT:                  array.write %[[VAL_172]]{{\[}}%[[VAL_269]], %[[VAL_270]]] = %[[VAL_256]] : <2,2 x !pod.type<[@count: index, @comp: !struct.type<@matElemMul_0::@matElemMul_0<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@matElemMul_0::@matElemMul_0<[]>>, @params: !pod.type<[]>]>
 // CHECK-NEXT:                }
-// CHECK-NEXT:                %[[VAL_265:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:                %[[VAL_266:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_205]], %[[VAL_265]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:                scf.yield %[[VAL_266]], %[[VAL_206]] : !felt.type<"bn128">, !array.type<2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>>
+// CHECK-NEXT:                %[[VAL_271:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:                %[[VAL_272:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_205]], %[[VAL_271]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:                scf.yield %[[VAL_272]], %[[VAL_206]] : !felt.type<"bn128">, !array.type<2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>>
 // CHECK-NEXT:              }
-// CHECK-NEXT:              %[[VAL_267:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:              %[[VAL_268:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_269:[0-9a-zA-Z_\.]+]] = %[[VAL_267]], %[[VAL_270:[0-9a-zA-Z_\.]+]] = %[[VAL_198]]) : (!felt.type<"bn128">, !array.type<2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>]>>) -> (!felt.type<"bn128">, !array.type<2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>]>>) {
-// CHECK-NEXT:                %[[VAL_271:[0-9a-zA-Z_\.]+]] = felt.const  3 : <"bn128">
-// CHECK-NEXT:                %[[VAL_272:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_269]], %[[VAL_271]]) : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:                scf.condition(%[[VAL_272]]) %[[VAL_269]], %[[VAL_270]] : !felt.type<"bn128">, !array.type<2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>]>>
+// CHECK-NEXT:              %[[VAL_273:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:              %[[VAL_274:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_275:[0-9a-zA-Z_\.]+]] = %[[VAL_273]], %[[VAL_276:[0-9a-zA-Z_\.]+]] = %[[VAL_198]]) : (!felt.type<"bn128">, !array.type<2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>]>>) -> (!felt.type<"bn128">, !array.type<2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>]>>) {
+// CHECK-NEXT:                %[[VAL_277:[0-9a-zA-Z_\.]+]] = felt.const  3 : <"bn128">
+// CHECK-NEXT:                %[[VAL_278:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_275]], %[[VAL_277]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:                scf.condition(%[[VAL_278]]) %[[VAL_275]], %[[VAL_276]] : !felt.type<"bn128">, !array.type<2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>]>>
 // CHECK-NEXT:              } do {
-// CHECK-NEXT:              ^bb0(%[[VAL_273:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">, %[[VAL_274:[0-9a-zA-Z_\.]+]]: !array.type<2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>]>>):
-// CHECK-NEXT:                %[[VAL_275:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_186]] : !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_276:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_196]] : !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_277:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_172]]{{\[}}%[[VAL_275]], %[[VAL_276]]] : <2,2 x !pod.type<[@count: index, @comp: !struct.type<@matElemMul_0::@matElemMul_0<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@matElemMul_0::@matElemMul_0<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:                %[[VAL_278:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_277]][@comp] : <[@count: index, @comp: !struct.type<@matElemMul_0::@matElemMul_0<[]>>, @params: !pod.type<[]>]>, !struct.type<@matElemMul_0::@matElemMul_0<[]>>
-// CHECK-NEXT:                %[[VAL_279:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_278]][@out] : <@matElemMul_0::@matElemMul_0<[]>>, !array.type<1,3 x !felt.type<"bn128">>
-// CHECK-NEXT:                %[[VAL_280:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:                %[[VAL_281:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_280]] : !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_282:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_273]] : !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_283:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_279]]{{\[}}%[[VAL_281]], %[[VAL_282]]] : <1,3 x !felt.type<"bn128">>, !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_284:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_186]] : !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_285:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_196]] : !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_286:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_274]]{{\[}}%[[VAL_284]], %[[VAL_285]]] : <2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>]>>, !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>]>
-// CHECK-NEXT:                %[[VAL_287:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_286]][@a] : <[@a: !array.type<1,3 x !felt.type<"bn128">>]>, !array.type<1,3 x !felt.type<"bn128">>
-// CHECK-NEXT:                %[[VAL_288:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:                %[[VAL_289:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_288]] : !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_290:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_273]] : !felt.type<"bn128">
-// CHECK-NEXT:                array.write %[[VAL_287]]{{\[}}%[[VAL_289]], %[[VAL_290]]] = %[[VAL_283]] : <1,3 x !felt.type<"bn128">>, !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_291:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_186]] : !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_292:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_196]] : !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_293:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_274]]{{\[}}%[[VAL_291]], %[[VAL_292]]] : <2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>]>>, !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>]>
-// CHECK-NEXT:                pod.write %[[VAL_293]][@a] = %[[VAL_287]] : <[@a: !array.type<1,3 x !felt.type<"bn128">>]>, !array.type<1,3 x !felt.type<"bn128">>
-// CHECK-NEXT:                %[[VAL_294:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_186]] : !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_295:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_196]] : !felt.type<"bn128">
-// CHECK-NEXT:                array.write %[[VAL_274]]{{\[}}%[[VAL_294]], %[[VAL_295]]] = %[[VAL_293]] : <2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>]>>, !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>]>
-// CHECK-NEXT:                %[[VAL_296:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_186]] : !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_297:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_196]] : !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_298:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_174]]{{\[}}%[[VAL_296]], %[[VAL_297]]] : <2,2 x !pod.type<[@count: index, @comp: !struct.type<@matElemSum_1::@matElemSum_1<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@matElemSum_1::@matElemSum_1<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:                %[[VAL_299:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_298]][@count] : <[@count: index, @comp: !struct.type<@matElemSum_1::@matElemSum_1<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:                %[[VAL_300:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:                %[[VAL_301:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_299]], %[[VAL_300]] : index
-// CHECK-NEXT:                pod.write %[[VAL_298]][@count] = %[[VAL_301]] : <[@count: index, @comp: !struct.type<@matElemSum_1::@matElemSum_1<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:                %[[VAL_302:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:                %[[VAL_303:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_301]], %[[VAL_302]] : index
-// CHECK-NEXT:                scf.if %[[VAL_303]] {
-// CHECK-NEXT:                  %[[VAL_304:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_298]][@params] : <[@count: index, @comp: !struct.type<@matElemSum_1::@matElemSum_1<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
-// CHECK-NEXT:                  %[[VAL_305:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_293]][@a] : <[@a: !array.type<1,3 x !felt.type<"bn128">>]>, !array.type<1,3 x !felt.type<"bn128">>
-// CHECK-NEXT:                  %[[VAL_306:[0-9a-zA-Z_\.]+]] = function.call @matElemSum_1::@matElemSum_1::@compute(%[[VAL_305]]) : (!array.type<1,3 x !felt.type<"bn128">>) -> !struct.type<@matElemSum_1::@matElemSum_1<[]>>
-// CHECK-NEXT:                  pod.write %[[VAL_298]][@comp] = %[[VAL_306]] : <[@count: index, @comp: !struct.type<@matElemSum_1::@matElemSum_1<[]>>, @params: !pod.type<[]>]>, !struct.type<@matElemSum_1::@matElemSum_1<[]>>
-// CHECK-NEXT:                  %[[VAL_307:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_186]] : !felt.type<"bn128">
-// CHECK-NEXT:                  %[[VAL_308:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_196]] : !felt.type<"bn128">
-// CHECK-NEXT:                  array.write %[[VAL_174]]{{\[}}%[[VAL_307]], %[[VAL_308]]] = %[[VAL_298]] : <2,2 x !pod.type<[@count: index, @comp: !struct.type<@matElemSum_1::@matElemSum_1<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@matElemSum_1::@matElemSum_1<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:              ^bb0(%[[VAL_279:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">, %[[VAL_280:[0-9a-zA-Z_\.]+]]: !array.type<2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>]>>):
+// CHECK-NEXT:                %[[VAL_281:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_186]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_282:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_196]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_283:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_172]]{{\[}}%[[VAL_281]], %[[VAL_282]]] : <2,2 x !pod.type<[@count: index, @comp: !struct.type<@matElemMul_0::@matElemMul_0<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@matElemMul_0::@matElemMul_0<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:                %[[VAL_284:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_283]][@comp] : <[@count: index, @comp: !struct.type<@matElemMul_0::@matElemMul_0<[]>>, @params: !pod.type<[]>]>, !struct.type<@matElemMul_0::@matElemMul_0<[]>>
+// CHECK-NEXT:                %[[VAL_285:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_284]][@out] : <@matElemMul_0::@matElemMul_0<[]>>, !array.type<1,3 x !felt.type<"bn128">>
+// CHECK-NEXT:                %[[VAL_286:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:                %[[VAL_287:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_286]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_288:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_279]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_289:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_285]]{{\[}}%[[VAL_287]], %[[VAL_288]]] : <1,3 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_290:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_186]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_291:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_196]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_292:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_280]]{{\[}}%[[VAL_290]], %[[VAL_291]]] : <2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>]>>, !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                %[[VAL_293:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_292]][@a] : <[@a: !array.type<1,3 x !felt.type<"bn128">>]>, !array.type<1,3 x !felt.type<"bn128">>
+// CHECK-NEXT:                %[[VAL_294:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:                %[[VAL_295:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_294]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_296:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_279]] : !felt.type<"bn128">
+// CHECK-NEXT:                array.write %[[VAL_293]]{{\[}}%[[VAL_295]], %[[VAL_296]]] = %[[VAL_289]] : <1,3 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_297:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_186]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_298:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_196]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_299:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_280]]{{\[}}%[[VAL_297]], %[[VAL_298]]] : <2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>]>>, !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                pod.write %[[VAL_299]][@a] = %[[VAL_293]] : <[@a: !array.type<1,3 x !felt.type<"bn128">>]>, !array.type<1,3 x !felt.type<"bn128">>
+// CHECK-NEXT:                %[[VAL_300:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_186]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_301:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_196]] : !felt.type<"bn128">
+// CHECK-NEXT:                array.write %[[VAL_280]]{{\[}}%[[VAL_300]], %[[VAL_301]]] = %[[VAL_299]] : <2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>]>>, !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                %[[VAL_302:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_186]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_303:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_196]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_304:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_174]]{{\[}}%[[VAL_302]], %[[VAL_303]]] : <2,2 x !pod.type<[@count: index, @comp: !struct.type<@matElemSum_1::@matElemSum_1<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@matElemSum_1::@matElemSum_1<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:                %[[VAL_305:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_186]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_306:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_196]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_307:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_280]]{{\[}}%[[VAL_305]], %[[VAL_306]]] : <2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>]>>, !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                %[[VAL_308:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_304]][@count] : <[@count: index, @comp: !struct.type<@matElemSum_1::@matElemSum_1<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:                %[[VAL_309:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:                %[[VAL_310:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_308]], %[[VAL_309]] : index
+// CHECK-NEXT:                pod.write %[[VAL_304]][@count] = %[[VAL_310]] : <[@count: index, @comp: !struct.type<@matElemSum_1::@matElemSum_1<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:                %[[VAL_311:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:                %[[VAL_312:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_310]], %[[VAL_311]] : index
+// CHECK-NEXT:                scf.if %[[VAL_312]] {
+// CHECK-NEXT:                  %[[VAL_313:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_304]][@params] : <[@count: index, @comp: !struct.type<@matElemSum_1::@matElemSum_1<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
+// CHECK-NEXT:                  %[[VAL_314:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_307]][@a] : <[@a: !array.type<1,3 x !felt.type<"bn128">>]>, !array.type<1,3 x !felt.type<"bn128">>
+// CHECK-NEXT:                  %[[VAL_315:[0-9a-zA-Z_\.]+]] = function.call @matElemSum_1::@matElemSum_1::@compute(%[[VAL_314]]) : (!array.type<1,3 x !felt.type<"bn128">>) -> !struct.type<@matElemSum_1::@matElemSum_1<[]>>
+// CHECK-NEXT:                  pod.write %[[VAL_304]][@comp] = %[[VAL_315]] : <[@count: index, @comp: !struct.type<@matElemSum_1::@matElemSum_1<[]>>, @params: !pod.type<[]>]>, !struct.type<@matElemSum_1::@matElemSum_1<[]>>
+// CHECK-NEXT:                  %[[VAL_316:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_186]] : !felt.type<"bn128">
+// CHECK-NEXT:                  %[[VAL_317:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_196]] : !felt.type<"bn128">
+// CHECK-NEXT:                  array.write %[[VAL_174]]{{\[}}%[[VAL_316]], %[[VAL_317]]] = %[[VAL_304]] : <2,2 x !pod.type<[@count: index, @comp: !struct.type<@matElemSum_1::@matElemSum_1<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@matElemSum_1::@matElemSum_1<[]>>, @params: !pod.type<[]>]>
 // CHECK-NEXT:                }
-// CHECK-NEXT:                %[[VAL_309:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:                %[[VAL_310:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_273]], %[[VAL_309]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:                scf.yield %[[VAL_310]], %[[VAL_274]] : !felt.type<"bn128">, !array.type<2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>]>>
+// CHECK-NEXT:                %[[VAL_318:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:                %[[VAL_319:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_279]], %[[VAL_318]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:                scf.yield %[[VAL_319]], %[[VAL_280]] : !felt.type<"bn128">, !array.type<2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>]>>
 // CHECK-NEXT:              }
-// CHECK-NEXT:              %[[VAL_311:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_186]] : !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_312:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_196]] : !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_313:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_174]]{{\[}}%[[VAL_311]], %[[VAL_312]]] : <2,2 x !pod.type<[@count: index, @comp: !struct.type<@matElemSum_1::@matElemSum_1<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@matElemSum_1::@matElemSum_1<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:              %[[VAL_314:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_313]][@comp] : <[@count: index, @comp: !struct.type<@matElemSum_1::@matElemSum_1<[]>>, @params: !pod.type<[]>]>, !struct.type<@matElemSum_1::@matElemSum_1<[]>>
-// CHECK-NEXT:              %[[VAL_315:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_314]][@out] : <@matElemSum_1::@matElemSum_1<[]>>, !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_316:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_186]] : !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_317:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_196]] : !felt.type<"bn128">
-// CHECK-NEXT:              array.write %[[VAL_171]]{{\[}}%[[VAL_316]], %[[VAL_317]]] = %[[VAL_315]] : <2,2 x !felt.type<"bn128">>, !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_318:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:              %[[VAL_319:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_196]], %[[VAL_318]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:              scf.yield %[[VAL_319]], %[[VAL_200]]#1, %[[VAL_268]]#1 : !felt.type<"bn128">, !array.type<2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>>, !array.type<2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>]>>
+// CHECK-NEXT:              %[[VAL_320:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_186]] : !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_321:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_196]] : !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_322:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_174]]{{\[}}%[[VAL_320]], %[[VAL_321]]] : <2,2 x !pod.type<[@count: index, @comp: !struct.type<@matElemSum_1::@matElemSum_1<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@matElemSum_1::@matElemSum_1<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:              %[[VAL_323:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_322]][@comp] : <[@count: index, @comp: !struct.type<@matElemSum_1::@matElemSum_1<[]>>, @params: !pod.type<[]>]>, !struct.type<@matElemSum_1::@matElemSum_1<[]>>
+// CHECK-NEXT:              %[[VAL_324:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_323]][@out] : <@matElemSum_1::@matElemSum_1<[]>>, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_325:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_186]] : !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_326:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_196]] : !felt.type<"bn128">
+// CHECK-NEXT:              array.write %[[VAL_171]]{{\[}}%[[VAL_325]], %[[VAL_326]]] = %[[VAL_324]] : <2,2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_327:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:              %[[VAL_328:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_196]], %[[VAL_327]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:              scf.yield %[[VAL_328]], %[[VAL_200]]#1, %[[VAL_274]]#1 : !felt.type<"bn128">, !array.type<2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>>, !array.type<2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>]>>
 // CHECK-NEXT:            }
-// CHECK-NEXT:            %[[VAL_320:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_321:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_186]], %[[VAL_320]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            scf.yield %[[VAL_321]], %[[VAL_190]]#1, %[[VAL_190]]#2 : !felt.type<"bn128">, !array.type<2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>>, !array.type<2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>]>>
+// CHECK-NEXT:            %[[VAL_329:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_330:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_186]], %[[VAL_329]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_330]], %[[VAL_190]]#1, %[[VAL_190]]#2 : !felt.type<"bn128">, !array.type<2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>>, !array.type<2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>]>>
 // CHECK-NEXT:          }
 // CHECK-NEXT:          struct.writem %[[VAL_170]][@matElemMulComp$inputs] = %[[VAL_180]]#1 : <@matMul_2::@matMul_2<[]>>, !array.type<2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>>
-// CHECK-NEXT:          %[[VAL_322:[0-9a-zA-Z_\.]+]] = array.new  : <2,2 x !struct.type<@matElemMul_0::@matElemMul_0<[]>>>
-// CHECK-NEXT:          %[[VAL_323:[0-9a-zA-Z_\.]+]] = arith.constant 2 : index
-// CHECK-NEXT:          %[[VAL_324:[0-9a-zA-Z_\.]+]] = arith.constant 2 : index
-// CHECK-NEXT:          %[[VAL_325:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[VAL_326:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:          scf.for %[[VAL_327:[0-9a-zA-Z_\.]+]] = %[[VAL_325]] to %[[VAL_323]] step %[[VAL_326]] {
-// CHECK-NEXT:            scf.for %[[VAL_328:[0-9a-zA-Z_\.]+]] = %[[VAL_325]] to %[[VAL_324]] step %[[VAL_326]] {
-// CHECK-NEXT:              %[[VAL_329:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_172]]{{\[}}%[[VAL_327]], %[[VAL_328]]] : <2,2 x !pod.type<[@count: index, @comp: !struct.type<@matElemMul_0::@matElemMul_0<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@matElemMul_0::@matElemMul_0<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:              %[[VAL_330:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_329]][@comp] : <[@count: index, @comp: !struct.type<@matElemMul_0::@matElemMul_0<[]>>, @params: !pod.type<[]>]>, !struct.type<@matElemMul_0::@matElemMul_0<[]>>
-// CHECK-NEXT:              array.write %[[VAL_322]]{{\[}}%[[VAL_327]], %[[VAL_328]]] = %[[VAL_330]] : <2,2 x !struct.type<@matElemMul_0::@matElemMul_0<[]>>>, !struct.type<@matElemMul_0::@matElemMul_0<[]>>
-// CHECK-NEXT:            }
-// CHECK-NEXT:          }
-// CHECK-NEXT:          struct.writem %[[VAL_170]][@matElemMulComp] = %[[VAL_322]] : <@matMul_2::@matMul_2<[]>>, !array.type<2,2 x !struct.type<@matElemMul_0::@matElemMul_0<[]>>>
-// CHECK-NEXT:          struct.writem %[[VAL_170]][@matElemSumComp$inputs] = %[[VAL_180]]#2 : <@matMul_2::@matMul_2<[]>>, !array.type<2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>]>>
-// CHECK-NEXT:          %[[VAL_331:[0-9a-zA-Z_\.]+]] = array.new  : <2,2 x !struct.type<@matElemSum_1::@matElemSum_1<[]>>>
+// CHECK-NEXT:          %[[VAL_331:[0-9a-zA-Z_\.]+]] = array.new  : <2,2 x !struct.type<@matElemMul_0::@matElemMul_0<[]>>>
 // CHECK-NEXT:          %[[VAL_332:[0-9a-zA-Z_\.]+]] = arith.constant 2 : index
 // CHECK-NEXT:          %[[VAL_333:[0-9a-zA-Z_\.]+]] = arith.constant 2 : index
 // CHECK-NEXT:          %[[VAL_334:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
 // CHECK-NEXT:          %[[VAL_335:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
 // CHECK-NEXT:          scf.for %[[VAL_336:[0-9a-zA-Z_\.]+]] = %[[VAL_334]] to %[[VAL_332]] step %[[VAL_335]] {
 // CHECK-NEXT:            scf.for %[[VAL_337:[0-9a-zA-Z_\.]+]] = %[[VAL_334]] to %[[VAL_333]] step %[[VAL_335]] {
-// CHECK-NEXT:              %[[VAL_338:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_174]]{{\[}}%[[VAL_336]], %[[VAL_337]]] : <2,2 x !pod.type<[@count: index, @comp: !struct.type<@matElemSum_1::@matElemSum_1<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@matElemSum_1::@matElemSum_1<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:              %[[VAL_339:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_338]][@comp] : <[@count: index, @comp: !struct.type<@matElemSum_1::@matElemSum_1<[]>>, @params: !pod.type<[]>]>, !struct.type<@matElemSum_1::@matElemSum_1<[]>>
-// CHECK-NEXT:              array.write %[[VAL_331]]{{\[}}%[[VAL_336]], %[[VAL_337]]] = %[[VAL_339]] : <2,2 x !struct.type<@matElemSum_1::@matElemSum_1<[]>>>, !struct.type<@matElemSum_1::@matElemSum_1<[]>>
+// CHECK-NEXT:              %[[VAL_338:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_172]]{{\[}}%[[VAL_336]], %[[VAL_337]]] : <2,2 x !pod.type<[@count: index, @comp: !struct.type<@matElemMul_0::@matElemMul_0<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@matElemMul_0::@matElemMul_0<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:              %[[VAL_339:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_338]][@comp] : <[@count: index, @comp: !struct.type<@matElemMul_0::@matElemMul_0<[]>>, @params: !pod.type<[]>]>, !struct.type<@matElemMul_0::@matElemMul_0<[]>>
+// CHECK-NEXT:              array.write %[[VAL_331]]{{\[}}%[[VAL_336]], %[[VAL_337]]] = %[[VAL_339]] : <2,2 x !struct.type<@matElemMul_0::@matElemMul_0<[]>>>, !struct.type<@matElemMul_0::@matElemMul_0<[]>>
 // CHECK-NEXT:            }
 // CHECK-NEXT:          }
-// CHECK-NEXT:          struct.writem %[[VAL_170]][@matElemSumComp] = %[[VAL_331]] : <@matMul_2::@matMul_2<[]>>, !array.type<2,2 x !struct.type<@matElemSum_1::@matElemSum_1<[]>>>
+// CHECK-NEXT:          struct.writem %[[VAL_170]][@matElemMulComp] = %[[VAL_331]] : <@matMul_2::@matMul_2<[]>>, !array.type<2,2 x !struct.type<@matElemMul_0::@matElemMul_0<[]>>>
+// CHECK-NEXT:          struct.writem %[[VAL_170]][@matElemSumComp$inputs] = %[[VAL_180]]#2 : <@matMul_2::@matMul_2<[]>>, !array.type<2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>]>>
+// CHECK-NEXT:          %[[VAL_340:[0-9a-zA-Z_\.]+]] = array.new  : <2,2 x !struct.type<@matElemSum_1::@matElemSum_1<[]>>>
+// CHECK-NEXT:          %[[VAL_341:[0-9a-zA-Z_\.]+]] = arith.constant 2 : index
+// CHECK-NEXT:          %[[VAL_342:[0-9a-zA-Z_\.]+]] = arith.constant 2 : index
+// CHECK-NEXT:          %[[VAL_343:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_344:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          scf.for %[[VAL_345:[0-9a-zA-Z_\.]+]] = %[[VAL_343]] to %[[VAL_341]] step %[[VAL_344]] {
+// CHECK-NEXT:            scf.for %[[VAL_346:[0-9a-zA-Z_\.]+]] = %[[VAL_343]] to %[[VAL_342]] step %[[VAL_344]] {
+// CHECK-NEXT:              %[[VAL_347:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_174]]{{\[}}%[[VAL_345]], %[[VAL_346]]] : <2,2 x !pod.type<[@count: index, @comp: !struct.type<@matElemSum_1::@matElemSum_1<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@matElemSum_1::@matElemSum_1<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:              %[[VAL_348:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_347]][@comp] : <[@count: index, @comp: !struct.type<@matElemSum_1::@matElemSum_1<[]>>, @params: !pod.type<[]>]>, !struct.type<@matElemSum_1::@matElemSum_1<[]>>
+// CHECK-NEXT:              array.write %[[VAL_340]]{{\[}}%[[VAL_345]], %[[VAL_346]]] = %[[VAL_348]] : <2,2 x !struct.type<@matElemSum_1::@matElemSum_1<[]>>>, !struct.type<@matElemSum_1::@matElemSum_1<[]>>
+// CHECK-NEXT:            }
+// CHECK-NEXT:          }
+// CHECK-NEXT:          struct.writem %[[VAL_170]][@matElemSumComp] = %[[VAL_340]] : <@matMul_2::@matMul_2<[]>>, !array.type<2,2 x !struct.type<@matElemSum_1::@matElemSum_1<[]>>>
 // CHECK-NEXT:          struct.writem %[[VAL_170]][@out] = %[[VAL_171]] : <@matMul_2::@matMul_2<[]>>, !array.type<2,2 x !felt.type<"bn128">>
 // CHECK-NEXT:          function.return %[[VAL_170]] : !struct.type<@matMul_2::@matMul_2<[]>>
 // CHECK-NEXT:        }
-// CHECK-NEXT:        function.def @constrain(%[[VAL_340:[0-9a-zA-Z_\.]+]]: !struct.type<@matMul_2::@matMul_2<[]>>, %[[VAL_341:[0-9a-zA-Z_\.]+]]: !array.type<2,3 x !felt.type<"bn128">>, %[[VAL_342:[0-9a-zA-Z_\.]+]]: !array.type<3,2 x !felt.type<"bn128">>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:          %[[VAL_343:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_340]][@out] : <@matMul_2::@matMul_2<[]>>, !array.type<2,2 x !felt.type<"bn128">>
-// CHECK-NEXT:          %[[VAL_344:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_340]][@matElemMulComp] : <@matMul_2::@matMul_2<[]>>, !array.type<2,2 x !struct.type<@matElemMul_0::@matElemMul_0<[]>>>
-// CHECK-NEXT:          %[[VAL_345:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_340]][@matElemMulComp$inputs] : <@matMul_2::@matMul_2<[]>>, !array.type<2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>>
-// CHECK-NEXT:          %[[VAL_346:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_340]][@matElemSumComp] : <@matMul_2::@matMul_2<[]>>, !array.type<2,2 x !struct.type<@matElemSum_1::@matElemSum_1<[]>>>
-// CHECK-NEXT:          %[[VAL_347:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_340]][@matElemSumComp$inputs] : <@matMul_2::@matMul_2<[]>>, !array.type<2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>]>>
-// CHECK-NEXT:          %[[VAL_348:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
-// CHECK-NEXT:          %[[VAL_349:[0-9a-zA-Z_\.]+]] = felt.const  3 : <"bn128">
-// CHECK-NEXT:          %[[VAL_350:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
-// CHECK-NEXT:          %[[VAL_351:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:          %[[VAL_352:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_353:[0-9a-zA-Z_\.]+]] = %[[VAL_351]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
-// CHECK-NEXT:            %[[VAL_354:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
-// CHECK-NEXT:            %[[VAL_355:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_353]], %[[VAL_354]]) : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            scf.condition(%[[VAL_355]]) %[[VAL_353]] : !felt.type<"bn128">
+// CHECK-NEXT:        function.def @constrain(%[[VAL_349:[0-9a-zA-Z_\.]+]]: !struct.type<@matMul_2::@matMul_2<[]>>, %[[VAL_350:[0-9a-zA-Z_\.]+]]: !array.type<2,3 x !felt.type<"bn128">>, %[[VAL_351:[0-9a-zA-Z_\.]+]]: !array.type<3,2 x !felt.type<"bn128">>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_352:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_349]][@out] : <@matMul_2::@matMul_2<[]>>, !array.type<2,2 x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_353:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_349]][@matElemMulComp] : <@matMul_2::@matMul_2<[]>>, !array.type<2,2 x !struct.type<@matElemMul_0::@matElemMul_0<[]>>>
+// CHECK-NEXT:          %[[VAL_354:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_349]][@matElemMulComp$inputs] : <@matMul_2::@matMul_2<[]>>, !array.type<2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>>
+// CHECK-NEXT:          %[[VAL_355:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_349]][@matElemSumComp] : <@matMul_2::@matMul_2<[]>>, !array.type<2,2 x !struct.type<@matElemSum_1::@matElemSum_1<[]>>>
+// CHECK-NEXT:          %[[VAL_356:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_349]][@matElemSumComp$inputs] : <@matMul_2::@matMul_2<[]>>, !array.type<2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>]>>
+// CHECK-NEXT:          %[[VAL_357:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
+// CHECK-NEXT:          %[[VAL_358:[0-9a-zA-Z_\.]+]] = felt.const  3 : <"bn128">
+// CHECK-NEXT:          %[[VAL_359:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
+// CHECK-NEXT:          %[[VAL_360:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_361:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_362:[0-9a-zA-Z_\.]+]] = %[[VAL_360]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
+// CHECK-NEXT:            %[[VAL_363:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
+// CHECK-NEXT:            %[[VAL_364:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_362]], %[[VAL_363]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.condition(%[[VAL_364]]) %[[VAL_362]] : !felt.type<"bn128">
 // CHECK-NEXT:          } do {
-// CHECK-NEXT:          ^bb0(%[[VAL_356:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
-// CHECK-NEXT:            %[[VAL_357:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:            %[[VAL_358:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_359:[0-9a-zA-Z_\.]+]] = %[[VAL_357]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
-// CHECK-NEXT:              %[[VAL_360:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
-// CHECK-NEXT:              %[[VAL_361:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_359]], %[[VAL_360]]) : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:              scf.condition(%[[VAL_361]]) %[[VAL_359]] : !felt.type<"bn128">
+// CHECK-NEXT:          ^bb0(%[[VAL_365:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
+// CHECK-NEXT:            %[[VAL_366:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:            %[[VAL_367:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_368:[0-9a-zA-Z_\.]+]] = %[[VAL_366]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
+// CHECK-NEXT:              %[[VAL_369:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
+// CHECK-NEXT:              %[[VAL_370:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_368]], %[[VAL_369]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:              scf.condition(%[[VAL_370]]) %[[VAL_368]] : !felt.type<"bn128">
 // CHECK-NEXT:            } do {
-// CHECK-NEXT:            ^bb0(%[[VAL_362:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
-// CHECK-NEXT:              %[[VAL_363:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:              %[[VAL_364:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_365:[0-9a-zA-Z_\.]+]] = %[[VAL_363]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
-// CHECK-NEXT:                %[[VAL_366:[0-9a-zA-Z_\.]+]] = felt.const  3 : <"bn128">
-// CHECK-NEXT:                %[[VAL_367:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_365]], %[[VAL_366]]) : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:                scf.condition(%[[VAL_367]]) %[[VAL_365]] : !felt.type<"bn128">
+// CHECK-NEXT:            ^bb0(%[[VAL_371:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
+// CHECK-NEXT:              %[[VAL_372:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:              %[[VAL_373:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_374:[0-9a-zA-Z_\.]+]] = %[[VAL_372]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
+// CHECK-NEXT:                %[[VAL_375:[0-9a-zA-Z_\.]+]] = felt.const  3 : <"bn128">
+// CHECK-NEXT:                %[[VAL_376:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_374]], %[[VAL_375]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:                scf.condition(%[[VAL_376]]) %[[VAL_374]] : !felt.type<"bn128">
 // CHECK-NEXT:              } do {
-// CHECK-NEXT:              ^bb0(%[[VAL_368:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
-// CHECK-NEXT:                %[[VAL_369:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_356]] : !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_370:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_368]] : !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_371:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_341]]{{\[}}%[[VAL_369]], %[[VAL_370]]] : <2,3 x !felt.type<"bn128">>, !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_372:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_356]] : !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_373:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_362]] : !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_374:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_345]]{{\[}}%[[VAL_372]], %[[VAL_373]]] : <2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>>, !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>
-// CHECK-NEXT:                %[[VAL_375:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_374]][@a] : <[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>, !array.type<1,3 x !felt.type<"bn128">>
-// CHECK-NEXT:                %[[VAL_376:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:                %[[VAL_377:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_376]] : !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_378:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_368]] : !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_379:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_375]]{{\[}}%[[VAL_377]], %[[VAL_378]]] : <1,3 x !felt.type<"bn128">>, !felt.type<"bn128">
-// CHECK-NEXT:                constrain.eq %[[VAL_379]], %[[VAL_371]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_380:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_368]] : !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_381:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_362]] : !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_382:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_342]]{{\[}}%[[VAL_380]], %[[VAL_381]]] : <3,2 x !felt.type<"bn128">>, !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_383:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_356]] : !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_384:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_362]] : !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_385:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_345]]{{\[}}%[[VAL_383]], %[[VAL_384]]] : <2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>>, !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>
-// CHECK-NEXT:                %[[VAL_386:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_385]][@b] : <[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>, !array.type<1,3 x !felt.type<"bn128">>
-// CHECK-NEXT:                %[[VAL_387:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:                %[[VAL_388:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_387]] : !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_389:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_368]] : !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_390:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_386]]{{\[}}%[[VAL_388]], %[[VAL_389]]] : <1,3 x !felt.type<"bn128">>, !felt.type<"bn128">
-// CHECK-NEXT:                constrain.eq %[[VAL_390]], %[[VAL_382]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_391:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:                %[[VAL_392:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_368]], %[[VAL_391]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:                scf.yield %[[VAL_392]] : !felt.type<"bn128">
+// CHECK-NEXT:              ^bb0(%[[VAL_377:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
+// CHECK-NEXT:                %[[VAL_378:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_365]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_379:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_377]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_380:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_350]]{{\[}}%[[VAL_378]], %[[VAL_379]]] : <2,3 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_381:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_365]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_382:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_371]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_383:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_354]]{{\[}}%[[VAL_381]], %[[VAL_382]]] : <2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>>, !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                %[[VAL_384:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_383]][@a] : <[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>, !array.type<1,3 x !felt.type<"bn128">>
+// CHECK-NEXT:                %[[VAL_385:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:                %[[VAL_386:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_385]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_387:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_377]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_388:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_384]]{{\[}}%[[VAL_386]], %[[VAL_387]]] : <1,3 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:                constrain.eq %[[VAL_388]], %[[VAL_380]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_389:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_377]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_390:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_371]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_391:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_351]]{{\[}}%[[VAL_389]], %[[VAL_390]]] : <3,2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_392:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_365]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_393:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_371]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_394:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_354]]{{\[}}%[[VAL_392]], %[[VAL_393]]] : <2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>>, !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                %[[VAL_395:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_394]][@b] : <[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>, !array.type<1,3 x !felt.type<"bn128">>
+// CHECK-NEXT:                %[[VAL_396:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:                %[[VAL_397:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_396]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_398:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_377]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_399:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_395]]{{\[}}%[[VAL_397]], %[[VAL_398]]] : <1,3 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:                constrain.eq %[[VAL_399]], %[[VAL_391]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_400:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:                %[[VAL_401:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_377]], %[[VAL_400]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:                scf.yield %[[VAL_401]] : !felt.type<"bn128">
 // CHECK-NEXT:              }
-// CHECK-NEXT:              %[[VAL_393:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:              %[[VAL_394:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_395:[0-9a-zA-Z_\.]+]] = %[[VAL_393]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
-// CHECK-NEXT:                %[[VAL_396:[0-9a-zA-Z_\.]+]] = felt.const  3 : <"bn128">
-// CHECK-NEXT:                %[[VAL_397:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_395]], %[[VAL_396]]) : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:                scf.condition(%[[VAL_397]]) %[[VAL_395]] : !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_402:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:              %[[VAL_403:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_404:[0-9a-zA-Z_\.]+]] = %[[VAL_402]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
+// CHECK-NEXT:                %[[VAL_405:[0-9a-zA-Z_\.]+]] = felt.const  3 : <"bn128">
+// CHECK-NEXT:                %[[VAL_406:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_404]], %[[VAL_405]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:                scf.condition(%[[VAL_406]]) %[[VAL_404]] : !felt.type<"bn128">
 // CHECK-NEXT:              } do {
-// CHECK-NEXT:              ^bb0(%[[VAL_398:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
-// CHECK-NEXT:                %[[VAL_399:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_356]] : !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_400:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_362]] : !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_401:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_344]]{{\[}}%[[VAL_399]], %[[VAL_400]]] : <2,2 x !struct.type<@matElemMul_0::@matElemMul_0<[]>>>, !struct.type<@matElemMul_0::@matElemMul_0<[]>>
-// CHECK-NEXT:                %[[VAL_402:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_401]][@out] : <@matElemMul_0::@matElemMul_0<[]>>, !array.type<1,3 x !felt.type<"bn128">>
-// CHECK-NEXT:                %[[VAL_403:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:                %[[VAL_404:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_403]] : !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_405:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_398]] : !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_406:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_402]]{{\[}}%[[VAL_404]], %[[VAL_405]]] : <1,3 x !felt.type<"bn128">>, !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_407:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_356]] : !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_408:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_362]] : !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_409:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_347]]{{\[}}%[[VAL_407]], %[[VAL_408]]] : <2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>]>>, !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>]>
-// CHECK-NEXT:                %[[VAL_410:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_409]][@a] : <[@a: !array.type<1,3 x !felt.type<"bn128">>]>, !array.type<1,3 x !felt.type<"bn128">>
-// CHECK-NEXT:                %[[VAL_411:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:                %[[VAL_412:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_411]] : !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_413:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_398]] : !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_414:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_410]]{{\[}}%[[VAL_412]], %[[VAL_413]]] : <1,3 x !felt.type<"bn128">>, !felt.type<"bn128">
-// CHECK-NEXT:                constrain.eq %[[VAL_414]], %[[VAL_406]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_415:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:                %[[VAL_416:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_398]], %[[VAL_415]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:                scf.yield %[[VAL_416]] : !felt.type<"bn128">
+// CHECK-NEXT:              ^bb0(%[[VAL_407:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
+// CHECK-NEXT:                %[[VAL_408:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_365]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_409:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_371]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_410:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_353]]{{\[}}%[[VAL_408]], %[[VAL_409]]] : <2,2 x !struct.type<@matElemMul_0::@matElemMul_0<[]>>>, !struct.type<@matElemMul_0::@matElemMul_0<[]>>
+// CHECK-NEXT:                %[[VAL_411:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_410]][@out] : <@matElemMul_0::@matElemMul_0<[]>>, !array.type<1,3 x !felt.type<"bn128">>
+// CHECK-NEXT:                %[[VAL_412:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:                %[[VAL_413:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_412]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_414:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_407]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_415:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_411]]{{\[}}%[[VAL_413]], %[[VAL_414]]] : <1,3 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_416:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_365]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_417:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_371]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_418:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_356]]{{\[}}%[[VAL_416]], %[[VAL_417]]] : <2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>]>>, !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                %[[VAL_419:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_418]][@a] : <[@a: !array.type<1,3 x !felt.type<"bn128">>]>, !array.type<1,3 x !felt.type<"bn128">>
+// CHECK-NEXT:                %[[VAL_420:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:                %[[VAL_421:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_420]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_422:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_407]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_423:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_419]]{{\[}}%[[VAL_421]], %[[VAL_422]]] : <1,3 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:                constrain.eq %[[VAL_423]], %[[VAL_415]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_424:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:                %[[VAL_425:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_407]], %[[VAL_424]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:                scf.yield %[[VAL_425]] : !felt.type<"bn128">
 // CHECK-NEXT:              }
-// CHECK-NEXT:              %[[VAL_417:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_356]] : !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_418:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_362]] : !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_419:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_346]]{{\[}}%[[VAL_417]], %[[VAL_418]]] : <2,2 x !struct.type<@matElemSum_1::@matElemSum_1<[]>>>, !struct.type<@matElemSum_1::@matElemSum_1<[]>>
-// CHECK-NEXT:              %[[VAL_420:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_419]][@out] : <@matElemSum_1::@matElemSum_1<[]>>, !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_421:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_356]] : !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_422:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_362]] : !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_423:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_343]]{{\[}}%[[VAL_421]], %[[VAL_422]]] : <2,2 x !felt.type<"bn128">>, !felt.type<"bn128">
-// CHECK-NEXT:              constrain.eq %[[VAL_423]], %[[VAL_420]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_424:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:              %[[VAL_425:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_362]], %[[VAL_424]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:              scf.yield %[[VAL_425]] : !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_426:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_365]] : !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_427:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_371]] : !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_428:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_355]]{{\[}}%[[VAL_426]], %[[VAL_427]]] : <2,2 x !struct.type<@matElemSum_1::@matElemSum_1<[]>>>, !struct.type<@matElemSum_1::@matElemSum_1<[]>>
+// CHECK-NEXT:              %[[VAL_429:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_428]][@out] : <@matElemSum_1::@matElemSum_1<[]>>, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_430:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_365]] : !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_431:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_371]] : !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_432:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_352]]{{\[}}%[[VAL_430]], %[[VAL_431]]] : <2,2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:              constrain.eq %[[VAL_432]], %[[VAL_429]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_433:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:              %[[VAL_434:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_371]], %[[VAL_433]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:              scf.yield %[[VAL_434]] : !felt.type<"bn128">
 // CHECK-NEXT:            }
-// CHECK-NEXT:            %[[VAL_426:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_427:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_356]], %[[VAL_426]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            scf.yield %[[VAL_427]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_435:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_436:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_365]], %[[VAL_435]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_436]] : !felt.type<"bn128">
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[VAL_428:[0-9a-zA-Z_\.]+]] = arith.constant 2 : index
-// CHECK-NEXT:          %[[VAL_429:[0-9a-zA-Z_\.]+]] = arith.constant 2 : index
-// CHECK-NEXT:          %[[VAL_430:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[VAL_431:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:          scf.for %[[VAL_432:[0-9a-zA-Z_\.]+]] = %[[VAL_430]] to %[[VAL_428]] step %[[VAL_431]] {
-// CHECK-NEXT:            scf.for %[[VAL_433:[0-9a-zA-Z_\.]+]] = %[[VAL_430]] to %[[VAL_429]] step %[[VAL_431]] {
-// CHECK-NEXT:              %[[VAL_434:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_344]]{{\[}}%[[VAL_432]], %[[VAL_433]]] : <2,2 x !struct.type<@matElemMul_0::@matElemMul_0<[]>>>, !struct.type<@matElemMul_0::@matElemMul_0<[]>>
-// CHECK-NEXT:              %[[VAL_435:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_345]]{{\[}}%[[VAL_432]], %[[VAL_433]]] : <2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>>, !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>
-// CHECK-NEXT:              %[[VAL_436:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_435]][@a] : <[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>, !array.type<1,3 x !felt.type<"bn128">>
-// CHECK-NEXT:              %[[VAL_437:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_435]][@b] : <[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>, !array.type<1,3 x !felt.type<"bn128">>
-// CHECK-NEXT:              function.call @matElemMul_0::@matElemMul_0::@constrain(%[[VAL_434]], %[[VAL_436]], %[[VAL_437]]) : (!struct.type<@matElemMul_0::@matElemMul_0<[]>>, !array.type<1,3 x !felt.type<"bn128">>, !array.type<1,3 x !felt.type<"bn128">>) -> ()
-// CHECK-NEXT:            }
-// CHECK-NEXT:          }
+// CHECK-NEXT:          %[[VAL_437:[0-9a-zA-Z_\.]+]] = arith.constant 2 : index
 // CHECK-NEXT:          %[[VAL_438:[0-9a-zA-Z_\.]+]] = arith.constant 2 : index
-// CHECK-NEXT:          %[[VAL_439:[0-9a-zA-Z_\.]+]] = arith.constant 2 : index
-// CHECK-NEXT:          %[[VAL_440:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[VAL_441:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:          scf.for %[[VAL_442:[0-9a-zA-Z_\.]+]] = %[[VAL_440]] to %[[VAL_438]] step %[[VAL_441]] {
-// CHECK-NEXT:            scf.for %[[VAL_443:[0-9a-zA-Z_\.]+]] = %[[VAL_440]] to %[[VAL_439]] step %[[VAL_441]] {
-// CHECK-NEXT:              %[[VAL_444:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_346]]{{\[}}%[[VAL_442]], %[[VAL_443]]] : <2,2 x !struct.type<@matElemSum_1::@matElemSum_1<[]>>>, !struct.type<@matElemSum_1::@matElemSum_1<[]>>
-// CHECK-NEXT:              %[[VAL_445:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_347]]{{\[}}%[[VAL_442]], %[[VAL_443]]] : <2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>]>>, !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>]>
-// CHECK-NEXT:              %[[VAL_446:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_445]][@a] : <[@a: !array.type<1,3 x !felt.type<"bn128">>]>, !array.type<1,3 x !felt.type<"bn128">>
-// CHECK-NEXT:              function.call @matElemSum_1::@matElemSum_1::@constrain(%[[VAL_444]], %[[VAL_446]]) : (!struct.type<@matElemSum_1::@matElemSum_1<[]>>, !array.type<1,3 x !felt.type<"bn128">>) -> ()
+// CHECK-NEXT:          %[[VAL_439:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_440:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          scf.for %[[VAL_441:[0-9a-zA-Z_\.]+]] = %[[VAL_439]] to %[[VAL_437]] step %[[VAL_440]] {
+// CHECK-NEXT:            scf.for %[[VAL_442:[0-9a-zA-Z_\.]+]] = %[[VAL_439]] to %[[VAL_438]] step %[[VAL_440]] {
+// CHECK-NEXT:              %[[VAL_443:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_353]]{{\[}}%[[VAL_441]], %[[VAL_442]]] : <2,2 x !struct.type<@matElemMul_0::@matElemMul_0<[]>>>, !struct.type<@matElemMul_0::@matElemMul_0<[]>>
+// CHECK-NEXT:              %[[VAL_444:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_354]]{{\[}}%[[VAL_441]], %[[VAL_442]]] : <2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>>, !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>
+// CHECK-NEXT:              %[[VAL_445:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_444]][@a] : <[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>, !array.type<1,3 x !felt.type<"bn128">>
+// CHECK-NEXT:              %[[VAL_446:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_444]][@b] : <[@a: !array.type<1,3 x !felt.type<"bn128">>, @b: !array.type<1,3 x !felt.type<"bn128">>]>, !array.type<1,3 x !felt.type<"bn128">>
+// CHECK-NEXT:              function.call @matElemMul_0::@matElemMul_0::@constrain(%[[VAL_443]], %[[VAL_445]], %[[VAL_446]]) : (!struct.type<@matElemMul_0::@matElemMul_0<[]>>, !array.type<1,3 x !felt.type<"bn128">>, !array.type<1,3 x !felt.type<"bn128">>) -> ()
+// CHECK-NEXT:            }
+// CHECK-NEXT:          }
+// CHECK-NEXT:          %[[VAL_447:[0-9a-zA-Z_\.]+]] = arith.constant 2 : index
+// CHECK-NEXT:          %[[VAL_448:[0-9a-zA-Z_\.]+]] = arith.constant 2 : index
+// CHECK-NEXT:          %[[VAL_449:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_450:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          scf.for %[[VAL_451:[0-9a-zA-Z_\.]+]] = %[[VAL_449]] to %[[VAL_447]] step %[[VAL_450]] {
+// CHECK-NEXT:            scf.for %[[VAL_452:[0-9a-zA-Z_\.]+]] = %[[VAL_449]] to %[[VAL_448]] step %[[VAL_450]] {
+// CHECK-NEXT:              %[[VAL_453:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_355]]{{\[}}%[[VAL_451]], %[[VAL_452]]] : <2,2 x !struct.type<@matElemSum_1::@matElemSum_1<[]>>>, !struct.type<@matElemSum_1::@matElemSum_1<[]>>
+// CHECK-NEXT:              %[[VAL_454:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_356]]{{\[}}%[[VAL_451]], %[[VAL_452]]] : <2,2 x !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>]>>, !pod.type<[@a: !array.type<1,3 x !felt.type<"bn128">>]>
+// CHECK-NEXT:              %[[VAL_455:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_454]][@a] : <[@a: !array.type<1,3 x !felt.type<"bn128">>]>, !array.type<1,3 x !felt.type<"bn128">>
+// CHECK-NEXT:              function.call @matElemSum_1::@matElemSum_1::@constrain(%[[VAL_453]], %[[VAL_455]]) : (!struct.type<@matElemSum_1::@matElemSum_1<[]>>, !array.type<1,3 x !felt.type<"bn128">>) -> ()
 // CHECK-NEXT:            }
 // CHECK-NEXT:          }
 // CHECK-NEXT:          function.return

--- a/circom/tests/from_concrete/conflicting_types_array_read.circom
+++ b/circom/tests/from_concrete/conflicting_types_array_read.circom
@@ -216,13 +216,11 @@ component main = Outer();
 // CHECK-NEXT:                    %[[VAL_130:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_128]] -> (!pod.type<[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>) {
 // CHECK-NEXT:                      %[[VAL_131:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_101]][@idx_1] : <[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>, !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>
 // CHECK-NEXT:                      pod.write %[[VAL_131]][@in] = %[[VAL_119]] : <[@in: !array.type<4 x !felt.type<"bn128">>]>, !array.type<4 x !felt.type<"bn128">>
-// CHECK-NEXT:                      %[[VAL_132:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_93]] : !felt.type<"bn128">
 // CHECK-NEXT:                      scf.yield %[[VAL_101]] : !pod.type<[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>
 // CHECK-NEXT:                    } else {
 // CHECK-NEXT:                      %[[VAL_133:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_125]] -> (!pod.type<[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>) {
 // CHECK-NEXT:                        %[[VAL_134:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_101]][@idx_0] : <[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>, !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>
 // CHECK-NEXT:                        pod.write %[[VAL_134]][@in] = %[[VAL_119]] : <[@in: !array.type<4 x !felt.type<"bn128">>]>, !array.type<4 x !felt.type<"bn128">>
-// CHECK-NEXT:                        %[[VAL_135:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_93]] : !felt.type<"bn128">
 // CHECK-NEXT:                        scf.yield %[[VAL_101]] : !pod.type<[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>
 // CHECK-NEXT:                      } else {
 // CHECK-NEXT:                        %[[VAL_136:[0-9a-zA-Z_\.]+]] = llzk.nondet : !pod.type<[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>
@@ -278,7 +276,6 @@ component main = Outer();
 // CHECK-NEXT:                        %[[VAL_166:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_154]][@in] : <[@in: !array.type<4 x !felt.type<"bn128">>]>, !array.type<4 x !felt.type<"bn128">>
 // CHECK-NEXT:                        %[[VAL_167:[0-9a-zA-Z_\.]+]] = function.call @Inner_1::@Inner_1::@compute(%[[VAL_166]]) : (!array.type<4 x !felt.type<"bn128">>) -> !struct.type<@Inner_1::@Inner_1<[]>>
 // CHECK-NEXT:                        pod.write %[[VAL_145]][@comp] = %[[VAL_167]] : <[@count: index, @comp: !struct.type<@Inner_1::@Inner_1<[]>>, @params: !pod.type<[]>]>, !struct.type<@Inner_1::@Inner_1<[]>>
-// CHECK-NEXT:                        %[[VAL_168:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_93]] : !felt.type<"bn128">
 // CHECK-NEXT:                      }
 // CHECK-NEXT:                    } else {
 // CHECK-NEXT:                      scf.if %[[VAL_141]] {
@@ -318,7 +315,6 @@ component main = Outer();
 // CHECK-NEXT:                          %[[VAL_190:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_178]][@in] : <[@in: !array.type<4 x !felt.type<"bn128">>]>, !array.type<4 x !felt.type<"bn128">>
 // CHECK-NEXT:                          %[[VAL_191:[0-9a-zA-Z_\.]+]] = function.call @Inner_0::@Inner_0::@compute(%[[VAL_190]]) : (!array.type<4 x !felt.type<"bn128">>) -> !struct.type<@Inner_0::@Inner_0<[]>>
 // CHECK-NEXT:                          pod.write %[[VAL_169]][@comp] = %[[VAL_191]] : <[@count: index, @comp: !struct.type<@Inner_0::@Inner_0<[]>>, @params: !pod.type<[]>]>, !struct.type<@Inner_0::@Inner_0<[]>>
-// CHECK-NEXT:                          %[[VAL_192:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_93]] : !felt.type<"bn128">
 // CHECK-NEXT:                        }
 // CHECK-NEXT:                      } else {
 // CHECK-NEXT:                      }
@@ -344,13 +340,11 @@ component main = Outer();
 // CHECK-NEXT:                      %[[VAL_206:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_204]] -> (!pod.type<[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>) {
 // CHECK-NEXT:                        %[[VAL_207:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_101]][@idx_1] : <[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>, !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>
 // CHECK-NEXT:                        pod.write %[[VAL_207]][@in] = %[[VAL_195]] : <[@in: !array.type<4 x !felt.type<"bn128">>]>, !array.type<4 x !felt.type<"bn128">>
-// CHECK-NEXT:                        %[[VAL_208:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_93]] : !felt.type<"bn128">
 // CHECK-NEXT:                        scf.yield %[[VAL_101]] : !pod.type<[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>
 // CHECK-NEXT:                      } else {
 // CHECK-NEXT:                        %[[VAL_209:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_201]] -> (!pod.type<[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>) {
 // CHECK-NEXT:                          %[[VAL_210:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_101]][@idx_0] : <[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>, !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>
 // CHECK-NEXT:                          pod.write %[[VAL_210]][@in] = %[[VAL_195]] : <[@in: !array.type<4 x !felt.type<"bn128">>]>, !array.type<4 x !felt.type<"bn128">>
-// CHECK-NEXT:                          %[[VAL_211:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_93]] : !felt.type<"bn128">
 // CHECK-NEXT:                          scf.yield %[[VAL_101]] : !pod.type<[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>
 // CHECK-NEXT:                        } else {
 // CHECK-NEXT:                          %[[VAL_212:[0-9a-zA-Z_\.]+]] = llzk.nondet : !pod.type<[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>
@@ -406,7 +400,6 @@ component main = Outer();
 // CHECK-NEXT:                          %[[VAL_242:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_230]][@in] : <[@in: !array.type<4 x !felt.type<"bn128">>]>, !array.type<4 x !felt.type<"bn128">>
 // CHECK-NEXT:                          %[[VAL_243:[0-9a-zA-Z_\.]+]] = function.call @Inner_1::@Inner_1::@compute(%[[VAL_242]]) : (!array.type<4 x !felt.type<"bn128">>) -> !struct.type<@Inner_1::@Inner_1<[]>>
 // CHECK-NEXT:                          pod.write %[[VAL_221]][@comp] = %[[VAL_243]] : <[@count: index, @comp: !struct.type<@Inner_1::@Inner_1<[]>>, @params: !pod.type<[]>]>, !struct.type<@Inner_1::@Inner_1<[]>>
-// CHECK-NEXT:                          %[[VAL_244:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_93]] : !felt.type<"bn128">
 // CHECK-NEXT:                        }
 // CHECK-NEXT:                      } else {
 // CHECK-NEXT:                        scf.if %[[VAL_217]] {
@@ -446,7 +439,6 @@ component main = Outer();
 // CHECK-NEXT:                            %[[VAL_266:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_254]][@in] : <[@in: !array.type<4 x !felt.type<"bn128">>]>, !array.type<4 x !felt.type<"bn128">>
 // CHECK-NEXT:                            %[[VAL_267:[0-9a-zA-Z_\.]+]] = function.call @Inner_0::@Inner_0::@compute(%[[VAL_266]]) : (!array.type<4 x !felt.type<"bn128">>) -> !struct.type<@Inner_0::@Inner_0<[]>>
 // CHECK-NEXT:                            pod.write %[[VAL_245]][@comp] = %[[VAL_267]] : <[@count: index, @comp: !struct.type<@Inner_0::@Inner_0<[]>>, @params: !pod.type<[]>]>, !struct.type<@Inner_0::@Inner_0<[]>>
-// CHECK-NEXT:                            %[[VAL_268:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_93]] : !felt.type<"bn128">
 // CHECK-NEXT:                          }
 // CHECK-NEXT:                        } else {
 // CHECK-NEXT:                        }

--- a/circom/tests/from_concrete/conflicting_types_array_read.circom
+++ b/circom/tests/from_concrete/conflicting_types_array_read.circom
@@ -40,3 +40,650 @@ template Outer() {
 }
 
 component main = Outer();
+// CHECK-LABEL: module attributes {llzk.lang, llzk.main = !struct.type<@Outer_2::@Outer_2<[]>>} {
+// CHECK-NEXT:    poly.template @Inner_0 {
+// CHECK-NEXT:      struct.def @Inner_0 {
+// CHECK-NEXT:        struct.member @out : !array.type<4 x !felt.type<"bn128">> {llzk.pub}
+// CHECK-NEXT:        function.def @compute(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !array.type<4 x !felt.type<"bn128">>) -> !struct.type<@Inner_0::@Inner_0<[]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
+// CHECK-NEXT:          %[[VAL_1:[0-9a-zA-Z_\.]+]] = struct.new : <@Inner_0::@Inner_0<[]>>
+// CHECK-NEXT:          %[[VAL_2:[0-9a-zA-Z_\.]+]] = llzk.nondet : !array.type<4 x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_3:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_4:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_5:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_6:[0-9a-zA-Z_\.]+]] = %[[VAL_4]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
+// CHECK-NEXT:            %[[VAL_7:[0-9a-zA-Z_\.]+]] = felt.const  4 : <"bn128">
+// CHECK-NEXT:            %[[VAL_8:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_6]], %[[VAL_7]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.condition(%[[VAL_8]]) %[[VAL_6]] : !felt.type<"bn128">
+// CHECK-NEXT:          } do {
+// CHECK-NEXT:          ^bb0(%[[VAL_9:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
+// CHECK-NEXT:            %[[VAL_10:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_9]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_11:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_0]]{{\[}}%[[VAL_10]]] : <4 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_12:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:            %[[VAL_13:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_11]], %[[VAL_12]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_14:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_9]] : !felt.type<"bn128">
+// CHECK-NEXT:            array.write %[[VAL_2]]{{\[}}%[[VAL_14]]] = %[[VAL_13]] : <4 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_15:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_16:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_9]], %[[VAL_15]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_16]] : !felt.type<"bn128">
+// CHECK-NEXT:          }
+// CHECK-NEXT:          struct.writem %[[VAL_1]][@out] = %[[VAL_2]] : <@Inner_0::@Inner_0<[]>>, !array.type<4 x !felt.type<"bn128">>
+// CHECK-NEXT:          function.return %[[VAL_1]] : !struct.type<@Inner_0::@Inner_0<[]>>
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.def @constrain(%[[VAL_17:[0-9a-zA-Z_\.]+]]: !struct.type<@Inner_0::@Inner_0<[]>>, %[[VAL_18:[0-9a-zA-Z_\.]+]]: !array.type<4 x !felt.type<"bn128">>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_19:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_17]][@out] : <@Inner_0::@Inner_0<[]>>, !array.type<4 x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_20:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_21:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_22:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_23:[0-9a-zA-Z_\.]+]] = %[[VAL_21]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
+// CHECK-NEXT:            %[[VAL_24:[0-9a-zA-Z_\.]+]] = felt.const  4 : <"bn128">
+// CHECK-NEXT:            %[[VAL_25:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_23]], %[[VAL_24]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.condition(%[[VAL_25]]) %[[VAL_23]] : !felt.type<"bn128">
+// CHECK-NEXT:          } do {
+// CHECK-NEXT:          ^bb0(%[[VAL_26:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
+// CHECK-NEXT:            %[[VAL_27:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_26]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_28:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_18]]{{\[}}%[[VAL_27]]] : <4 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_29:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:            %[[VAL_30:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_28]], %[[VAL_29]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_31:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_26]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_32:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_19]]{{\[}}%[[VAL_31]]] : <4 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            constrain.eq %[[VAL_32]], %[[VAL_30]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_33:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_34:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_26]], %[[VAL_33]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_34]] : !felt.type<"bn128">
+// CHECK-NEXT:          }
+// CHECK-NEXT:          function.return
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    poly.template @Inner_1 {
+// CHECK-NEXT:      struct.def @Inner_1 {
+// CHECK-NEXT:        struct.member @out : !array.type<4 x !felt.type<"bn128">> {llzk.pub}
+// CHECK-NEXT:        function.def @compute(%[[VAL_35:[0-9a-zA-Z_\.]+]]: !array.type<4 x !felt.type<"bn128">>) -> !struct.type<@Inner_1::@Inner_1<[]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
+// CHECK-NEXT:          %[[VAL_36:[0-9a-zA-Z_\.]+]] = struct.new : <@Inner_1::@Inner_1<[]>>
+// CHECK-NEXT:          %[[VAL_37:[0-9a-zA-Z_\.]+]] = llzk.nondet : !array.type<4 x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_38:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_39:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_40:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_41:[0-9a-zA-Z_\.]+]] = %[[VAL_39]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
+// CHECK-NEXT:            %[[VAL_42:[0-9a-zA-Z_\.]+]] = felt.const  4 : <"bn128">
+// CHECK-NEXT:            %[[VAL_43:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_41]], %[[VAL_42]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.condition(%[[VAL_43]]) %[[VAL_41]] : !felt.type<"bn128">
+// CHECK-NEXT:          } do {
+// CHECK-NEXT:          ^bb0(%[[VAL_44:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
+// CHECK-NEXT:            %[[VAL_45:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_44]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_46:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_35]]{{\[}}%[[VAL_45]]] : <4 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_47:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_48:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_46]], %[[VAL_47]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_49:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_44]] : !felt.type<"bn128">
+// CHECK-NEXT:            array.write %[[VAL_37]]{{\[}}%[[VAL_49]]] = %[[VAL_48]] : <4 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_50:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_51:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_44]], %[[VAL_50]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_51]] : !felt.type<"bn128">
+// CHECK-NEXT:          }
+// CHECK-NEXT:          struct.writem %[[VAL_36]][@out] = %[[VAL_37]] : <@Inner_1::@Inner_1<[]>>, !array.type<4 x !felt.type<"bn128">>
+// CHECK-NEXT:          function.return %[[VAL_36]] : !struct.type<@Inner_1::@Inner_1<[]>>
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.def @constrain(%[[VAL_52:[0-9a-zA-Z_\.]+]]: !struct.type<@Inner_1::@Inner_1<[]>>, %[[VAL_53:[0-9a-zA-Z_\.]+]]: !array.type<4 x !felt.type<"bn128">>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_54:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_52]][@out] : <@Inner_1::@Inner_1<[]>>, !array.type<4 x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_55:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_56:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_57:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_58:[0-9a-zA-Z_\.]+]] = %[[VAL_56]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
+// CHECK-NEXT:            %[[VAL_59:[0-9a-zA-Z_\.]+]] = felt.const  4 : <"bn128">
+// CHECK-NEXT:            %[[VAL_60:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_58]], %[[VAL_59]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.condition(%[[VAL_60]]) %[[VAL_58]] : !felt.type<"bn128">
+// CHECK-NEXT:          } do {
+// CHECK-NEXT:          ^bb0(%[[VAL_61:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
+// CHECK-NEXT:            %[[VAL_62:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_61]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_63:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_53]]{{\[}}%[[VAL_62]]] : <4 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_64:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_65:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_63]], %[[VAL_64]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_66:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_61]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_67:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_54]]{{\[}}%[[VAL_66]]] : <4 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            constrain.eq %[[VAL_67]], %[[VAL_65]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_68:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_69:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_61]], %[[VAL_68]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_69]] : !felt.type<"bn128">
+// CHECK-NEXT:          }
+// CHECK-NEXT:          function.return
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    poly.template @Outer_2 {
+// CHECK-NEXT:      struct.def @Outer_2 {
+// CHECK-NEXT:        struct.member @out : !array.type<8 x !felt.type<"bn128">> {llzk.pub}
+// CHECK-NEXT:        struct.member @mid : !array.type<8 x !felt.type<"bn128">>
+// CHECK-NEXT:        struct.member @inner : !pod.type<[@idx_0: !struct.type<@Inner_0::@Inner_0<[]>>, @idx_1: !struct.type<@Inner_1::@Inner_1<[]>>]>
+// CHECK-NEXT:        struct.member @inner$inputs : !pod.type<[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>
+// CHECK-NEXT:        function.def @compute(%[[VAL_70:[0-9a-zA-Z_\.]+]]: !array.type<8 x !felt.type<"bn128">>) -> !struct.type<@Outer_2::@Outer_2<[]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
+// CHECK-NEXT:          %[[VAL_71:[0-9a-zA-Z_\.]+]] = struct.new : <@Outer_2::@Outer_2<[]>>
+// CHECK-NEXT:          %[[VAL_72:[0-9a-zA-Z_\.]+]] = llzk.nondet : !array.type<8 x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_73:[0-9a-zA-Z_\.]+]] = llzk.nondet : !array.type<8 x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_74:[0-9a-zA-Z_\.]+]] = llzk.nondet : !pod.type<[@idx_0: !pod.type<[@count: index, @comp: !struct.type<@Inner_0::@Inner_0<[]>>, @params: !pod.type<[]>]>, @idx_1: !pod.type<[@count: index, @comp: !struct.type<@Inner_1::@Inner_1<[]>>, @params: !pod.type<[]>]>]>
+// CHECK-NEXT:          %[[VAL_75:[0-9a-zA-Z_\.]+]] = pod.new : <[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>
+// CHECK-NEXT:          %[[VAL_76:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_77:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_78:[0-9a-zA-Z_\.]+]] = %[[VAL_76]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
+// CHECK-NEXT:            %[[VAL_79:[0-9a-zA-Z_\.]+]] = felt.const  8 : <"bn128">
+// CHECK-NEXT:            %[[VAL_80:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_78]], %[[VAL_79]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.condition(%[[VAL_80]]) %[[VAL_78]] : !felt.type<"bn128">
+// CHECK-NEXT:          } do {
+// CHECK-NEXT:          ^bb0(%[[VAL_81:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
+// CHECK-NEXT:            %[[VAL_82:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_81]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_83:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_70]]{{\[}}%[[VAL_82]]] : <8 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_84:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_81]] : !felt.type<"bn128">
+// CHECK-NEXT:            array.write %[[VAL_72]]{{\[}}%[[VAL_84]]] = %[[VAL_83]] : <8 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_85:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_86:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_81]], %[[VAL_85]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_86]] : !felt.type<"bn128">
+// CHECK-NEXT:          }
+// CHECK-NEXT:          %[[VAL_87:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_88:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_89:[0-9a-zA-Z_\.]+]] = %[[VAL_87]], %[[VAL_90:[0-9a-zA-Z_\.]+]] = %[[VAL_75]]) : (!felt.type<"bn128">, !pod.type<[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>) -> (!felt.type<"bn128">, !pod.type<[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>) {
+// CHECK-NEXT:            %[[VAL_91:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
+// CHECK-NEXT:            %[[VAL_92:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_89]], %[[VAL_91]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.condition(%[[VAL_92]]) %[[VAL_89]], %[[VAL_90]] : !felt.type<"bn128">, !pod.type<[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>
+// CHECK-NEXT:          } do {
+// CHECK-NEXT:          ^bb0(%[[VAL_93:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">, %[[VAL_94:[0-9a-zA-Z_\.]+]]: !pod.type<[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>):
+// CHECK-NEXT:            %[[VAL_95:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:            %[[VAL_96:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_97:[0-9a-zA-Z_\.]+]] = %[[VAL_94]], %[[VAL_98:[0-9a-zA-Z_\.]+]] = %[[VAL_95]]) : (!pod.type<[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>, !felt.type<"bn128">) -> (!pod.type<[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>, !felt.type<"bn128">) {
+// CHECK-NEXT:              %[[VAL_99:[0-9a-zA-Z_\.]+]] = felt.const  4 : <"bn128">
+// CHECK-NEXT:              %[[VAL_100:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_98]], %[[VAL_99]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:              scf.condition(%[[VAL_100]]) %[[VAL_97]], %[[VAL_98]] : !pod.type<[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>, !felt.type<"bn128">
+// CHECK-NEXT:            } do {
+// CHECK-NEXT:            ^bb0(%[[VAL_101:[0-9a-zA-Z_\.]+]]: !pod.type<[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>, %[[VAL_102:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
+// CHECK-NEXT:              %[[VAL_103:[0-9a-zA-Z_\.]+]] = felt.const  4 : <"bn128">
+// CHECK-NEXT:              %[[VAL_104:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_93]], %[[VAL_103]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_105:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_104]], %[[VAL_102]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_106:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_105]] : !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_107:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_72]]{{\[}}%[[VAL_106]]] : <8 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_108:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_93]] : !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_109:[0-9a-zA-Z_\.]+]] = arith.constant true
+// CHECK-NEXT:              %[[VAL_110:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:              %[[VAL_111:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_108]], %[[VAL_110]] : index
+// CHECK-NEXT:              %[[VAL_112:[0-9a-zA-Z_\.]+]] = bool.and %[[VAL_109]], %[[VAL_111]] : i1, i1
+// CHECK-NEXT:              %[[VAL_113:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:              %[[VAL_114:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_108]], %[[VAL_113]] : index
+// CHECK-NEXT:              %[[VAL_115:[0-9a-zA-Z_\.]+]] = bool.and %[[VAL_109]], %[[VAL_114]] : i1, i1
+// CHECK-NEXT:              %[[VAL_116:[0-9a-zA-Z_\.]+]] = scf.execute_region -> !pod.type<[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]> {
+// CHECK-NEXT:                %[[VAL_117:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_115]] -> (!pod.type<[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>) {
+// CHECK-NEXT:                  %[[VAL_118:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_101]][@idx_1] : <[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>, !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                  %[[VAL_119:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_118]][@in] : <[@in: !array.type<4 x !felt.type<"bn128">>]>, !array.type<4 x !felt.type<"bn128">>
+// CHECK-NEXT:                  %[[VAL_120:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_102]] : !felt.type<"bn128">
+// CHECK-NEXT:                  array.write %[[VAL_119]]{{\[}}%[[VAL_120]]] = %[[VAL_107]] : <4 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:                  %[[VAL_121:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_93]] : !felt.type<"bn128">
+// CHECK-NEXT:                  %[[VAL_122:[0-9a-zA-Z_\.]+]] = arith.constant true
+// CHECK-NEXT:                  %[[VAL_123:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:                  %[[VAL_124:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_121]], %[[VAL_123]] : index
+// CHECK-NEXT:                  %[[VAL_125:[0-9a-zA-Z_\.]+]] = bool.and %[[VAL_122]], %[[VAL_124]] : i1, i1
+// CHECK-NEXT:                  %[[VAL_126:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:                  %[[VAL_127:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_121]], %[[VAL_126]] : index
+// CHECK-NEXT:                  %[[VAL_128:[0-9a-zA-Z_\.]+]] = bool.and %[[VAL_122]], %[[VAL_127]] : i1, i1
+// CHECK-NEXT:                  %[[VAL_129:[0-9a-zA-Z_\.]+]] = scf.execute_region -> !pod.type<[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]> {
+// CHECK-NEXT:                    %[[VAL_130:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_128]] -> (!pod.type<[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>) {
+// CHECK-NEXT:                      %[[VAL_131:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_101]][@idx_1] : <[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>, !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                      pod.write %[[VAL_131]][@in] = %[[VAL_119]] : <[@in: !array.type<4 x !felt.type<"bn128">>]>, !array.type<4 x !felt.type<"bn128">>
+// CHECK-NEXT:                      %[[VAL_132:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_93]] : !felt.type<"bn128">
+// CHECK-NEXT:                      scf.yield %[[VAL_101]] : !pod.type<[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>
+// CHECK-NEXT:                    } else {
+// CHECK-NEXT:                      %[[VAL_133:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_125]] -> (!pod.type<[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>) {
+// CHECK-NEXT:                        %[[VAL_134:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_101]][@idx_0] : <[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>, !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                        pod.write %[[VAL_134]][@in] = %[[VAL_119]] : <[@in: !array.type<4 x !felt.type<"bn128">>]>, !array.type<4 x !felt.type<"bn128">>
+// CHECK-NEXT:                        %[[VAL_135:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_93]] : !felt.type<"bn128">
+// CHECK-NEXT:                        scf.yield %[[VAL_101]] : !pod.type<[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>
+// CHECK-NEXT:                      } else {
+// CHECK-NEXT:                        %[[VAL_136:[0-9a-zA-Z_\.]+]] = llzk.nondet : !pod.type<[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>
+// CHECK-NEXT:                        scf.yield %[[VAL_136]] : !pod.type<[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>
+// CHECK-NEXT:                      }
+// CHECK-NEXT:                      scf.yield %[[VAL_133]] : !pod.type<[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>
+// CHECK-NEXT:                    }
+// CHECK-NEXT:                    scf.yield %[[VAL_130]] : !pod.type<[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>
+// CHECK-NEXT:                  }
+// CHECK-NEXT:                  %[[VAL_137:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_93]] : !felt.type<"bn128">
+// CHECK-NEXT:                  %[[VAL_138:[0-9a-zA-Z_\.]+]] = arith.constant true
+// CHECK-NEXT:                  %[[VAL_139:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:                  %[[VAL_140:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_137]], %[[VAL_139]] : index
+// CHECK-NEXT:                  %[[VAL_141:[0-9a-zA-Z_\.]+]] = bool.and %[[VAL_138]], %[[VAL_140]] : i1, i1
+// CHECK-NEXT:                  %[[VAL_142:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:                  %[[VAL_143:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_137]], %[[VAL_142]] : index
+// CHECK-NEXT:                  %[[VAL_144:[0-9a-zA-Z_\.]+]] = bool.and %[[VAL_138]], %[[VAL_143]] : i1, i1
+// CHECK-NEXT:                  scf.execute_region {
+// CHECK-NEXT:                    scf.if %[[VAL_144]] {
+// CHECK-NEXT:                      %[[VAL_145:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_74]][@idx_1] : <[@idx_0: !pod.type<[@count: index, @comp: !struct.type<@Inner_0::@Inner_0<[]>>, @params: !pod.type<[]>]>, @idx_1: !pod.type<[@count: index, @comp: !struct.type<@Inner_1::@Inner_1<[]>>, @params: !pod.type<[]>]>]>, !pod.type<[@count: index, @comp: !struct.type<@Inner_1::@Inner_1<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:                      %[[VAL_146:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_93]] : !felt.type<"bn128">
+// CHECK-NEXT:                      %[[VAL_147:[0-9a-zA-Z_\.]+]] = arith.constant true
+// CHECK-NEXT:                      %[[VAL_148:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:                      %[[VAL_149:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_146]], %[[VAL_148]] : index
+// CHECK-NEXT:                      %[[VAL_150:[0-9a-zA-Z_\.]+]] = bool.and %[[VAL_147]], %[[VAL_149]] : i1, i1
+// CHECK-NEXT:                      %[[VAL_151:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:                      %[[VAL_152:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_146]], %[[VAL_151]] : index
+// CHECK-NEXT:                      %[[VAL_153:[0-9a-zA-Z_\.]+]] = bool.and %[[VAL_147]], %[[VAL_152]] : i1, i1
+// CHECK-NEXT:                      %[[VAL_154:[0-9a-zA-Z_\.]+]] = scf.execute_region -> !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]> {
+// CHECK-NEXT:                        %[[VAL_155:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_153]] -> (!pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>) {
+// CHECK-NEXT:                          %[[VAL_156:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_129]][@idx_1] : <[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>, !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                          scf.yield %[[VAL_156]] : !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                        } else {
+// CHECK-NEXT:                          %[[VAL_157:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_150]] -> (!pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>) {
+// CHECK-NEXT:                            %[[VAL_158:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_129]][@idx_0] : <[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>, !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                            scf.yield %[[VAL_158]] : !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                          } else {
+// CHECK-NEXT:                            %[[VAL_159:[0-9a-zA-Z_\.]+]] = llzk.nondet : !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                            scf.yield %[[VAL_159]] : !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                          }
+// CHECK-NEXT:                          scf.yield %[[VAL_157]] : !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                        }
+// CHECK-NEXT:                        scf.yield %[[VAL_155]] : !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                      }
+// CHECK-NEXT:                      %[[VAL_160:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_145]][@count] : <[@count: index, @comp: !struct.type<@Inner_1::@Inner_1<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:                      %[[VAL_161:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:                      %[[VAL_162:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_160]], %[[VAL_161]] : index
+// CHECK-NEXT:                      pod.write %[[VAL_145]][@count] = %[[VAL_162]] : <[@count: index, @comp: !struct.type<@Inner_1::@Inner_1<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:                      %[[VAL_163:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:                      %[[VAL_164:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_162]], %[[VAL_163]] : index
+// CHECK-NEXT:                      scf.if %[[VAL_164]] {
+// CHECK-NEXT:                        %[[VAL_165:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_145]][@params] : <[@count: index, @comp: !struct.type<@Inner_1::@Inner_1<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
+// CHECK-NEXT:                        %[[VAL_166:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_154]][@in] : <[@in: !array.type<4 x !felt.type<"bn128">>]>, !array.type<4 x !felt.type<"bn128">>
+// CHECK-NEXT:                        %[[VAL_167:[0-9a-zA-Z_\.]+]] = function.call @Inner_1::@Inner_1::@compute(%[[VAL_166]]) : (!array.type<4 x !felt.type<"bn128">>) -> !struct.type<@Inner_1::@Inner_1<[]>>
+// CHECK-NEXT:                        pod.write %[[VAL_145]][@comp] = %[[VAL_167]] : <[@count: index, @comp: !struct.type<@Inner_1::@Inner_1<[]>>, @params: !pod.type<[]>]>, !struct.type<@Inner_1::@Inner_1<[]>>
+// CHECK-NEXT:                        %[[VAL_168:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_93]] : !felt.type<"bn128">
+// CHECK-NEXT:                      }
+// CHECK-NEXT:                    } else {
+// CHECK-NEXT:                      scf.if %[[VAL_141]] {
+// CHECK-NEXT:                        %[[VAL_169:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_74]][@idx_0] : <[@idx_0: !pod.type<[@count: index, @comp: !struct.type<@Inner_0::@Inner_0<[]>>, @params: !pod.type<[]>]>, @idx_1: !pod.type<[@count: index, @comp: !struct.type<@Inner_1::@Inner_1<[]>>, @params: !pod.type<[]>]>]>, !pod.type<[@count: index, @comp: !struct.type<@Inner_0::@Inner_0<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:                        %[[VAL_170:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_93]] : !felt.type<"bn128">
+// CHECK-NEXT:                        %[[VAL_171:[0-9a-zA-Z_\.]+]] = arith.constant true
+// CHECK-NEXT:                        %[[VAL_172:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:                        %[[VAL_173:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_170]], %[[VAL_172]] : index
+// CHECK-NEXT:                        %[[VAL_174:[0-9a-zA-Z_\.]+]] = bool.and %[[VAL_171]], %[[VAL_173]] : i1, i1
+// CHECK-NEXT:                        %[[VAL_175:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:                        %[[VAL_176:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_170]], %[[VAL_175]] : index
+// CHECK-NEXT:                        %[[VAL_177:[0-9a-zA-Z_\.]+]] = bool.and %[[VAL_171]], %[[VAL_176]] : i1, i1
+// CHECK-NEXT:                        %[[VAL_178:[0-9a-zA-Z_\.]+]] = scf.execute_region -> !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]> {
+// CHECK-NEXT:                          %[[VAL_179:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_177]] -> (!pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>) {
+// CHECK-NEXT:                            %[[VAL_180:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_129]][@idx_1] : <[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>, !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                            scf.yield %[[VAL_180]] : !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                          } else {
+// CHECK-NEXT:                            %[[VAL_181:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_174]] -> (!pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>) {
+// CHECK-NEXT:                              %[[VAL_182:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_129]][@idx_0] : <[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>, !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                              scf.yield %[[VAL_182]] : !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                            } else {
+// CHECK-NEXT:                              %[[VAL_183:[0-9a-zA-Z_\.]+]] = llzk.nondet : !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                              scf.yield %[[VAL_183]] : !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                            }
+// CHECK-NEXT:                            scf.yield %[[VAL_181]] : !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                          }
+// CHECK-NEXT:                          scf.yield %[[VAL_179]] : !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                        }
+// CHECK-NEXT:                        %[[VAL_184:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_169]][@count] : <[@count: index, @comp: !struct.type<@Inner_0::@Inner_0<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:                        %[[VAL_185:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:                        %[[VAL_186:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_184]], %[[VAL_185]] : index
+// CHECK-NEXT:                        pod.write %[[VAL_169]][@count] = %[[VAL_186]] : <[@count: index, @comp: !struct.type<@Inner_0::@Inner_0<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:                        %[[VAL_187:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:                        %[[VAL_188:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_186]], %[[VAL_187]] : index
+// CHECK-NEXT:                        scf.if %[[VAL_188]] {
+// CHECK-NEXT:                          %[[VAL_189:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_169]][@params] : <[@count: index, @comp: !struct.type<@Inner_0::@Inner_0<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
+// CHECK-NEXT:                          %[[VAL_190:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_178]][@in] : <[@in: !array.type<4 x !felt.type<"bn128">>]>, !array.type<4 x !felt.type<"bn128">>
+// CHECK-NEXT:                          %[[VAL_191:[0-9a-zA-Z_\.]+]] = function.call @Inner_0::@Inner_0::@compute(%[[VAL_190]]) : (!array.type<4 x !felt.type<"bn128">>) -> !struct.type<@Inner_0::@Inner_0<[]>>
+// CHECK-NEXT:                          pod.write %[[VAL_169]][@comp] = %[[VAL_191]] : <[@count: index, @comp: !struct.type<@Inner_0::@Inner_0<[]>>, @params: !pod.type<[]>]>, !struct.type<@Inner_0::@Inner_0<[]>>
+// CHECK-NEXT:                          %[[VAL_192:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_93]] : !felt.type<"bn128">
+// CHECK-NEXT:                        }
+// CHECK-NEXT:                      } else {
+// CHECK-NEXT:                      }
+// CHECK-NEXT:                    }
+// CHECK-NEXT:                    scf.yield
+// CHECK-NEXT:                  }
+// CHECK-NEXT:                  scf.yield %[[VAL_101]] : !pod.type<[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>
+// CHECK-NEXT:                } else {
+// CHECK-NEXT:                  %[[VAL_193:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_112]] -> (!pod.type<[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>) {
+// CHECK-NEXT:                    %[[VAL_194:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_101]][@idx_0] : <[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>, !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                    %[[VAL_195:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_194]][@in] : <[@in: !array.type<4 x !felt.type<"bn128">>]>, !array.type<4 x !felt.type<"bn128">>
+// CHECK-NEXT:                    %[[VAL_196:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_102]] : !felt.type<"bn128">
+// CHECK-NEXT:                    array.write %[[VAL_195]]{{\[}}%[[VAL_196]]] = %[[VAL_107]] : <4 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:                    %[[VAL_197:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_93]] : !felt.type<"bn128">
+// CHECK-NEXT:                    %[[VAL_198:[0-9a-zA-Z_\.]+]] = arith.constant true
+// CHECK-NEXT:                    %[[VAL_199:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:                    %[[VAL_200:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_197]], %[[VAL_199]] : index
+// CHECK-NEXT:                    %[[VAL_201:[0-9a-zA-Z_\.]+]] = bool.and %[[VAL_198]], %[[VAL_200]] : i1, i1
+// CHECK-NEXT:                    %[[VAL_202:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:                    %[[VAL_203:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_197]], %[[VAL_202]] : index
+// CHECK-NEXT:                    %[[VAL_204:[0-9a-zA-Z_\.]+]] = bool.and %[[VAL_198]], %[[VAL_203]] : i1, i1
+// CHECK-NEXT:                    %[[VAL_205:[0-9a-zA-Z_\.]+]] = scf.execute_region -> !pod.type<[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]> {
+// CHECK-NEXT:                      %[[VAL_206:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_204]] -> (!pod.type<[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>) {
+// CHECK-NEXT:                        %[[VAL_207:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_101]][@idx_1] : <[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>, !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                        pod.write %[[VAL_207]][@in] = %[[VAL_195]] : <[@in: !array.type<4 x !felt.type<"bn128">>]>, !array.type<4 x !felt.type<"bn128">>
+// CHECK-NEXT:                        %[[VAL_208:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_93]] : !felt.type<"bn128">
+// CHECK-NEXT:                        scf.yield %[[VAL_101]] : !pod.type<[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>
+// CHECK-NEXT:                      } else {
+// CHECK-NEXT:                        %[[VAL_209:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_201]] -> (!pod.type<[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>) {
+// CHECK-NEXT:                          %[[VAL_210:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_101]][@idx_0] : <[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>, !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                          pod.write %[[VAL_210]][@in] = %[[VAL_195]] : <[@in: !array.type<4 x !felt.type<"bn128">>]>, !array.type<4 x !felt.type<"bn128">>
+// CHECK-NEXT:                          %[[VAL_211:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_93]] : !felt.type<"bn128">
+// CHECK-NEXT:                          scf.yield %[[VAL_101]] : !pod.type<[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>
+// CHECK-NEXT:                        } else {
+// CHECK-NEXT:                          %[[VAL_212:[0-9a-zA-Z_\.]+]] = llzk.nondet : !pod.type<[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>
+// CHECK-NEXT:                          scf.yield %[[VAL_212]] : !pod.type<[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>
+// CHECK-NEXT:                        }
+// CHECK-NEXT:                        scf.yield %[[VAL_209]] : !pod.type<[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>
+// CHECK-NEXT:                      }
+// CHECK-NEXT:                      scf.yield %[[VAL_206]] : !pod.type<[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>
+// CHECK-NEXT:                    }
+// CHECK-NEXT:                    %[[VAL_213:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_93]] : !felt.type<"bn128">
+// CHECK-NEXT:                    %[[VAL_214:[0-9a-zA-Z_\.]+]] = arith.constant true
+// CHECK-NEXT:                    %[[VAL_215:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:                    %[[VAL_216:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_213]], %[[VAL_215]] : index
+// CHECK-NEXT:                    %[[VAL_217:[0-9a-zA-Z_\.]+]] = bool.and %[[VAL_214]], %[[VAL_216]] : i1, i1
+// CHECK-NEXT:                    %[[VAL_218:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:                    %[[VAL_219:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_213]], %[[VAL_218]] : index
+// CHECK-NEXT:                    %[[VAL_220:[0-9a-zA-Z_\.]+]] = bool.and %[[VAL_214]], %[[VAL_219]] : i1, i1
+// CHECK-NEXT:                    scf.execute_region {
+// CHECK-NEXT:                      scf.if %[[VAL_220]] {
+// CHECK-NEXT:                        %[[VAL_221:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_74]][@idx_1] : <[@idx_0: !pod.type<[@count: index, @comp: !struct.type<@Inner_0::@Inner_0<[]>>, @params: !pod.type<[]>]>, @idx_1: !pod.type<[@count: index, @comp: !struct.type<@Inner_1::@Inner_1<[]>>, @params: !pod.type<[]>]>]>, !pod.type<[@count: index, @comp: !struct.type<@Inner_1::@Inner_1<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:                        %[[VAL_222:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_93]] : !felt.type<"bn128">
+// CHECK-NEXT:                        %[[VAL_223:[0-9a-zA-Z_\.]+]] = arith.constant true
+// CHECK-NEXT:                        %[[VAL_224:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:                        %[[VAL_225:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_222]], %[[VAL_224]] : index
+// CHECK-NEXT:                        %[[VAL_226:[0-9a-zA-Z_\.]+]] = bool.and %[[VAL_223]], %[[VAL_225]] : i1, i1
+// CHECK-NEXT:                        %[[VAL_227:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:                        %[[VAL_228:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_222]], %[[VAL_227]] : index
+// CHECK-NEXT:                        %[[VAL_229:[0-9a-zA-Z_\.]+]] = bool.and %[[VAL_223]], %[[VAL_228]] : i1, i1
+// CHECK-NEXT:                        %[[VAL_230:[0-9a-zA-Z_\.]+]] = scf.execute_region -> !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]> {
+// CHECK-NEXT:                          %[[VAL_231:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_229]] -> (!pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>) {
+// CHECK-NEXT:                            %[[VAL_232:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_205]][@idx_1] : <[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>, !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                            scf.yield %[[VAL_232]] : !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                          } else {
+// CHECK-NEXT:                            %[[VAL_233:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_226]] -> (!pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>) {
+// CHECK-NEXT:                              %[[VAL_234:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_205]][@idx_0] : <[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>, !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                              scf.yield %[[VAL_234]] : !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                            } else {
+// CHECK-NEXT:                              %[[VAL_235:[0-9a-zA-Z_\.]+]] = llzk.nondet : !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                              scf.yield %[[VAL_235]] : !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                            }
+// CHECK-NEXT:                            scf.yield %[[VAL_233]] : !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                          }
+// CHECK-NEXT:                          scf.yield %[[VAL_231]] : !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                        }
+// CHECK-NEXT:                        %[[VAL_236:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_221]][@count] : <[@count: index, @comp: !struct.type<@Inner_1::@Inner_1<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:                        %[[VAL_237:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:                        %[[VAL_238:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_236]], %[[VAL_237]] : index
+// CHECK-NEXT:                        pod.write %[[VAL_221]][@count] = %[[VAL_238]] : <[@count: index, @comp: !struct.type<@Inner_1::@Inner_1<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:                        %[[VAL_239:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:                        %[[VAL_240:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_238]], %[[VAL_239]] : index
+// CHECK-NEXT:                        scf.if %[[VAL_240]] {
+// CHECK-NEXT:                          %[[VAL_241:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_221]][@params] : <[@count: index, @comp: !struct.type<@Inner_1::@Inner_1<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
+// CHECK-NEXT:                          %[[VAL_242:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_230]][@in] : <[@in: !array.type<4 x !felt.type<"bn128">>]>, !array.type<4 x !felt.type<"bn128">>
+// CHECK-NEXT:                          %[[VAL_243:[0-9a-zA-Z_\.]+]] = function.call @Inner_1::@Inner_1::@compute(%[[VAL_242]]) : (!array.type<4 x !felt.type<"bn128">>) -> !struct.type<@Inner_1::@Inner_1<[]>>
+// CHECK-NEXT:                          pod.write %[[VAL_221]][@comp] = %[[VAL_243]] : <[@count: index, @comp: !struct.type<@Inner_1::@Inner_1<[]>>, @params: !pod.type<[]>]>, !struct.type<@Inner_1::@Inner_1<[]>>
+// CHECK-NEXT:                          %[[VAL_244:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_93]] : !felt.type<"bn128">
+// CHECK-NEXT:                        }
+// CHECK-NEXT:                      } else {
+// CHECK-NEXT:                        scf.if %[[VAL_217]] {
+// CHECK-NEXT:                          %[[VAL_245:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_74]][@idx_0] : <[@idx_0: !pod.type<[@count: index, @comp: !struct.type<@Inner_0::@Inner_0<[]>>, @params: !pod.type<[]>]>, @idx_1: !pod.type<[@count: index, @comp: !struct.type<@Inner_1::@Inner_1<[]>>, @params: !pod.type<[]>]>]>, !pod.type<[@count: index, @comp: !struct.type<@Inner_0::@Inner_0<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:                          %[[VAL_246:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_93]] : !felt.type<"bn128">
+// CHECK-NEXT:                          %[[VAL_247:[0-9a-zA-Z_\.]+]] = arith.constant true
+// CHECK-NEXT:                          %[[VAL_248:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:                          %[[VAL_249:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_246]], %[[VAL_248]] : index
+// CHECK-NEXT:                          %[[VAL_250:[0-9a-zA-Z_\.]+]] = bool.and %[[VAL_247]], %[[VAL_249]] : i1, i1
+// CHECK-NEXT:                          %[[VAL_251:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:                          %[[VAL_252:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_246]], %[[VAL_251]] : index
+// CHECK-NEXT:                          %[[VAL_253:[0-9a-zA-Z_\.]+]] = bool.and %[[VAL_247]], %[[VAL_252]] : i1, i1
+// CHECK-NEXT:                          %[[VAL_254:[0-9a-zA-Z_\.]+]] = scf.execute_region -> !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]> {
+// CHECK-NEXT:                            %[[VAL_255:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_253]] -> (!pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>) {
+// CHECK-NEXT:                              %[[VAL_256:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_205]][@idx_1] : <[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>, !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                              scf.yield %[[VAL_256]] : !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                            } else {
+// CHECK-NEXT:                              %[[VAL_257:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_250]] -> (!pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>) {
+// CHECK-NEXT:                                %[[VAL_258:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_205]][@idx_0] : <[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>, !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                                scf.yield %[[VAL_258]] : !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                              } else {
+// CHECK-NEXT:                                %[[VAL_259:[0-9a-zA-Z_\.]+]] = llzk.nondet : !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                                scf.yield %[[VAL_259]] : !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                              }
+// CHECK-NEXT:                              scf.yield %[[VAL_257]] : !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                            }
+// CHECK-NEXT:                            scf.yield %[[VAL_255]] : !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                          }
+// CHECK-NEXT:                          %[[VAL_260:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_245]][@count] : <[@count: index, @comp: !struct.type<@Inner_0::@Inner_0<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:                          %[[VAL_261:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:                          %[[VAL_262:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_260]], %[[VAL_261]] : index
+// CHECK-NEXT:                          pod.write %[[VAL_245]][@count] = %[[VAL_262]] : <[@count: index, @comp: !struct.type<@Inner_0::@Inner_0<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:                          %[[VAL_263:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:                          %[[VAL_264:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_262]], %[[VAL_263]] : index
+// CHECK-NEXT:                          scf.if %[[VAL_264]] {
+// CHECK-NEXT:                            %[[VAL_265:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_245]][@params] : <[@count: index, @comp: !struct.type<@Inner_0::@Inner_0<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
+// CHECK-NEXT:                            %[[VAL_266:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_254]][@in] : <[@in: !array.type<4 x !felt.type<"bn128">>]>, !array.type<4 x !felt.type<"bn128">>
+// CHECK-NEXT:                            %[[VAL_267:[0-9a-zA-Z_\.]+]] = function.call @Inner_0::@Inner_0::@compute(%[[VAL_266]]) : (!array.type<4 x !felt.type<"bn128">>) -> !struct.type<@Inner_0::@Inner_0<[]>>
+// CHECK-NEXT:                            pod.write %[[VAL_245]][@comp] = %[[VAL_267]] : <[@count: index, @comp: !struct.type<@Inner_0::@Inner_0<[]>>, @params: !pod.type<[]>]>, !struct.type<@Inner_0::@Inner_0<[]>>
+// CHECK-NEXT:                            %[[VAL_268:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_93]] : !felt.type<"bn128">
+// CHECK-NEXT:                          }
+// CHECK-NEXT:                        } else {
+// CHECK-NEXT:                        }
+// CHECK-NEXT:                      }
+// CHECK-NEXT:                      scf.yield
+// CHECK-NEXT:                    }
+// CHECK-NEXT:                    scf.yield %[[VAL_101]] : !pod.type<[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>
+// CHECK-NEXT:                  } else {
+// CHECK-NEXT:                    %[[VAL_269:[0-9a-zA-Z_\.]+]] = llzk.nondet : !pod.type<[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>
+// CHECK-NEXT:                    scf.yield %[[VAL_269]] : !pod.type<[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>
+// CHECK-NEXT:                  }
+// CHECK-NEXT:                  scf.yield %[[VAL_193]] : !pod.type<[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>
+// CHECK-NEXT:                }
+// CHECK-NEXT:                scf.yield %[[VAL_117]] : !pod.type<[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>
+// CHECK-NEXT:              }
+// CHECK-NEXT:              %[[VAL_270:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:              %[[VAL_271:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_102]], %[[VAL_270]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:              scf.yield %[[VAL_116]], %[[VAL_271]] : !pod.type<[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>, !felt.type<"bn128">
+// CHECK-NEXT:            }
+// CHECK-NEXT:            %[[VAL_272:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_273:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_93]], %[[VAL_272]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_273]], %[[VAL_96]]#0 : !felt.type<"bn128">, !pod.type<[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>
+// CHECK-NEXT:          }
+// CHECK-NEXT:          %[[VAL_274:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_275:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_276:[0-9a-zA-Z_\.]+]] = %[[VAL_274]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
+// CHECK-NEXT:            %[[VAL_277:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
+// CHECK-NEXT:            %[[VAL_278:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_276]], %[[VAL_277]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.condition(%[[VAL_278]]) %[[VAL_276]] : !felt.type<"bn128">
+// CHECK-NEXT:          } do {
+// CHECK-NEXT:          ^bb0(%[[VAL_279:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
+// CHECK-NEXT:            %[[VAL_280:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:            %[[VAL_281:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_282:[0-9a-zA-Z_\.]+]] = %[[VAL_280]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
+// CHECK-NEXT:              %[[VAL_283:[0-9a-zA-Z_\.]+]] = felt.const  4 : <"bn128">
+// CHECK-NEXT:              %[[VAL_284:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_282]], %[[VAL_283]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:              scf.condition(%[[VAL_284]]) %[[VAL_282]] : !felt.type<"bn128">
+// CHECK-NEXT:            } do {
+// CHECK-NEXT:            ^bb0(%[[VAL_285:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
+// CHECK-NEXT:              %[[VAL_286:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_279]] : !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_287:[0-9a-zA-Z_\.]+]] = arith.constant true
+// CHECK-NEXT:              %[[VAL_288:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:              %[[VAL_289:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_286]], %[[VAL_288]] : index
+// CHECK-NEXT:              %[[VAL_290:[0-9a-zA-Z_\.]+]] = bool.and %[[VAL_287]], %[[VAL_289]] : i1, i1
+// CHECK-NEXT:              %[[VAL_291:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:              %[[VAL_292:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_286]], %[[VAL_291]] : index
+// CHECK-NEXT:              %[[VAL_293:[0-9a-zA-Z_\.]+]] = bool.and %[[VAL_287]], %[[VAL_292]] : i1, i1
+// CHECK-NEXT:              %[[VAL_294:[0-9a-zA-Z_\.]+]] = scf.execute_region -> !felt.type<"bn128"> {
+// CHECK-NEXT:                %[[VAL_295:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_293]] -> (!felt.type<"bn128">) {
+// CHECK-NEXT:                  %[[VAL_296:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_74]][@idx_1] : <[@idx_0: !pod.type<[@count: index, @comp: !struct.type<@Inner_0::@Inner_0<[]>>, @params: !pod.type<[]>]>, @idx_1: !pod.type<[@count: index, @comp: !struct.type<@Inner_1::@Inner_1<[]>>, @params: !pod.type<[]>]>]>, !pod.type<[@count: index, @comp: !struct.type<@Inner_1::@Inner_1<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:                  %[[VAL_297:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_296]][@comp] : <[@count: index, @comp: !struct.type<@Inner_1::@Inner_1<[]>>, @params: !pod.type<[]>]>, !struct.type<@Inner_1::@Inner_1<[]>>
+// CHECK-NEXT:                  %[[VAL_298:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_297]][@out] : <@Inner_1::@Inner_1<[]>>, !array.type<4 x !felt.type<"bn128">>
+// CHECK-NEXT:                  %[[VAL_299:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_285]] : !felt.type<"bn128">
+// CHECK-NEXT:                  %[[VAL_300:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_298]]{{\[}}%[[VAL_299]]] : <4 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:                  scf.yield %[[VAL_300]] : !felt.type<"bn128">
+// CHECK-NEXT:                } else {
+// CHECK-NEXT:                  %[[VAL_301:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_290]] -> (!felt.type<"bn128">) {
+// CHECK-NEXT:                    %[[VAL_302:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_74]][@idx_0] : <[@idx_0: !pod.type<[@count: index, @comp: !struct.type<@Inner_0::@Inner_0<[]>>, @params: !pod.type<[]>]>, @idx_1: !pod.type<[@count: index, @comp: !struct.type<@Inner_1::@Inner_1<[]>>, @params: !pod.type<[]>]>]>, !pod.type<[@count: index, @comp: !struct.type<@Inner_0::@Inner_0<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:                    %[[VAL_303:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_302]][@comp] : <[@count: index, @comp: !struct.type<@Inner_0::@Inner_0<[]>>, @params: !pod.type<[]>]>, !struct.type<@Inner_0::@Inner_0<[]>>
+// CHECK-NEXT:                    %[[VAL_304:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_303]][@out] : <@Inner_0::@Inner_0<[]>>, !array.type<4 x !felt.type<"bn128">>
+// CHECK-NEXT:                    %[[VAL_305:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_285]] : !felt.type<"bn128">
+// CHECK-NEXT:                    %[[VAL_306:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_304]]{{\[}}%[[VAL_305]]] : <4 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:                    scf.yield %[[VAL_306]] : !felt.type<"bn128">
+// CHECK-NEXT:                  } else {
+// CHECK-NEXT:                    %[[VAL_307:[0-9a-zA-Z_\.]+]] = llzk.nondet : !felt.type<"bn128">
+// CHECK-NEXT:                    scf.yield %[[VAL_307]] : !felt.type<"bn128">
+// CHECK-NEXT:                  }
+// CHECK-NEXT:                  scf.yield %[[VAL_301]] : !felt.type<"bn128">
+// CHECK-NEXT:                }
+// CHECK-NEXT:                scf.yield %[[VAL_295]] : !felt.type<"bn128">
+// CHECK-NEXT:              }
+// CHECK-NEXT:              %[[VAL_308:[0-9a-zA-Z_\.]+]] = felt.const  4 : <"bn128">
+// CHECK-NEXT:              %[[VAL_309:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_279]], %[[VAL_308]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_310:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_309]], %[[VAL_285]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_311:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_310]] : !felt.type<"bn128">
+// CHECK-NEXT:              array.write %[[VAL_73]]{{\[}}%[[VAL_311]]] = %[[VAL_294]] : <8 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_312:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:              %[[VAL_313:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_285]], %[[VAL_312]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:              scf.yield %[[VAL_313]] : !felt.type<"bn128">
+// CHECK-NEXT:            }
+// CHECK-NEXT:            %[[VAL_314:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_315:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_279]], %[[VAL_314]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_315]] : !felt.type<"bn128">
+// CHECK-NEXT:          }
+// CHECK-NEXT:          struct.writem %[[VAL_71]][@inner$inputs] = %[[VAL_88]]#1 : <@Outer_2::@Outer_2<[]>>, !pod.type<[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>
+// CHECK-NEXT:          %[[VAL_316:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_74]][@idx_0] : <[@idx_0: !pod.type<[@count: index, @comp: !struct.type<@Inner_0::@Inner_0<[]>>, @params: !pod.type<[]>]>, @idx_1: !pod.type<[@count: index, @comp: !struct.type<@Inner_1::@Inner_1<[]>>, @params: !pod.type<[]>]>]>, !pod.type<[@count: index, @comp: !struct.type<@Inner_0::@Inner_0<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:          %[[VAL_317:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_316]][@comp] : <[@count: index, @comp: !struct.type<@Inner_0::@Inner_0<[]>>, @params: !pod.type<[]>]>, !struct.type<@Inner_0::@Inner_0<[]>>
+// CHECK-NEXT:          %[[VAL_318:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_74]][@idx_1] : <[@idx_0: !pod.type<[@count: index, @comp: !struct.type<@Inner_0::@Inner_0<[]>>, @params: !pod.type<[]>]>, @idx_1: !pod.type<[@count: index, @comp: !struct.type<@Inner_1::@Inner_1<[]>>, @params: !pod.type<[]>]>]>, !pod.type<[@count: index, @comp: !struct.type<@Inner_1::@Inner_1<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:          %[[VAL_319:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_318]][@comp] : <[@count: index, @comp: !struct.type<@Inner_1::@Inner_1<[]>>, @params: !pod.type<[]>]>, !struct.type<@Inner_1::@Inner_1<[]>>
+// CHECK-NEXT:          %[[VAL_320:[0-9a-zA-Z_\.]+]] = pod.new { @idx_0 = %[[VAL_317]], @idx_1 = %[[VAL_319]] }  : <[@idx_0: !struct.type<@Inner_0::@Inner_0<[]>>, @idx_1: !struct.type<@Inner_1::@Inner_1<[]>>]>
+// CHECK-NEXT:          struct.writem %[[VAL_71]][@inner] = %[[VAL_320]] : <@Outer_2::@Outer_2<[]>>, !pod.type<[@idx_0: !struct.type<@Inner_0::@Inner_0<[]>>, @idx_1: !struct.type<@Inner_1::@Inner_1<[]>>]>
+// CHECK-NEXT:          struct.writem %[[VAL_71]][@mid] = %[[VAL_72]] : <@Outer_2::@Outer_2<[]>>, !array.type<8 x !felt.type<"bn128">>
+// CHECK-NEXT:          struct.writem %[[VAL_71]][@out] = %[[VAL_73]] : <@Outer_2::@Outer_2<[]>>, !array.type<8 x !felt.type<"bn128">>
+// CHECK-NEXT:          function.return %[[VAL_71]] : !struct.type<@Outer_2::@Outer_2<[]>>
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.def @constrain(%[[VAL_321:[0-9a-zA-Z_\.]+]]: !struct.type<@Outer_2::@Outer_2<[]>>, %[[VAL_322:[0-9a-zA-Z_\.]+]]: !array.type<8 x !felt.type<"bn128">>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_323:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_321]][@out] : <@Outer_2::@Outer_2<[]>>, !array.type<8 x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_324:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_321]][@mid] : <@Outer_2::@Outer_2<[]>>, !array.type<8 x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_325:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_321]][@inner] : <@Outer_2::@Outer_2<[]>>, !pod.type<[@idx_0: !struct.type<@Inner_0::@Inner_0<[]>>, @idx_1: !struct.type<@Inner_1::@Inner_1<[]>>]>
+// CHECK-NEXT:          %[[VAL_326:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_321]][@inner$inputs] : <@Outer_2::@Outer_2<[]>>, !pod.type<[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>
+// CHECK-NEXT:          %[[VAL_327:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_328:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_329:[0-9a-zA-Z_\.]+]] = %[[VAL_327]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
+// CHECK-NEXT:            %[[VAL_330:[0-9a-zA-Z_\.]+]] = felt.const  8 : <"bn128">
+// CHECK-NEXT:            %[[VAL_331:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_329]], %[[VAL_330]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.condition(%[[VAL_331]]) %[[VAL_329]] : !felt.type<"bn128">
+// CHECK-NEXT:          } do {
+// CHECK-NEXT:          ^bb0(%[[VAL_332:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
+// CHECK-NEXT:            %[[VAL_333:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_332]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_334:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_322]]{{\[}}%[[VAL_333]]] : <8 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_335:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_332]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_336:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_324]]{{\[}}%[[VAL_335]]] : <8 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            constrain.eq %[[VAL_336]], %[[VAL_334]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_337:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_338:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_332]], %[[VAL_337]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_338]] : !felt.type<"bn128">
+// CHECK-NEXT:          }
+// CHECK-NEXT:          %[[VAL_339:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_340:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_341:[0-9a-zA-Z_\.]+]] = %[[VAL_339]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
+// CHECK-NEXT:            %[[VAL_342:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
+// CHECK-NEXT:            %[[VAL_343:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_341]], %[[VAL_342]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.condition(%[[VAL_343]]) %[[VAL_341]] : !felt.type<"bn128">
+// CHECK-NEXT:          } do {
+// CHECK-NEXT:          ^bb0(%[[VAL_344:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
+// CHECK-NEXT:            %[[VAL_345:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:            %[[VAL_346:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_347:[0-9a-zA-Z_\.]+]] = %[[VAL_345]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
+// CHECK-NEXT:              %[[VAL_348:[0-9a-zA-Z_\.]+]] = felt.const  4 : <"bn128">
+// CHECK-NEXT:              %[[VAL_349:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_347]], %[[VAL_348]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:              scf.condition(%[[VAL_349]]) %[[VAL_347]] : !felt.type<"bn128">
+// CHECK-NEXT:            } do {
+// CHECK-NEXT:            ^bb0(%[[VAL_350:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
+// CHECK-NEXT:              %[[VAL_351:[0-9a-zA-Z_\.]+]] = felt.const  4 : <"bn128">
+// CHECK-NEXT:              %[[VAL_352:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_344]], %[[VAL_351]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_353:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_352]], %[[VAL_350]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_354:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_353]] : !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_355:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_324]]{{\[}}%[[VAL_354]]] : <8 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_356:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_344]] : !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_357:[0-9a-zA-Z_\.]+]] = arith.constant true
+// CHECK-NEXT:              %[[VAL_358:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:              %[[VAL_359:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_356]], %[[VAL_358]] : index
+// CHECK-NEXT:              %[[VAL_360:[0-9a-zA-Z_\.]+]] = bool.and %[[VAL_357]], %[[VAL_359]] : i1, i1
+// CHECK-NEXT:              %[[VAL_361:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:              %[[VAL_362:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_356]], %[[VAL_361]] : index
+// CHECK-NEXT:              %[[VAL_363:[0-9a-zA-Z_\.]+]] = bool.and %[[VAL_357]], %[[VAL_362]] : i1, i1
+// CHECK-NEXT:              scf.execute_region {
+// CHECK-NEXT:                scf.if %[[VAL_363]] {
+// CHECK-NEXT:                  %[[VAL_364:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_326]][@idx_1] : <[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>, !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                  %[[VAL_365:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_364]][@in] : <[@in: !array.type<4 x !felt.type<"bn128">>]>, !array.type<4 x !felt.type<"bn128">>
+// CHECK-NEXT:                  %[[VAL_366:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_350]] : !felt.type<"bn128">
+// CHECK-NEXT:                  %[[VAL_367:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_365]]{{\[}}%[[VAL_366]]] : <4 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:                  constrain.eq %[[VAL_367]], %[[VAL_355]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:                } else {
+// CHECK-NEXT:                  scf.if %[[VAL_360]] {
+// CHECK-NEXT:                    %[[VAL_368:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_326]][@idx_0] : <[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>, !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>
+// CHECK-NEXT:                    %[[VAL_369:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_368]][@in] : <[@in: !array.type<4 x !felt.type<"bn128">>]>, !array.type<4 x !felt.type<"bn128">>
+// CHECK-NEXT:                    %[[VAL_370:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_350]] : !felt.type<"bn128">
+// CHECK-NEXT:                    %[[VAL_371:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_369]]{{\[}}%[[VAL_370]]] : <4 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:                    constrain.eq %[[VAL_371]], %[[VAL_355]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:                  } else {
+// CHECK-NEXT:                  }
+// CHECK-NEXT:                }
+// CHECK-NEXT:                scf.yield
+// CHECK-NEXT:              }
+// CHECK-NEXT:              %[[VAL_372:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:              %[[VAL_373:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_350]], %[[VAL_372]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:              scf.yield %[[VAL_373]] : !felt.type<"bn128">
+// CHECK-NEXT:            }
+// CHECK-NEXT:            %[[VAL_374:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_375:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_344]], %[[VAL_374]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_375]] : !felt.type<"bn128">
+// CHECK-NEXT:          }
+// CHECK-NEXT:          %[[VAL_376:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_377:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_378:[0-9a-zA-Z_\.]+]] = %[[VAL_376]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
+// CHECK-NEXT:            %[[VAL_379:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
+// CHECK-NEXT:            %[[VAL_380:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_378]], %[[VAL_379]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.condition(%[[VAL_380]]) %[[VAL_378]] : !felt.type<"bn128">
+// CHECK-NEXT:          } do {
+// CHECK-NEXT:          ^bb0(%[[VAL_381:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
+// CHECK-NEXT:            %[[VAL_382:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:            %[[VAL_383:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_384:[0-9a-zA-Z_\.]+]] = %[[VAL_382]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
+// CHECK-NEXT:              %[[VAL_385:[0-9a-zA-Z_\.]+]] = felt.const  4 : <"bn128">
+// CHECK-NEXT:              %[[VAL_386:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_384]], %[[VAL_385]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:              scf.condition(%[[VAL_386]]) %[[VAL_384]] : !felt.type<"bn128">
+// CHECK-NEXT:            } do {
+// CHECK-NEXT:            ^bb0(%[[VAL_387:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
+// CHECK-NEXT:              %[[VAL_388:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_381]] : !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_389:[0-9a-zA-Z_\.]+]] = arith.constant true
+// CHECK-NEXT:              %[[VAL_390:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:              %[[VAL_391:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_388]], %[[VAL_390]] : index
+// CHECK-NEXT:              %[[VAL_392:[0-9a-zA-Z_\.]+]] = bool.and %[[VAL_389]], %[[VAL_391]] : i1, i1
+// CHECK-NEXT:              %[[VAL_393:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:              %[[VAL_394:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_388]], %[[VAL_393]] : index
+// CHECK-NEXT:              %[[VAL_395:[0-9a-zA-Z_\.]+]] = bool.and %[[VAL_389]], %[[VAL_394]] : i1, i1
+// CHECK-NEXT:              %[[VAL_396:[0-9a-zA-Z_\.]+]] = scf.execute_region -> !felt.type<"bn128"> {
+// CHECK-NEXT:                %[[VAL_397:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_395]] -> (!felt.type<"bn128">) {
+// CHECK-NEXT:                  %[[VAL_398:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_325]][@idx_1] : <[@idx_0: !struct.type<@Inner_0::@Inner_0<[]>>, @idx_1: !struct.type<@Inner_1::@Inner_1<[]>>]>, !struct.type<@Inner_1::@Inner_1<[]>>
+// CHECK-NEXT:                  %[[VAL_399:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_398]][@out] : <@Inner_1::@Inner_1<[]>>, !array.type<4 x !felt.type<"bn128">>
+// CHECK-NEXT:                  %[[VAL_400:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_387]] : !felt.type<"bn128">
+// CHECK-NEXT:                  %[[VAL_401:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_399]]{{\[}}%[[VAL_400]]] : <4 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:                  scf.yield %[[VAL_401]] : !felt.type<"bn128">
+// CHECK-NEXT:                } else {
+// CHECK-NEXT:                  %[[VAL_402:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_392]] -> (!felt.type<"bn128">) {
+// CHECK-NEXT:                    %[[VAL_403:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_325]][@idx_0] : <[@idx_0: !struct.type<@Inner_0::@Inner_0<[]>>, @idx_1: !struct.type<@Inner_1::@Inner_1<[]>>]>, !struct.type<@Inner_0::@Inner_0<[]>>
+// CHECK-NEXT:                    %[[VAL_404:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_403]][@out] : <@Inner_0::@Inner_0<[]>>, !array.type<4 x !felt.type<"bn128">>
+// CHECK-NEXT:                    %[[VAL_405:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_387]] : !felt.type<"bn128">
+// CHECK-NEXT:                    %[[VAL_406:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_404]]{{\[}}%[[VAL_405]]] : <4 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:                    scf.yield %[[VAL_406]] : !felt.type<"bn128">
+// CHECK-NEXT:                  } else {
+// CHECK-NEXT:                    %[[VAL_407:[0-9a-zA-Z_\.]+]] = llzk.nondet : !felt.type<"bn128">
+// CHECK-NEXT:                    scf.yield %[[VAL_407]] : !felt.type<"bn128">
+// CHECK-NEXT:                  }
+// CHECK-NEXT:                  scf.yield %[[VAL_402]] : !felt.type<"bn128">
+// CHECK-NEXT:                }
+// CHECK-NEXT:                scf.yield %[[VAL_397]] : !felt.type<"bn128">
+// CHECK-NEXT:              }
+// CHECK-NEXT:              %[[VAL_408:[0-9a-zA-Z_\.]+]] = felt.const  4 : <"bn128">
+// CHECK-NEXT:              %[[VAL_409:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_381]], %[[VAL_408]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_410:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_409]], %[[VAL_387]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_411:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_410]] : !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_412:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_323]]{{\[}}%[[VAL_411]]] : <8 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:              constrain.eq %[[VAL_412]], %[[VAL_396]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_413:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:              %[[VAL_414:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_387]], %[[VAL_413]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:              scf.yield %[[VAL_414]] : !felt.type<"bn128">
+// CHECK-NEXT:            }
+// CHECK-NEXT:            %[[VAL_415:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_416:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_381]], %[[VAL_415]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_416]] : !felt.type<"bn128">
+// CHECK-NEXT:          }
+// CHECK-NEXT:          %[[VAL_417:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_325]][@idx_0] : <[@idx_0: !struct.type<@Inner_0::@Inner_0<[]>>, @idx_1: !struct.type<@Inner_1::@Inner_1<[]>>]>, !struct.type<@Inner_0::@Inner_0<[]>>
+// CHECK-NEXT:          %[[VAL_418:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_326]][@idx_0] : <[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>, !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>
+// CHECK-NEXT:          %[[VAL_419:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_418]][@in] : <[@in: !array.type<4 x !felt.type<"bn128">>]>, !array.type<4 x !felt.type<"bn128">>
+// CHECK-NEXT:          function.call @Inner_0::@Inner_0::@constrain(%[[VAL_417]], %[[VAL_419]]) : (!struct.type<@Inner_0::@Inner_0<[]>>, !array.type<4 x !felt.type<"bn128">>) -> ()
+// CHECK-NEXT:          %[[VAL_420:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_325]][@idx_1] : <[@idx_0: !struct.type<@Inner_0::@Inner_0<[]>>, @idx_1: !struct.type<@Inner_1::@Inner_1<[]>>]>, !struct.type<@Inner_1::@Inner_1<[]>>
+// CHECK-NEXT:          %[[VAL_421:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_326]][@idx_1] : <[@idx_0: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>, @idx_1: !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>]>, !pod.type<[@in: !array.type<4 x !felt.type<"bn128">>]>
+// CHECK-NEXT:          %[[VAL_422:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_421]][@in] : <[@in: !array.type<4 x !felt.type<"bn128">>]>, !array.type<4 x !felt.type<"bn128">>
+// CHECK-NEXT:          function.call @Inner_1::@Inner_1::@constrain(%[[VAL_420]], %[[VAL_422]]) : (!struct.type<@Inner_1::@Inner_1<[]>>, !array.type<4 x !felt.type<"bn128">>) -> ()
+// CHECK-NEXT:          function.return
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/from_concrete/conflicting_types_array_read.circom
+++ b/circom/tests/from_concrete/conflicting_types_array_read.circom
@@ -1,7 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --stabilize --llzk=concrete --llzk_plaintext -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL: *
 
 pragma circom 2.0.0;
 

--- a/circom/tests/from_concrete/conflicting_types_array_read.circom
+++ b/circom/tests/from_concrete/conflicting_types_array_read.circom
@@ -1,0 +1,42 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --stabilize --llzk=concrete --llzk_plaintext -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
+// XFAIL: *
+
+pragma circom 2.0.0;
+
+template Inner(P) {
+    signal input in[4];
+    signal output out[4];
+    for (var k = 0; k < 4; k++) {
+        out[k] <== in[k] + P;
+    }
+}
+
+template Outer() {
+    signal input in[8];
+    signal output out[8];
+
+    component inner[2];
+    signal mid[2 * 4];
+
+    for (var i = 0; i < 8; i++) {
+        mid[i] <== in[i];
+    }
+
+    for (var i = 0; i < 2; i++) {
+        inner[i] = Inner(i);
+        for (var k = 0; k < 4; k++) {
+            // Failed to generate LLZK IR: Conflicting types to read array at loc("conflicting_types_array_read.circom":31:13)
+            inner[i].in[k] <== mid[i * 4 + k];
+        }
+    }
+
+    for (var i = 0; i < 2; i++) {
+        for (var k = 0; k < 4; k++) {
+            out[i * 4 + k] <== inner[i].out[k];
+        }
+    }
+}
+
+component main = Outer();

--- a/circom/tests/loops/assign_in_loop_01.circom
+++ b/circom/tests/loops/assign_in_loop_01.circom
@@ -72,69 +72,71 @@ component main = Num2Bits(3);
 // CHECK-NEXT:            array.write %[[VAL_18]]{{\[}}%[[VAL_26]]] = %[[VAL_25]] : <@n x !pod.type<[@in: !felt.type<"bn128">]>>, !pod.type<[@in: !felt.type<"bn128">]>
 // CHECK-NEXT:            %[[VAL_27:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_19]] : !felt.type<"bn128">
 // CHECK-NEXT:            %[[VAL_28:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_11]]{{\[}}%[[VAL_27]]] : <@n x !pod.type<[@count: index, @comp: !struct.type<@Inner::@Inner<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Inner::@Inner<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:            %[[VAL_29:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_28]][@count] : <[@count: index, @comp: !struct.type<@Inner::@Inner<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:            %[[VAL_30:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:            %[[VAL_31:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_29]], %[[VAL_30]] : index
-// CHECK-NEXT:            pod.write %[[VAL_28]][@count] = %[[VAL_31]] : <[@count: index, @comp: !struct.type<@Inner::@Inner<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:            %[[VAL_32:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:            %[[VAL_33:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_31]], %[[VAL_32]] : index
-// CHECK-NEXT:            scf.if %[[VAL_33]] {
-// CHECK-NEXT:              %[[VAL_34:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_28]][@params] : <[@count: index, @comp: !struct.type<@Inner::@Inner<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
-// CHECK-NEXT:              %[[VAL_35:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_25]][@in] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_36:[0-9a-zA-Z_\.]+]] = function.call @Inner::@Inner::@compute(%[[VAL_35]]) : (!felt.type<"bn128">) -> !struct.type<@Inner::@Inner<[]>>
-// CHECK-NEXT:              pod.write %[[VAL_28]][@comp] = %[[VAL_36]] : <[@count: index, @comp: !struct.type<@Inner::@Inner<[]>>, @params: !pod.type<[]>]>, !struct.type<@Inner::@Inner<[]>>
-// CHECK-NEXT:              %[[VAL_37:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_19]] : !felt.type<"bn128">
-// CHECK-NEXT:              array.write %[[VAL_11]]{{\[}}%[[VAL_37]]] = %[[VAL_28]] : <@n x !pod.type<[@count: index, @comp: !struct.type<@Inner::@Inner<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Inner::@Inner<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:            %[[VAL_29:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_19]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_30:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_18]]{{\[}}%[[VAL_29]]] : <@n x !pod.type<[@in: !felt.type<"bn128">]>>, !pod.type<[@in: !felt.type<"bn128">]>
+// CHECK-NEXT:            %[[VAL_31:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_28]][@count] : <[@count: index, @comp: !struct.type<@Inner::@Inner<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:            %[[VAL_32:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:            %[[VAL_33:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_31]], %[[VAL_32]] : index
+// CHECK-NEXT:            pod.write %[[VAL_28]][@count] = %[[VAL_33]] : <[@count: index, @comp: !struct.type<@Inner::@Inner<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:            %[[VAL_34:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:            %[[VAL_35:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_33]], %[[VAL_34]] : index
+// CHECK-NEXT:            scf.if %[[VAL_35]] {
+// CHECK-NEXT:              %[[VAL_36:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_28]][@params] : <[@count: index, @comp: !struct.type<@Inner::@Inner<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
+// CHECK-NEXT:              %[[VAL_37:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_30]][@in] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_38:[0-9a-zA-Z_\.]+]] = function.call @Inner::@Inner::@compute(%[[VAL_37]]) : (!felt.type<"bn128">) -> !struct.type<@Inner::@Inner<[]>>
+// CHECK-NEXT:              pod.write %[[VAL_28]][@comp] = %[[VAL_38]] : <[@count: index, @comp: !struct.type<@Inner::@Inner<[]>>, @params: !pod.type<[]>]>, !struct.type<@Inner::@Inner<[]>>
+// CHECK-NEXT:              %[[VAL_39:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_19]] : !felt.type<"bn128">
+// CHECK-NEXT:              array.write %[[VAL_11]]{{\[}}%[[VAL_39]]] = %[[VAL_28]] : <@n x !pod.type<[@count: index, @comp: !struct.type<@Inner::@Inner<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Inner::@Inner<[]>>, @params: !pod.type<[]>]>
 // CHECK-NEXT:            }
-// CHECK-NEXT:            %[[VAL_38:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_19]] : !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_39:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_11]]{{\[}}%[[VAL_38]]] : <@n x !pod.type<[@count: index, @comp: !struct.type<@Inner::@Inner<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Inner::@Inner<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:            %[[VAL_40:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_39]][@comp] : <[@count: index, @comp: !struct.type<@Inner::@Inner<[]>>, @params: !pod.type<[]>]>, !struct.type<@Inner::@Inner<[]>>
-// CHECK-NEXT:            %[[VAL_41:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_40]][@out] : <@Inner::@Inner<[]>>, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_42:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_19]] : !felt.type<"bn128">
-// CHECK-NEXT:            array.write %[[VAL_10]]{{\[}}%[[VAL_42]]] = %[[VAL_41]] : <@n x !felt.type<"bn128">>, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_43:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_44:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_19]], %[[VAL_43]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            scf.yield %[[VAL_18]], %[[VAL_44]] : !array.type<@n x !pod.type<[@in: !felt.type<"bn128">]>>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_40:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_19]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_41:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_11]]{{\[}}%[[VAL_40]]] : <@n x !pod.type<[@count: index, @comp: !struct.type<@Inner::@Inner<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Inner::@Inner<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:            %[[VAL_42:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_41]][@comp] : <[@count: index, @comp: !struct.type<@Inner::@Inner<[]>>, @params: !pod.type<[]>]>, !struct.type<@Inner::@Inner<[]>>
+// CHECK-NEXT:            %[[VAL_43:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_42]][@out] : <@Inner::@Inner<[]>>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_44:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_19]] : !felt.type<"bn128">
+// CHECK-NEXT:            array.write %[[VAL_10]]{{\[}}%[[VAL_44]]] = %[[VAL_43]] : <@n x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_45:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_46:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_19]], %[[VAL_45]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_18]], %[[VAL_46]] : !array.type<@n x !pod.type<[@in: !felt.type<"bn128">]>>, !felt.type<"bn128">
 // CHECK-NEXT:          }
 // CHECK-NEXT:          struct.writem %[[VAL_8]][@c$inputs] = %[[VAL_14]]#0 : <@Num2Bits::@Num2Bits<[@n]>>, !array.type<@n x !pod.type<[@in: !felt.type<"bn128">]>>
-// CHECK-NEXT:          %[[VAL_45:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !struct.type<@Inner::@Inner<[]>>>
-// CHECK-NEXT:          %[[VAL_46:[0-9a-zA-Z_\.]+]] = poly.read_const @n : index
-// CHECK-NEXT:          %[[VAL_47:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[VAL_48:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:          scf.for %[[VAL_49:[0-9a-zA-Z_\.]+]] = %[[VAL_47]] to %[[VAL_46]] step %[[VAL_48]] {
-// CHECK-NEXT:            %[[VAL_50:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_11]]{{\[}}%[[VAL_49]]] : <@n x !pod.type<[@count: index, @comp: !struct.type<@Inner::@Inner<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Inner::@Inner<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:            %[[VAL_51:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_50]][@comp] : <[@count: index, @comp: !struct.type<@Inner::@Inner<[]>>, @params: !pod.type<[]>]>, !struct.type<@Inner::@Inner<[]>>
-// CHECK-NEXT:            array.write %[[VAL_45]]{{\[}}%[[VAL_49]]] = %[[VAL_51]] : <@n x !struct.type<@Inner::@Inner<[]>>>, !struct.type<@Inner::@Inner<[]>>
+// CHECK-NEXT:          %[[VAL_47:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !struct.type<@Inner::@Inner<[]>>>
+// CHECK-NEXT:          %[[VAL_48:[0-9a-zA-Z_\.]+]] = poly.read_const @n : index
+// CHECK-NEXT:          %[[VAL_49:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_50:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          scf.for %[[VAL_51:[0-9a-zA-Z_\.]+]] = %[[VAL_49]] to %[[VAL_48]] step %[[VAL_50]] {
+// CHECK-NEXT:            %[[VAL_52:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_11]]{{\[}}%[[VAL_51]]] : <@n x !pod.type<[@count: index, @comp: !struct.type<@Inner::@Inner<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Inner::@Inner<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:            %[[VAL_53:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_52]][@comp] : <[@count: index, @comp: !struct.type<@Inner::@Inner<[]>>, @params: !pod.type<[]>]>, !struct.type<@Inner::@Inner<[]>>
+// CHECK-NEXT:            array.write %[[VAL_47]]{{\[}}%[[VAL_51]]] = %[[VAL_53]] : <@n x !struct.type<@Inner::@Inner<[]>>>, !struct.type<@Inner::@Inner<[]>>
 // CHECK-NEXT:          }
-// CHECK-NEXT:          struct.writem %[[VAL_8]][@c] = %[[VAL_45]] : <@Num2Bits::@Num2Bits<[@n]>>, !array.type<@n x !struct.type<@Inner::@Inner<[]>>>
+// CHECK-NEXT:          struct.writem %[[VAL_8]][@c] = %[[VAL_47]] : <@Num2Bits::@Num2Bits<[@n]>>, !array.type<@n x !struct.type<@Inner::@Inner<[]>>>
 // CHECK-NEXT:          struct.writem %[[VAL_8]][@out] = %[[VAL_10]] : <@Num2Bits::@Num2Bits<[@n]>>, !array.type<@n x !felt.type<"bn128">>
 // CHECK-NEXT:          function.return %[[VAL_8]] : !struct.type<@Num2Bits::@Num2Bits<[@n]>>
 // CHECK-NEXT:        }
-// CHECK-NEXT:        function.def @constrain(%[[VAL_52:[0-9a-zA-Z_\.]+]]: !struct.type<@Num2Bits::@Num2Bits<[@n]>>, %[[VAL_53:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:          %[[VAL_54:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_55:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_52]][@out] : <@Num2Bits::@Num2Bits<[@n]>>, !array.type<@n x !felt.type<"bn128">>
-// CHECK-NEXT:          %[[VAL_56:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_52]][@c] : <@Num2Bits::@Num2Bits<[@n]>>, !array.type<@n x !struct.type<@Inner::@Inner<[]>>>
-// CHECK-NEXT:          %[[VAL_57:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_52]][@c$inputs] : <@Num2Bits::@Num2Bits<[@n]>>, !array.type<@n x !pod.type<[@in: !felt.type<"bn128">]>>
-// CHECK-NEXT:          %[[VAL_58:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:          %[[VAL_59:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_60:[0-9a-zA-Z_\.]+]] = %[[VAL_58]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
-// CHECK-NEXT:            %[[VAL_61:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_60]], %[[VAL_54]]) : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            scf.condition(%[[VAL_61]]) %[[VAL_60]] : !felt.type<"bn128">
+// CHECK-NEXT:        function.def @constrain(%[[VAL_54:[0-9a-zA-Z_\.]+]]: !struct.type<@Num2Bits::@Num2Bits<[@n]>>, %[[VAL_55:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_56:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_57:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_54]][@out] : <@Num2Bits::@Num2Bits<[@n]>>, !array.type<@n x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_58:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_54]][@c] : <@Num2Bits::@Num2Bits<[@n]>>, !array.type<@n x !struct.type<@Inner::@Inner<[]>>>
+// CHECK-NEXT:          %[[VAL_59:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_54]][@c$inputs] : <@Num2Bits::@Num2Bits<[@n]>>, !array.type<@n x !pod.type<[@in: !felt.type<"bn128">]>>
+// CHECK-NEXT:          %[[VAL_60:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_61:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_62:[0-9a-zA-Z_\.]+]] = %[[VAL_60]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
+// CHECK-NEXT:            %[[VAL_63:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_62]], %[[VAL_56]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.condition(%[[VAL_63]]) %[[VAL_62]] : !felt.type<"bn128">
 // CHECK-NEXT:          } do {
-// CHECK-NEXT:          ^bb0(%[[VAL_62:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
-// CHECK-NEXT:            %[[VAL_63:[0-9a-zA-Z_\.]+]] = pod.new : <[]>
-// CHECK-NEXT:            %[[VAL_64:[0-9a-zA-Z_\.]+]] = pod.new : <[@count: index, @comp: !struct.type<@Inner::@Inner<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:            %[[VAL_65:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_66:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_62]], %[[VAL_65]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            scf.yield %[[VAL_66]] : !felt.type<"bn128">
+// CHECK-NEXT:          ^bb0(%[[VAL_64:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
+// CHECK-NEXT:            %[[VAL_65:[0-9a-zA-Z_\.]+]] = pod.new : <[]>
+// CHECK-NEXT:            %[[VAL_66:[0-9a-zA-Z_\.]+]] = pod.new : <[@count: index, @comp: !struct.type<@Inner::@Inner<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:            %[[VAL_67:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_68:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_64]], %[[VAL_67]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_68]] : !felt.type<"bn128">
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[VAL_67:[0-9a-zA-Z_\.]+]] = poly.read_const @n : index
-// CHECK-NEXT:          %[[VAL_68:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[VAL_69:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:          scf.for %[[VAL_70:[0-9a-zA-Z_\.]+]] = %[[VAL_68]] to %[[VAL_67]] step %[[VAL_69]] {
-// CHECK-NEXT:            %[[VAL_71:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_56]]{{\[}}%[[VAL_70]]] : <@n x !struct.type<@Inner::@Inner<[]>>>, !struct.type<@Inner::@Inner<[]>>
-// CHECK-NEXT:            %[[VAL_72:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_57]]{{\[}}%[[VAL_70]]] : <@n x !pod.type<[@in: !felt.type<"bn128">]>>, !pod.type<[@in: !felt.type<"bn128">]>
-// CHECK-NEXT:            %[[VAL_73:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_72]][@in] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:            function.call @Inner::@Inner::@constrain(%[[VAL_71]], %[[VAL_73]]) : (!struct.type<@Inner::@Inner<[]>>, !felt.type<"bn128">) -> ()
+// CHECK-NEXT:          %[[VAL_69:[0-9a-zA-Z_\.]+]] = poly.read_const @n : index
+// CHECK-NEXT:          %[[VAL_70:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_71:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          scf.for %[[VAL_72:[0-9a-zA-Z_\.]+]] = %[[VAL_70]] to %[[VAL_69]] step %[[VAL_71]] {
+// CHECK-NEXT:            %[[VAL_73:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_58]]{{\[}}%[[VAL_72]]] : <@n x !struct.type<@Inner::@Inner<[]>>>, !struct.type<@Inner::@Inner<[]>>
+// CHECK-NEXT:            %[[VAL_74:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_59]]{{\[}}%[[VAL_72]]] : <@n x !pod.type<[@in: !felt.type<"bn128">]>>, !pod.type<[@in: !felt.type<"bn128">]>
+// CHECK-NEXT:            %[[VAL_75:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_74]][@in] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:            function.call @Inner::@Inner::@constrain(%[[VAL_73]], %[[VAL_75]]) : (!struct.type<@Inner::@Inner<[]>>, !felt.type<"bn128">) -> ()
 // CHECK-NEXT:          }
 // CHECK-NEXT:          function.return
 // CHECK-NEXT:        }

--- a/circom/tests/loops/inner_conditional_10.circom
+++ b/circom/tests/loops/inner_conditional_10.circom
@@ -67,86 +67,88 @@ component main = Poseidon();
 // CHECK-NEXT:              array.write %[[VAL_11]]{{\[}}%[[VAL_29]]] = %[[VAL_28]] : <2 x !pod.type<[@inp: !felt.type<"bn128">]>>, !pod.type<[@inp: !felt.type<"bn128">]>
 // CHECK-NEXT:              %[[VAL_30:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_20]] : !felt.type<"bn128">
 // CHECK-NEXT:              %[[VAL_31:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_2]]{{\[}}%[[VAL_30]]] : <2 x !pod.type<[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:              %[[VAL_32:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_31]][@count] : <[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:              %[[VAL_33:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:              %[[VAL_34:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_32]], %[[VAL_33]] : index
-// CHECK-NEXT:              pod.write %[[VAL_31]][@count] = %[[VAL_34]] : <[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:              %[[VAL_35:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:              %[[VAL_36:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_34]], %[[VAL_35]] : index
-// CHECK-NEXT:              scf.if %[[VAL_36]] {
-// CHECK-NEXT:                %[[VAL_37:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_31]][@params] : <[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
-// CHECK-NEXT:                %[[VAL_38:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_28]][@inp] : <[@inp: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_39:[0-9a-zA-Z_\.]+]] = function.call @Sigma::@Sigma::@compute(%[[VAL_38]]) : (!felt.type<"bn128">) -> !struct.type<@Sigma::@Sigma<[]>>
-// CHECK-NEXT:                pod.write %[[VAL_31]][@comp] = %[[VAL_39]] : <[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>, !struct.type<@Sigma::@Sigma<[]>>
-// CHECK-NEXT:                %[[VAL_40:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_20]] : !felt.type<"bn128">
-// CHECK-NEXT:                array.write %[[VAL_2]]{{\[}}%[[VAL_40]]] = %[[VAL_31]] : <2 x !pod.type<[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:              %[[VAL_32:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_20]] : !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_33:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_11]]{{\[}}%[[VAL_32]]] : <2 x !pod.type<[@inp: !felt.type<"bn128">]>>, !pod.type<[@inp: !felt.type<"bn128">]>
+// CHECK-NEXT:              %[[VAL_34:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_31]][@count] : <[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:              %[[VAL_35:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:              %[[VAL_36:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_34]], %[[VAL_35]] : index
+// CHECK-NEXT:              pod.write %[[VAL_31]][@count] = %[[VAL_36]] : <[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:              %[[VAL_37:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:              %[[VAL_38:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_36]], %[[VAL_37]] : index
+// CHECK-NEXT:              scf.if %[[VAL_38]] {
+// CHECK-NEXT:                %[[VAL_39:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_31]][@params] : <[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
+// CHECK-NEXT:                %[[VAL_40:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_33]][@inp] : <[@inp: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_41:[0-9a-zA-Z_\.]+]] = function.call @Sigma::@Sigma::@compute(%[[VAL_40]]) : (!felt.type<"bn128">) -> !struct.type<@Sigma::@Sigma<[]>>
+// CHECK-NEXT:                pod.write %[[VAL_31]][@comp] = %[[VAL_41]] : <[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>, !struct.type<@Sigma::@Sigma<[]>>
+// CHECK-NEXT:                %[[VAL_42:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_20]] : !felt.type<"bn128">
+// CHECK-NEXT:                array.write %[[VAL_2]]{{\[}}%[[VAL_42]]] = %[[VAL_31]] : <2 x !pod.type<[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>
 // CHECK-NEXT:              }
 // CHECK-NEXT:              scf.yield %[[VAL_11]] : !array.type<2 x !pod.type<[@inp: !felt.type<"bn128">]>>
 // CHECK-NEXT:            } else {
 // CHECK-NEXT:              scf.yield %[[VAL_11]] : !array.type<2 x !pod.type<[@inp: !felt.type<"bn128">]>>
 // CHECK-NEXT:            }
-// CHECK-NEXT:            %[[VAL_41:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_42:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_10]], %[[VAL_41]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            scf.yield %[[VAL_42]], %[[VAL_17]] : !felt.type<"bn128">, !array.type<2 x !pod.type<[@inp: !felt.type<"bn128">]>>
+// CHECK-NEXT:            %[[VAL_43:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_44:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_10]], %[[VAL_43]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_44]], %[[VAL_17]] : !felt.type<"bn128">, !array.type<2 x !pod.type<[@inp: !felt.type<"bn128">]>>
 // CHECK-NEXT:          }
 // CHECK-NEXT:          struct.writem %[[VAL_1]][@sigmaF$inputs] = %[[VAL_5]]#1 : <@Poseidon::@Poseidon<[]>>, !array.type<2 x !pod.type<[@inp: !felt.type<"bn128">]>>
-// CHECK-NEXT:          %[[VAL_43:[0-9a-zA-Z_\.]+]] = array.new  : <2 x !struct.type<@Sigma::@Sigma<[]>>>
-// CHECK-NEXT:          %[[VAL_44:[0-9a-zA-Z_\.]+]] = arith.constant 2 : index
-// CHECK-NEXT:          %[[VAL_45:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[VAL_46:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:          scf.for %[[VAL_47:[0-9a-zA-Z_\.]+]] = %[[VAL_45]] to %[[VAL_44]] step %[[VAL_46]] {
-// CHECK-NEXT:            %[[VAL_48:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_2]]{{\[}}%[[VAL_47]]] : <2 x !pod.type<[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:            %[[VAL_49:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_48]][@comp] : <[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>, !struct.type<@Sigma::@Sigma<[]>>
-// CHECK-NEXT:            array.write %[[VAL_43]]{{\[}}%[[VAL_47]]] = %[[VAL_49]] : <2 x !struct.type<@Sigma::@Sigma<[]>>>, !struct.type<@Sigma::@Sigma<[]>>
+// CHECK-NEXT:          %[[VAL_45:[0-9a-zA-Z_\.]+]] = array.new  : <2 x !struct.type<@Sigma::@Sigma<[]>>>
+// CHECK-NEXT:          %[[VAL_46:[0-9a-zA-Z_\.]+]] = arith.constant 2 : index
+// CHECK-NEXT:          %[[VAL_47:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_48:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          scf.for %[[VAL_49:[0-9a-zA-Z_\.]+]] = %[[VAL_47]] to %[[VAL_46]] step %[[VAL_48]] {
+// CHECK-NEXT:            %[[VAL_50:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_2]]{{\[}}%[[VAL_49]]] : <2 x !pod.type<[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:            %[[VAL_51:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_50]][@comp] : <[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>, !struct.type<@Sigma::@Sigma<[]>>
+// CHECK-NEXT:            array.write %[[VAL_45]]{{\[}}%[[VAL_49]]] = %[[VAL_51]] : <2 x !struct.type<@Sigma::@Sigma<[]>>>, !struct.type<@Sigma::@Sigma<[]>>
 // CHECK-NEXT:          }
-// CHECK-NEXT:          struct.writem %[[VAL_1]][@sigmaF] = %[[VAL_43]] : <@Poseidon::@Poseidon<[]>>, !array.type<2 x !struct.type<@Sigma::@Sigma<[]>>>
+// CHECK-NEXT:          struct.writem %[[VAL_1]][@sigmaF] = %[[VAL_45]] : <@Poseidon::@Poseidon<[]>>, !array.type<2 x !struct.type<@Sigma::@Sigma<[]>>>
 // CHECK-NEXT:          function.return %[[VAL_1]] : !struct.type<@Poseidon::@Poseidon<[]>>
 // CHECK-NEXT:        }
-// CHECK-NEXT:        function.def @constrain(%[[VAL_50:[0-9a-zA-Z_\.]+]]: !struct.type<@Poseidon::@Poseidon<[]>>, %[[VAL_51:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:          %[[VAL_52:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_50]][@sigmaF] : <@Poseidon::@Poseidon<[]>>, !array.type<2 x !struct.type<@Sigma::@Sigma<[]>>>
-// CHECK-NEXT:          %[[VAL_53:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_50]][@sigmaF$inputs] : <@Poseidon::@Poseidon<[]>>, !array.type<2 x !pod.type<[@inp: !felt.type<"bn128">]>>
-// CHECK-NEXT:          %[[VAL_54:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:          %[[VAL_55:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_56:[0-9a-zA-Z_\.]+]] = %[[VAL_54]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
-// CHECK-NEXT:            %[[VAL_57:[0-9a-zA-Z_\.]+]] = felt.const  4 : <"bn128">
-// CHECK-NEXT:            %[[VAL_58:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_56]], %[[VAL_57]]) : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            scf.condition(%[[VAL_58]]) %[[VAL_56]] : !felt.type<"bn128">
+// CHECK-NEXT:        function.def @constrain(%[[VAL_52:[0-9a-zA-Z_\.]+]]: !struct.type<@Poseidon::@Poseidon<[]>>, %[[VAL_53:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_54:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_52]][@sigmaF] : <@Poseidon::@Poseidon<[]>>, !array.type<2 x !struct.type<@Sigma::@Sigma<[]>>>
+// CHECK-NEXT:          %[[VAL_55:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_52]][@sigmaF$inputs] : <@Poseidon::@Poseidon<[]>>, !array.type<2 x !pod.type<[@inp: !felt.type<"bn128">]>>
+// CHECK-NEXT:          %[[VAL_56:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_57:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_58:[0-9a-zA-Z_\.]+]] = %[[VAL_56]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
+// CHECK-NEXT:            %[[VAL_59:[0-9a-zA-Z_\.]+]] = felt.const  4 : <"bn128">
+// CHECK-NEXT:            %[[VAL_60:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_58]], %[[VAL_59]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.condition(%[[VAL_60]]) %[[VAL_58]] : !felt.type<"bn128">
 // CHECK-NEXT:          } do {
-// CHECK-NEXT:          ^bb0(%[[VAL_59:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
-// CHECK-NEXT:            %[[VAL_60:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_61:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_59]], %[[VAL_60]]) : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_62:[0-9a-zA-Z_\.]+]] = felt.const  3 : <"bn128">
-// CHECK-NEXT:            %[[VAL_63:[0-9a-zA-Z_\.]+]] = bool.cmp ge(%[[VAL_59]], %[[VAL_62]]) : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_64:[0-9a-zA-Z_\.]+]] = bool.or %[[VAL_61]], %[[VAL_63]] : i1, i1
-// CHECK-NEXT:            scf.if %[[VAL_64]] {
-// CHECK-NEXT:              %[[VAL_65:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:              %[[VAL_66:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_59]], %[[VAL_65]]) : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_67:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_66]] -> (!felt.type<"bn128">) {
-// CHECK-NEXT:                %[[VAL_68:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:                scf.yield %[[VAL_68]] : !felt.type<"bn128">
+// CHECK-NEXT:          ^bb0(%[[VAL_61:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
+// CHECK-NEXT:            %[[VAL_62:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_63:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_61]], %[[VAL_62]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_64:[0-9a-zA-Z_\.]+]] = felt.const  3 : <"bn128">
+// CHECK-NEXT:            %[[VAL_65:[0-9a-zA-Z_\.]+]] = bool.cmp ge(%[[VAL_61]], %[[VAL_64]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_66:[0-9a-zA-Z_\.]+]] = bool.or %[[VAL_63]], %[[VAL_65]] : i1, i1
+// CHECK-NEXT:            scf.if %[[VAL_66]] {
+// CHECK-NEXT:              %[[VAL_67:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:              %[[VAL_68:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_61]], %[[VAL_67]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_69:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_68]] -> (!felt.type<"bn128">) {
+// CHECK-NEXT:                %[[VAL_70:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:                scf.yield %[[VAL_70]] : !felt.type<"bn128">
 // CHECK-NEXT:              } else {
-// CHECK-NEXT:                %[[VAL_69:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:                scf.yield %[[VAL_69]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_71:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:                scf.yield %[[VAL_71]] : !felt.type<"bn128">
 // CHECK-NEXT:              }
-// CHECK-NEXT:              %[[VAL_70:[0-9a-zA-Z_\.]+]] = pod.new : <[]>
-// CHECK-NEXT:              %[[VAL_71:[0-9a-zA-Z_\.]+]] = pod.new : <[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:              %[[VAL_72:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_67]] : !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_73:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_53]]{{\[}}%[[VAL_72]]] : <2 x !pod.type<[@inp: !felt.type<"bn128">]>>, !pod.type<[@inp: !felt.type<"bn128">]>
-// CHECK-NEXT:              %[[VAL_74:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_73]][@inp] : <[@inp: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:              constrain.eq %[[VAL_74]], %[[VAL_51]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_72:[0-9a-zA-Z_\.]+]] = pod.new : <[]>
+// CHECK-NEXT:              %[[VAL_73:[0-9a-zA-Z_\.]+]] = pod.new : <[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:              %[[VAL_74:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_69]] : !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_75:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_55]]{{\[}}%[[VAL_74]]] : <2 x !pod.type<[@inp: !felt.type<"bn128">]>>, !pod.type<[@inp: !felt.type<"bn128">]>
+// CHECK-NEXT:              %[[VAL_76:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_75]][@inp] : <[@inp: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:              constrain.eq %[[VAL_76]], %[[VAL_53]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:            } else {
 // CHECK-NEXT:            }
-// CHECK-NEXT:            %[[VAL_75:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_76:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_59]], %[[VAL_75]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            scf.yield %[[VAL_76]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_77:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_78:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_61]], %[[VAL_77]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_78]] : !felt.type<"bn128">
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[VAL_77:[0-9a-zA-Z_\.]+]] = arith.constant 2 : index
-// CHECK-NEXT:          %[[VAL_78:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[VAL_79:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:          scf.for %[[VAL_80:[0-9a-zA-Z_\.]+]] = %[[VAL_78]] to %[[VAL_77]] step %[[VAL_79]] {
-// CHECK-NEXT:            %[[VAL_81:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_52]]{{\[}}%[[VAL_80]]] : <2 x !struct.type<@Sigma::@Sigma<[]>>>, !struct.type<@Sigma::@Sigma<[]>>
-// CHECK-NEXT:            %[[VAL_82:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_53]]{{\[}}%[[VAL_80]]] : <2 x !pod.type<[@inp: !felt.type<"bn128">]>>, !pod.type<[@inp: !felt.type<"bn128">]>
-// CHECK-NEXT:            %[[VAL_83:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_82]][@inp] : <[@inp: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:            function.call @Sigma::@Sigma::@constrain(%[[VAL_81]], %[[VAL_83]]) : (!struct.type<@Sigma::@Sigma<[]>>, !felt.type<"bn128">) -> ()
+// CHECK-NEXT:          %[[VAL_79:[0-9a-zA-Z_\.]+]] = arith.constant 2 : index
+// CHECK-NEXT:          %[[VAL_80:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_81:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          scf.for %[[VAL_82:[0-9a-zA-Z_\.]+]] = %[[VAL_80]] to %[[VAL_79]] step %[[VAL_81]] {
+// CHECK-NEXT:            %[[VAL_83:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_54]]{{\[}}%[[VAL_82]]] : <2 x !struct.type<@Sigma::@Sigma<[]>>>, !struct.type<@Sigma::@Sigma<[]>>
+// CHECK-NEXT:            %[[VAL_84:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_55]]{{\[}}%[[VAL_82]]] : <2 x !pod.type<[@inp: !felt.type<"bn128">]>>, !pod.type<[@inp: !felt.type<"bn128">]>
+// CHECK-NEXT:            %[[VAL_85:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_84]][@inp] : <[@inp: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:            function.call @Sigma::@Sigma::@constrain(%[[VAL_83]], %[[VAL_85]]) : (!struct.type<@Sigma::@Sigma<[]>>, !felt.type<"bn128">) -> ()
 // CHECK-NEXT:          }
 // CHECK-NEXT:          function.return
 // CHECK-NEXT:        }
@@ -155,12 +157,12 @@ component main = Poseidon();
 // CHECK-NEXT:    poly.template @Sigma {
 // CHECK-NEXT:      struct.def @Sigma {
 // CHECK-NEXT:        struct.member @out : !felt.type<"bn128"> {llzk.pub}
-// CHECK-NEXT:        function.def @compute(%[[VAL_84:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) -> !struct.type<@Sigma::@Sigma<[]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
-// CHECK-NEXT:          %[[VAL_85:[0-9a-zA-Z_\.]+]] = struct.new : <@Sigma::@Sigma<[]>>
-// CHECK-NEXT:          function.return %[[VAL_85]] : !struct.type<@Sigma::@Sigma<[]>>
+// CHECK-NEXT:        function.def @compute(%[[VAL_86:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) -> !struct.type<@Sigma::@Sigma<[]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
+// CHECK-NEXT:          %[[VAL_87:[0-9a-zA-Z_\.]+]] = struct.new : <@Sigma::@Sigma<[]>>
+// CHECK-NEXT:          function.return %[[VAL_87]] : !struct.type<@Sigma::@Sigma<[]>>
 // CHECK-NEXT:        }
-// CHECK-NEXT:        function.def @constrain(%[[VAL_86:[0-9a-zA-Z_\.]+]]: !struct.type<@Sigma::@Sigma<[]>>, %[[VAL_87:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:          %[[VAL_88:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_86]][@out] : <@Sigma::@Sigma<[]>>, !felt.type<"bn128">
+// CHECK-NEXT:        function.def @constrain(%[[VAL_88:[0-9a-zA-Z_\.]+]]: !struct.type<@Sigma::@Sigma<[]>>, %[[VAL_89:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_90:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_88]][@out] : <@Sigma::@Sigma<[]>>, !felt.type<"bn128">
 // CHECK-NEXT:          function.return
 // CHECK-NEXT:        }
 // CHECK-NEXT:      }

--- a/circom/tests/loops/inner_conditional_11.circom
+++ b/circom/tests/loops/inner_conditional_11.circom
@@ -63,126 +63,132 @@ component main = Poseidon();
 // CHECK-NEXT:              %[[VAL_25:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
 // CHECK-NEXT:              %[[VAL_26:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_25]] : !felt.type<"bn128">
 // CHECK-NEXT:              %[[VAL_27:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_2]]{{\[}}%[[VAL_26]]] : <2 x !pod.type<[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:              %[[VAL_28:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_27]][@count] : <[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:              %[[VAL_29:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:              %[[VAL_30:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_28]], %[[VAL_29]] : index
-// CHECK-NEXT:              pod.write %[[VAL_27]][@count] = %[[VAL_30]] : <[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:              %[[VAL_31:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:              %[[VAL_32:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_30]], %[[VAL_31]] : index
-// CHECK-NEXT:              scf.if %[[VAL_32]] {
-// CHECK-NEXT:                %[[VAL_33:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_27]][@params] : <[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
-// CHECK-NEXT:                %[[VAL_34:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_22]][@inp] : <[@inp: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_35:[0-9a-zA-Z_\.]+]] = function.call @Sigma::@Sigma::@compute(%[[VAL_34]]) : (!felt.type<"bn128">) -> !struct.type<@Sigma::@Sigma<[]>>
-// CHECK-NEXT:                pod.write %[[VAL_27]][@comp] = %[[VAL_35]] : <[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>, !struct.type<@Sigma::@Sigma<[]>>
-// CHECK-NEXT:                %[[VAL_36:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:                %[[VAL_37:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_36]] : !felt.type<"bn128">
-// CHECK-NEXT:                array.write %[[VAL_2]]{{\[}}%[[VAL_37]]] = %[[VAL_27]] : <2 x !pod.type<[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:              %[[VAL_28:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:              %[[VAL_29:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_28]] : !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_30:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_11]]{{\[}}%[[VAL_29]]] : <2 x !pod.type<[@inp: !felt.type<"bn128">]>>, !pod.type<[@inp: !felt.type<"bn128">]>
+// CHECK-NEXT:              %[[VAL_31:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_27]][@count] : <[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:              %[[VAL_32:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:              %[[VAL_33:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_31]], %[[VAL_32]] : index
+// CHECK-NEXT:              pod.write %[[VAL_27]][@count] = %[[VAL_33]] : <[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:              %[[VAL_34:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:              %[[VAL_35:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_33]], %[[VAL_34]] : index
+// CHECK-NEXT:              scf.if %[[VAL_35]] {
+// CHECK-NEXT:                %[[VAL_36:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_27]][@params] : <[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
+// CHECK-NEXT:                %[[VAL_37:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_30]][@inp] : <[@inp: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_38:[0-9a-zA-Z_\.]+]] = function.call @Sigma::@Sigma::@compute(%[[VAL_37]]) : (!felt.type<"bn128">) -> !struct.type<@Sigma::@Sigma<[]>>
+// CHECK-NEXT:                pod.write %[[VAL_27]][@comp] = %[[VAL_38]] : <[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>, !struct.type<@Sigma::@Sigma<[]>>
+// CHECK-NEXT:                %[[VAL_39:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:                %[[VAL_40:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_39]] : !felt.type<"bn128">
+// CHECK-NEXT:                array.write %[[VAL_2]]{{\[}}%[[VAL_40]]] = %[[VAL_27]] : <2 x !pod.type<[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>
 // CHECK-NEXT:              }
 // CHECK-NEXT:              scf.yield %[[VAL_11]] : !array.type<2 x !pod.type<[@inp: !felt.type<"bn128">]>>
 // CHECK-NEXT:            } else {
-// CHECK-NEXT:              %[[VAL_38:[0-9a-zA-Z_\.]+]] = felt.const  3 : <"bn128">
-// CHECK-NEXT:              %[[VAL_39:[0-9a-zA-Z_\.]+]] = bool.cmp ge(%[[VAL_10]], %[[VAL_38]]) : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_40:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_39]] -> (!array.type<2 x !pod.type<[@inp: !felt.type<"bn128">]>>) {
-// CHECK-NEXT:                %[[VAL_41:[0-9a-zA-Z_\.]+]] = pod.new : <[]>
-// CHECK-NEXT:                %[[VAL_42:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:                %[[VAL_43:[0-9a-zA-Z_\.]+]] = pod.new { @count = %[[VAL_42]], @params = %[[VAL_41]] }  : <[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:                %[[VAL_44:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:                %[[VAL_45:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_44]] : !felt.type<"bn128">
-// CHECK-NEXT:                array.write %[[VAL_2]]{{\[}}%[[VAL_45]]] = %[[VAL_43]] : <2 x !pod.type<[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:                %[[VAL_46:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:                %[[VAL_47:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_46]] : !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_48:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_11]]{{\[}}%[[VAL_47]]] : <2 x !pod.type<[@inp: !felt.type<"bn128">]>>, !pod.type<[@inp: !felt.type<"bn128">]>
-// CHECK-NEXT:                pod.write %[[VAL_48]][@inp] = %[[VAL_0]] : <[@inp: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_41:[0-9a-zA-Z_\.]+]] = felt.const  3 : <"bn128">
+// CHECK-NEXT:              %[[VAL_42:[0-9a-zA-Z_\.]+]] = bool.cmp ge(%[[VAL_10]], %[[VAL_41]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_43:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_42]] -> (!array.type<2 x !pod.type<[@inp: !felt.type<"bn128">]>>) {
+// CHECK-NEXT:                %[[VAL_44:[0-9a-zA-Z_\.]+]] = pod.new : <[]>
+// CHECK-NEXT:                %[[VAL_45:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:                %[[VAL_46:[0-9a-zA-Z_\.]+]] = pod.new { @count = %[[VAL_45]], @params = %[[VAL_44]] }  : <[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:                %[[VAL_47:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:                %[[VAL_48:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_47]] : !felt.type<"bn128">
+// CHECK-NEXT:                array.write %[[VAL_2]]{{\[}}%[[VAL_48]]] = %[[VAL_46]] : <2 x !pod.type<[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>
 // CHECK-NEXT:                %[[VAL_49:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
 // CHECK-NEXT:                %[[VAL_50:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_49]] : !felt.type<"bn128">
-// CHECK-NEXT:                array.write %[[VAL_11]]{{\[}}%[[VAL_50]]] = %[[VAL_48]] : <2 x !pod.type<[@inp: !felt.type<"bn128">]>>, !pod.type<[@inp: !felt.type<"bn128">]>
-// CHECK-NEXT:                %[[VAL_51:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:                %[[VAL_52:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_51]] : !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_53:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_2]]{{\[}}%[[VAL_52]]] : <2 x !pod.type<[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:                %[[VAL_54:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_53]][@count] : <[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:                %[[VAL_55:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:                %[[VAL_56:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_54]], %[[VAL_55]] : index
-// CHECK-NEXT:                pod.write %[[VAL_53]][@count] = %[[VAL_56]] : <[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:                %[[VAL_57:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:                %[[VAL_58:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_56]], %[[VAL_57]] : index
-// CHECK-NEXT:                scf.if %[[VAL_58]] {
-// CHECK-NEXT:                  %[[VAL_59:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_53]][@params] : <[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
-// CHECK-NEXT:                  %[[VAL_60:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_48]][@inp] : <[@inp: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:                  %[[VAL_61:[0-9a-zA-Z_\.]+]] = function.call @Sigma::@Sigma::@compute(%[[VAL_60]]) : (!felt.type<"bn128">) -> !struct.type<@Sigma::@Sigma<[]>>
-// CHECK-NEXT:                  pod.write %[[VAL_53]][@comp] = %[[VAL_61]] : <[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>, !struct.type<@Sigma::@Sigma<[]>>
-// CHECK-NEXT:                  %[[VAL_62:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:                  %[[VAL_63:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_62]] : !felt.type<"bn128">
-// CHECK-NEXT:                  array.write %[[VAL_2]]{{\[}}%[[VAL_63]]] = %[[VAL_53]] : <2 x !pod.type<[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:                %[[VAL_51:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_11]]{{\[}}%[[VAL_50]]] : <2 x !pod.type<[@inp: !felt.type<"bn128">]>>, !pod.type<[@inp: !felt.type<"bn128">]>
+// CHECK-NEXT:                pod.write %[[VAL_51]][@inp] = %[[VAL_0]] : <[@inp: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_52:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:                %[[VAL_53:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_52]] : !felt.type<"bn128">
+// CHECK-NEXT:                array.write %[[VAL_11]]{{\[}}%[[VAL_53]]] = %[[VAL_51]] : <2 x !pod.type<[@inp: !felt.type<"bn128">]>>, !pod.type<[@inp: !felt.type<"bn128">]>
+// CHECK-NEXT:                %[[VAL_54:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:                %[[VAL_55:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_54]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_56:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_2]]{{\[}}%[[VAL_55]]] : <2 x !pod.type<[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:                %[[VAL_57:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:                %[[VAL_58:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_57]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_59:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_11]]{{\[}}%[[VAL_58]]] : <2 x !pod.type<[@inp: !felt.type<"bn128">]>>, !pod.type<[@inp: !felt.type<"bn128">]>
+// CHECK-NEXT:                %[[VAL_60:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_56]][@count] : <[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:                %[[VAL_61:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:                %[[VAL_62:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_60]], %[[VAL_61]] : index
+// CHECK-NEXT:                pod.write %[[VAL_56]][@count] = %[[VAL_62]] : <[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:                %[[VAL_63:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:                %[[VAL_64:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_62]], %[[VAL_63]] : index
+// CHECK-NEXT:                scf.if %[[VAL_64]] {
+// CHECK-NEXT:                  %[[VAL_65:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_56]][@params] : <[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
+// CHECK-NEXT:                  %[[VAL_66:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_59]][@inp] : <[@inp: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:                  %[[VAL_67:[0-9a-zA-Z_\.]+]] = function.call @Sigma::@Sigma::@compute(%[[VAL_66]]) : (!felt.type<"bn128">) -> !struct.type<@Sigma::@Sigma<[]>>
+// CHECK-NEXT:                  pod.write %[[VAL_56]][@comp] = %[[VAL_67]] : <[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>, !struct.type<@Sigma::@Sigma<[]>>
+// CHECK-NEXT:                  %[[VAL_68:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:                  %[[VAL_69:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_68]] : !felt.type<"bn128">
+// CHECK-NEXT:                  array.write %[[VAL_2]]{{\[}}%[[VAL_69]]] = %[[VAL_56]] : <2 x !pod.type<[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>
 // CHECK-NEXT:                }
 // CHECK-NEXT:                scf.yield %[[VAL_11]] : !array.type<2 x !pod.type<[@inp: !felt.type<"bn128">]>>
 // CHECK-NEXT:              } else {
 // CHECK-NEXT:                scf.yield %[[VAL_11]] : !array.type<2 x !pod.type<[@inp: !felt.type<"bn128">]>>
 // CHECK-NEXT:              }
-// CHECK-NEXT:              scf.yield %[[VAL_40]] : !array.type<2 x !pod.type<[@inp: !felt.type<"bn128">]>>
+// CHECK-NEXT:              scf.yield %[[VAL_43]] : !array.type<2 x !pod.type<[@inp: !felt.type<"bn128">]>>
 // CHECK-NEXT:            }
-// CHECK-NEXT:            %[[VAL_64:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_65:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_10]], %[[VAL_64]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            scf.yield %[[VAL_65]], %[[VAL_14]] : !felt.type<"bn128">, !array.type<2 x !pod.type<[@inp: !felt.type<"bn128">]>>
+// CHECK-NEXT:            %[[VAL_70:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_71:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_10]], %[[VAL_70]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_71]], %[[VAL_14]] : !felt.type<"bn128">, !array.type<2 x !pod.type<[@inp: !felt.type<"bn128">]>>
 // CHECK-NEXT:          }
 // CHECK-NEXT:          struct.writem %[[VAL_1]][@sigmaF$inputs] = %[[VAL_5]]#1 : <@Poseidon::@Poseidon<[]>>, !array.type<2 x !pod.type<[@inp: !felt.type<"bn128">]>>
-// CHECK-NEXT:          %[[VAL_66:[0-9a-zA-Z_\.]+]] = array.new  : <2 x !struct.type<@Sigma::@Sigma<[]>>>
-// CHECK-NEXT:          %[[VAL_67:[0-9a-zA-Z_\.]+]] = arith.constant 2 : index
-// CHECK-NEXT:          %[[VAL_68:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[VAL_69:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:          scf.for %[[VAL_70:[0-9a-zA-Z_\.]+]] = %[[VAL_68]] to %[[VAL_67]] step %[[VAL_69]] {
-// CHECK-NEXT:            %[[VAL_71:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_2]]{{\[}}%[[VAL_70]]] : <2 x !pod.type<[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:            %[[VAL_72:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_71]][@comp] : <[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>, !struct.type<@Sigma::@Sigma<[]>>
-// CHECK-NEXT:            array.write %[[VAL_66]]{{\[}}%[[VAL_70]]] = %[[VAL_72]] : <2 x !struct.type<@Sigma::@Sigma<[]>>>, !struct.type<@Sigma::@Sigma<[]>>
+// CHECK-NEXT:          %[[VAL_72:[0-9a-zA-Z_\.]+]] = array.new  : <2 x !struct.type<@Sigma::@Sigma<[]>>>
+// CHECK-NEXT:          %[[VAL_73:[0-9a-zA-Z_\.]+]] = arith.constant 2 : index
+// CHECK-NEXT:          %[[VAL_74:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_75:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          scf.for %[[VAL_76:[0-9a-zA-Z_\.]+]] = %[[VAL_74]] to %[[VAL_73]] step %[[VAL_75]] {
+// CHECK-NEXT:            %[[VAL_77:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_2]]{{\[}}%[[VAL_76]]] : <2 x !pod.type<[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:            %[[VAL_78:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_77]][@comp] : <[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>, !struct.type<@Sigma::@Sigma<[]>>
+// CHECK-NEXT:            array.write %[[VAL_72]]{{\[}}%[[VAL_76]]] = %[[VAL_78]] : <2 x !struct.type<@Sigma::@Sigma<[]>>>, !struct.type<@Sigma::@Sigma<[]>>
 // CHECK-NEXT:          }
-// CHECK-NEXT:          struct.writem %[[VAL_1]][@sigmaF] = %[[VAL_66]] : <@Poseidon::@Poseidon<[]>>, !array.type<2 x !struct.type<@Sigma::@Sigma<[]>>>
+// CHECK-NEXT:          struct.writem %[[VAL_1]][@sigmaF] = %[[VAL_72]] : <@Poseidon::@Poseidon<[]>>, !array.type<2 x !struct.type<@Sigma::@Sigma<[]>>>
 // CHECK-NEXT:          function.return %[[VAL_1]] : !struct.type<@Poseidon::@Poseidon<[]>>
 // CHECK-NEXT:        }
-// CHECK-NEXT:        function.def @constrain(%[[VAL_73:[0-9a-zA-Z_\.]+]]: !struct.type<@Poseidon::@Poseidon<[]>>, %[[VAL_74:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:          %[[VAL_75:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_73]][@sigmaF] : <@Poseidon::@Poseidon<[]>>, !array.type<2 x !struct.type<@Sigma::@Sigma<[]>>>
-// CHECK-NEXT:          %[[VAL_76:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_73]][@sigmaF$inputs] : <@Poseidon::@Poseidon<[]>>, !array.type<2 x !pod.type<[@inp: !felt.type<"bn128">]>>
-// CHECK-NEXT:          %[[VAL_77:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:          %[[VAL_78:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_79:[0-9a-zA-Z_\.]+]] = %[[VAL_77]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
-// CHECK-NEXT:            %[[VAL_80:[0-9a-zA-Z_\.]+]] = felt.const  4 : <"bn128">
-// CHECK-NEXT:            %[[VAL_81:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_79]], %[[VAL_80]]) : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            scf.condition(%[[VAL_81]]) %[[VAL_79]] : !felt.type<"bn128">
+// CHECK-NEXT:        function.def @constrain(%[[VAL_79:[0-9a-zA-Z_\.]+]]: !struct.type<@Poseidon::@Poseidon<[]>>, %[[VAL_80:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_81:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_79]][@sigmaF] : <@Poseidon::@Poseidon<[]>>, !array.type<2 x !struct.type<@Sigma::@Sigma<[]>>>
+// CHECK-NEXT:          %[[VAL_82:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_79]][@sigmaF$inputs] : <@Poseidon::@Poseidon<[]>>, !array.type<2 x !pod.type<[@inp: !felt.type<"bn128">]>>
+// CHECK-NEXT:          %[[VAL_83:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_84:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_85:[0-9a-zA-Z_\.]+]] = %[[VAL_83]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
+// CHECK-NEXT:            %[[VAL_86:[0-9a-zA-Z_\.]+]] = felt.const  4 : <"bn128">
+// CHECK-NEXT:            %[[VAL_87:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_85]], %[[VAL_86]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.condition(%[[VAL_87]]) %[[VAL_85]] : !felt.type<"bn128">
 // CHECK-NEXT:          } do {
-// CHECK-NEXT:          ^bb0(%[[VAL_82:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
-// CHECK-NEXT:            %[[VAL_83:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_84:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_82]], %[[VAL_83]]) : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            scf.if %[[VAL_84]] {
-// CHECK-NEXT:              %[[VAL_85:[0-9a-zA-Z_\.]+]] = pod.new : <[]>
-// CHECK-NEXT:              %[[VAL_86:[0-9a-zA-Z_\.]+]] = pod.new : <[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:              %[[VAL_87:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:              %[[VAL_88:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_87]] : !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_89:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_76]]{{\[}}%[[VAL_88]]] : <2 x !pod.type<[@inp: !felt.type<"bn128">]>>, !pod.type<[@inp: !felt.type<"bn128">]>
-// CHECK-NEXT:              %[[VAL_90:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_89]][@inp] : <[@inp: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:              constrain.eq %[[VAL_90]], %[[VAL_74]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          ^bb0(%[[VAL_88:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
+// CHECK-NEXT:            %[[VAL_89:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_90:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_88]], %[[VAL_89]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.if %[[VAL_90]] {
+// CHECK-NEXT:              %[[VAL_91:[0-9a-zA-Z_\.]+]] = pod.new : <[]>
+// CHECK-NEXT:              %[[VAL_92:[0-9a-zA-Z_\.]+]] = pod.new : <[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:              %[[VAL_93:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:              %[[VAL_94:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_93]] : !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_95:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_82]]{{\[}}%[[VAL_94]]] : <2 x !pod.type<[@inp: !felt.type<"bn128">]>>, !pod.type<[@inp: !felt.type<"bn128">]>
+// CHECK-NEXT:              %[[VAL_96:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_95]][@inp] : <[@inp: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:              constrain.eq %[[VAL_96]], %[[VAL_80]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:            } else {
-// CHECK-NEXT:              %[[VAL_91:[0-9a-zA-Z_\.]+]] = felt.const  3 : <"bn128">
-// CHECK-NEXT:              %[[VAL_92:[0-9a-zA-Z_\.]+]] = bool.cmp ge(%[[VAL_82]], %[[VAL_91]]) : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:              scf.if %[[VAL_92]] {
-// CHECK-NEXT:                %[[VAL_93:[0-9a-zA-Z_\.]+]] = pod.new : <[]>
-// CHECK-NEXT:                %[[VAL_94:[0-9a-zA-Z_\.]+]] = pod.new : <[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:                %[[VAL_95:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:                %[[VAL_96:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_95]] : !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_97:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_76]]{{\[}}%[[VAL_96]]] : <2 x !pod.type<[@inp: !felt.type<"bn128">]>>, !pod.type<[@inp: !felt.type<"bn128">]>
-// CHECK-NEXT:                %[[VAL_98:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_97]][@inp] : <[@inp: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:                constrain.eq %[[VAL_98]], %[[VAL_74]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_97:[0-9a-zA-Z_\.]+]] = felt.const  3 : <"bn128">
+// CHECK-NEXT:              %[[VAL_98:[0-9a-zA-Z_\.]+]] = bool.cmp ge(%[[VAL_88]], %[[VAL_97]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:              scf.if %[[VAL_98]] {
+// CHECK-NEXT:                %[[VAL_99:[0-9a-zA-Z_\.]+]] = pod.new : <[]>
+// CHECK-NEXT:                %[[VAL_100:[0-9a-zA-Z_\.]+]] = pod.new : <[@count: index, @comp: !struct.type<@Sigma::@Sigma<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:                %[[VAL_101:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:                %[[VAL_102:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_101]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_103:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_82]]{{\[}}%[[VAL_102]]] : <2 x !pod.type<[@inp: !felt.type<"bn128">]>>, !pod.type<[@inp: !felt.type<"bn128">]>
+// CHECK-NEXT:                %[[VAL_104:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_103]][@inp] : <[@inp: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:                constrain.eq %[[VAL_104]], %[[VAL_80]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:              } else {
 // CHECK-NEXT:              }
 // CHECK-NEXT:            }
-// CHECK-NEXT:            %[[VAL_99:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_100:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_82]], %[[VAL_99]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            scf.yield %[[VAL_100]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_105:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_106:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_88]], %[[VAL_105]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_106]] : !felt.type<"bn128">
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[VAL_101:[0-9a-zA-Z_\.]+]] = arith.constant 2 : index
-// CHECK-NEXT:          %[[VAL_102:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[VAL_103:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:          scf.for %[[VAL_104:[0-9a-zA-Z_\.]+]] = %[[VAL_102]] to %[[VAL_101]] step %[[VAL_103]] {
-// CHECK-NEXT:            %[[VAL_105:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_75]]{{\[}}%[[VAL_104]]] : <2 x !struct.type<@Sigma::@Sigma<[]>>>, !struct.type<@Sigma::@Sigma<[]>>
-// CHECK-NEXT:            %[[VAL_106:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_76]]{{\[}}%[[VAL_104]]] : <2 x !pod.type<[@inp: !felt.type<"bn128">]>>, !pod.type<[@inp: !felt.type<"bn128">]>
-// CHECK-NEXT:            %[[VAL_107:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_106]][@inp] : <[@inp: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:            function.call @Sigma::@Sigma::@constrain(%[[VAL_105]], %[[VAL_107]]) : (!struct.type<@Sigma::@Sigma<[]>>, !felt.type<"bn128">) -> ()
+// CHECK-NEXT:          %[[VAL_107:[0-9a-zA-Z_\.]+]] = arith.constant 2 : index
+// CHECK-NEXT:          %[[VAL_108:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_109:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          scf.for %[[VAL_110:[0-9a-zA-Z_\.]+]] = %[[VAL_108]] to %[[VAL_107]] step %[[VAL_109]] {
+// CHECK-NEXT:            %[[VAL_111:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_81]]{{\[}}%[[VAL_110]]] : <2 x !struct.type<@Sigma::@Sigma<[]>>>, !struct.type<@Sigma::@Sigma<[]>>
+// CHECK-NEXT:            %[[VAL_112:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_82]]{{\[}}%[[VAL_110]]] : <2 x !pod.type<[@inp: !felt.type<"bn128">]>>, !pod.type<[@inp: !felt.type<"bn128">]>
+// CHECK-NEXT:            %[[VAL_113:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_112]][@inp] : <[@inp: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:            function.call @Sigma::@Sigma::@constrain(%[[VAL_111]], %[[VAL_113]]) : (!struct.type<@Sigma::@Sigma<[]>>, !felt.type<"bn128">) -> ()
 // CHECK-NEXT:          }
 // CHECK-NEXT:          function.return
 // CHECK-NEXT:        }
@@ -191,12 +197,12 @@ component main = Poseidon();
 // CHECK-NEXT:    poly.template @Sigma {
 // CHECK-NEXT:      struct.def @Sigma {
 // CHECK-NEXT:        struct.member @out : !felt.type<"bn128"> {llzk.pub}
-// CHECK-NEXT:        function.def @compute(%[[VAL_108:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) -> !struct.type<@Sigma::@Sigma<[]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
-// CHECK-NEXT:          %[[VAL_109:[0-9a-zA-Z_\.]+]] = struct.new : <@Sigma::@Sigma<[]>>
-// CHECK-NEXT:          function.return %[[VAL_109]] : !struct.type<@Sigma::@Sigma<[]>>
+// CHECK-NEXT:        function.def @compute(%[[VAL_114:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) -> !struct.type<@Sigma::@Sigma<[]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
+// CHECK-NEXT:          %[[VAL_115:[0-9a-zA-Z_\.]+]] = struct.new : <@Sigma::@Sigma<[]>>
+// CHECK-NEXT:          function.return %[[VAL_115]] : !struct.type<@Sigma::@Sigma<[]>>
 // CHECK-NEXT:        }
-// CHECK-NEXT:        function.def @constrain(%[[VAL_110:[0-9a-zA-Z_\.]+]]: !struct.type<@Sigma::@Sigma<[]>>, %[[VAL_111:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:          %[[VAL_112:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_110]][@out] : <@Sigma::@Sigma<[]>>, !felt.type<"bn128">
+// CHECK-NEXT:        function.def @constrain(%[[VAL_116:[0-9a-zA-Z_\.]+]]: !struct.type<@Sigma::@Sigma<[]>>, %[[VAL_117:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_118:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_116]][@out] : <@Sigma::@Sigma<[]>>, !felt.type<"bn128">
 // CHECK-NEXT:          function.return
 // CHECK-NEXT:        }
 // CHECK-NEXT:      }

--- a/circom/tests/misc/circomlib_smtprocessor.circom
+++ b/circom/tests/misc/circomlib_smtprocessor.circom
@@ -60,142 +60,150 @@ component main = SMTProcessor(2);
 // CHECK-NEXT:              array.write %[[VAL_11]]{{\[}}%[[VAL_22]]] = %[[VAL_21]] : <@nLevels x !pod.type<[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>>, !pod.type<[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>
 // CHECK-NEXT:              %[[VAL_23:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_10]] : !felt.type<"bn128">
 // CHECK-NEXT:              %[[VAL_24:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_3]]{{\[}}%[[VAL_23]]] : <@nLevels x !pod.type<[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:              %[[VAL_25:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_24]][@count] : <[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:              %[[VAL_26:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:              %[[VAL_27:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_25]], %[[VAL_26]] : index
-// CHECK-NEXT:              pod.write %[[VAL_24]][@count] = %[[VAL_27]] : <[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:              %[[VAL_28:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:              %[[VAL_29:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_27]], %[[VAL_28]] : index
-// CHECK-NEXT:              scf.if %[[VAL_29]] {
-// CHECK-NEXT:                %[[VAL_30:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_24]][@params] : <[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
-// CHECK-NEXT:                %[[VAL_31:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_21]][@prev_new1] : <[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_32:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_21]][@prev_na] : <[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_33:[0-9a-zA-Z_\.]+]] = function.call @SMTProcessorSM::@SMTProcessorSM::@compute(%[[VAL_31]], %[[VAL_32]]) : (!felt.type<"bn128">, !felt.type<"bn128">) -> !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>
-// CHECK-NEXT:                pod.write %[[VAL_24]][@comp] = %[[VAL_33]] : <[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>, !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>
-// CHECK-NEXT:                %[[VAL_34:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_10]] : !felt.type<"bn128">
-// CHECK-NEXT:                array.write %[[VAL_3]]{{\[}}%[[VAL_34]]] = %[[VAL_24]] : <@nLevels x !pod.type<[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:              %[[VAL_25:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_10]] : !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_26:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_11]]{{\[}}%[[VAL_25]]] : <@nLevels x !pod.type<[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>>, !pod.type<[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>
+// CHECK-NEXT:              %[[VAL_27:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_24]][@count] : <[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:              %[[VAL_28:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:              %[[VAL_29:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_27]], %[[VAL_28]] : index
+// CHECK-NEXT:              pod.write %[[VAL_24]][@count] = %[[VAL_29]] : <[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:              %[[VAL_30:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:              %[[VAL_31:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_29]], %[[VAL_30]] : index
+// CHECK-NEXT:              scf.if %[[VAL_31]] {
+// CHECK-NEXT:                %[[VAL_32:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_24]][@params] : <[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
+// CHECK-NEXT:                %[[VAL_33:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_26]][@prev_new1] : <[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_34:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_26]][@prev_na] : <[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_35:[0-9a-zA-Z_\.]+]] = function.call @SMTProcessorSM::@SMTProcessorSM::@compute(%[[VAL_33]], %[[VAL_34]]) : (!felt.type<"bn128">, !felt.type<"bn128">) -> !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>
+// CHECK-NEXT:                pod.write %[[VAL_24]][@comp] = %[[VAL_35]] : <[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>, !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>
+// CHECK-NEXT:                %[[VAL_36:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_10]] : !felt.type<"bn128">
+// CHECK-NEXT:                array.write %[[VAL_3]]{{\[}}%[[VAL_36]]] = %[[VAL_24]] : <@nLevels x !pod.type<[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>
 // CHECK-NEXT:              }
-// CHECK-NEXT:              %[[VAL_35:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:              %[[VAL_36:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_35]], %[[VAL_0]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_37:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_10]] : !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_38:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_11]]{{\[}}%[[VAL_37]]] : <@nLevels x !pod.type<[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>>, !pod.type<[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>
-// CHECK-NEXT:              pod.write %[[VAL_38]][@prev_na] = %[[VAL_36]] : <[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_37:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:              %[[VAL_38:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_37]], %[[VAL_0]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:              %[[VAL_39:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_10]] : !felt.type<"bn128">
-// CHECK-NEXT:              array.write %[[VAL_11]]{{\[}}%[[VAL_39]]] = %[[VAL_38]] : <@nLevels x !pod.type<[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>>, !pod.type<[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>
-// CHECK-NEXT:              %[[VAL_40:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_10]] : !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_41:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_3]]{{\[}}%[[VAL_40]]] : <@nLevels x !pod.type<[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:              %[[VAL_42:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_41]][@count] : <[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:              %[[VAL_43:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:              %[[VAL_44:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_42]], %[[VAL_43]] : index
-// CHECK-NEXT:              pod.write %[[VAL_41]][@count] = %[[VAL_44]] : <[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:              %[[VAL_45:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:              %[[VAL_46:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_44]], %[[VAL_45]] : index
-// CHECK-NEXT:              scf.if %[[VAL_46]] {
-// CHECK-NEXT:                %[[VAL_47:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_41]][@params] : <[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
-// CHECK-NEXT:                %[[VAL_48:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_38]][@prev_new1] : <[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_49:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_38]][@prev_na] : <[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_50:[0-9a-zA-Z_\.]+]] = function.call @SMTProcessorSM::@SMTProcessorSM::@compute(%[[VAL_48]], %[[VAL_49]]) : (!felt.type<"bn128">, !felt.type<"bn128">) -> !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>
-// CHECK-NEXT:                pod.write %[[VAL_41]][@comp] = %[[VAL_50]] : <[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>, !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>
-// CHECK-NEXT:                %[[VAL_51:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_10]] : !felt.type<"bn128">
-// CHECK-NEXT:                array.write %[[VAL_3]]{{\[}}%[[VAL_51]]] = %[[VAL_41]] : <@nLevels x !pod.type<[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:              %[[VAL_40:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_11]]{{\[}}%[[VAL_39]]] : <@nLevels x !pod.type<[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>>, !pod.type<[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>
+// CHECK-NEXT:              pod.write %[[VAL_40]][@prev_na] = %[[VAL_38]] : <[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_41:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_10]] : !felt.type<"bn128">
+// CHECK-NEXT:              array.write %[[VAL_11]]{{\[}}%[[VAL_41]]] = %[[VAL_40]] : <@nLevels x !pod.type<[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>>, !pod.type<[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>
+// CHECK-NEXT:              %[[VAL_42:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_10]] : !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_43:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_3]]{{\[}}%[[VAL_42]]] : <@nLevels x !pod.type<[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:              %[[VAL_44:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_10]] : !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_45:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_11]]{{\[}}%[[VAL_44]]] : <@nLevels x !pod.type<[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>>, !pod.type<[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>
+// CHECK-NEXT:              %[[VAL_46:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_43]][@count] : <[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:              %[[VAL_47:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:              %[[VAL_48:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_46]], %[[VAL_47]] : index
+// CHECK-NEXT:              pod.write %[[VAL_43]][@count] = %[[VAL_48]] : <[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:              %[[VAL_49:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:              %[[VAL_50:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_48]], %[[VAL_49]] : index
+// CHECK-NEXT:              scf.if %[[VAL_50]] {
+// CHECK-NEXT:                %[[VAL_51:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_43]][@params] : <[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
+// CHECK-NEXT:                %[[VAL_52:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_45]][@prev_new1] : <[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_53:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_45]][@prev_na] : <[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_54:[0-9a-zA-Z_\.]+]] = function.call @SMTProcessorSM::@SMTProcessorSM::@compute(%[[VAL_52]], %[[VAL_53]]) : (!felt.type<"bn128">, !felt.type<"bn128">) -> !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>
+// CHECK-NEXT:                pod.write %[[VAL_43]][@comp] = %[[VAL_54]] : <[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>, !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>
+// CHECK-NEXT:                %[[VAL_55:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_10]] : !felt.type<"bn128">
+// CHECK-NEXT:                array.write %[[VAL_3]]{{\[}}%[[VAL_55]]] = %[[VAL_43]] : <@nLevels x !pod.type<[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>
 // CHECK-NEXT:              }
 // CHECK-NEXT:              scf.yield %[[VAL_11]] : !array.type<@nLevels x !pod.type<[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>>
 // CHECK-NEXT:            } else {
-// CHECK-NEXT:              %[[VAL_52:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:              %[[VAL_53:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_10]] : !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_54:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_11]]{{\[}}%[[VAL_53]]] : <@nLevels x !pod.type<[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>>, !pod.type<[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>
-// CHECK-NEXT:              pod.write %[[VAL_54]][@prev_new1] = %[[VAL_52]] : <[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_55:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_10]] : !felt.type<"bn128">
-// CHECK-NEXT:              array.write %[[VAL_11]]{{\[}}%[[VAL_55]]] = %[[VAL_54]] : <@nLevels x !pod.type<[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>>, !pod.type<[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>
-// CHECK-NEXT:              %[[VAL_56:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_10]] : !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_57:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_3]]{{\[}}%[[VAL_56]]] : <@nLevels x !pod.type<[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:              %[[VAL_58:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_57]][@count] : <[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:              %[[VAL_59:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:              %[[VAL_60:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_58]], %[[VAL_59]] : index
-// CHECK-NEXT:              pod.write %[[VAL_57]][@count] = %[[VAL_60]] : <[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:              %[[VAL_61:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:              %[[VAL_62:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_60]], %[[VAL_61]] : index
-// CHECK-NEXT:              scf.if %[[VAL_62]] {
-// CHECK-NEXT:                %[[VAL_63:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_57]][@params] : <[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
-// CHECK-NEXT:                %[[VAL_64:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_54]][@prev_new1] : <[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_65:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_54]][@prev_na] : <[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_66:[0-9a-zA-Z_\.]+]] = function.call @SMTProcessorSM::@SMTProcessorSM::@compute(%[[VAL_64]], %[[VAL_65]]) : (!felt.type<"bn128">, !felt.type<"bn128">) -> !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>
-// CHECK-NEXT:                pod.write %[[VAL_57]][@comp] = %[[VAL_66]] : <[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>, !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>
-// CHECK-NEXT:                %[[VAL_67:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_10]] : !felt.type<"bn128">
-// CHECK-NEXT:                array.write %[[VAL_3]]{{\[}}%[[VAL_67]]] = %[[VAL_57]] : <@nLevels x !pod.type<[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:              %[[VAL_56:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:              %[[VAL_57:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_10]] : !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_58:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_11]]{{\[}}%[[VAL_57]]] : <@nLevels x !pod.type<[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>>, !pod.type<[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>
+// CHECK-NEXT:              pod.write %[[VAL_58]][@prev_new1] = %[[VAL_56]] : <[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_59:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_10]] : !felt.type<"bn128">
+// CHECK-NEXT:              array.write %[[VAL_11]]{{\[}}%[[VAL_59]]] = %[[VAL_58]] : <@nLevels x !pod.type<[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>>, !pod.type<[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>
+// CHECK-NEXT:              %[[VAL_60:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_10]] : !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_61:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_3]]{{\[}}%[[VAL_60]]] : <@nLevels x !pod.type<[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:              %[[VAL_62:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_10]] : !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_63:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_11]]{{\[}}%[[VAL_62]]] : <@nLevels x !pod.type<[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>>, !pod.type<[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>
+// CHECK-NEXT:              %[[VAL_64:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_61]][@count] : <[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:              %[[VAL_65:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:              %[[VAL_66:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_64]], %[[VAL_65]] : index
+// CHECK-NEXT:              pod.write %[[VAL_61]][@count] = %[[VAL_66]] : <[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:              %[[VAL_67:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:              %[[VAL_68:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_66]], %[[VAL_67]] : index
+// CHECK-NEXT:              scf.if %[[VAL_68]] {
+// CHECK-NEXT:                %[[VAL_69:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_61]][@params] : <[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
+// CHECK-NEXT:                %[[VAL_70:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_63]][@prev_new1] : <[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_71:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_63]][@prev_na] : <[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_72:[0-9a-zA-Z_\.]+]] = function.call @SMTProcessorSM::@SMTProcessorSM::@compute(%[[VAL_70]], %[[VAL_71]]) : (!felt.type<"bn128">, !felt.type<"bn128">) -> !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>
+// CHECK-NEXT:                pod.write %[[VAL_61]][@comp] = %[[VAL_72]] : <[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>, !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>
+// CHECK-NEXT:                %[[VAL_73:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_10]] : !felt.type<"bn128">
+// CHECK-NEXT:                array.write %[[VAL_3]]{{\[}}%[[VAL_73]]] = %[[VAL_61]] : <@nLevels x !pod.type<[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>
 // CHECK-NEXT:              }
-// CHECK-NEXT:              %[[VAL_68:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:              %[[VAL_69:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_10]] : !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_70:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_11]]{{\[}}%[[VAL_69]]] : <@nLevels x !pod.type<[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>>, !pod.type<[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>
-// CHECK-NEXT:              pod.write %[[VAL_70]][@prev_na] = %[[VAL_68]] : <[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_71:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_10]] : !felt.type<"bn128">
-// CHECK-NEXT:              array.write %[[VAL_11]]{{\[}}%[[VAL_71]]] = %[[VAL_70]] : <@nLevels x !pod.type<[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>>, !pod.type<[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>
-// CHECK-NEXT:              %[[VAL_72:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_10]] : !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_73:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_3]]{{\[}}%[[VAL_72]]] : <@nLevels x !pod.type<[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:              %[[VAL_74:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_73]][@count] : <[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:              %[[VAL_75:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:              %[[VAL_76:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_74]], %[[VAL_75]] : index
-// CHECK-NEXT:              pod.write %[[VAL_73]][@count] = %[[VAL_76]] : <[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:              %[[VAL_77:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:              %[[VAL_78:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_76]], %[[VAL_77]] : index
-// CHECK-NEXT:              scf.if %[[VAL_78]] {
-// CHECK-NEXT:                %[[VAL_79:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_73]][@params] : <[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
-// CHECK-NEXT:                %[[VAL_80:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_70]][@prev_new1] : <[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_81:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_70]][@prev_na] : <[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_82:[0-9a-zA-Z_\.]+]] = function.call @SMTProcessorSM::@SMTProcessorSM::@compute(%[[VAL_80]], %[[VAL_81]]) : (!felt.type<"bn128">, !felt.type<"bn128">) -> !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>
-// CHECK-NEXT:                pod.write %[[VAL_73]][@comp] = %[[VAL_82]] : <[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>, !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>
-// CHECK-NEXT:                %[[VAL_83:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_10]] : !felt.type<"bn128">
-// CHECK-NEXT:                array.write %[[VAL_3]]{{\[}}%[[VAL_83]]] = %[[VAL_73]] : <@nLevels x !pod.type<[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:              %[[VAL_74:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:              %[[VAL_75:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_10]] : !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_76:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_11]]{{\[}}%[[VAL_75]]] : <@nLevels x !pod.type<[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>>, !pod.type<[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>
+// CHECK-NEXT:              pod.write %[[VAL_76]][@prev_na] = %[[VAL_74]] : <[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_77:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_10]] : !felt.type<"bn128">
+// CHECK-NEXT:              array.write %[[VAL_11]]{{\[}}%[[VAL_77]]] = %[[VAL_76]] : <@nLevels x !pod.type<[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>>, !pod.type<[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>
+// CHECK-NEXT:              %[[VAL_78:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_10]] : !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_79:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_3]]{{\[}}%[[VAL_78]]] : <@nLevels x !pod.type<[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:              %[[VAL_80:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_10]] : !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_81:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_11]]{{\[}}%[[VAL_80]]] : <@nLevels x !pod.type<[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>>, !pod.type<[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>
+// CHECK-NEXT:              %[[VAL_82:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_79]][@count] : <[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:              %[[VAL_83:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:              %[[VAL_84:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_82]], %[[VAL_83]] : index
+// CHECK-NEXT:              pod.write %[[VAL_79]][@count] = %[[VAL_84]] : <[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:              %[[VAL_85:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:              %[[VAL_86:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_84]], %[[VAL_85]] : index
+// CHECK-NEXT:              scf.if %[[VAL_86]] {
+// CHECK-NEXT:                %[[VAL_87:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_79]][@params] : <[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
+// CHECK-NEXT:                %[[VAL_88:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_81]][@prev_new1] : <[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_89:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_81]][@prev_na] : <[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_90:[0-9a-zA-Z_\.]+]] = function.call @SMTProcessorSM::@SMTProcessorSM::@compute(%[[VAL_88]], %[[VAL_89]]) : (!felt.type<"bn128">, !felt.type<"bn128">) -> !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>
+// CHECK-NEXT:                pod.write %[[VAL_79]][@comp] = %[[VAL_90]] : <[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>, !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>
+// CHECK-NEXT:                %[[VAL_91:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_10]] : !felt.type<"bn128">
+// CHECK-NEXT:                array.write %[[VAL_3]]{{\[}}%[[VAL_91]]] = %[[VAL_79]] : <@nLevels x !pod.type<[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>
 // CHECK-NEXT:              }
 // CHECK-NEXT:              scf.yield %[[VAL_11]] : !array.type<@nLevels x !pod.type<[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>>
 // CHECK-NEXT:            }
-// CHECK-NEXT:            %[[VAL_84:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_85:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_10]], %[[VAL_84]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            scf.yield %[[VAL_85]], %[[VAL_18]] : !felt.type<"bn128">, !array.type<@nLevels x !pod.type<[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>>
+// CHECK-NEXT:            %[[VAL_92:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_93:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_10]], %[[VAL_92]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_93]], %[[VAL_18]] : !felt.type<"bn128">, !array.type<@nLevels x !pod.type<[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>>
 // CHECK-NEXT:          }
 // CHECK-NEXT:          struct.writem %[[VAL_1]][@sm$inputs] = %[[VAL_6]]#1 : <@SMTProcessor::@SMTProcessor<[@nLevels]>>, !array.type<@nLevels x !pod.type<[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>>
-// CHECK-NEXT:          %[[VAL_86:[0-9a-zA-Z_\.]+]] = array.new  : <@nLevels x !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>>
-// CHECK-NEXT:          %[[VAL_87:[0-9a-zA-Z_\.]+]] = poly.read_const @nLevels : index
-// CHECK-NEXT:          %[[VAL_88:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[VAL_89:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:          scf.for %[[VAL_90:[0-9a-zA-Z_\.]+]] = %[[VAL_88]] to %[[VAL_87]] step %[[VAL_89]] {
-// CHECK-NEXT:            %[[VAL_91:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_3]]{{\[}}%[[VAL_90]]] : <@nLevels x !pod.type<[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:            %[[VAL_92:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_91]][@comp] : <[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>, !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>
-// CHECK-NEXT:            array.write %[[VAL_86]]{{\[}}%[[VAL_90]]] = %[[VAL_92]] : <@nLevels x !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>>, !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>
+// CHECK-NEXT:          %[[VAL_94:[0-9a-zA-Z_\.]+]] = array.new  : <@nLevels x !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>>
+// CHECK-NEXT:          %[[VAL_95:[0-9a-zA-Z_\.]+]] = poly.read_const @nLevels : index
+// CHECK-NEXT:          %[[VAL_96:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_97:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          scf.for %[[VAL_98:[0-9a-zA-Z_\.]+]] = %[[VAL_96]] to %[[VAL_95]] step %[[VAL_97]] {
+// CHECK-NEXT:            %[[VAL_99:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_3]]{{\[}}%[[VAL_98]]] : <@nLevels x !pod.type<[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:            %[[VAL_100:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_99]][@comp] : <[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>, !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>
+// CHECK-NEXT:            array.write %[[VAL_94]]{{\[}}%[[VAL_98]]] = %[[VAL_100]] : <@nLevels x !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>>, !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>
 // CHECK-NEXT:          }
-// CHECK-NEXT:          struct.writem %[[VAL_1]][@sm] = %[[VAL_86]] : <@SMTProcessor::@SMTProcessor<[@nLevels]>>, !array.type<@nLevels x !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>>
+// CHECK-NEXT:          struct.writem %[[VAL_1]][@sm] = %[[VAL_94]] : <@SMTProcessor::@SMTProcessor<[@nLevels]>>, !array.type<@nLevels x !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>>
 // CHECK-NEXT:          function.return %[[VAL_1]] : !struct.type<@SMTProcessor::@SMTProcessor<[@nLevels]>>
 // CHECK-NEXT:        }
-// CHECK-NEXT:        function.def @constrain(%[[VAL_93:[0-9a-zA-Z_\.]+]]: !struct.type<@SMTProcessor::@SMTProcessor<[@nLevels]>>, %[[VAL_94:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:          %[[VAL_95:[0-9a-zA-Z_\.]+]] = poly.read_const @nLevels : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_96:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_93]][@sm] : <@SMTProcessor::@SMTProcessor<[@nLevels]>>, !array.type<@nLevels x !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>>
-// CHECK-NEXT:          %[[VAL_97:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_93]][@sm$inputs] : <@SMTProcessor::@SMTProcessor<[@nLevels]>>, !array.type<@nLevels x !pod.type<[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>>
-// CHECK-NEXT:          %[[VAL_98:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:          %[[VAL_99:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_100:[0-9a-zA-Z_\.]+]] = %[[VAL_98]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
-// CHECK-NEXT:            %[[VAL_101:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_100]], %[[VAL_95]]) : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            scf.condition(%[[VAL_101]]) %[[VAL_100]] : !felt.type<"bn128">
+// CHECK-NEXT:        function.def @constrain(%[[VAL_101:[0-9a-zA-Z_\.]+]]: !struct.type<@SMTProcessor::@SMTProcessor<[@nLevels]>>, %[[VAL_102:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_103:[0-9a-zA-Z_\.]+]] = poly.read_const @nLevels : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_104:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_101]][@sm] : <@SMTProcessor::@SMTProcessor<[@nLevels]>>, !array.type<@nLevels x !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>>
+// CHECK-NEXT:          %[[VAL_105:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_101]][@sm$inputs] : <@SMTProcessor::@SMTProcessor<[@nLevels]>>, !array.type<@nLevels x !pod.type<[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>>
+// CHECK-NEXT:          %[[VAL_106:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_107:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_108:[0-9a-zA-Z_\.]+]] = %[[VAL_106]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
+// CHECK-NEXT:            %[[VAL_109:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_108]], %[[VAL_103]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.condition(%[[VAL_109]]) %[[VAL_108]] : !felt.type<"bn128">
 // CHECK-NEXT:          } do {
-// CHECK-NEXT:          ^bb0(%[[VAL_102:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
-// CHECK-NEXT:            %[[VAL_103:[0-9a-zA-Z_\.]+]] = pod.new : <[]>
-// CHECK-NEXT:            %[[VAL_104:[0-9a-zA-Z_\.]+]] = pod.new : <[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:            %[[VAL_105:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:            %[[VAL_106:[0-9a-zA-Z_\.]+]] = bool.cmp eq(%[[VAL_102]], %[[VAL_105]]) : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            scf.if %[[VAL_106]] {
+// CHECK-NEXT:          ^bb0(%[[VAL_110:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
+// CHECK-NEXT:            %[[VAL_111:[0-9a-zA-Z_\.]+]] = pod.new : <[]>
+// CHECK-NEXT:            %[[VAL_112:[0-9a-zA-Z_\.]+]] = pod.new : <[@count: index, @comp: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:            %[[VAL_113:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:            %[[VAL_114:[0-9a-zA-Z_\.]+]] = bool.cmp eq(%[[VAL_110]], %[[VAL_113]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.if %[[VAL_114]] {
 // CHECK-NEXT:            } else {
 // CHECK-NEXT:            }
-// CHECK-NEXT:            %[[VAL_107:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_108:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_102]], %[[VAL_107]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            scf.yield %[[VAL_108]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_115:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_116:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_110]], %[[VAL_115]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_116]] : !felt.type<"bn128">
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[VAL_109:[0-9a-zA-Z_\.]+]] = poly.read_const @nLevels : index
-// CHECK-NEXT:          %[[VAL_110:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[VAL_111:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:          scf.for %[[VAL_112:[0-9a-zA-Z_\.]+]] = %[[VAL_110]] to %[[VAL_109]] step %[[VAL_111]] {
-// CHECK-NEXT:            %[[VAL_113:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_96]]{{\[}}%[[VAL_112]]] : <@nLevels x !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>>, !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>
-// CHECK-NEXT:            %[[VAL_114:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_97]]{{\[}}%[[VAL_112]]] : <@nLevels x !pod.type<[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>>, !pod.type<[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>
-// CHECK-NEXT:            %[[VAL_115:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_114]][@prev_new1] : <[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_116:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_114]][@prev_na] : <[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:            function.call @SMTProcessorSM::@SMTProcessorSM::@constrain(%[[VAL_113]], %[[VAL_115]], %[[VAL_116]]) : (!struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, !felt.type<"bn128">, !felt.type<"bn128">) -> ()
+// CHECK-NEXT:          %[[VAL_117:[0-9a-zA-Z_\.]+]] = poly.read_const @nLevels : index
+// CHECK-NEXT:          %[[VAL_118:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_119:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          scf.for %[[VAL_120:[0-9a-zA-Z_\.]+]] = %[[VAL_118]] to %[[VAL_117]] step %[[VAL_119]] {
+// CHECK-NEXT:            %[[VAL_121:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_104]]{{\[}}%[[VAL_120]]] : <@nLevels x !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>>, !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>
+// CHECK-NEXT:            %[[VAL_122:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_105]]{{\[}}%[[VAL_120]]] : <@nLevels x !pod.type<[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>>, !pod.type<[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>
+// CHECK-NEXT:            %[[VAL_123:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_122]][@prev_new1] : <[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_124:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_122]][@prev_na] : <[@prev_new1: !felt.type<"bn128">, @prev_na: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:            function.call @SMTProcessorSM::@SMTProcessorSM::@constrain(%[[VAL_121]], %[[VAL_123]], %[[VAL_124]]) : (!struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, !felt.type<"bn128">, !felt.type<"bn128">) -> ()
 // CHECK-NEXT:          }
 // CHECK-NEXT:          function.return
 // CHECK-NEXT:        }
@@ -203,11 +211,11 @@ component main = SMTProcessor(2);
 // CHECK-NEXT:    }
 // CHECK-NEXT:    poly.template @SMTProcessorSM {
 // CHECK-NEXT:      struct.def @SMTProcessorSM {
-// CHECK-NEXT:        function.def @compute(%[[VAL_117:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">, %[[VAL_118:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) -> !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
-// CHECK-NEXT:          %[[VAL_119:[0-9a-zA-Z_\.]+]] = struct.new : <@SMTProcessorSM::@SMTProcessorSM<[]>>
-// CHECK-NEXT:          function.return %[[VAL_119]] : !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>
+// CHECK-NEXT:        function.def @compute(%[[VAL_125:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">, %[[VAL_126:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) -> !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
+// CHECK-NEXT:          %[[VAL_127:[0-9a-zA-Z_\.]+]] = struct.new : <@SMTProcessorSM::@SMTProcessorSM<[]>>
+// CHECK-NEXT:          function.return %[[VAL_127]] : !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>
 // CHECK-NEXT:        }
-// CHECK-NEXT:        function.def @constrain(%[[VAL_120:[0-9a-zA-Z_\.]+]]: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, %[[VAL_121:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">, %[[VAL_122:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        function.def @constrain(%[[VAL_128:[0-9a-zA-Z_\.]+]]: !struct.type<@SMTProcessorSM::@SMTProcessorSM<[]>>, %[[VAL_129:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">, %[[VAL_130:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:          function.return
 // CHECK-NEXT:        }
 // CHECK-NEXT:      }

--- a/circom/tests/misc/unreachable_code_crash.circom
+++ b/circom/tests/misc/unreachable_code_crash.circom
@@ -89,129 +89,137 @@ component main = InvalidArgIndex(3, 2);
 // CHECK-NEXT:                %[[VAL_50:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_49]], %[[VAL_26]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:                %[[VAL_51:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_50]] : !felt.type<"bn128">
 // CHECK-NEXT:                %[[VAL_52:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_7]]{{\[}}%[[VAL_51]]] : <@"k_Mul_n@338" x !pod.type<[@count: index, @comp: !struct.type<@OR::@OR<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@OR::@OR<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:                %[[VAL_53:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_52]][@count] : <[@count: index, @comp: !struct.type<@OR::@OR<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:                %[[VAL_54:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:                %[[VAL_55:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_53]], %[[VAL_54]] : index
-// CHECK-NEXT:                pod.write %[[VAL_52]][@count] = %[[VAL_55]] : <[@count: index, @comp: !struct.type<@OR::@OR<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:                %[[VAL_56:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:                %[[VAL_57:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_55]], %[[VAL_56]] : index
-// CHECK-NEXT:                scf.if %[[VAL_57]] {
-// CHECK-NEXT:                  %[[VAL_58:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_52]][@params] : <[@count: index, @comp: !struct.type<@OR::@OR<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
-// CHECK-NEXT:                  %[[VAL_59:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_45]][@a] : <[@a: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:                  %[[VAL_60:[0-9a-zA-Z_\.]+]] = function.call @OR::@OR::@compute(%[[VAL_59]]) : (!felt.type<"bn128">) -> !struct.type<@OR::@OR<[]>>
-// CHECK-NEXT:                  pod.write %[[VAL_52]][@comp] = %[[VAL_60]] : <[@count: index, @comp: !struct.type<@OR::@OR<[]>>, @params: !pod.type<[]>]>, !struct.type<@OR::@OR<[]>>
-// CHECK-NEXT:                  %[[VAL_61:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_6]], %[[VAL_17]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:                  %[[VAL_62:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_61]], %[[VAL_26]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:                  %[[VAL_63:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_62]] : !felt.type<"bn128">
-// CHECK-NEXT:                  array.write %[[VAL_7]]{{\[}}%[[VAL_63]]] = %[[VAL_52]] : <@"k_Mul_n@338" x !pod.type<[@count: index, @comp: !struct.type<@OR::@OR<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@OR::@OR<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:                %[[VAL_53:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_6]], %[[VAL_17]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_54:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_53]], %[[VAL_26]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_55:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_54]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_56:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_25]]{{\[}}%[[VAL_55]]] : <@"k_Mul_n@338" x !pod.type<[@a: !felt.type<"bn128">]>>, !pod.type<[@a: !felt.type<"bn128">]>
+// CHECK-NEXT:                %[[VAL_57:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_52]][@count] : <[@count: index, @comp: !struct.type<@OR::@OR<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:                %[[VAL_58:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:                %[[VAL_59:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_57]], %[[VAL_58]] : index
+// CHECK-NEXT:                pod.write %[[VAL_52]][@count] = %[[VAL_59]] : <[@count: index, @comp: !struct.type<@OR::@OR<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:                %[[VAL_60:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:                %[[VAL_61:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_59]], %[[VAL_60]] : index
+// CHECK-NEXT:                scf.if %[[VAL_61]] {
+// CHECK-NEXT:                  %[[VAL_62:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_52]][@params] : <[@count: index, @comp: !struct.type<@OR::@OR<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
+// CHECK-NEXT:                  %[[VAL_63:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_56]][@a] : <[@a: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:                  %[[VAL_64:[0-9a-zA-Z_\.]+]] = function.call @OR::@OR::@compute(%[[VAL_63]]) : (!felt.type<"bn128">) -> !struct.type<@OR::@OR<[]>>
+// CHECK-NEXT:                  pod.write %[[VAL_52]][@comp] = %[[VAL_64]] : <[@count: index, @comp: !struct.type<@OR::@OR<[]>>, @params: !pod.type<[]>]>, !struct.type<@OR::@OR<[]>>
+// CHECK-NEXT:                  %[[VAL_65:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_6]], %[[VAL_17]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:                  %[[VAL_66:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_65]], %[[VAL_26]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:                  %[[VAL_67:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_66]] : !felt.type<"bn128">
+// CHECK-NEXT:                  array.write %[[VAL_7]]{{\[}}%[[VAL_67]]] = %[[VAL_52]] : <@"k_Mul_n@338" x !pod.type<[@count: index, @comp: !struct.type<@OR::@OR<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@OR::@OR<[]>>, @params: !pod.type<[]>]>
 // CHECK-NEXT:                }
 // CHECK-NEXT:                scf.yield %[[VAL_25]] : !array.type<@"k_Mul_n@338" x !pod.type<[@a: !felt.type<"bn128">]>>
 // CHECK-NEXT:              } else {
-// CHECK-NEXT:                %[[VAL_64:[0-9a-zA-Z_\.]+]] = felt.const  33 : <"bn128">
-// CHECK-NEXT:                %[[VAL_65:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_6]], %[[VAL_17]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_66:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_65]], %[[VAL_26]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_67:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_66]] : !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_68:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_25]]{{\[}}%[[VAL_67]]] : <@"k_Mul_n@338" x !pod.type<[@a: !felt.type<"bn128">]>>, !pod.type<[@a: !felt.type<"bn128">]>
-// CHECK-NEXT:                pod.write %[[VAL_68]][@a] = %[[VAL_64]] : <[@a: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_68:[0-9a-zA-Z_\.]+]] = felt.const  33 : <"bn128">
 // CHECK-NEXT:                %[[VAL_69:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_6]], %[[VAL_17]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:                %[[VAL_70:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_69]], %[[VAL_26]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:                %[[VAL_71:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_70]] : !felt.type<"bn128">
-// CHECK-NEXT:                array.write %[[VAL_25]]{{\[}}%[[VAL_71]]] = %[[VAL_68]] : <@"k_Mul_n@338" x !pod.type<[@a: !felt.type<"bn128">]>>, !pod.type<[@a: !felt.type<"bn128">]>
-// CHECK-NEXT:                %[[VAL_72:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_6]], %[[VAL_17]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_73:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_72]], %[[VAL_26]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_74:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_73]] : !felt.type<"bn128">
-// CHECK-NEXT:                %[[VAL_75:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_7]]{{\[}}%[[VAL_74]]] : <@"k_Mul_n@338" x !pod.type<[@count: index, @comp: !struct.type<@OR::@OR<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@OR::@OR<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:                %[[VAL_76:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_75]][@count] : <[@count: index, @comp: !struct.type<@OR::@OR<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:                %[[VAL_77:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:                %[[VAL_78:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_76]], %[[VAL_77]] : index
-// CHECK-NEXT:                pod.write %[[VAL_75]][@count] = %[[VAL_78]] : <[@count: index, @comp: !struct.type<@OR::@OR<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:                %[[VAL_79:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:                %[[VAL_80:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_78]], %[[VAL_79]] : index
-// CHECK-NEXT:                scf.if %[[VAL_80]] {
-// CHECK-NEXT:                  %[[VAL_81:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_75]][@params] : <[@count: index, @comp: !struct.type<@OR::@OR<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
-// CHECK-NEXT:                  %[[VAL_82:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_68]][@a] : <[@a: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:                  %[[VAL_83:[0-9a-zA-Z_\.]+]] = function.call @OR::@OR::@compute(%[[VAL_82]]) : (!felt.type<"bn128">) -> !struct.type<@OR::@OR<[]>>
-// CHECK-NEXT:                  pod.write %[[VAL_75]][@comp] = %[[VAL_83]] : <[@count: index, @comp: !struct.type<@OR::@OR<[]>>, @params: !pod.type<[]>]>, !struct.type<@OR::@OR<[]>>
-// CHECK-NEXT:                  %[[VAL_84:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_6]], %[[VAL_17]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:                  %[[VAL_85:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_84]], %[[VAL_26]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:                  %[[VAL_86:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_85]] : !felt.type<"bn128">
-// CHECK-NEXT:                  array.write %[[VAL_7]]{{\[}}%[[VAL_86]]] = %[[VAL_75]] : <@"k_Mul_n@338" x !pod.type<[@count: index, @comp: !struct.type<@OR::@OR<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@OR::@OR<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:                %[[VAL_72:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_25]]{{\[}}%[[VAL_71]]] : <@"k_Mul_n@338" x !pod.type<[@a: !felt.type<"bn128">]>>, !pod.type<[@a: !felt.type<"bn128">]>
+// CHECK-NEXT:                pod.write %[[VAL_72]][@a] = %[[VAL_68]] : <[@a: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_73:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_6]], %[[VAL_17]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_74:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_73]], %[[VAL_26]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_75:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_74]] : !felt.type<"bn128">
+// CHECK-NEXT:                array.write %[[VAL_25]]{{\[}}%[[VAL_75]]] = %[[VAL_72]] : <@"k_Mul_n@338" x !pod.type<[@a: !felt.type<"bn128">]>>, !pod.type<[@a: !felt.type<"bn128">]>
+// CHECK-NEXT:                %[[VAL_76:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_6]], %[[VAL_17]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_77:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_76]], %[[VAL_26]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_78:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_77]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_79:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_7]]{{\[}}%[[VAL_78]]] : <@"k_Mul_n@338" x !pod.type<[@count: index, @comp: !struct.type<@OR::@OR<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@OR::@OR<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:                %[[VAL_80:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_6]], %[[VAL_17]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_81:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_80]], %[[VAL_26]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_82:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_81]] : !felt.type<"bn128">
+// CHECK-NEXT:                %[[VAL_83:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_25]]{{\[}}%[[VAL_82]]] : <@"k_Mul_n@338" x !pod.type<[@a: !felt.type<"bn128">]>>, !pod.type<[@a: !felt.type<"bn128">]>
+// CHECK-NEXT:                %[[VAL_84:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_79]][@count] : <[@count: index, @comp: !struct.type<@OR::@OR<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:                %[[VAL_85:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:                %[[VAL_86:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_84]], %[[VAL_85]] : index
+// CHECK-NEXT:                pod.write %[[VAL_79]][@count] = %[[VAL_86]] : <[@count: index, @comp: !struct.type<@OR::@OR<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:                %[[VAL_87:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:                %[[VAL_88:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_86]], %[[VAL_87]] : index
+// CHECK-NEXT:                scf.if %[[VAL_88]] {
+// CHECK-NEXT:                  %[[VAL_89:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_79]][@params] : <[@count: index, @comp: !struct.type<@OR::@OR<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
+// CHECK-NEXT:                  %[[VAL_90:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_83]][@a] : <[@a: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:                  %[[VAL_91:[0-9a-zA-Z_\.]+]] = function.call @OR::@OR::@compute(%[[VAL_90]]) : (!felt.type<"bn128">) -> !struct.type<@OR::@OR<[]>>
+// CHECK-NEXT:                  pod.write %[[VAL_79]][@comp] = %[[VAL_91]] : <[@count: index, @comp: !struct.type<@OR::@OR<[]>>, @params: !pod.type<[]>]>, !struct.type<@OR::@OR<[]>>
+// CHECK-NEXT:                  %[[VAL_92:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_6]], %[[VAL_17]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:                  %[[VAL_93:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_92]], %[[VAL_26]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:                  %[[VAL_94:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_93]] : !felt.type<"bn128">
+// CHECK-NEXT:                  array.write %[[VAL_7]]{{\[}}%[[VAL_94]]] = %[[VAL_79]] : <@"k_Mul_n@338" x !pod.type<[@count: index, @comp: !struct.type<@OR::@OR<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@OR::@OR<[]>>, @params: !pod.type<[]>]>
 // CHECK-NEXT:                }
 // CHECK-NEXT:                scf.yield %[[VAL_25]] : !array.type<@"k_Mul_n@338" x !pod.type<[@a: !felt.type<"bn128">]>>
 // CHECK-NEXT:              }
-// CHECK-NEXT:              %[[VAL_87:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:              %[[VAL_88:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_26]], %[[VAL_87]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:              scf.yield %[[VAL_40]], %[[VAL_88]] : !array.type<@"k_Mul_n@338" x !pod.type<[@a: !felt.type<"bn128">]>>, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_95:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:              %[[VAL_96:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_26]], %[[VAL_95]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:              scf.yield %[[VAL_40]], %[[VAL_96]] : !array.type<@"k_Mul_n@338" x !pod.type<[@a: !felt.type<"bn128">]>>, !felt.type<"bn128">
 // CHECK-NEXT:            }
-// CHECK-NEXT:            %[[VAL_89:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_90:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_17]], %[[VAL_89]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            scf.yield %[[VAL_20]]#0, %[[VAL_90]] : !array.type<@"k_Mul_n@338" x !pod.type<[@a: !felt.type<"bn128">]>>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_97:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_98:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_17]], %[[VAL_97]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_20]]#0, %[[VAL_98]] : !array.type<@"k_Mul_n@338" x !pod.type<[@a: !felt.type<"bn128">]>>, !felt.type<"bn128">
 // CHECK-NEXT:          }
 // CHECK-NEXT:          struct.writem %[[VAL_3]][@has_prev_non_zero$inputs] = %[[VAL_11]]#0 : <@InvalidArgIndex::@InvalidArgIndex<[@n, @k]>>, !array.type<@"k_Mul_n@338" x !pod.type<[@a: !felt.type<"bn128">]>>
-// CHECK-NEXT:          %[[VAL_91:[0-9a-zA-Z_\.]+]] = array.new  : <@"k_Mul_n@338" x !struct.type<@OR::@OR<[]>>>
-// CHECK-NEXT:          %[[VAL_92:[0-9a-zA-Z_\.]+]] = poly.read_const @"k_Mul_n@338" : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_93:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_92]] : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_94:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[VAL_95:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:          scf.for %[[VAL_96:[0-9a-zA-Z_\.]+]] = %[[VAL_94]] to %[[VAL_93]] step %[[VAL_95]] {
-// CHECK-NEXT:            %[[VAL_97:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_7]]{{\[}}%[[VAL_96]]] : <@"k_Mul_n@338" x !pod.type<[@count: index, @comp: !struct.type<@OR::@OR<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@OR::@OR<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:            %[[VAL_98:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_97]][@comp] : <[@count: index, @comp: !struct.type<@OR::@OR<[]>>, @params: !pod.type<[]>]>, !struct.type<@OR::@OR<[]>>
-// CHECK-NEXT:            array.write %[[VAL_91]]{{\[}}%[[VAL_96]]] = %[[VAL_98]] : <@"k_Mul_n@338" x !struct.type<@OR::@OR<[]>>>, !struct.type<@OR::@OR<[]>>
+// CHECK-NEXT:          %[[VAL_99:[0-9a-zA-Z_\.]+]] = array.new  : <@"k_Mul_n@338" x !struct.type<@OR::@OR<[]>>>
+// CHECK-NEXT:          %[[VAL_100:[0-9a-zA-Z_\.]+]] = poly.read_const @"k_Mul_n@338" : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_101:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_100]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_102:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_103:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          scf.for %[[VAL_104:[0-9a-zA-Z_\.]+]] = %[[VAL_102]] to %[[VAL_101]] step %[[VAL_103]] {
+// CHECK-NEXT:            %[[VAL_105:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_7]]{{\[}}%[[VAL_104]]] : <@"k_Mul_n@338" x !pod.type<[@count: index, @comp: !struct.type<@OR::@OR<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@OR::@OR<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:            %[[VAL_106:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_105]][@comp] : <[@count: index, @comp: !struct.type<@OR::@OR<[]>>, @params: !pod.type<[]>]>, !struct.type<@OR::@OR<[]>>
+// CHECK-NEXT:            array.write %[[VAL_99]]{{\[}}%[[VAL_104]]] = %[[VAL_106]] : <@"k_Mul_n@338" x !struct.type<@OR::@OR<[]>>>, !struct.type<@OR::@OR<[]>>
 // CHECK-NEXT:          }
-// CHECK-NEXT:          struct.writem %[[VAL_3]][@has_prev_non_zero] = %[[VAL_91]] : <@InvalidArgIndex::@InvalidArgIndex<[@n, @k]>>, !array.type<@"k_Mul_n@338" x !struct.type<@OR::@OR<[]>>>
+// CHECK-NEXT:          struct.writem %[[VAL_3]][@has_prev_non_zero] = %[[VAL_99]] : <@InvalidArgIndex::@InvalidArgIndex<[@n, @k]>>, !array.type<@"k_Mul_n@338" x !struct.type<@OR::@OR<[]>>>
 // CHECK-NEXT:          function.return %[[VAL_3]] : !struct.type<@InvalidArgIndex::@InvalidArgIndex<[@n, @k]>>
 // CHECK-NEXT:        }
-// CHECK-NEXT:        function.def @constrain(%[[VAL_99:[0-9a-zA-Z_\.]+]]: !struct.type<@InvalidArgIndex::@InvalidArgIndex<[@n, @k]>>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:          %[[VAL_100:[0-9a-zA-Z_\.]+]] = poly.read_const @k : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_101:[0-9a-zA-Z_\.]+]] = poly.read_const @"k_Mul_n@338" : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_102:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_103:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_99]][@has_prev_non_zero] : <@InvalidArgIndex::@InvalidArgIndex<[@n, @k]>>, !array.type<@"k_Mul_n@338" x !struct.type<@OR::@OR<[]>>>
-// CHECK-NEXT:          %[[VAL_104:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_99]][@has_prev_non_zero$inputs] : <@InvalidArgIndex::@InvalidArgIndex<[@n, @k]>>, !array.type<@"k_Mul_n@338" x !pod.type<[@a: !felt.type<"bn128">]>>
-// CHECK-NEXT:          %[[VAL_105:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:          %[[VAL_106:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_100]], %[[VAL_105]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_107:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_108:[0-9a-zA-Z_\.]+]] = %[[VAL_106]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
-// CHECK-NEXT:            %[[VAL_109:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:            %[[VAL_110:[0-9a-zA-Z_\.]+]] = bool.cmp ge(%[[VAL_108]], %[[VAL_109]]) : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            scf.condition(%[[VAL_110]]) %[[VAL_108]] : !felt.type<"bn128">
+// CHECK-NEXT:        function.def @constrain(%[[VAL_107:[0-9a-zA-Z_\.]+]]: !struct.type<@InvalidArgIndex::@InvalidArgIndex<[@n, @k]>>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_108:[0-9a-zA-Z_\.]+]] = poly.read_const @k : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_109:[0-9a-zA-Z_\.]+]] = poly.read_const @"k_Mul_n@338" : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_110:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_111:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_107]][@has_prev_non_zero] : <@InvalidArgIndex::@InvalidArgIndex<[@n, @k]>>, !array.type<@"k_Mul_n@338" x !struct.type<@OR::@OR<[]>>>
+// CHECK-NEXT:          %[[VAL_112:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_107]][@has_prev_non_zero$inputs] : <@InvalidArgIndex::@InvalidArgIndex<[@n, @k]>>, !array.type<@"k_Mul_n@338" x !pod.type<[@a: !felt.type<"bn128">]>>
+// CHECK-NEXT:          %[[VAL_113:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_114:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_108]], %[[VAL_113]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_115:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_116:[0-9a-zA-Z_\.]+]] = %[[VAL_114]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
+// CHECK-NEXT:            %[[VAL_117:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:            %[[VAL_118:[0-9a-zA-Z_\.]+]] = bool.cmp ge(%[[VAL_116]], %[[VAL_117]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.condition(%[[VAL_118]]) %[[VAL_116]] : !felt.type<"bn128">
 // CHECK-NEXT:          } do {
-// CHECK-NEXT:          ^bb0(%[[VAL_111:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
-// CHECK-NEXT:            %[[VAL_112:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_113:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_102]], %[[VAL_112]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_114:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_115:[0-9a-zA-Z_\.]+]] = %[[VAL_113]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
-// CHECK-NEXT:              %[[VAL_116:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:              %[[VAL_117:[0-9a-zA-Z_\.]+]] = bool.cmp ge(%[[VAL_115]], %[[VAL_116]]) : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:              scf.condition(%[[VAL_117]]) %[[VAL_115]] : !felt.type<"bn128">
+// CHECK-NEXT:          ^bb0(%[[VAL_119:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
+// CHECK-NEXT:            %[[VAL_120:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_121:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_110]], %[[VAL_120]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_122:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_123:[0-9a-zA-Z_\.]+]] = %[[VAL_121]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
+// CHECK-NEXT:              %[[VAL_124:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:              %[[VAL_125:[0-9a-zA-Z_\.]+]] = bool.cmp ge(%[[VAL_123]], %[[VAL_124]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:              scf.condition(%[[VAL_125]]) %[[VAL_123]] : !felt.type<"bn128">
 // CHECK-NEXT:            } do {
-// CHECK-NEXT:            ^bb0(%[[VAL_118:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
-// CHECK-NEXT:              %[[VAL_119:[0-9a-zA-Z_\.]+]] = pod.new : <[]>
-// CHECK-NEXT:              %[[VAL_120:[0-9a-zA-Z_\.]+]] = pod.new : <[@count: index, @comp: !struct.type<@OR::@OR<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:              %[[VAL_121:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:              %[[VAL_122:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_100]], %[[VAL_121]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_123:[0-9a-zA-Z_\.]+]] = bool.cmp eq(%[[VAL_111]], %[[VAL_122]]) : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_124:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:              %[[VAL_125:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_102]], %[[VAL_124]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_126:[0-9a-zA-Z_\.]+]] = bool.cmp eq(%[[VAL_118]], %[[VAL_125]]) : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_127:[0-9a-zA-Z_\.]+]] = bool.and %[[VAL_123]], %[[VAL_126]] : i1, i1
-// CHECK-NEXT:              scf.if %[[VAL_127]] {
+// CHECK-NEXT:            ^bb0(%[[VAL_126:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
+// CHECK-NEXT:              %[[VAL_127:[0-9a-zA-Z_\.]+]] = pod.new : <[]>
+// CHECK-NEXT:              %[[VAL_128:[0-9a-zA-Z_\.]+]] = pod.new : <[@count: index, @comp: !struct.type<@OR::@OR<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:              %[[VAL_129:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:              %[[VAL_130:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_108]], %[[VAL_129]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_131:[0-9a-zA-Z_\.]+]] = bool.cmp eq(%[[VAL_119]], %[[VAL_130]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_132:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:              %[[VAL_133:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_110]], %[[VAL_132]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_134:[0-9a-zA-Z_\.]+]] = bool.cmp eq(%[[VAL_126]], %[[VAL_133]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_135:[0-9a-zA-Z_\.]+]] = bool.and %[[VAL_131]], %[[VAL_134]] : i1, i1
+// CHECK-NEXT:              scf.if %[[VAL_135]] {
 // CHECK-NEXT:              } else {
 // CHECK-NEXT:              }
-// CHECK-NEXT:              %[[VAL_128:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:              %[[VAL_129:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_118]], %[[VAL_128]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:              scf.yield %[[VAL_129]] : !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_136:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:              %[[VAL_137:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_126]], %[[VAL_136]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:              scf.yield %[[VAL_137]] : !felt.type<"bn128">
 // CHECK-NEXT:            }
-// CHECK-NEXT:            %[[VAL_130:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_131:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_111]], %[[VAL_130]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            scf.yield %[[VAL_131]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_138:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_139:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_119]], %[[VAL_138]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_139]] : !felt.type<"bn128">
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[VAL_132:[0-9a-zA-Z_\.]+]] = poly.read_const @"k_Mul_n@338" : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_133:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_132]] : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_134:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[VAL_135:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:          scf.for %[[VAL_136:[0-9a-zA-Z_\.]+]] = %[[VAL_134]] to %[[VAL_133]] step %[[VAL_135]] {
-// CHECK-NEXT:            %[[VAL_137:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_103]]{{\[}}%[[VAL_136]]] : <@"k_Mul_n@338" x !struct.type<@OR::@OR<[]>>>, !struct.type<@OR::@OR<[]>>
-// CHECK-NEXT:            %[[VAL_138:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_104]]{{\[}}%[[VAL_136]]] : <@"k_Mul_n@338" x !pod.type<[@a: !felt.type<"bn128">]>>, !pod.type<[@a: !felt.type<"bn128">]>
-// CHECK-NEXT:            %[[VAL_139:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_138]][@a] : <[@a: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:            function.call @OR::@OR::@constrain(%[[VAL_137]], %[[VAL_139]]) : (!struct.type<@OR::@OR<[]>>, !felt.type<"bn128">) -> ()
+// CHECK-NEXT:          %[[VAL_140:[0-9a-zA-Z_\.]+]] = poly.read_const @"k_Mul_n@338" : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_141:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_140]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_142:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_143:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          scf.for %[[VAL_144:[0-9a-zA-Z_\.]+]] = %[[VAL_142]] to %[[VAL_141]] step %[[VAL_143]] {
+// CHECK-NEXT:            %[[VAL_145:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_111]]{{\[}}%[[VAL_144]]] : <@"k_Mul_n@338" x !struct.type<@OR::@OR<[]>>>, !struct.type<@OR::@OR<[]>>
+// CHECK-NEXT:            %[[VAL_146:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_112]]{{\[}}%[[VAL_144]]] : <@"k_Mul_n@338" x !pod.type<[@a: !felt.type<"bn128">]>>, !pod.type<[@a: !felt.type<"bn128">]>
+// CHECK-NEXT:            %[[VAL_147:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_146]][@a] : <[@a: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:            function.call @OR::@OR::@constrain(%[[VAL_145]], %[[VAL_147]]) : (!struct.type<@OR::@OR<[]>>, !felt.type<"bn128">) -> ()
 // CHECK-NEXT:          }
 // CHECK-NEXT:          function.return
 // CHECK-NEXT:        }
@@ -219,11 +227,11 @@ component main = InvalidArgIndex(3, 2);
 // CHECK-NEXT:    }
 // CHECK-NEXT:    poly.template @OR {
 // CHECK-NEXT:      struct.def @OR {
-// CHECK-NEXT:        function.def @compute(%[[VAL_140:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) -> !struct.type<@OR::@OR<[]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
-// CHECK-NEXT:          %[[VAL_141:[0-9a-zA-Z_\.]+]] = struct.new : <@OR::@OR<[]>>
-// CHECK-NEXT:          function.return %[[VAL_141]] : !struct.type<@OR::@OR<[]>>
+// CHECK-NEXT:        function.def @compute(%[[VAL_148:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) -> !struct.type<@OR::@OR<[]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
+// CHECK-NEXT:          %[[VAL_149:[0-9a-zA-Z_\.]+]] = struct.new : <@OR::@OR<[]>>
+// CHECK-NEXT:          function.return %[[VAL_149]] : !struct.type<@OR::@OR<[]>>
 // CHECK-NEXT:        }
-// CHECK-NEXT:        function.def @constrain(%[[VAL_142:[0-9a-zA-Z_\.]+]]: !struct.type<@OR::@OR<[]>>, %[[VAL_143:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:        function.def @constrain(%[[VAL_150:[0-9a-zA-Z_\.]+]]: !struct.type<@OR::@OR<[]>>, %[[VAL_151:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
 // CHECK-NEXT:          function.return
 // CHECK-NEXT:        }
 // CHECK-NEXT:      }

--- a/circom/tests/subcmps/subcmps0A.circom
+++ b/circom/tests/subcmps/subcmps0A.circom
@@ -73,69 +73,71 @@ component main = SubCmps0A(2);
 // CHECK-NEXT:            array.write %[[VAL_18]]{{\[}}%[[VAL_27]]] = %[[VAL_26]] : <@n x !pod.type<[@in: !felt.type<"bn128">]>>, !pod.type<[@in: !felt.type<"bn128">]>
 // CHECK-NEXT:            %[[VAL_28:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_17]] : !felt.type<"bn128">
 // CHECK-NEXT:            %[[VAL_29:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_10]]{{\[}}%[[VAL_28]]] : <@n x !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:            %[[VAL_30:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_29]][@count] : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:            %[[VAL_31:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:            %[[VAL_32:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_30]], %[[VAL_31]] : index
-// CHECK-NEXT:            pod.write %[[VAL_29]][@count] = %[[VAL_32]] : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:            %[[VAL_33:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:            %[[VAL_34:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_32]], %[[VAL_33]] : index
-// CHECK-NEXT:            scf.if %[[VAL_34]] {
-// CHECK-NEXT:              %[[VAL_35:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_29]][@params] : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
-// CHECK-NEXT:              %[[VAL_36:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_26]][@in] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_37:[0-9a-zA-Z_\.]+]] = function.call @IsZero::@IsZero::@compute(%[[VAL_36]]) : (!felt.type<"bn128">) -> !struct.type<@IsZero::@IsZero<[]>>
-// CHECK-NEXT:              pod.write %[[VAL_29]][@comp] = %[[VAL_37]] : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>, !struct.type<@IsZero::@IsZero<[]>>
-// CHECK-NEXT:              %[[VAL_38:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_17]] : !felt.type<"bn128">
-// CHECK-NEXT:              array.write %[[VAL_10]]{{\[}}%[[VAL_38]]] = %[[VAL_29]] : <@n x !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:            %[[VAL_30:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_17]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_31:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_18]]{{\[}}%[[VAL_30]]] : <@n x !pod.type<[@in: !felt.type<"bn128">]>>, !pod.type<[@in: !felt.type<"bn128">]>
+// CHECK-NEXT:            %[[VAL_32:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_29]][@count] : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:            %[[VAL_33:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:            %[[VAL_34:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_32]], %[[VAL_33]] : index
+// CHECK-NEXT:            pod.write %[[VAL_29]][@count] = %[[VAL_34]] : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:            %[[VAL_35:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:            %[[VAL_36:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_34]], %[[VAL_35]] : index
+// CHECK-NEXT:            scf.if %[[VAL_36]] {
+// CHECK-NEXT:              %[[VAL_37:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_29]][@params] : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
+// CHECK-NEXT:              %[[VAL_38:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_31]][@in] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_39:[0-9a-zA-Z_\.]+]] = function.call @IsZero::@IsZero::@compute(%[[VAL_38]]) : (!felt.type<"bn128">) -> !struct.type<@IsZero::@IsZero<[]>>
+// CHECK-NEXT:              pod.write %[[VAL_29]][@comp] = %[[VAL_39]] : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>, !struct.type<@IsZero::@IsZero<[]>>
+// CHECK-NEXT:              %[[VAL_40:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_17]] : !felt.type<"bn128">
+// CHECK-NEXT:              array.write %[[VAL_10]]{{\[}}%[[VAL_40]]] = %[[VAL_29]] : <@n x !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>
 // CHECK-NEXT:            }
-// CHECK-NEXT:            %[[VAL_39:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_17]] : !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_40:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_10]]{{\[}}%[[VAL_39]]] : <@n x !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:            %[[VAL_41:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_40]][@comp] : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>, !struct.type<@IsZero::@IsZero<[]>>
-// CHECK-NEXT:            %[[VAL_42:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_41]][@out] : <@IsZero::@IsZero<[]>>, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_43:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_17]] : !felt.type<"bn128">
-// CHECK-NEXT:            array.write %[[VAL_9]]{{\[}}%[[VAL_43]]] = %[[VAL_42]] : <@n x !felt.type<"bn128">>, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_44:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_45:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_17]], %[[VAL_44]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            scf.yield %[[VAL_45]], %[[VAL_18]] : !felt.type<"bn128">, !array.type<@n x !pod.type<[@in: !felt.type<"bn128">]>>
+// CHECK-NEXT:            %[[VAL_41:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_17]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_42:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_10]]{{\[}}%[[VAL_41]]] : <@n x !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:            %[[VAL_43:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_42]][@comp] : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>, !struct.type<@IsZero::@IsZero<[]>>
+// CHECK-NEXT:            %[[VAL_44:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_43]][@out] : <@IsZero::@IsZero<[]>>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_45:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_17]] : !felt.type<"bn128">
+// CHECK-NEXT:            array.write %[[VAL_9]]{{\[}}%[[VAL_45]]] = %[[VAL_44]] : <@n x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_46:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_47:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_17]], %[[VAL_46]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_47]], %[[VAL_18]] : !felt.type<"bn128">, !array.type<@n x !pod.type<[@in: !felt.type<"bn128">]>>
 // CHECK-NEXT:          }
 // CHECK-NEXT:          struct.writem %[[VAL_7]][@zeros$inputs] = %[[VAL_13]]#1 : <@SubCmps0A::@SubCmps0A<[@n]>>, !array.type<@n x !pod.type<[@in: !felt.type<"bn128">]>>
-// CHECK-NEXT:          %[[VAL_46:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !struct.type<@IsZero::@IsZero<[]>>>
-// CHECK-NEXT:          %[[VAL_47:[0-9a-zA-Z_\.]+]] = poly.read_const @n : index
-// CHECK-NEXT:          %[[VAL_48:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[VAL_49:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:          scf.for %[[VAL_50:[0-9a-zA-Z_\.]+]] = %[[VAL_48]] to %[[VAL_47]] step %[[VAL_49]] {
-// CHECK-NEXT:            %[[VAL_51:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_10]]{{\[}}%[[VAL_50]]] : <@n x !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:            %[[VAL_52:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_51]][@comp] : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>, !struct.type<@IsZero::@IsZero<[]>>
-// CHECK-NEXT:            array.write %[[VAL_46]]{{\[}}%[[VAL_50]]] = %[[VAL_52]] : <@n x !struct.type<@IsZero::@IsZero<[]>>>, !struct.type<@IsZero::@IsZero<[]>>
+// CHECK-NEXT:          %[[VAL_48:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !struct.type<@IsZero::@IsZero<[]>>>
+// CHECK-NEXT:          %[[VAL_49:[0-9a-zA-Z_\.]+]] = poly.read_const @n : index
+// CHECK-NEXT:          %[[VAL_50:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_51:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          scf.for %[[VAL_52:[0-9a-zA-Z_\.]+]] = %[[VAL_50]] to %[[VAL_49]] step %[[VAL_51]] {
+// CHECK-NEXT:            %[[VAL_53:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_10]]{{\[}}%[[VAL_52]]] : <@n x !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:            %[[VAL_54:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_53]][@comp] : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>, !struct.type<@IsZero::@IsZero<[]>>
+// CHECK-NEXT:            array.write %[[VAL_48]]{{\[}}%[[VAL_52]]] = %[[VAL_54]] : <@n x !struct.type<@IsZero::@IsZero<[]>>>, !struct.type<@IsZero::@IsZero<[]>>
 // CHECK-NEXT:          }
-// CHECK-NEXT:          struct.writem %[[VAL_7]][@zeros] = %[[VAL_46]] : <@SubCmps0A::@SubCmps0A<[@n]>>, !array.type<@n x !struct.type<@IsZero::@IsZero<[]>>>
+// CHECK-NEXT:          struct.writem %[[VAL_7]][@zeros] = %[[VAL_48]] : <@SubCmps0A::@SubCmps0A<[@n]>>, !array.type<@n x !struct.type<@IsZero::@IsZero<[]>>>
 // CHECK-NEXT:          struct.writem %[[VAL_7]][@outs] = %[[VAL_9]] : <@SubCmps0A::@SubCmps0A<[@n]>>, !array.type<@n x !felt.type<"bn128">>
 // CHECK-NEXT:          function.return %[[VAL_7]] : !struct.type<@SubCmps0A::@SubCmps0A<[@n]>>
 // CHECK-NEXT:        }
-// CHECK-NEXT:        function.def @constrain(%[[VAL_53:[0-9a-zA-Z_\.]+]]: !struct.type<@SubCmps0A::@SubCmps0A<[@n]>>, %[[VAL_54:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type<"bn128">>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:          %[[VAL_55:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_56:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_53]][@outs] : <@SubCmps0A::@SubCmps0A<[@n]>>, !array.type<@n x !felt.type<"bn128">>
-// CHECK-NEXT:          %[[VAL_57:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_53]][@zeros] : <@SubCmps0A::@SubCmps0A<[@n]>>, !array.type<@n x !struct.type<@IsZero::@IsZero<[]>>>
-// CHECK-NEXT:          %[[VAL_58:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_53]][@zeros$inputs] : <@SubCmps0A::@SubCmps0A<[@n]>>, !array.type<@n x !pod.type<[@in: !felt.type<"bn128">]>>
-// CHECK-NEXT:          %[[VAL_59:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:          %[[VAL_60:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_61:[0-9a-zA-Z_\.]+]] = %[[VAL_59]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
-// CHECK-NEXT:            %[[VAL_62:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_61]], %[[VAL_55]]) : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            scf.condition(%[[VAL_62]]) %[[VAL_61]] : !felt.type<"bn128">
+// CHECK-NEXT:        function.def @constrain(%[[VAL_55:[0-9a-zA-Z_\.]+]]: !struct.type<@SubCmps0A::@SubCmps0A<[@n]>>, %[[VAL_56:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type<"bn128">>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_57:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_58:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_55]][@outs] : <@SubCmps0A::@SubCmps0A<[@n]>>, !array.type<@n x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_59:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_55]][@zeros] : <@SubCmps0A::@SubCmps0A<[@n]>>, !array.type<@n x !struct.type<@IsZero::@IsZero<[]>>>
+// CHECK-NEXT:          %[[VAL_60:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_55]][@zeros$inputs] : <@SubCmps0A::@SubCmps0A<[@n]>>, !array.type<@n x !pod.type<[@in: !felt.type<"bn128">]>>
+// CHECK-NEXT:          %[[VAL_61:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_62:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_63:[0-9a-zA-Z_\.]+]] = %[[VAL_61]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
+// CHECK-NEXT:            %[[VAL_64:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_63]], %[[VAL_57]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.condition(%[[VAL_64]]) %[[VAL_63]] : !felt.type<"bn128">
 // CHECK-NEXT:          } do {
-// CHECK-NEXT:          ^bb0(%[[VAL_63:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
-// CHECK-NEXT:            %[[VAL_64:[0-9a-zA-Z_\.]+]] = pod.new : <[]>
-// CHECK-NEXT:            %[[VAL_65:[0-9a-zA-Z_\.]+]] = pod.new : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:            %[[VAL_66:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_67:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_63]], %[[VAL_66]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            scf.yield %[[VAL_67]] : !felt.type<"bn128">
+// CHECK-NEXT:          ^bb0(%[[VAL_65:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
+// CHECK-NEXT:            %[[VAL_66:[0-9a-zA-Z_\.]+]] = pod.new : <[]>
+// CHECK-NEXT:            %[[VAL_67:[0-9a-zA-Z_\.]+]] = pod.new : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:            %[[VAL_68:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_69:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_65]], %[[VAL_68]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_69]] : !felt.type<"bn128">
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[VAL_68:[0-9a-zA-Z_\.]+]] = poly.read_const @n : index
-// CHECK-NEXT:          %[[VAL_69:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[VAL_70:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:          scf.for %[[VAL_71:[0-9a-zA-Z_\.]+]] = %[[VAL_69]] to %[[VAL_68]] step %[[VAL_70]] {
-// CHECK-NEXT:            %[[VAL_72:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_57]]{{\[}}%[[VAL_71]]] : <@n x !struct.type<@IsZero::@IsZero<[]>>>, !struct.type<@IsZero::@IsZero<[]>>
-// CHECK-NEXT:            %[[VAL_73:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_58]]{{\[}}%[[VAL_71]]] : <@n x !pod.type<[@in: !felt.type<"bn128">]>>, !pod.type<[@in: !felt.type<"bn128">]>
-// CHECK-NEXT:            %[[VAL_74:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_73]][@in] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:            function.call @IsZero::@IsZero::@constrain(%[[VAL_72]], %[[VAL_74]]) : (!struct.type<@IsZero::@IsZero<[]>>, !felt.type<"bn128">) -> ()
+// CHECK-NEXT:          %[[VAL_70:[0-9a-zA-Z_\.]+]] = poly.read_const @n : index
+// CHECK-NEXT:          %[[VAL_71:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_72:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          scf.for %[[VAL_73:[0-9a-zA-Z_\.]+]] = %[[VAL_71]] to %[[VAL_70]] step %[[VAL_72]] {
+// CHECK-NEXT:            %[[VAL_74:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_59]]{{\[}}%[[VAL_73]]] : <@n x !struct.type<@IsZero::@IsZero<[]>>>, !struct.type<@IsZero::@IsZero<[]>>
+// CHECK-NEXT:            %[[VAL_75:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_60]]{{\[}}%[[VAL_73]]] : <@n x !pod.type<[@in: !felt.type<"bn128">]>>, !pod.type<[@in: !felt.type<"bn128">]>
+// CHECK-NEXT:            %[[VAL_76:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_75]][@in] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:            function.call @IsZero::@IsZero::@constrain(%[[VAL_74]], %[[VAL_76]]) : (!struct.type<@IsZero::@IsZero<[]>>, !felt.type<"bn128">) -> ()
 // CHECK-NEXT:          }
 // CHECK-NEXT:          function.return
 // CHECK-NEXT:        }

--- a/circom/tests/subcmps/subcmps0B.circom
+++ b/circom/tests/subcmps/subcmps0B.circom
@@ -75,77 +75,79 @@ component main = SubCmps0B(2);
 // CHECK-NEXT:            array.write %[[VAL_21]]{{\[}}%[[VAL_30]]] = %[[VAL_29]] : <@n x !pod.type<[@in: !felt.type<"bn128">]>>, !pod.type<[@in: !felt.type<"bn128">]>
 // CHECK-NEXT:            %[[VAL_31:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_19]] : !felt.type<"bn128">
 // CHECK-NEXT:            %[[VAL_32:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_10]]{{\[}}%[[VAL_31]]] : <@n x !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:            %[[VAL_33:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_32]][@count] : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:            %[[VAL_34:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:            %[[VAL_35:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_33]], %[[VAL_34]] : index
-// CHECK-NEXT:            pod.write %[[VAL_32]][@count] = %[[VAL_35]] : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:            %[[VAL_36:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:            %[[VAL_37:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_35]], %[[VAL_36]] : index
-// CHECK-NEXT:            scf.if %[[VAL_37]] {
-// CHECK-NEXT:              %[[VAL_38:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_32]][@params] : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
-// CHECK-NEXT:              %[[VAL_39:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_29]][@in] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_40:[0-9a-zA-Z_\.]+]] = function.call @IsZero::@IsZero::@compute(%[[VAL_39]]) : (!felt.type<"bn128">) -> !struct.type<@IsZero::@IsZero<[]>>
-// CHECK-NEXT:              pod.write %[[VAL_32]][@comp] = %[[VAL_40]] : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>, !struct.type<@IsZero::@IsZero<[]>>
-// CHECK-NEXT:              %[[VAL_41:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_19]] : !felt.type<"bn128">
-// CHECK-NEXT:              array.write %[[VAL_10]]{{\[}}%[[VAL_41]]] = %[[VAL_32]] : <@n x !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:            %[[VAL_33:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_19]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_34:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_21]]{{\[}}%[[VAL_33]]] : <@n x !pod.type<[@in: !felt.type<"bn128">]>>, !pod.type<[@in: !felt.type<"bn128">]>
+// CHECK-NEXT:            %[[VAL_35:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_32]][@count] : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:            %[[VAL_36:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:            %[[VAL_37:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_35]], %[[VAL_36]] : index
+// CHECK-NEXT:            pod.write %[[VAL_32]][@count] = %[[VAL_37]] : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:            %[[VAL_38:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:            %[[VAL_39:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_37]], %[[VAL_38]] : index
+// CHECK-NEXT:            scf.if %[[VAL_39]] {
+// CHECK-NEXT:              %[[VAL_40:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_32]][@params] : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
+// CHECK-NEXT:              %[[VAL_41:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_34]][@in] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_42:[0-9a-zA-Z_\.]+]] = function.call @IsZero::@IsZero::@compute(%[[VAL_41]]) : (!felt.type<"bn128">) -> !struct.type<@IsZero::@IsZero<[]>>
+// CHECK-NEXT:              pod.write %[[VAL_32]][@comp] = %[[VAL_42]] : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>, !struct.type<@IsZero::@IsZero<[]>>
+// CHECK-NEXT:              %[[VAL_43:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_19]] : !felt.type<"bn128">
+// CHECK-NEXT:              array.write %[[VAL_10]]{{\[}}%[[VAL_43]]] = %[[VAL_32]] : <@n x !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>
 // CHECK-NEXT:            }
-// CHECK-NEXT:            %[[VAL_42:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_19]] : !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_43:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_10]]{{\[}}%[[VAL_42]]] : <@n x !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:            %[[VAL_44:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_43]][@comp] : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>, !struct.type<@IsZero::@IsZero<[]>>
-// CHECK-NEXT:            %[[VAL_45:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_44]][@out] : <@IsZero::@IsZero<[]>>, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_46:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_19]] : !felt.type<"bn128">
-// CHECK-NEXT:            array.write %[[VAL_9]]{{\[}}%[[VAL_46]]] = %[[VAL_45]] : <@n x !felt.type<"bn128">>, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_47:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_19]] : !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_48:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_10]]{{\[}}%[[VAL_47]]] : <@n x !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:            %[[VAL_49:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_48]][@comp] : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>, !struct.type<@IsZero::@IsZero<[]>>
-// CHECK-NEXT:            %[[VAL_50:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_49]][@out] : <@IsZero::@IsZero<[]>>, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_51:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_52:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_19]], %[[VAL_51]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            scf.yield %[[VAL_52]], %[[VAL_50]], %[[VAL_21]] : !felt.type<"bn128">, !felt.type<"bn128">, !array.type<@n x !pod.type<[@in: !felt.type<"bn128">]>>
+// CHECK-NEXT:            %[[VAL_44:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_19]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_45:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_10]]{{\[}}%[[VAL_44]]] : <@n x !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:            %[[VAL_46:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_45]][@comp] : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>, !struct.type<@IsZero::@IsZero<[]>>
+// CHECK-NEXT:            %[[VAL_47:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_46]][@out] : <@IsZero::@IsZero<[]>>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_48:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_19]] : !felt.type<"bn128">
+// CHECK-NEXT:            array.write %[[VAL_9]]{{\[}}%[[VAL_48]]] = %[[VAL_47]] : <@n x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_49:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_19]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_50:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_10]]{{\[}}%[[VAL_49]]] : <@n x !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:            %[[VAL_51:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_50]][@comp] : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>, !struct.type<@IsZero::@IsZero<[]>>
+// CHECK-NEXT:            %[[VAL_52:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_51]][@out] : <@IsZero::@IsZero<[]>>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_53:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_54:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_19]], %[[VAL_53]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_54]], %[[VAL_52]], %[[VAL_21]] : !felt.type<"bn128">, !felt.type<"bn128">, !array.type<@n x !pod.type<[@in: !felt.type<"bn128">]>>
 // CHECK-NEXT:          }
 // CHECK-NEXT:          struct.writem %[[VAL_7]][@zeros$inputs] = %[[VAL_14]]#2 : <@SubCmps0B::@SubCmps0B<[@n]>>, !array.type<@n x !pod.type<[@in: !felt.type<"bn128">]>>
-// CHECK-NEXT:          %[[VAL_53:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !struct.type<@IsZero::@IsZero<[]>>>
-// CHECK-NEXT:          %[[VAL_54:[0-9a-zA-Z_\.]+]] = poly.read_const @n : index
-// CHECK-NEXT:          %[[VAL_55:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[VAL_56:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:          scf.for %[[VAL_57:[0-9a-zA-Z_\.]+]] = %[[VAL_55]] to %[[VAL_54]] step %[[VAL_56]] {
-// CHECK-NEXT:            %[[VAL_58:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_10]]{{\[}}%[[VAL_57]]] : <@n x !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:            %[[VAL_59:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_58]][@comp] : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>, !struct.type<@IsZero::@IsZero<[]>>
-// CHECK-NEXT:            array.write %[[VAL_53]]{{\[}}%[[VAL_57]]] = %[[VAL_59]] : <@n x !struct.type<@IsZero::@IsZero<[]>>>, !struct.type<@IsZero::@IsZero<[]>>
+// CHECK-NEXT:          %[[VAL_55:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !struct.type<@IsZero::@IsZero<[]>>>
+// CHECK-NEXT:          %[[VAL_56:[0-9a-zA-Z_\.]+]] = poly.read_const @n : index
+// CHECK-NEXT:          %[[VAL_57:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_58:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          scf.for %[[VAL_59:[0-9a-zA-Z_\.]+]] = %[[VAL_57]] to %[[VAL_56]] step %[[VAL_58]] {
+// CHECK-NEXT:            %[[VAL_60:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_10]]{{\[}}%[[VAL_59]]] : <@n x !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:            %[[VAL_61:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_60]][@comp] : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>, !struct.type<@IsZero::@IsZero<[]>>
+// CHECK-NEXT:            array.write %[[VAL_55]]{{\[}}%[[VAL_59]]] = %[[VAL_61]] : <@n x !struct.type<@IsZero::@IsZero<[]>>>, !struct.type<@IsZero::@IsZero<[]>>
 // CHECK-NEXT:          }
-// CHECK-NEXT:          struct.writem %[[VAL_7]][@zeros] = %[[VAL_53]] : <@SubCmps0B::@SubCmps0B<[@n]>>, !array.type<@n x !struct.type<@IsZero::@IsZero<[]>>>
+// CHECK-NEXT:          struct.writem %[[VAL_7]][@zeros] = %[[VAL_55]] : <@SubCmps0B::@SubCmps0B<[@n]>>, !array.type<@n x !struct.type<@IsZero::@IsZero<[]>>>
 // CHECK-NEXT:          struct.writem %[[VAL_7]][@outs] = %[[VAL_9]] : <@SubCmps0B::@SubCmps0B<[@n]>>, !array.type<@n x !felt.type<"bn128">>
 // CHECK-NEXT:          function.return %[[VAL_7]] : !struct.type<@SubCmps0B::@SubCmps0B<[@n]>>
 // CHECK-NEXT:        }
-// CHECK-NEXT:        function.def @constrain(%[[VAL_60:[0-9a-zA-Z_\.]+]]: !struct.type<@SubCmps0B::@SubCmps0B<[@n]>>, %[[VAL_61:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type<"bn128">>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:          %[[VAL_62:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_63:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_60]][@outs] : <@SubCmps0B::@SubCmps0B<[@n]>>, !array.type<@n x !felt.type<"bn128">>
-// CHECK-NEXT:          %[[VAL_64:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_60]][@zeros] : <@SubCmps0B::@SubCmps0B<[@n]>>, !array.type<@n x !struct.type<@IsZero::@IsZero<[]>>>
-// CHECK-NEXT:          %[[VAL_65:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_60]][@zeros$inputs] : <@SubCmps0B::@SubCmps0B<[@n]>>, !array.type<@n x !pod.type<[@in: !felt.type<"bn128">]>>
-// CHECK-NEXT:          %[[VAL_66:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:          %[[VAL_67:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:          %[[VAL_68:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_69:[0-9a-zA-Z_\.]+]] = %[[VAL_67]], %[[VAL_70:[0-9a-zA-Z_\.]+]] = %[[VAL_66]]) : (!felt.type<"bn128">, !felt.type<"bn128">) -> (!felt.type<"bn128">, !felt.type<"bn128">) {
-// CHECK-NEXT:            %[[VAL_71:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_69]], %[[VAL_62]]) : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            scf.condition(%[[VAL_71]]) %[[VAL_69]], %[[VAL_70]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:        function.def @constrain(%[[VAL_62:[0-9a-zA-Z_\.]+]]: !struct.type<@SubCmps0B::@SubCmps0B<[@n]>>, %[[VAL_63:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type<"bn128">>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_64:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_65:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_62]][@outs] : <@SubCmps0B::@SubCmps0B<[@n]>>, !array.type<@n x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_66:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_62]][@zeros] : <@SubCmps0B::@SubCmps0B<[@n]>>, !array.type<@n x !struct.type<@IsZero::@IsZero<[]>>>
+// CHECK-NEXT:          %[[VAL_67:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_62]][@zeros$inputs] : <@SubCmps0B::@SubCmps0B<[@n]>>, !array.type<@n x !pod.type<[@in: !felt.type<"bn128">]>>
+// CHECK-NEXT:          %[[VAL_68:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_69:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_70:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_71:[0-9a-zA-Z_\.]+]] = %[[VAL_69]], %[[VAL_72:[0-9a-zA-Z_\.]+]] = %[[VAL_68]]) : (!felt.type<"bn128">, !felt.type<"bn128">) -> (!felt.type<"bn128">, !felt.type<"bn128">) {
+// CHECK-NEXT:            %[[VAL_73:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_71]], %[[VAL_64]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.condition(%[[VAL_73]]) %[[VAL_71]], %[[VAL_72]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:          } do {
-// CHECK-NEXT:          ^bb0(%[[VAL_72:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">, %[[VAL_73:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
-// CHECK-NEXT:            %[[VAL_74:[0-9a-zA-Z_\.]+]] = pod.new : <[]>
-// CHECK-NEXT:            %[[VAL_75:[0-9a-zA-Z_\.]+]] = pod.new : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:            %[[VAL_76:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_72]] : !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_77:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_64]]{{\[}}%[[VAL_76]]] : <@n x !struct.type<@IsZero::@IsZero<[]>>>, !struct.type<@IsZero::@IsZero<[]>>
-// CHECK-NEXT:            %[[VAL_78:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_77]][@out] : <@IsZero::@IsZero<[]>>, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_79:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_80:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_72]], %[[VAL_79]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            scf.yield %[[VAL_80]], %[[VAL_78]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          ^bb0(%[[VAL_74:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">, %[[VAL_75:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
+// CHECK-NEXT:            %[[VAL_76:[0-9a-zA-Z_\.]+]] = pod.new : <[]>
+// CHECK-NEXT:            %[[VAL_77:[0-9a-zA-Z_\.]+]] = pod.new : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:            %[[VAL_78:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_74]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_79:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_66]]{{\[}}%[[VAL_78]]] : <@n x !struct.type<@IsZero::@IsZero<[]>>>, !struct.type<@IsZero::@IsZero<[]>>
+// CHECK-NEXT:            %[[VAL_80:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_79]][@out] : <@IsZero::@IsZero<[]>>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_81:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_82:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_74]], %[[VAL_81]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_82]], %[[VAL_80]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[VAL_81:[0-9a-zA-Z_\.]+]] = poly.read_const @n : index
-// CHECK-NEXT:          %[[VAL_82:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[VAL_83:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:          scf.for %[[VAL_84:[0-9a-zA-Z_\.]+]] = %[[VAL_82]] to %[[VAL_81]] step %[[VAL_83]] {
-// CHECK-NEXT:            %[[VAL_85:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_64]]{{\[}}%[[VAL_84]]] : <@n x !struct.type<@IsZero::@IsZero<[]>>>, !struct.type<@IsZero::@IsZero<[]>>
-// CHECK-NEXT:            %[[VAL_86:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_65]]{{\[}}%[[VAL_84]]] : <@n x !pod.type<[@in: !felt.type<"bn128">]>>, !pod.type<[@in: !felt.type<"bn128">]>
-// CHECK-NEXT:            %[[VAL_87:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_86]][@in] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:            function.call @IsZero::@IsZero::@constrain(%[[VAL_85]], %[[VAL_87]]) : (!struct.type<@IsZero::@IsZero<[]>>, !felt.type<"bn128">) -> ()
+// CHECK-NEXT:          %[[VAL_83:[0-9a-zA-Z_\.]+]] = poly.read_const @n : index
+// CHECK-NEXT:          %[[VAL_84:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_85:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          scf.for %[[VAL_86:[0-9a-zA-Z_\.]+]] = %[[VAL_84]] to %[[VAL_83]] step %[[VAL_85]] {
+// CHECK-NEXT:            %[[VAL_87:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_66]]{{\[}}%[[VAL_86]]] : <@n x !struct.type<@IsZero::@IsZero<[]>>>, !struct.type<@IsZero::@IsZero<[]>>
+// CHECK-NEXT:            %[[VAL_88:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_67]]{{\[}}%[[VAL_86]]] : <@n x !pod.type<[@in: !felt.type<"bn128">]>>, !pod.type<[@in: !felt.type<"bn128">]>
+// CHECK-NEXT:            %[[VAL_89:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_88]][@in] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:            function.call @IsZero::@IsZero::@constrain(%[[VAL_87]], %[[VAL_89]]) : (!struct.type<@IsZero::@IsZero<[]>>, !felt.type<"bn128">) -> ()
 // CHECK-NEXT:          }
 // CHECK-NEXT:          function.return
 // CHECK-NEXT:        }

--- a/circom/tests/subcmps/subcmps0C.circom
+++ b/circom/tests/subcmps/subcmps0C.circom
@@ -77,69 +77,71 @@ component main = SubCmps0C(2);
 // CHECK-NEXT:            array.write %[[VAL_20]]{{\[}}%[[VAL_29]]] = %[[VAL_28]] : <@n x !pod.type<[@in: !felt.type<"bn128">]>>, !pod.type<[@in: !felt.type<"bn128">]>
 // CHECK-NEXT:            %[[VAL_30:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_19]] : !felt.type<"bn128">
 // CHECK-NEXT:            %[[VAL_31:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_12]]{{\[}}%[[VAL_30]]] : <@n x !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:            %[[VAL_32:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_31]][@count] : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:            %[[VAL_33:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:            %[[VAL_34:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_32]], %[[VAL_33]] : index
-// CHECK-NEXT:            pod.write %[[VAL_31]][@count] = %[[VAL_34]] : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:            %[[VAL_35:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:            %[[VAL_36:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_34]], %[[VAL_35]] : index
-// CHECK-NEXT:            scf.if %[[VAL_36]] {
-// CHECK-NEXT:              %[[VAL_37:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_31]][@params] : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
-// CHECK-NEXT:              %[[VAL_38:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_28]][@in] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_39:[0-9a-zA-Z_\.]+]] = function.call @IsZero::@IsZero::@compute(%[[VAL_38]]) : (!felt.type<"bn128">) -> !struct.type<@IsZero::@IsZero<[]>>
-// CHECK-NEXT:              pod.write %[[VAL_31]][@comp] = %[[VAL_39]] : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>, !struct.type<@IsZero::@IsZero<[]>>
-// CHECK-NEXT:              %[[VAL_40:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_19]] : !felt.type<"bn128">
-// CHECK-NEXT:              array.write %[[VAL_12]]{{\[}}%[[VAL_40]]] = %[[VAL_31]] : <@n x !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:            %[[VAL_32:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_19]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_33:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_20]]{{\[}}%[[VAL_32]]] : <@n x !pod.type<[@in: !felt.type<"bn128">]>>, !pod.type<[@in: !felt.type<"bn128">]>
+// CHECK-NEXT:            %[[VAL_34:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_31]][@count] : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:            %[[VAL_35:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:            %[[VAL_36:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_34]], %[[VAL_35]] : index
+// CHECK-NEXT:            pod.write %[[VAL_31]][@count] = %[[VAL_36]] : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:            %[[VAL_37:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:            %[[VAL_38:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_36]], %[[VAL_37]] : index
+// CHECK-NEXT:            scf.if %[[VAL_38]] {
+// CHECK-NEXT:              %[[VAL_39:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_31]][@params] : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
+// CHECK-NEXT:              %[[VAL_40:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_33]][@in] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_41:[0-9a-zA-Z_\.]+]] = function.call @IsZero::@IsZero::@compute(%[[VAL_40]]) : (!felt.type<"bn128">) -> !struct.type<@IsZero::@IsZero<[]>>
+// CHECK-NEXT:              pod.write %[[VAL_31]][@comp] = %[[VAL_41]] : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>, !struct.type<@IsZero::@IsZero<[]>>
+// CHECK-NEXT:              %[[VAL_42:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_19]] : !felt.type<"bn128">
+// CHECK-NEXT:              array.write %[[VAL_12]]{{\[}}%[[VAL_42]]] = %[[VAL_31]] : <@n x !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>
 // CHECK-NEXT:            }
-// CHECK-NEXT:            %[[VAL_41:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_19]] : !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_42:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_12]]{{\[}}%[[VAL_41]]] : <@n x !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:            %[[VAL_43:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_42]][@comp] : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>, !struct.type<@IsZero::@IsZero<[]>>
-// CHECK-NEXT:            %[[VAL_44:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_43]][@out] : <@IsZero::@IsZero<[]>>, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_45:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_19]] : !felt.type<"bn128">
-// CHECK-NEXT:            array.write %[[VAL_11]]{{\[}}%[[VAL_45]]] = %[[VAL_44]] : <@n x !felt.type<"bn128">>, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_46:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_47:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_19]], %[[VAL_46]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            scf.yield %[[VAL_47]], %[[VAL_20]] : !felt.type<"bn128">, !array.type<@n x !pod.type<[@in: !felt.type<"bn128">]>>
+// CHECK-NEXT:            %[[VAL_43:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_19]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_44:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_12]]{{\[}}%[[VAL_43]]] : <@n x !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:            %[[VAL_45:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_44]][@comp] : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>, !struct.type<@IsZero::@IsZero<[]>>
+// CHECK-NEXT:            %[[VAL_46:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_45]][@out] : <@IsZero::@IsZero<[]>>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_47:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_19]] : !felt.type<"bn128">
+// CHECK-NEXT:            array.write %[[VAL_11]]{{\[}}%[[VAL_47]]] = %[[VAL_46]] : <@n x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_48:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_49:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_19]], %[[VAL_48]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_49]], %[[VAL_20]] : !felt.type<"bn128">, !array.type<@n x !pod.type<[@in: !felt.type<"bn128">]>>
 // CHECK-NEXT:          }
 // CHECK-NEXT:          struct.writem %[[VAL_9]][@zeros$inputs] = %[[VAL_15]]#1 : <@SubCmps0C::@SubCmps0C<[@n]>>, !array.type<@n x !pod.type<[@in: !felt.type<"bn128">]>>
-// CHECK-NEXT:          %[[VAL_48:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !struct.type<@IsZero::@IsZero<[]>>>
-// CHECK-NEXT:          %[[VAL_49:[0-9a-zA-Z_\.]+]] = poly.read_const @n : index
-// CHECK-NEXT:          %[[VAL_50:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[VAL_51:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:          scf.for %[[VAL_52:[0-9a-zA-Z_\.]+]] = %[[VAL_50]] to %[[VAL_49]] step %[[VAL_51]] {
-// CHECK-NEXT:            %[[VAL_53:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_12]]{{\[}}%[[VAL_52]]] : <@n x !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:            %[[VAL_54:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_53]][@comp] : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>, !struct.type<@IsZero::@IsZero<[]>>
-// CHECK-NEXT:            array.write %[[VAL_48]]{{\[}}%[[VAL_52]]] = %[[VAL_54]] : <@n x !struct.type<@IsZero::@IsZero<[]>>>, !struct.type<@IsZero::@IsZero<[]>>
+// CHECK-NEXT:          %[[VAL_50:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !struct.type<@IsZero::@IsZero<[]>>>
+// CHECK-NEXT:          %[[VAL_51:[0-9a-zA-Z_\.]+]] = poly.read_const @n : index
+// CHECK-NEXT:          %[[VAL_52:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_53:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          scf.for %[[VAL_54:[0-9a-zA-Z_\.]+]] = %[[VAL_52]] to %[[VAL_51]] step %[[VAL_53]] {
+// CHECK-NEXT:            %[[VAL_55:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_12]]{{\[}}%[[VAL_54]]] : <@n x !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:            %[[VAL_56:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_55]][@comp] : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>, !struct.type<@IsZero::@IsZero<[]>>
+// CHECK-NEXT:            array.write %[[VAL_50]]{{\[}}%[[VAL_54]]] = %[[VAL_56]] : <@n x !struct.type<@IsZero::@IsZero<[]>>>, !struct.type<@IsZero::@IsZero<[]>>
 // CHECK-NEXT:          }
-// CHECK-NEXT:          struct.writem %[[VAL_9]][@zeros] = %[[VAL_48]] : <@SubCmps0C::@SubCmps0C<[@n]>>, !array.type<@n x !struct.type<@IsZero::@IsZero<[]>>>
+// CHECK-NEXT:          struct.writem %[[VAL_9]][@zeros] = %[[VAL_50]] : <@SubCmps0C::@SubCmps0C<[@n]>>, !array.type<@n x !struct.type<@IsZero::@IsZero<[]>>>
 // CHECK-NEXT:          struct.writem %[[VAL_9]][@outs] = %[[VAL_11]] : <@SubCmps0C::@SubCmps0C<[@n]>>, !array.type<@n x !felt.type<"bn128">>
 // CHECK-NEXT:          function.return %[[VAL_9]] : !struct.type<@SubCmps0C::@SubCmps0C<[@n]>>
 // CHECK-NEXT:        }
-// CHECK-NEXT:        function.def @constrain(%[[VAL_55:[0-9a-zA-Z_\.]+]]: !struct.type<@SubCmps0C::@SubCmps0C<[@n]>>, %[[VAL_56:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type<"bn128">>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:          %[[VAL_57:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_58:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_55]][@outs] : <@SubCmps0C::@SubCmps0C<[@n]>>, !array.type<@n x !felt.type<"bn128">>
-// CHECK-NEXT:          %[[VAL_59:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_55]][@zeros] : <@SubCmps0C::@SubCmps0C<[@n]>>, !array.type<@n x !struct.type<@IsZero::@IsZero<[]>>>
-// CHECK-NEXT:          %[[VAL_60:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_55]][@zeros$inputs] : <@SubCmps0C::@SubCmps0C<[@n]>>, !array.type<@n x !pod.type<[@in: !felt.type<"bn128">]>>
-// CHECK-NEXT:          %[[VAL_61:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:          %[[VAL_62:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_63:[0-9a-zA-Z_\.]+]] = %[[VAL_61]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
-// CHECK-NEXT:            %[[VAL_64:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_63]], %[[VAL_57]]) : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            scf.condition(%[[VAL_64]]) %[[VAL_63]] : !felt.type<"bn128">
+// CHECK-NEXT:        function.def @constrain(%[[VAL_57:[0-9a-zA-Z_\.]+]]: !struct.type<@SubCmps0C::@SubCmps0C<[@n]>>, %[[VAL_58:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type<"bn128">>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_59:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_60:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_57]][@outs] : <@SubCmps0C::@SubCmps0C<[@n]>>, !array.type<@n x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_61:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_57]][@zeros] : <@SubCmps0C::@SubCmps0C<[@n]>>, !array.type<@n x !struct.type<@IsZero::@IsZero<[]>>>
+// CHECK-NEXT:          %[[VAL_62:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_57]][@zeros$inputs] : <@SubCmps0C::@SubCmps0C<[@n]>>, !array.type<@n x !pod.type<[@in: !felt.type<"bn128">]>>
+// CHECK-NEXT:          %[[VAL_63:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_64:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_65:[0-9a-zA-Z_\.]+]] = %[[VAL_63]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
+// CHECK-NEXT:            %[[VAL_66:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_65]], %[[VAL_59]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.condition(%[[VAL_66]]) %[[VAL_65]] : !felt.type<"bn128">
 // CHECK-NEXT:          } do {
-// CHECK-NEXT:          ^bb0(%[[VAL_65:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
-// CHECK-NEXT:            %[[VAL_66:[0-9a-zA-Z_\.]+]] = pod.new : <[]>
-// CHECK-NEXT:            %[[VAL_67:[0-9a-zA-Z_\.]+]] = pod.new : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:            %[[VAL_68:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_69:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_65]], %[[VAL_68]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            scf.yield %[[VAL_69]] : !felt.type<"bn128">
+// CHECK-NEXT:          ^bb0(%[[VAL_67:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
+// CHECK-NEXT:            %[[VAL_68:[0-9a-zA-Z_\.]+]] = pod.new : <[]>
+// CHECK-NEXT:            %[[VAL_69:[0-9a-zA-Z_\.]+]] = pod.new : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:            %[[VAL_70:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_71:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_67]], %[[VAL_70]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_71]] : !felt.type<"bn128">
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[VAL_70:[0-9a-zA-Z_\.]+]] = poly.read_const @n : index
-// CHECK-NEXT:          %[[VAL_71:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[VAL_72:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:          scf.for %[[VAL_73:[0-9a-zA-Z_\.]+]] = %[[VAL_71]] to %[[VAL_70]] step %[[VAL_72]] {
-// CHECK-NEXT:            %[[VAL_74:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_59]]{{\[}}%[[VAL_73]]] : <@n x !struct.type<@IsZero::@IsZero<[]>>>, !struct.type<@IsZero::@IsZero<[]>>
-// CHECK-NEXT:            %[[VAL_75:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_60]]{{\[}}%[[VAL_73]]] : <@n x !pod.type<[@in: !felt.type<"bn128">]>>, !pod.type<[@in: !felt.type<"bn128">]>
-// CHECK-NEXT:            %[[VAL_76:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_75]][@in] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:            function.call @IsZero::@IsZero::@constrain(%[[VAL_74]], %[[VAL_76]]) : (!struct.type<@IsZero::@IsZero<[]>>, !felt.type<"bn128">) -> ()
+// CHECK-NEXT:          %[[VAL_72:[0-9a-zA-Z_\.]+]] = poly.read_const @n : index
+// CHECK-NEXT:          %[[VAL_73:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_74:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          scf.for %[[VAL_75:[0-9a-zA-Z_\.]+]] = %[[VAL_73]] to %[[VAL_72]] step %[[VAL_74]] {
+// CHECK-NEXT:            %[[VAL_76:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_61]]{{\[}}%[[VAL_75]]] : <@n x !struct.type<@IsZero::@IsZero<[]>>>, !struct.type<@IsZero::@IsZero<[]>>
+// CHECK-NEXT:            %[[VAL_77:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_62]]{{\[}}%[[VAL_75]]] : <@n x !pod.type<[@in: !felt.type<"bn128">]>>, !pod.type<[@in: !felt.type<"bn128">]>
+// CHECK-NEXT:            %[[VAL_78:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_77]][@in] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:            function.call @IsZero::@IsZero::@constrain(%[[VAL_76]], %[[VAL_78]]) : (!struct.type<@IsZero::@IsZero<[]>>, !felt.type<"bn128">) -> ()
 // CHECK-NEXT:          }
 // CHECK-NEXT:          function.return
 // CHECK-NEXT:        }

--- a/circom/tests/subcmps/subcmps0D.circom
+++ b/circom/tests/subcmps/subcmps0D.circom
@@ -74,95 +74,99 @@ component main = SubCmps0D(3);
 // CHECK-NEXT:            array.write %[[VAL_19]]{{\[}}%[[VAL_29]]] = %[[VAL_28]] : <@n x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>, !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>
 // CHECK-NEXT:            %[[VAL_30:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_20]] : !felt.type<"bn128">
 // CHECK-NEXT:            %[[VAL_31:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_12]]{{\[}}%[[VAL_30]]] : <@n x !pod.type<[@count: index, @comp: !struct.type<@Add::@Add<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Add::@Add<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:            %[[VAL_32:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_31]][@count] : <[@count: index, @comp: !struct.type<@Add::@Add<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:            %[[VAL_33:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:            %[[VAL_34:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_32]], %[[VAL_33]] : index
-// CHECK-NEXT:            pod.write %[[VAL_31]][@count] = %[[VAL_34]] : <[@count: index, @comp: !struct.type<@Add::@Add<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:            %[[VAL_35:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:            %[[VAL_36:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_34]], %[[VAL_35]] : index
-// CHECK-NEXT:            scf.if %[[VAL_36]] {
-// CHECK-NEXT:              %[[VAL_37:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_31]][@params] : <[@count: index, @comp: !struct.type<@Add::@Add<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
-// CHECK-NEXT:              %[[VAL_38:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_28]][@in1] : <[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_39:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_28]][@in2] : <[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_40:[0-9a-zA-Z_\.]+]] = function.call @Add::@Add::@compute(%[[VAL_38]], %[[VAL_39]]) : (!felt.type<"bn128">, !felt.type<"bn128">) -> !struct.type<@Add::@Add<[]>>
-// CHECK-NEXT:              pod.write %[[VAL_31]][@comp] = %[[VAL_40]] : <[@count: index, @comp: !struct.type<@Add::@Add<[]>>, @params: !pod.type<[]>]>, !struct.type<@Add::@Add<[]>>
-// CHECK-NEXT:              %[[VAL_41:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_20]] : !felt.type<"bn128">
-// CHECK-NEXT:              array.write %[[VAL_12]]{{\[}}%[[VAL_41]]] = %[[VAL_31]] : <@n x !pod.type<[@count: index, @comp: !struct.type<@Add::@Add<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Add::@Add<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:            %[[VAL_32:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_20]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_33:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_19]]{{\[}}%[[VAL_32]]] : <@n x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>, !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>
+// CHECK-NEXT:            %[[VAL_34:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_31]][@count] : <[@count: index, @comp: !struct.type<@Add::@Add<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:            %[[VAL_35:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:            %[[VAL_36:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_34]], %[[VAL_35]] : index
+// CHECK-NEXT:            pod.write %[[VAL_31]][@count] = %[[VAL_36]] : <[@count: index, @comp: !struct.type<@Add::@Add<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:            %[[VAL_37:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:            %[[VAL_38:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_36]], %[[VAL_37]] : index
+// CHECK-NEXT:            scf.if %[[VAL_38]] {
+// CHECK-NEXT:              %[[VAL_39:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_31]][@params] : <[@count: index, @comp: !struct.type<@Add::@Add<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
+// CHECK-NEXT:              %[[VAL_40:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_33]][@in1] : <[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_41:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_33]][@in2] : <[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_42:[0-9a-zA-Z_\.]+]] = function.call @Add::@Add::@compute(%[[VAL_40]], %[[VAL_41]]) : (!felt.type<"bn128">, !felt.type<"bn128">) -> !struct.type<@Add::@Add<[]>>
+// CHECK-NEXT:              pod.write %[[VAL_31]][@comp] = %[[VAL_42]] : <[@count: index, @comp: !struct.type<@Add::@Add<[]>>, @params: !pod.type<[]>]>, !struct.type<@Add::@Add<[]>>
+// CHECK-NEXT:              %[[VAL_43:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_20]] : !felt.type<"bn128">
+// CHECK-NEXT:              array.write %[[VAL_12]]{{\[}}%[[VAL_43]]] = %[[VAL_31]] : <@n x !pod.type<[@count: index, @comp: !struct.type<@Add::@Add<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Add::@Add<[]>>, @params: !pod.type<[]>]>
 // CHECK-NEXT:            }
-// CHECK-NEXT:            %[[VAL_42:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_20]] : !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_43:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_8]]{{\[}}%[[VAL_42]]] : <@n x !felt.type<"bn128">>, !felt.type<"bn128">
 // CHECK-NEXT:            %[[VAL_44:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_20]] : !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_45:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_19]]{{\[}}%[[VAL_44]]] : <@n x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>, !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>
-// CHECK-NEXT:            pod.write %[[VAL_45]][@in2] = %[[VAL_43]] : <[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_45:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_8]]{{\[}}%[[VAL_44]]] : <@n x !felt.type<"bn128">>, !felt.type<"bn128">
 // CHECK-NEXT:            %[[VAL_46:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_20]] : !felt.type<"bn128">
-// CHECK-NEXT:            array.write %[[VAL_19]]{{\[}}%[[VAL_46]]] = %[[VAL_45]] : <@n x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>, !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>
-// CHECK-NEXT:            %[[VAL_47:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_20]] : !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_48:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_12]]{{\[}}%[[VAL_47]]] : <@n x !pod.type<[@count: index, @comp: !struct.type<@Add::@Add<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Add::@Add<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:            %[[VAL_49:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_48]][@count] : <[@count: index, @comp: !struct.type<@Add::@Add<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:            %[[VAL_50:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:            %[[VAL_51:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_49]], %[[VAL_50]] : index
-// CHECK-NEXT:            pod.write %[[VAL_48]][@count] = %[[VAL_51]] : <[@count: index, @comp: !struct.type<@Add::@Add<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:            %[[VAL_52:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:            %[[VAL_53:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_51]], %[[VAL_52]] : index
-// CHECK-NEXT:            scf.if %[[VAL_53]] {
-// CHECK-NEXT:              %[[VAL_54:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_48]][@params] : <[@count: index, @comp: !struct.type<@Add::@Add<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
-// CHECK-NEXT:              %[[VAL_55:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_45]][@in1] : <[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_56:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_45]][@in2] : <[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_57:[0-9a-zA-Z_\.]+]] = function.call @Add::@Add::@compute(%[[VAL_55]], %[[VAL_56]]) : (!felt.type<"bn128">, !felt.type<"bn128">) -> !struct.type<@Add::@Add<[]>>
-// CHECK-NEXT:              pod.write %[[VAL_48]][@comp] = %[[VAL_57]] : <[@count: index, @comp: !struct.type<@Add::@Add<[]>>, @params: !pod.type<[]>]>, !struct.type<@Add::@Add<[]>>
-// CHECK-NEXT:              %[[VAL_58:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_20]] : !felt.type<"bn128">
-// CHECK-NEXT:              array.write %[[VAL_12]]{{\[}}%[[VAL_58]]] = %[[VAL_48]] : <@n x !pod.type<[@count: index, @comp: !struct.type<@Add::@Add<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Add::@Add<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:            %[[VAL_47:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_19]]{{\[}}%[[VAL_46]]] : <@n x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>, !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>
+// CHECK-NEXT:            pod.write %[[VAL_47]][@in2] = %[[VAL_45]] : <[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_48:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_20]] : !felt.type<"bn128">
+// CHECK-NEXT:            array.write %[[VAL_19]]{{\[}}%[[VAL_48]]] = %[[VAL_47]] : <@n x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>, !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>
+// CHECK-NEXT:            %[[VAL_49:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_20]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_50:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_12]]{{\[}}%[[VAL_49]]] : <@n x !pod.type<[@count: index, @comp: !struct.type<@Add::@Add<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Add::@Add<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:            %[[VAL_51:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_20]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_52:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_19]]{{\[}}%[[VAL_51]]] : <@n x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>, !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>
+// CHECK-NEXT:            %[[VAL_53:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_50]][@count] : <[@count: index, @comp: !struct.type<@Add::@Add<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:            %[[VAL_54:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:            %[[VAL_55:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_53]], %[[VAL_54]] : index
+// CHECK-NEXT:            pod.write %[[VAL_50]][@count] = %[[VAL_55]] : <[@count: index, @comp: !struct.type<@Add::@Add<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:            %[[VAL_56:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:            %[[VAL_57:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_55]], %[[VAL_56]] : index
+// CHECK-NEXT:            scf.if %[[VAL_57]] {
+// CHECK-NEXT:              %[[VAL_58:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_50]][@params] : <[@count: index, @comp: !struct.type<@Add::@Add<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
+// CHECK-NEXT:              %[[VAL_59:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_52]][@in1] : <[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_60:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_52]][@in2] : <[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_61:[0-9a-zA-Z_\.]+]] = function.call @Add::@Add::@compute(%[[VAL_59]], %[[VAL_60]]) : (!felt.type<"bn128">, !felt.type<"bn128">) -> !struct.type<@Add::@Add<[]>>
+// CHECK-NEXT:              pod.write %[[VAL_50]][@comp] = %[[VAL_61]] : <[@count: index, @comp: !struct.type<@Add::@Add<[]>>, @params: !pod.type<[]>]>, !struct.type<@Add::@Add<[]>>
+// CHECK-NEXT:              %[[VAL_62:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_20]] : !felt.type<"bn128">
+// CHECK-NEXT:              array.write %[[VAL_12]]{{\[}}%[[VAL_62]]] = %[[VAL_50]] : <@n x !pod.type<[@count: index, @comp: !struct.type<@Add::@Add<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Add::@Add<[]>>, @params: !pod.type<[]>]>
 // CHECK-NEXT:            }
-// CHECK-NEXT:            %[[VAL_59:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_20]] : !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_60:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_12]]{{\[}}%[[VAL_59]]] : <@n x !pod.type<[@count: index, @comp: !struct.type<@Add::@Add<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Add::@Add<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:            %[[VAL_61:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_60]][@comp] : <[@count: index, @comp: !struct.type<@Add::@Add<[]>>, @params: !pod.type<[]>]>, !struct.type<@Add::@Add<[]>>
-// CHECK-NEXT:            %[[VAL_62:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_61]][@out] : <@Add::@Add<[]>>, !felt.type<"bn128">
 // CHECK-NEXT:            %[[VAL_63:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_20]] : !felt.type<"bn128">
-// CHECK-NEXT:            array.write %[[VAL_11]]{{\[}}%[[VAL_63]]] = %[[VAL_62]] : <@n x !felt.type<"bn128">>, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_64:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_65:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_20]], %[[VAL_64]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            scf.yield %[[VAL_19]], %[[VAL_65]] : !array.type<@n x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_64:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_12]]{{\[}}%[[VAL_63]]] : <@n x !pod.type<[@count: index, @comp: !struct.type<@Add::@Add<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Add::@Add<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:            %[[VAL_65:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_64]][@comp] : <[@count: index, @comp: !struct.type<@Add::@Add<[]>>, @params: !pod.type<[]>]>, !struct.type<@Add::@Add<[]>>
+// CHECK-NEXT:            %[[VAL_66:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_65]][@out] : <@Add::@Add<[]>>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_67:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_20]] : !felt.type<"bn128">
+// CHECK-NEXT:            array.write %[[VAL_11]]{{\[}}%[[VAL_67]]] = %[[VAL_66]] : <@n x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_68:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_69:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_20]], %[[VAL_68]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_19]], %[[VAL_69]] : !array.type<@n x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>, !felt.type<"bn128">
 // CHECK-NEXT:          }
 // CHECK-NEXT:          struct.writem %[[VAL_9]][@a$inputs] = %[[VAL_15]]#0 : <@SubCmps0D::@SubCmps0D<[@n]>>, !array.type<@n x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>
-// CHECK-NEXT:          %[[VAL_66:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !struct.type<@Add::@Add<[]>>>
-// CHECK-NEXT:          %[[VAL_67:[0-9a-zA-Z_\.]+]] = poly.read_const @n : index
-// CHECK-NEXT:          %[[VAL_68:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[VAL_69:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:          scf.for %[[VAL_70:[0-9a-zA-Z_\.]+]] = %[[VAL_68]] to %[[VAL_67]] step %[[VAL_69]] {
-// CHECK-NEXT:            %[[VAL_71:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_12]]{{\[}}%[[VAL_70]]] : <@n x !pod.type<[@count: index, @comp: !struct.type<@Add::@Add<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Add::@Add<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:            %[[VAL_72:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_71]][@comp] : <[@count: index, @comp: !struct.type<@Add::@Add<[]>>, @params: !pod.type<[]>]>, !struct.type<@Add::@Add<[]>>
-// CHECK-NEXT:            array.write %[[VAL_66]]{{\[}}%[[VAL_70]]] = %[[VAL_72]] : <@n x !struct.type<@Add::@Add<[]>>>, !struct.type<@Add::@Add<[]>>
+// CHECK-NEXT:          %[[VAL_70:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !struct.type<@Add::@Add<[]>>>
+// CHECK-NEXT:          %[[VAL_71:[0-9a-zA-Z_\.]+]] = poly.read_const @n : index
+// CHECK-NEXT:          %[[VAL_72:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_73:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          scf.for %[[VAL_74:[0-9a-zA-Z_\.]+]] = %[[VAL_72]] to %[[VAL_71]] step %[[VAL_73]] {
+// CHECK-NEXT:            %[[VAL_75:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_12]]{{\[}}%[[VAL_74]]] : <@n x !pod.type<[@count: index, @comp: !struct.type<@Add::@Add<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@Add::@Add<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:            %[[VAL_76:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_75]][@comp] : <[@count: index, @comp: !struct.type<@Add::@Add<[]>>, @params: !pod.type<[]>]>, !struct.type<@Add::@Add<[]>>
+// CHECK-NEXT:            array.write %[[VAL_70]]{{\[}}%[[VAL_74]]] = %[[VAL_76]] : <@n x !struct.type<@Add::@Add<[]>>>, !struct.type<@Add::@Add<[]>>
 // CHECK-NEXT:          }
-// CHECK-NEXT:          struct.writem %[[VAL_9]][@a] = %[[VAL_66]] : <@SubCmps0D::@SubCmps0D<[@n]>>, !array.type<@n x !struct.type<@Add::@Add<[]>>>
+// CHECK-NEXT:          struct.writem %[[VAL_9]][@a] = %[[VAL_70]] : <@SubCmps0D::@SubCmps0D<[@n]>>, !array.type<@n x !struct.type<@Add::@Add<[]>>>
 // CHECK-NEXT:          struct.writem %[[VAL_9]][@outs] = %[[VAL_11]] : <@SubCmps0D::@SubCmps0D<[@n]>>, !array.type<@n x !felt.type<"bn128">>
 // CHECK-NEXT:          function.return %[[VAL_9]] : !struct.type<@SubCmps0D::@SubCmps0D<[@n]>>
 // CHECK-NEXT:        }
-// CHECK-NEXT:        function.def @constrain(%[[VAL_73:[0-9a-zA-Z_\.]+]]: !struct.type<@SubCmps0D::@SubCmps0D<[@n]>>, %[[VAL_74:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type<"bn128">>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:          %[[VAL_75:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_76:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_73]][@outs] : <@SubCmps0D::@SubCmps0D<[@n]>>, !array.type<@n x !felt.type<"bn128">>
-// CHECK-NEXT:          %[[VAL_77:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_73]][@a] : <@SubCmps0D::@SubCmps0D<[@n]>>, !array.type<@n x !struct.type<@Add::@Add<[]>>>
-// CHECK-NEXT:          %[[VAL_78:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_73]][@a$inputs] : <@SubCmps0D::@SubCmps0D<[@n]>>, !array.type<@n x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>
-// CHECK-NEXT:          %[[VAL_79:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:          %[[VAL_80:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_81:[0-9a-zA-Z_\.]+]] = %[[VAL_79]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
-// CHECK-NEXT:            %[[VAL_82:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_81]], %[[VAL_75]]) : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            scf.condition(%[[VAL_82]]) %[[VAL_81]] : !felt.type<"bn128">
+// CHECK-NEXT:        function.def @constrain(%[[VAL_77:[0-9a-zA-Z_\.]+]]: !struct.type<@SubCmps0D::@SubCmps0D<[@n]>>, %[[VAL_78:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type<"bn128">>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_79:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_80:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_77]][@outs] : <@SubCmps0D::@SubCmps0D<[@n]>>, !array.type<@n x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_81:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_77]][@a] : <@SubCmps0D::@SubCmps0D<[@n]>>, !array.type<@n x !struct.type<@Add::@Add<[]>>>
+// CHECK-NEXT:          %[[VAL_82:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_77]][@a$inputs] : <@SubCmps0D::@SubCmps0D<[@n]>>, !array.type<@n x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>
+// CHECK-NEXT:          %[[VAL_83:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_84:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_85:[0-9a-zA-Z_\.]+]] = %[[VAL_83]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
+// CHECK-NEXT:            %[[VAL_86:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_85]], %[[VAL_79]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.condition(%[[VAL_86]]) %[[VAL_85]] : !felt.type<"bn128">
 // CHECK-NEXT:          } do {
-// CHECK-NEXT:          ^bb0(%[[VAL_83:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
-// CHECK-NEXT:            %[[VAL_84:[0-9a-zA-Z_\.]+]] = pod.new : <[]>
-// CHECK-NEXT:            %[[VAL_85:[0-9a-zA-Z_\.]+]] = pod.new : <[@count: index, @comp: !struct.type<@Add::@Add<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:            %[[VAL_86:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_87:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_83]], %[[VAL_86]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            scf.yield %[[VAL_87]] : !felt.type<"bn128">
+// CHECK-NEXT:          ^bb0(%[[VAL_87:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
+// CHECK-NEXT:            %[[VAL_88:[0-9a-zA-Z_\.]+]] = pod.new : <[]>
+// CHECK-NEXT:            %[[VAL_89:[0-9a-zA-Z_\.]+]] = pod.new : <[@count: index, @comp: !struct.type<@Add::@Add<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:            %[[VAL_90:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_91:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_87]], %[[VAL_90]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_91]] : !felt.type<"bn128">
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[VAL_88:[0-9a-zA-Z_\.]+]] = poly.read_const @n : index
-// CHECK-NEXT:          %[[VAL_89:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[VAL_90:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:          scf.for %[[VAL_91:[0-9a-zA-Z_\.]+]] = %[[VAL_89]] to %[[VAL_88]] step %[[VAL_90]] {
-// CHECK-NEXT:            %[[VAL_92:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_77]]{{\[}}%[[VAL_91]]] : <@n x !struct.type<@Add::@Add<[]>>>, !struct.type<@Add::@Add<[]>>
-// CHECK-NEXT:            %[[VAL_93:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_78]]{{\[}}%[[VAL_91]]] : <@n x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>, !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>
-// CHECK-NEXT:            %[[VAL_94:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_93]][@in1] : <[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_95:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_93]][@in2] : <[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:            function.call @Add::@Add::@constrain(%[[VAL_92]], %[[VAL_94]], %[[VAL_95]]) : (!struct.type<@Add::@Add<[]>>, !felt.type<"bn128">, !felt.type<"bn128">) -> ()
+// CHECK-NEXT:          %[[VAL_92:[0-9a-zA-Z_\.]+]] = poly.read_const @n : index
+// CHECK-NEXT:          %[[VAL_93:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_94:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          scf.for %[[VAL_95:[0-9a-zA-Z_\.]+]] = %[[VAL_93]] to %[[VAL_92]] step %[[VAL_94]] {
+// CHECK-NEXT:            %[[VAL_96:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_81]]{{\[}}%[[VAL_95]]] : <@n x !struct.type<@Add::@Add<[]>>>, !struct.type<@Add::@Add<[]>>
+// CHECK-NEXT:            %[[VAL_97:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_82]]{{\[}}%[[VAL_95]]] : <@n x !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>>, !pod.type<[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>
+// CHECK-NEXT:            %[[VAL_98:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_97]][@in1] : <[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_99:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_97]][@in2] : <[@in1: !felt.type<"bn128">, @in2: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:            function.call @Add::@Add::@constrain(%[[VAL_96]], %[[VAL_98]], %[[VAL_99]]) : (!struct.type<@Add::@Add<[]>>, !felt.type<"bn128">, !felt.type<"bn128">) -> ()
 // CHECK-NEXT:          }
 // CHECK-NEXT:          function.return
 // CHECK-NEXT:        }

--- a/circom/tests/subcmps/subcmps1.circom
+++ b/circom/tests/subcmps/subcmps1.circom
@@ -105,82 +105,84 @@ component main = SubCmps1(3);
 // CHECK-NEXT:            array.write %[[VAL_35]]{{\[}}%[[VAL_44]]] = %[[VAL_43]] : <@n x !pod.type<[@in: !felt.type<"bn128">]>>, !pod.type<[@in: !felt.type<"bn128">]>
 // CHECK-NEXT:            %[[VAL_45:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_34]] : !felt.type<"bn128">
 // CHECK-NEXT:            %[[VAL_46:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_26]]{{\[}}%[[VAL_45]]] : <@n x !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:            %[[VAL_47:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_46]][@count] : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:            %[[VAL_48:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:            %[[VAL_49:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_47]], %[[VAL_48]] : index
-// CHECK-NEXT:            pod.write %[[VAL_46]][@count] = %[[VAL_49]] : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>, index
-// CHECK-NEXT:            %[[VAL_50:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:            %[[VAL_51:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_49]], %[[VAL_50]] : index
-// CHECK-NEXT:            scf.if %[[VAL_51]] {
-// CHECK-NEXT:              %[[VAL_52:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_46]][@params] : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
-// CHECK-NEXT:              %[[VAL_53:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_43]][@in] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:              %[[VAL_54:[0-9a-zA-Z_\.]+]] = function.call @IsZero::@IsZero::@compute(%[[VAL_53]]) : (!felt.type<"bn128">) -> !struct.type<@IsZero::@IsZero<[]>>
-// CHECK-NEXT:              pod.write %[[VAL_46]][@comp] = %[[VAL_54]] : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>, !struct.type<@IsZero::@IsZero<[]>>
-// CHECK-NEXT:              %[[VAL_55:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_34]] : !felt.type<"bn128">
-// CHECK-NEXT:              array.write %[[VAL_26]]{{\[}}%[[VAL_55]]] = %[[VAL_46]] : <@n x !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:            %[[VAL_47:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_34]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_48:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_35]]{{\[}}%[[VAL_47]]] : <@n x !pod.type<[@in: !felt.type<"bn128">]>>, !pod.type<[@in: !felt.type<"bn128">]>
+// CHECK-NEXT:            %[[VAL_49:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_46]][@count] : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:            %[[VAL_50:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:            %[[VAL_51:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_49]], %[[VAL_50]] : index
+// CHECK-NEXT:            pod.write %[[VAL_46]][@count] = %[[VAL_51]] : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:            %[[VAL_52:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:            %[[VAL_53:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_51]], %[[VAL_52]] : index
+// CHECK-NEXT:            scf.if %[[VAL_53]] {
+// CHECK-NEXT:              %[[VAL_54:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_46]][@params] : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
+// CHECK-NEXT:              %[[VAL_55:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_48]][@in] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_56:[0-9a-zA-Z_\.]+]] = function.call @IsZero::@IsZero::@compute(%[[VAL_55]]) : (!felt.type<"bn128">) -> !struct.type<@IsZero::@IsZero<[]>>
+// CHECK-NEXT:              pod.write %[[VAL_46]][@comp] = %[[VAL_56]] : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>, !struct.type<@IsZero::@IsZero<[]>>
+// CHECK-NEXT:              %[[VAL_57:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_34]] : !felt.type<"bn128">
+// CHECK-NEXT:              array.write %[[VAL_26]]{{\[}}%[[VAL_57]]] = %[[VAL_46]] : <@n x !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>
 // CHECK-NEXT:            }
-// CHECK-NEXT:            %[[VAL_56:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_34]] : !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_57:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_26]]{{\[}}%[[VAL_56]]] : <@n x !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:            %[[VAL_58:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_57]][@comp] : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>, !struct.type<@IsZero::@IsZero<[]>>
-// CHECK-NEXT:            %[[VAL_59:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_58]][@out] : <@IsZero::@IsZero<[]>>, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_60:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_34]] : !felt.type<"bn128">
-// CHECK-NEXT:            array.write %[[VAL_25]]{{\[}}%[[VAL_60]]] = %[[VAL_59]] : <@n x !felt.type<"bn128">>, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_61:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_62:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_34]], %[[VAL_61]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            scf.yield %[[VAL_62]], %[[VAL_35]] : !felt.type<"bn128">, !array.type<@n x !pod.type<[@in: !felt.type<"bn128">]>>
+// CHECK-NEXT:            %[[VAL_58:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_34]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_59:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_26]]{{\[}}%[[VAL_58]]] : <@n x !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:            %[[VAL_60:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_59]][@comp] : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>, !struct.type<@IsZero::@IsZero<[]>>
+// CHECK-NEXT:            %[[VAL_61:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_60]][@out] : <@IsZero::@IsZero<[]>>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_62:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_34]] : !felt.type<"bn128">
+// CHECK-NEXT:            array.write %[[VAL_25]]{{\[}}%[[VAL_62]]] = %[[VAL_61]] : <@n x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_63:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_64:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_34]], %[[VAL_63]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_64]], %[[VAL_35]] : !felt.type<"bn128">, !array.type<@n x !pod.type<[@in: !felt.type<"bn128">]>>
 // CHECK-NEXT:          }
 // CHECK-NEXT:          struct.writem %[[VAL_23]][@zeros$inputs] = %[[VAL_30]]#1 : <@SubCmps1::@SubCmps1<[@n]>>, !array.type<@n x !pod.type<[@in: !felt.type<"bn128">]>>
-// CHECK-NEXT:          %[[VAL_63:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !struct.type<@IsZero::@IsZero<[]>>>
-// CHECK-NEXT:          %[[VAL_64:[0-9a-zA-Z_\.]+]] = poly.read_const @n : index
-// CHECK-NEXT:          %[[VAL_65:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[VAL_66:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:          scf.for %[[VAL_67:[0-9a-zA-Z_\.]+]] = %[[VAL_65]] to %[[VAL_64]] step %[[VAL_66]] {
-// CHECK-NEXT:            %[[VAL_68:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_26]]{{\[}}%[[VAL_67]]] : <@n x !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:            %[[VAL_69:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_68]][@comp] : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>, !struct.type<@IsZero::@IsZero<[]>>
-// CHECK-NEXT:            array.write %[[VAL_63]]{{\[}}%[[VAL_67]]] = %[[VAL_69]] : <@n x !struct.type<@IsZero::@IsZero<[]>>>, !struct.type<@IsZero::@IsZero<[]>>
+// CHECK-NEXT:          %[[VAL_65:[0-9a-zA-Z_\.]+]] = array.new  : <@n x !struct.type<@IsZero::@IsZero<[]>>>
+// CHECK-NEXT:          %[[VAL_66:[0-9a-zA-Z_\.]+]] = poly.read_const @n : index
+// CHECK-NEXT:          %[[VAL_67:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_68:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          scf.for %[[VAL_69:[0-9a-zA-Z_\.]+]] = %[[VAL_67]] to %[[VAL_66]] step %[[VAL_68]] {
+// CHECK-NEXT:            %[[VAL_70:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_26]]{{\[}}%[[VAL_69]]] : <@n x !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>>, !pod.type<[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:            %[[VAL_71:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_70]][@comp] : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>, !struct.type<@IsZero::@IsZero<[]>>
+// CHECK-NEXT:            array.write %[[VAL_65]]{{\[}}%[[VAL_69]]] = %[[VAL_71]] : <@n x !struct.type<@IsZero::@IsZero<[]>>>, !struct.type<@IsZero::@IsZero<[]>>
 // CHECK-NEXT:          }
-// CHECK-NEXT:          struct.writem %[[VAL_23]][@zeros] = %[[VAL_63]] : <@SubCmps1::@SubCmps1<[@n]>>, !array.type<@n x !struct.type<@IsZero::@IsZero<[]>>>
+// CHECK-NEXT:          struct.writem %[[VAL_23]][@zeros] = %[[VAL_65]] : <@SubCmps1::@SubCmps1<[@n]>>, !array.type<@n x !struct.type<@IsZero::@IsZero<[]>>>
 // CHECK-NEXT:          struct.writem %[[VAL_23]][@outs] = %[[VAL_25]] : <@SubCmps1::@SubCmps1<[@n]>>, !array.type<@n x !felt.type<"bn128">>
 // CHECK-NEXT:          function.return %[[VAL_23]] : !struct.type<@SubCmps1::@SubCmps1<[@n]>>
 // CHECK-NEXT:        }
-// CHECK-NEXT:        function.def @constrain(%[[VAL_70:[0-9a-zA-Z_\.]+]]: !struct.type<@SubCmps1::@SubCmps1<[@n]>>, %[[VAL_71:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type<"bn128">>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:          %[[VAL_72:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_73:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_70]][@outs] : <@SubCmps1::@SubCmps1<[@n]>>, !array.type<@n x !felt.type<"bn128">>
-// CHECK-NEXT:          %[[VAL_74:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_70]][@zeros] : <@SubCmps1::@SubCmps1<[@n]>>, !array.type<@n x !struct.type<@IsZero::@IsZero<[]>>>
-// CHECK-NEXT:          %[[VAL_75:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_70]][@zeros$inputs] : <@SubCmps1::@SubCmps1<[@n]>>, !array.type<@n x !pod.type<[@in: !felt.type<"bn128">]>>
-// CHECK-NEXT:          %[[VAL_76:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:          %[[VAL_77:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:          %[[VAL_78:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_79:[0-9a-zA-Z_\.]+]] = %[[VAL_77]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
-// CHECK-NEXT:            %[[VAL_80:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_79]], %[[VAL_72]]) : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            scf.condition(%[[VAL_80]]) %[[VAL_79]] : !felt.type<"bn128">
+// CHECK-NEXT:        function.def @constrain(%[[VAL_72:[0-9a-zA-Z_\.]+]]: !struct.type<@SubCmps1::@SubCmps1<[@n]>>, %[[VAL_73:[0-9a-zA-Z_\.]+]]: !array.type<@n x !felt.type<"bn128">>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_74:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_75:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_72]][@outs] : <@SubCmps1::@SubCmps1<[@n]>>, !array.type<@n x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_76:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_72]][@zeros] : <@SubCmps1::@SubCmps1<[@n]>>, !array.type<@n x !struct.type<@IsZero::@IsZero<[]>>>
+// CHECK-NEXT:          %[[VAL_77:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_72]][@zeros$inputs] : <@SubCmps1::@SubCmps1<[@n]>>, !array.type<@n x !pod.type<[@in: !felt.type<"bn128">]>>
+// CHECK-NEXT:          %[[VAL_78:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_79:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_80:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_81:[0-9a-zA-Z_\.]+]] = %[[VAL_79]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
+// CHECK-NEXT:            %[[VAL_82:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_81]], %[[VAL_74]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.condition(%[[VAL_82]]) %[[VAL_81]] : !felt.type<"bn128">
 // CHECK-NEXT:          } do {
-// CHECK-NEXT:          ^bb0(%[[VAL_81:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
-// CHECK-NEXT:            %[[VAL_82:[0-9a-zA-Z_\.]+]] = pod.new : <[]>
-// CHECK-NEXT:            %[[VAL_83:[0-9a-zA-Z_\.]+]] = pod.new : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>
-// CHECK-NEXT:            %[[VAL_84:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_81]] : !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_85:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_71]]{{\[}}%[[VAL_84]]] : <@n x !felt.type<"bn128">>, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_86:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_81]] : !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_87:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_75]]{{\[}}%[[VAL_86]]] : <@n x !pod.type<[@in: !felt.type<"bn128">]>>, !pod.type<[@in: !felt.type<"bn128">]>
-// CHECK-NEXT:            %[[VAL_88:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_87]][@in] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:            constrain.eq %[[VAL_88]], %[[VAL_85]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_89:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_81]] : !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_90:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_74]]{{\[}}%[[VAL_89]]] : <@n x !struct.type<@IsZero::@IsZero<[]>>>, !struct.type<@IsZero::@IsZero<[]>>
-// CHECK-NEXT:            %[[VAL_91:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_90]][@out] : <@IsZero::@IsZero<[]>>, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_92:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_81]] : !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_93:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_73]]{{\[}}%[[VAL_92]]] : <@n x !felt.type<"bn128">>, !felt.type<"bn128">
-// CHECK-NEXT:            constrain.eq %[[VAL_93]], %[[VAL_91]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_94:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_95:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_81]], %[[VAL_94]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            scf.yield %[[VAL_95]] : !felt.type<"bn128">
+// CHECK-NEXT:          ^bb0(%[[VAL_83:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
+// CHECK-NEXT:            %[[VAL_84:[0-9a-zA-Z_\.]+]] = pod.new : <[]>
+// CHECK-NEXT:            %[[VAL_85:[0-9a-zA-Z_\.]+]] = pod.new : <[@count: index, @comp: !struct.type<@IsZero::@IsZero<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:            %[[VAL_86:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_83]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_87:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_73]]{{\[}}%[[VAL_86]]] : <@n x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_88:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_83]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_89:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_77]]{{\[}}%[[VAL_88]]] : <@n x !pod.type<[@in: !felt.type<"bn128">]>>, !pod.type<[@in: !felt.type<"bn128">]>
+// CHECK-NEXT:            %[[VAL_90:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_89]][@in] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:            constrain.eq %[[VAL_90]], %[[VAL_87]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_91:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_83]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_92:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_76]]{{\[}}%[[VAL_91]]] : <@n x !struct.type<@IsZero::@IsZero<[]>>>, !struct.type<@IsZero::@IsZero<[]>>
+// CHECK-NEXT:            %[[VAL_93:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_92]][@out] : <@IsZero::@IsZero<[]>>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_94:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_83]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_95:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_75]]{{\[}}%[[VAL_94]]] : <@n x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            constrain.eq %[[VAL_95]], %[[VAL_93]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_96:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_97:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_83]], %[[VAL_96]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_97]] : !felt.type<"bn128">
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[VAL_96:[0-9a-zA-Z_\.]+]] = poly.read_const @n : index
-// CHECK-NEXT:          %[[VAL_97:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[VAL_98:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:          scf.for %[[VAL_99:[0-9a-zA-Z_\.]+]] = %[[VAL_97]] to %[[VAL_96]] step %[[VAL_98]] {
-// CHECK-NEXT:            %[[VAL_100:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_74]]{{\[}}%[[VAL_99]]] : <@n x !struct.type<@IsZero::@IsZero<[]>>>, !struct.type<@IsZero::@IsZero<[]>>
-// CHECK-NEXT:            %[[VAL_101:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_75]]{{\[}}%[[VAL_99]]] : <@n x !pod.type<[@in: !felt.type<"bn128">]>>, !pod.type<[@in: !felt.type<"bn128">]>
-// CHECK-NEXT:            %[[VAL_102:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_101]][@in] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
-// CHECK-NEXT:            function.call @IsZero::@IsZero::@constrain(%[[VAL_100]], %[[VAL_102]]) : (!struct.type<@IsZero::@IsZero<[]>>, !felt.type<"bn128">) -> ()
+// CHECK-NEXT:          %[[VAL_98:[0-9a-zA-Z_\.]+]] = poly.read_const @n : index
+// CHECK-NEXT:          %[[VAL_99:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_100:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          scf.for %[[VAL_101:[0-9a-zA-Z_\.]+]] = %[[VAL_99]] to %[[VAL_98]] step %[[VAL_100]] {
+// CHECK-NEXT:            %[[VAL_102:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_76]]{{\[}}%[[VAL_101]]] : <@n x !struct.type<@IsZero::@IsZero<[]>>>, !struct.type<@IsZero::@IsZero<[]>>
+// CHECK-NEXT:            %[[VAL_103:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_77]]{{\[}}%[[VAL_101]]] : <@n x !pod.type<[@in: !felt.type<"bn128">]>>, !pod.type<[@in: !felt.type<"bn128">]>
+// CHECK-NEXT:            %[[VAL_104:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_103]][@in] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:            function.call @IsZero::@IsZero::@constrain(%[[VAL_102]], %[[VAL_104]]) : (!struct.type<@IsZero::@IsZero<[]>>, !felt.type<"bn128">) -> ()
 // CHECK-NEXT:          }
 // CHECK-NEXT:          function.return
 // CHECK-NEXT:        }

--- a/llzk_backend/src/function.rs
+++ b/llzk_backend/src/function.rs
@@ -83,9 +83,9 @@ use std::ops::DerefMut;
 /// [Null objects](https://en.wikipedia.org/wiki/Null_object_pattern). The former is used while
 /// lowering expressions inside a template and the latter used while lowering inside a function.
 #[derive(Copy, Clone, Debug)]
-pub struct InfoProviders<'info> {
+pub struct InfoProviders<'info, 'ctx> {
     /// Subcomponent information.
-    pub subcmp_info: &'info dyn SubcmpInfo,
+    pub subcmp_info: &'info dyn SubcmpInfo<'ctx>,
     /// Signals write information.
     ///
     /// TODO: We may be able to remove this field if the lowering in this file does not need to use
@@ -95,14 +95,14 @@ pub struct InfoProviders<'info> {
     pub signal_write_info: &'info dyn SignalWriteInfo,
 }
 
-impl Default for InfoProviders<'_> {
+impl Default for InfoProviders<'_, '_> {
     fn default() -> Self {
         Self { subcmp_info: &NoSubcmps, signal_write_info: &NoSignalsInfo }
     }
 }
 
 impl<'tmpl, 'ctx, 'str, 'func, 'blk, 'val>
-    From<&'tmpl TemplateContext<'_, 'ctx, 'str, 'func, 'blk, 'val>> for InfoProviders<'tmpl>
+    From<&'tmpl TemplateContext<'_, 'ctx, 'str, 'func, 'blk, 'val>> for InfoProviders<'tmpl, 'ctx>
 {
     fn from(template: &'tmpl TemplateContext<'_, 'ctx, 'str, 'func, 'blk, 'val>) -> Self {
         Self { subcmp_info: template, signal_write_info: template }
@@ -524,7 +524,7 @@ where
         &self,
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
         function: &mut FunctionContext<'_, 'ctx, 'func, 'blk, 'val>,
-        info: InfoProviders<'info>,
+        info: InfoProviders<'info, 'ctx>,
     ) -> Result<Self::Output>;
 }
 
@@ -651,7 +651,7 @@ where
 fn gen_if_then_else<'ctx, 'func, 'blk, 'val, 'info>(
     codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
     function: &mut FunctionContext<'_, 'ctx, 'func, 'blk, 'val>,
-    info: InfoProviders<'info>,
+    info: InfoProviders<'info, 'ctx>,
     meta: &Meta,
     cond: &Expression,
     if_case: &Statement,
@@ -742,7 +742,7 @@ where
 fn gen_while<'ctx, 'func, 'blk, 'val, 'info>(
     codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
     function: &mut FunctionContext<'_, 'ctx, 'func, 'blk, 'val>,
-    info: InfoProviders<'info>,
+    info: InfoProviders<'info, 'ctx>,
     meta: &Meta,
     cond: &Expression,
     body_stmt: &Statement,
@@ -826,7 +826,7 @@ where
 fn gen_init_block<'ctx, 'func, 'blk, 'val>(
     codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
     function: &mut FunctionContext<'_, 'ctx, 'func, 'blk, 'val>,
-    info: InfoProviders<'_>,
+    info: InfoProviders<'_, 'ctx>,
     initializations: &[Statement],
 ) -> Result<()>
 where
@@ -851,7 +851,7 @@ where
         &self,
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
         function: &mut FunctionContext<'_, 'ctx, 'func, 'blk, 'val>,
-        info: InfoProviders<'info>,
+        info: InfoProviders<'info, 'ctx>,
     ) -> Result<Self::Output> {
         let _guard = codegen.trace_statement(self);
         match self {
@@ -954,7 +954,7 @@ where
         &self,
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
         function: &mut FunctionContext<'_, 'ctx, 'func, 'blk, 'val>,
-        info: InfoProviders<'info>,
+        info: InfoProviders<'info, 'ctx>,
     ) -> Result<Self::Output> {
         for s in self {
             let skip_rest_of_block = s.gen_llzk_in_function(codegen, function, info)?;

--- a/llzk_backend/src/function.rs
+++ b/llzk_backend/src/function.rs
@@ -151,6 +151,28 @@ where
     }
 }
 
+impl<'decls, 'ctx, 'blk, 'val> AsMut<BlockGenContext<'decls, 'ctx, 'blk, 'val>>
+    for FunctionContext<'decls, 'ctx, '_, 'blk, 'val>
+where
+    'ctx: 'blk,
+    'blk: 'val,
+{
+    fn as_mut(&mut self) -> &mut BlockGenContext<'decls, 'ctx, 'blk, 'val> {
+        self.deref_mut()
+    }
+}
+
+impl<'decls, 'ctx, 'blk, 'val> AsRef<BlockGenContext<'decls, 'ctx, 'blk, 'val>>
+    for FunctionContext<'decls, 'ctx, '_, 'blk, 'val>
+where
+    'ctx: 'blk,
+    'blk: 'val,
+{
+    fn as_ref(&self) -> &BlockGenContext<'decls, 'ctx, 'blk, 'val> {
+        self.deref()
+    }
+}
+
 /// Cache block yield/return result value while performing early-return refactoring.
 enum RefactoringBlockResultType<'ctx> {
     /// Single result value from the block.

--- a/llzk_backend/src/gen_context.rs
+++ b/llzk_backend/src/gen_context.rs
@@ -451,8 +451,7 @@ where
 impl Default for NestedBlockInfo<'_, '_, '_> {
     #[inline]
     fn default() -> Self {
-        let (region, block) = new_region_and_block(&[]);
-        NestedBlockInfo { region, block, var_overwrites: Default::default() }
+        Self::new()
     }
 }
 
@@ -461,6 +460,47 @@ where
     'ctx: 'blk,
     'blk: 'val,
 {
+    /// Creates an empty block info instance.
+    pub fn new() -> Self {
+        let (region, block) = new_region_and_block(&[]);
+        NestedBlockInfo { region, block, var_overwrites: Default::default() }
+    }
+
+    /// Creates a new instance using the common pattern of pushing the block into the stack, emitting some IR, and then
+    /// popping the block.
+    pub fn with_scope<'decls, R, C>(
+        block_gen: &mut C,
+        cb: impl FnOnce(&mut C) -> Result<R>,
+    ) -> Result<(Self, R)>
+    where
+        C: AsMut<BlockGenContext<'decls, 'ctx, 'blk, 'val>>,
+        'ctx: 'decls,
+    {
+        let mut info = Self::new();
+        let r = info.enter_scope(block_gen, cb)?;
+        Ok((info, r))
+    }
+
+    /// Pushes the block into the stack, runs the callback and then pops the block out of the
+    /// stack, filling the overwrites.
+    ///
+    /// Handling the overwrites follows the rules of [`add_overwrites`].
+    pub fn enter_scope<'decls, R, C>(
+        &mut self,
+        block_gen: &mut C,
+        cb: impl FnOnce(&mut C) -> Result<R>,
+    ) -> Result<R>
+    where
+        C: AsMut<BlockGenContext<'decls, 'ctx, 'blk, 'val>>,
+        'ctx: 'decls,
+    {
+        block_gen.as_mut().block_ctx.push(self.block);
+        let r = cb(block_gen)?;
+        let overwrites = block_gen.as_mut().block_ctx.pop();
+        self.add_overwrites(&overwrites, block_gen.as_mut())?;
+        Ok(r)
+    }
+
     /// Update `self.var_overwrites` to ensure it has all keys from `other.var_overwrites`, using
     /// values from the current scope in the [BlockGenContext] for missing keys.
     pub fn add_missing_values(
@@ -468,7 +508,21 @@ where
         other: &NestedBlockInfo<'ctx, 'blk, 'val>,
         fc: &BlockGenContext<'_, 'ctx, 'blk, 'val>,
     ) -> Result<()> {
-        for name in other.var_overwrites.keys() {
+        self.add_overwrites(&other.var_overwrites, fc)
+    }
+
+    /// Update `self.var_overwrites` to ensure it has all keys from the given overwrites, using
+    /// values from the current scope in the [BlockGenContext] for missing keys.
+    ///
+    /// Use this method instead of [`add_missing_values`] in situations where you cannot have a
+    /// reference to the other [`NestedBlockInfo`]. For example, if you partially moved it to give
+    /// the region to an op factory.
+    pub fn add_overwrites(
+        &mut self,
+        overwrites: &HashMap<String, Value<'ctx, 'val>>,
+        fc: &BlockGenContext<'_, 'ctx, 'blk, 'val>,
+    ) -> Result<()> {
+        for name in overwrites.keys() {
             if !self.var_overwrites.contains_key(name) {
                 self.var_overwrites.insert(name.clone(), *fc.block_ctx.get_named_value(name)?);
             }
@@ -622,6 +676,12 @@ where
     poly_template_binding_names: HashMap<String, Option<Type<'ctx>>>,
 }
 
+impl AsMut<Self> for BlockGenContext<'_, '_, '_, '_> {
+    fn as_mut(&mut self) -> &mut Self {
+        self
+    }
+}
+
 impl<'decls, 'ctx, 'blk, 'val> BlockGenContext<'decls, 'ctx, 'blk, 'val>
 where
     'ctx: 'blk,
@@ -677,6 +737,22 @@ where
     /// name in the circom code.
     pub fn append_op_unnamed_result(&mut self, op: Operation<'ctx>) -> Result<Value<'ctx, 'val>> {
         single_result_as_value(self.append_op(op))
+    }
+
+    /// Append an operation that must produce one or more results and is NOT associated with a variable
+    /// name in the circom code.
+    pub fn append_op_many_unnamed_results(
+        &mut self,
+        op: Operation<'ctx>,
+    ) -> Result<Vec<Value<'ctx, 'val>>> {
+        let op = self.append_op(op);
+        if op.result_count() < 1 {
+            anyhow::bail!(
+                "Expected operation to have one or more results, found {}",
+                op.result_count()
+            );
+        }
+        Ok(op.results().map(Value::from).collect())
     }
 
     /// Append an operation that must produce a single result and store the mapping of the circom
@@ -1410,6 +1486,54 @@ where
             return self.cast_to_expected_type_if_needed(codegen, location, if_op_result?, expect);
         }
         if_op_result
+    }
+
+    /// Append an `scf.if` op using pre-generated branch regions that each yield the same number of values.
+    /// Ensures both yielded values have the same type, emits the `scf.if`, and casts the
+    /// result to `expected_result_type` when provided and unifiable.
+    pub fn gen_safe_scf_multivalued_if(
+        &mut self,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+        location: Location<'ctx>,
+        condition: Value<'ctx, 'val>,
+        (then_region, then_values): (Region<'ctx>, &[Value<'ctx, 'val>]),
+        (else_region, else_values): (Region<'ctx>, &[Value<'ctx, 'val>]),
+        expected_result_types: Option<&[Type<'ctx>]>,
+    ) -> Result<Vec<Value<'ctx, 'val>>> {
+        assert_eq!(
+            then_values.len(),
+            else_values.len(),
+            "branches of scf.if must have identical length"
+        );
+        if let Some(expected_result_types) = expected_result_types {
+            assert_eq!(
+                then_values.len(),
+                expected_result_types.len(),
+                "branches of scf.id and expected result types must have identical length"
+            );
+        }
+        for (then_value, else_value) in std::iter::zip(then_values, else_values) {
+            // Ensure values yielded from both blocks have the same type. Strict equality per `scf.if`.
+            assert_eq!(
+                then_value.r#type(),
+                else_value.r#type(),
+                "branches of scf.if must yield identical value types"
+            );
+        }
+        let yield_types = then_values.iter().map(|v| v.r#type()).collect::<Vec<_>>();
+        let if_op_result =
+            self.append_op(scf::r#if(condition, &yield_types, then_region, else_region, location));
+
+        let values = if_op_result.results().map(|r| unsafe { Value::from_raw(r.to_raw()) });
+
+        match expected_result_types {
+            Some(expected) => std::iter::zip(values, expected)
+                .map(|(value, expected)| {
+                    self.cast_to_expected_type_if_needed(codegen, location, value, *expected)
+                })
+                .collect(),
+            None => Ok(values.collect()),
+        }
     }
 
     /// Generate an `scf.if` op based on the given [NestedBlockInfo] for each branch and update the
@@ -2199,6 +2323,7 @@ where
                     info.subcmp_info,
                     codegen.location_from_meta(meta),
                     None,
+                    &|value, _: &mut BlockGenContext<'_, 'ctx, 'blk, 'val>| Ok(value),
                 )
             }
             Expression::InfixOp { meta, lhe, infix_op, rhe } => {

--- a/llzk_backend/src/gen_context.rs
+++ b/llzk_backend/src/gen_context.rs
@@ -466,8 +466,8 @@ where
         NestedBlockInfo { region, block, var_overwrites: Default::default() }
     }
 
-    /// Creates a new instance using the common pattern of pushing the block into the stack, emitting some IR, and then
-    /// popping the block.
+    /// Creates a new instance using the common pattern of pushing the block into the stack,
+    /// emitting some IR, and then popping the block.
     pub fn with_scope<'decls, R, C>(
         block_gen: &mut C,
         cb: impl FnOnce(&mut C) -> Result<R>,
@@ -739,8 +739,8 @@ where
         single_result_as_value(self.append_op(op))
     }
 
-    /// Append an operation that must produce one or more results and is NOT associated with a variable
-    /// name in the circom code.
+    /// Append an operation that must produce one or more results and is NOT associated with a
+    /// variable name in the circom code.
     pub fn append_op_many_unnamed_results(
         &mut self,
         op: Operation<'ctx>,
@@ -1488,9 +1488,9 @@ where
         if_op_result
     }
 
-    /// Append an `scf.if` op using pre-generated branch regions that each yield the same number of values.
-    /// Ensures both yielded values have the same type, emits the `scf.if`, and casts the
-    /// result to `expected_result_type` when provided and unifiable.
+    /// Append an `scf.if` op using pre-generated branch regions that each yield the same number of
+    /// values. Ensures both yielded values have the same type, emits the `scf.if`, and casts
+    /// the result to `expected_result_type` when provided and unifiable.
     pub fn gen_safe_scf_multivalued_if(
         &mut self,
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
@@ -1513,7 +1513,8 @@ where
             );
         }
         for (then_value, else_value) in std::iter::zip(then_values, else_values) {
-            // Ensure values yielded from both blocks have the same type. Strict equality per `scf.if`.
+            // Ensure values yielded from both blocks have the same type. Strict equality per
+            // `scf.if`.
             assert_eq!(
                 then_value.r#type(),
                 else_value.r#type(),
@@ -2323,7 +2324,7 @@ where
                     info.subcmp_info,
                     codegen.location_from_meta(meta),
                     None,
-                    &|value, _: &mut BlockGenContext<'_, 'ctx, 'blk, 'val>| Ok(value),
+                    &|value, _: &mut BlockGenContext<'_, '_, '_, '_>| Ok(value),
                 )
             }
             Expression::InfixOp { meta, lhe, infix_op, rhe } => {

--- a/llzk_backend/src/gen_context.rs
+++ b/llzk_backend/src/gen_context.rs
@@ -1055,7 +1055,7 @@ where
     pub fn handle_substitution_stmt_nonsignal<'info>(
         &mut self,
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        info: InfoProviders<'info>,
+        info: InfoProviders<'info, 'ctx>,
         meta: &Meta,
         var: &String,
         access: &[Access],
@@ -1097,7 +1097,7 @@ where
         indices: impl IntoIterator<Item = &'ast E>,
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
         location: Location<'ctx>,
-        info: InfoProviders<'info>,
+        info: InfoProviders<'info, 'ctx>,
     ) -> Result<Vec<Value<'ctx, 'val>>>
     where
         E: GenerateLLZKInAnyBlock<'ctx, 'blk, 'val> + 'ast,
@@ -2157,7 +2157,7 @@ where
         &self,
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
         block_gen: &mut BlockGenContext<'_, 'ctx, 'blk, 'val>,
-        info: InfoProviders<'info>,
+        info: InfoProviders<'info, 'ctx>,
     ) -> Result<Value<'ctx, 'val>>;
 }
 
@@ -2177,7 +2177,7 @@ where
         &self,
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
         block_gen: &mut BlockGenContext<'_, 'ctx, 'blk, 'val>,
-        info: InfoProviders<'info>,
+        info: InfoProviders<'info, 'ctx>,
     ) -> Result<Value<'ctx, 'val>> {
         match self {
             Expression::Number(meta, big_int) => {

--- a/llzk_backend/src/lvalue.rs
+++ b/llzk_backend/src/lvalue.rs
@@ -136,10 +136,10 @@ impl<'ast> Lvalue<'ast> {
 
     /// Handle [Lvalue::Array] case of [`Lvalue::get_value`].
     ///
-    /// The value read from the array is returned via the continuation.
-    /// If the array is an actual LLZK array then the continuation is called only once.
-    /// However, if the array is actual an array of mixed subcomponents, the continuation is
-    /// called for each branch of the dispatch table.
+    /// The value read from the array is returned via the continuation. If the array is an
+    /// actual LLZK array then the continuation is called only once. However, if the array
+    /// is actually an array of mixed subcomponents, the continuation is called for each
+    /// branch of the dispatch table.
     #[allow(clippy::too_many_arguments)]
     fn get_array_value<'decls, 'ctx, 'blk, 'val, 'cont, R, C>(
         &self,
@@ -663,12 +663,8 @@ fn emit_condition<'ctx, 'val>(
     let entry_indices_values = entry_indices
         .iter()
         .map(|idx| {
-            let attr = IntegerAttribute::new(codegen.index_type(), *idx as i64);
-            block_gen.append_op_unnamed_result(arith::constant(
-                codegen.context,
-                attr.into(),
-                location,
-            ))
+            let idx = i64::try_from(*idx).expect("index too large");
+            block_gen.append_op_unnamed_result(codegen.new_index_const_op(idx, location))
         })
         .collect::<Result<Vec<_>>>()?;
     if entry_indices_values.len() != indices.len() {

--- a/llzk_backend/src/lvalue.rs
+++ b/llzk_backend/src/lvalue.rs
@@ -20,11 +20,6 @@ use llzk::prelude::Value;
 use llzk::prelude::ValueLike as _;
 use melior::dialect::arith;
 use melior::dialect::scf;
-use melior::ir::Block;
-use melior::ir::BlockLike;
-use melior::ir::Region;
-use melior::ir::RegionLike;
-use melior::ir::Type;
 use num_traits::ToPrimitive;
 use program_structure::ast::Access;
 use program_structure::ast::AssignOp;
@@ -145,6 +140,7 @@ impl<'ast> Lvalue<'ast> {
     /// If the array is an actual LLZK array then the continuation is called only once.
     /// However, if the array is actual an array of mixed subcomponents, the continuation is
     /// called for each branch of the dispatch table.
+    #[allow(clippy::too_many_arguments)]
     fn get_array_value<'decls, 'ctx, 'blk, 'val, 'cont, R, C>(
         &self,
         indices: &[&Expression],
@@ -223,6 +219,7 @@ impl<'ast> Lvalue<'ast> {
     }
 
     /// Emits the IR for a conditional check for array indices in a mixed subcomponent.
+    #[allow(clippy::too_many_arguments)]
     fn emit_mixed_subcmp_if_body<'decls, 'ctx, 'blk, 'val, 'cont, R, C>(
         &self,
         prev: Value<'ctx, 'val>,
@@ -698,7 +695,10 @@ fn emit_condition<'ctx, 'val>(
     })
 }
 
+/// Private module for holding `CombineSealed`.
 mod sealed {
+    /// Sealed trait to avoid more implementations of `Combine` other than the two
+    /// provided in this file.
     pub trait CombineSealed {}
 }
 
@@ -713,6 +713,7 @@ pub struct CombineEntry<'ctx, 'blk, 'val, C> {
 }
 
 impl<'ctx, 'blk, 'val, C> CombineEntry<'ctx, 'blk, 'val, C> {
+    /// Creates a new entry.
     fn new(condition: Value<'ctx, 'val>, data: C, info: NestedBlockInfo<'ctx, 'blk, 'val>) -> Self {
         Self { condition, data, info }
     }
@@ -725,6 +726,10 @@ impl<'ctx, 'blk, 'val, C> CombineEntry<'ctx, 'blk, 'val, C> {
 /// Both create the if-then-else chain with the difference that the former returns the value and
 /// the latter doesn't.
 pub trait Combine<'ctx, 'val>: sealed::CombineSealed + Sized + Copy {
+    /// Creates the tail which is the final branch of the if-then-else chain.
+    ///
+    /// This branch should be unreachable but is generated for keeping the type system consistent.
+    /// May generate undef ops for the yield values the if-then-else chain may generate.
     fn make_tail<'blk>(
         entries: &[CombineEntry<'ctx, 'blk, 'val, Self>],
         block_gen: &mut BlockGenContext<'_, 'ctx, 'blk, 'val>,
@@ -732,10 +737,17 @@ pub trait Combine<'ctx, 'val>: sealed::CombineSealed + Sized + Copy {
         location: Location<'ctx>,
     ) -> Result<(NestedBlockInfo<'ctx, 'blk, 'val>, Self)>;
 
+    /// Converts `Self` to a vaule.
     fn data_as_value(self) -> Option<Value<'ctx, 'val>>;
 
+    /// Creates an instance of `Self` from a value.
     fn from_value(value: Option<Value<'ctx, 'val>>) -> Self;
 
+    /// Combines the entries into a single if-then-else chain.
+    ///
+    /// Overwritten variables and possible yield values are aggregated and returned by the chain.
+    ///
+    /// The overwritten variables are then set to the final yield of the chain.
     fn combine<'blk>(
         entries: Vec<CombineEntry<'ctx, 'blk, 'val, Self>>,
         block_gen: &mut BlockGenContext<'_, 'ctx, 'blk, 'val>,
@@ -814,7 +826,7 @@ pub trait Combine<'ctx, 'val>: sealed::CombineSealed + Sized + Copy {
 
                 Ok((
                     new_info,
-                    Self::from_value(values.get(0).copied()),
+                    Self::from_value(values.first().copied()),
                     (values, overwrites_offset, vars),
                 ))
             },
@@ -840,26 +852,45 @@ pub trait Combine<'ctx, 'val>: sealed::CombineSealed + Sized + Copy {
             .into_iter()
             .try_for_each(|(var, value)| block_gen.block_ctx.set_named_value(var, *value))?;
 
-        Ok(Self::from_value(results.get(0).copied()))
+        Ok(Self::from_value(results.first().copied()))
     }
 }
 
 impl sealed::CombineSealed for () {}
 impl sealed::CombineSealed for Value<'_, '_> {}
 
+/// Convenience alias.
 type OverwriteMap<'ctx, 'val> = HashMap<String, Value<'ctx, 'val>>;
 
 /// Cases for combining overwrites between two if-then-else branches.
 enum Overwrite<'ctx, 'val> {
     /// Both cases have the variable
-    Both { var: String, then: Value<'ctx, 'val>, r#else: Value<'ctx, 'val> },
+    Both {
+        /// Var name.
+        var: String,
+        /// Value for the then branch.
+        then: Value<'ctx, 'val>,
+        /// Value for the else branch.
+        r#else: Value<'ctx, 'val>,
+    },
     /// Only the then branch has this variable
-    Then { var: String, value: Value<'ctx, 'val> },
+    Then {
+        /// Var name.
+        var: String,
+        /// Value for the then branch.
+        value: Value<'ctx, 'val>,
+    },
     /// Only the else branch has this variable
-    Else { var: String, value: Value<'ctx, 'val> },
+    Else {
+        /// Var name.
+        var: String,
+        /// Value for the else branch.
+        value: Value<'ctx, 'val>,
+    },
 }
 
 impl Overwrite<'_, '_> {
+    /// Returns the var name.
     fn var(&self) -> &str {
         match self {
             Overwrite::Both { var, .. }
@@ -947,9 +978,7 @@ impl<'ctx, 'val> Combine<'ctx, 'val> for () {
         None
     }
 
-    fn from_value(_: Option<Value<'ctx, 'val>>) -> Self {
-        ()
-    }
+    fn from_value(_: Option<Value<'ctx, 'val>>) -> Self {}
 }
 
 impl<'ctx, 'val> Combine<'ctx, 'val> for Value<'ctx, 'val> {
@@ -978,6 +1007,7 @@ impl<'ctx, 'val> Combine<'ctx, 'val> for Value<'ctx, 'val> {
 /// `impl Fn(...)` causes the rust compiler to enter an infinite loop of instantiations.
 /// Using this trait as a `dyn` trait fixes the problem.
 pub trait Continuation<'ctx, 'val, R, C> {
+    /// Runs the continuation.
     fn cont<'decls, 'blk>(&self, value: Value<'ctx, 'val>, block_gen: &mut C) -> Result<R>
     where
         C: AsMut<BlockGenContext<'decls, 'ctx, 'blk, 'val>>,

--- a/llzk_backend/src/lvalue.rs
+++ b/llzk_backend/src/lvalue.rs
@@ -2,6 +2,7 @@
 
 use crate::function::InfoProviders;
 use crate::gen_context::BlockGenContext;
+use crate::gen_context::NestedBlockInfo;
 use crate::program_ext::ProgramLike;
 use crate::shared;
 use crate::shared::LlzkCodegen;
@@ -18,11 +19,12 @@ use llzk::prelude::StructType;
 use llzk::prelude::Value;
 use llzk::prelude::ValueLike as _;
 use melior::dialect::arith;
-use melior::dialect::ods::scf;
+use melior::dialect::scf;
 use melior::ir::Block;
 use melior::ir::BlockLike;
 use melior::ir::Region;
 use melior::ir::RegionLike;
+use melior::ir::Type;
 use num_traits::ToPrimitive;
 use program_structure::ast::Access;
 use program_structure::ast::AssignOp;
@@ -31,8 +33,11 @@ use program_structure::ast::ExpressionInfixOpcode;
 use program_structure::ast::ExpressionPrefixOpcode;
 use std::borrow::Cow;
 use std::cmp;
+use std::collections::HashMap;
+use std::collections::HashSet;
 use std::convert::TryFrom as _;
 use std::fmt;
+use std::iter::FromIterator as _;
 
 /// Decorator trait that can modify the name of the root variable.
 pub trait OverrideVar {
@@ -140,31 +145,37 @@ impl<'ast> Lvalue<'ast> {
     /// If the array is an actual LLZK array then the continuation is called only once.
     /// However, if the array is actual an array of mixed subcomponents, the continuation is
     /// called for each branch of the dispatch table.
-    fn get_array_value<'ctx, 'val>(
+    fn get_array_value<'decls, 'ctx, 'blk, 'val, 'cont, R, C>(
         &self,
         indices: &[&Expression],
         prev: Value<'ctx, 'val>,
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        block_gen: &mut BlockGenContext<'_, 'ctx, '_, 'val>,
+        block_gen: &mut C,
         location: Location<'ctx>,
         info: InfoProviders<'_, 'ctx>,
-        cont: &impl Fn(
-            Value<'ctx, 'val>,
-            &mut BlockGenContext<'_, 'ctx, '_, 'val>,
-        ) -> Result<Value<'ctx, 'val>>,
-    ) -> Result<Value<'ctx, 'val>> {
-        let indices = block_gen.gen_index_ops(indices.iter().copied(), codegen, location, info)?;
+        cont: &'cont dyn Continuation<'ctx, 'val, R, C>,
+    ) -> Result<R>
+    where
+        R: Combine<'ctx, 'val>,
+        C: AsMut<BlockGenContext<'decls, 'ctx, 'blk, 'val>>,
+        'ctx: 'cont + 'decls,
+        'val: 'cont,
+        'ctx: 'blk,
+        'blk: 'val,
+    {
+        let indices =
+            block_gen.as_mut().gen_index_ops(indices.iter().copied(), codegen, location, info)?;
         // Whatever I do on `WriteChain::write_array` I need to do a similar thing here for reading
         // the "arrays".
         let Ok(prev_pod_type) = PodType::try_from(prev.r#type()) else {
-            let value = block_gen.append_array_read(prev, &indices, location, None)?;
-            return cont(value, block_gen);
+            let value = block_gen.as_mut().append_array_read(prev, &indices, location, None)?;
+            return cont.cont(value, block_gen);
         };
         // Constant true used as starting point for concatenating the conditions for a particular
         // index set together with a fold.
         let true_value = {
             let attr = IntegerAttribute::new(codegen.bool_type().into(), 1);
-            block_gen.append_op_unnamed_result(arith::constant(
+            block_gen.as_mut().append_op_unnamed_result(arith::constant(
                 codegen.context,
                 attr.into(),
                 location,
@@ -183,13 +194,13 @@ impl<'ast> Lvalue<'ast> {
                 let cond = emit_condition(
                     entry_indices,
                     codegen,
-                    block_gen,
+                    block_gen.as_mut(),
                     location,
                     true_value,
                     &indices,
                 )?;
 
-                let (region, yield_value) = self.emit_mixed_subcmp_if_body(
+                let (info, yield_value) = self.emit_mixed_subcmp_if_body(
                     prev,
                     entry_indices,
                     codegen,
@@ -200,7 +211,7 @@ impl<'ast> Lvalue<'ast> {
                     cont,
                 )?;
 
-                Ok((cond, region, yield_value))
+                Ok(CombineEntry::new(cond, yield_value, info))
             })
             .collect::<Result<Vec<_>>>()?;
 
@@ -208,101 +219,49 @@ impl<'ast> Lvalue<'ast> {
             anyhow::bail!("No indices for mixed subcomponent array '{}'", self.root_var());
         }
 
-        let fallthrough_type = entries[0].2.r#type();
-        let tail = {
-            let region = Region::new();
-            let body = region.append_block(Block::new(&[]));
-            block_gen.block_ctx.push(body);
-
-            let value = block_gen.append_op_unnamed_result(nondet(location, fallthrough_type))?;
-
-            let overwrites = block_gen.block_ctx.pop();
-            assert!(overwrites.is_empty());
-
-            (region, value)
-        };
-
-        let (region, yield_value) = entries.into_iter().try_fold(
-            tail,
-            |(tail_region, tail_value),
-             (condition, region, yield_value)|
-             -> Result<(Region<'ctx>, Value<'ctx, 'val>)> {
-                let new_region = Region::new();
-                let body = new_region.append_block(Block::new(&[]));
-
-                block_gen.block_ctx.push(body);
-                let yield_value = block_gen.gen_safe_scf_if(
-                    codegen,
-                    location,
-                    condition,
-                    (region, yield_value),
-                    (tail_region, tail_value),
-                    None,
-                )?;
-
-                let overwrites = block_gen.block_ctx.pop();
-                assert!(overwrites.is_empty());
-
-                Ok((new_region, yield_value))
-            },
-        )?;
-
-        // Wrap the region in a scf.execute_region. It's easier to add ops than to steal the ops
-        // inside the region and the canonicalizer will get rid of it.
-        {
-            // Pass the yield_value to a scf.yield op to satisfy scf.execute_region's requirements.
-            let yield_op = scf::r#yield(codegen.context, &[yield_value], location);
-            let fst = region.first_block().unwrap(); // We just created it!
-            assert!(fst.next_in_region().is_none(), "should create only one block!");
-            fst.append_operation(yield_op.into());
-        }
-        block_gen
-            .append_op_unnamed_result(scf::execute_region(codegen.context, region, location).into())
+        R::combine(entries, block_gen.as_mut(), codegen, location)
     }
 
     /// Emits the IR for a conditional check for array indices in a mixed subcomponent.
-    fn emit_mixed_subcmp_if_body<'ctx, 'val>(
+    fn emit_mixed_subcmp_if_body<'decls, 'ctx, 'blk, 'val, 'cont, R, C>(
         &self,
         prev: Value<'ctx, 'val>,
         entry_indices: &[usize],
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        block_gen: &mut BlockGenContext<'_, 'ctx, '_, 'val>,
+        block_gen: &mut C,
         location: Location<'ctx>,
         prev_pod_type: PodType<'ctx>,
         info: InfoProviders<'_, 'ctx>,
-        cont: &impl Fn(
-            Value<'ctx, 'val>,
-            &mut BlockGenContext<'_, 'ctx, '_, 'val>,
-        ) -> Result<Value<'ctx, 'val>>,
-    ) -> Result<(Region<'ctx>, Value<'ctx, 'val>)> {
-        let region = Region::new();
-        let body = region.append_block(Block::new(&[]));
-        block_gen.block_ctx.push(body);
-
-        let record_name = info
-            .subcmp_info
-            .mixed_subcmp_record_for_indices(self.root_var(), entry_indices)
-            .ok_or_else(|| {
-                anyhow::anyhow!(
-                    "Mixed subcomponent entry for '{}'{entry_indices:?} not found",
-                    self.root_var()
-                )
+        cont: &'cont dyn Continuation<'ctx, 'val, R, C>,
+    ) -> Result<(NestedBlockInfo<'ctx, 'blk, 'val>, R)>
+    where
+        C: AsMut<BlockGenContext<'decls, 'ctx, 'blk, 'val>>,
+        'ctx: 'cont + 'blk + 'decls,
+        'val: 'cont,
+        'blk: 'val,
+    {
+        NestedBlockInfo::with_scope(block_gen, |block_gen| {
+            let record_name = info
+                .subcmp_info
+                .mixed_subcmp_record_for_indices(self.root_var(), entry_indices)
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "Mixed subcomponent entry for '{}'{entry_indices:?} not found",
+                        self.root_var()
+                    )
+                })?;
+            let record_type = prev_pod_type.get_type_of_record(record_name).ok_or_else(|| {
+                anyhow::anyhow!("record {record_name} not found in mixed subcomponent pod: {prev}")
             })?;
-        let record_type = prev_pod_type.get_type_of_record(record_name).ok_or_else(|| {
-            anyhow::anyhow!("record {record_name} not found in mixed subcomponent pod: {prev}")
-        })?;
-        let read_value = block_gen.append_op_unnamed_result(pod::read(
-            location,
-            prev,
-            codegen.flat_sym(record_name),
-            record_type,
-        ))?;
+            let read_value = block_gen.as_mut().append_op_unnamed_result(pod::read(
+                location,
+                prev,
+                codegen.flat_sym(record_name),
+                record_type,
+            ))?;
 
-        let yield_value = cont(read_value, block_gen)?;
-
-        let overwrites = block_gen.block_ctx.pop();
-        assert!(overwrites.is_empty());
-        Ok((region, yield_value))
+            cont.cont(read_value, block_gen)
+        })
     }
 
     /// Handle [Lvalue::Subcmp]  in [`Lvalue::get_value`] when the signal is an output of the
@@ -372,34 +331,27 @@ impl<'ast> Lvalue<'ast> {
 
     /// Returns the SSA [`Value`] representing the op.
     ///
-    /// It could be a placeholder operation at this point (usually represented with `llzk.nondet`).
-    pub fn get_value<'ctx, 'val>(
-        &self,
-        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        block_gen: &mut BlockGenContext<'_, 'ctx, '_, 'val>,
-        subcmp_info: &dyn SubcmpInfo<'ctx>,
-        location: Location<'ctx>,
-        ov: Option<&dyn OverrideVar>,
-    ) -> Result<Value<'ctx, 'val>> {
-        self.get_value_impl(codegen, block_gen, subcmp_info, location, ov, &|value, _| Ok(value))
-    }
-
-    /// Internal implementation of `get_value`.
+    /// Uses continuation passing style for handling the returned value.
     ///
-    /// Uses continuation passing style for handling recursivity. This allows for replaying a leaf
-    /// branch multiple times by a parent (for example, for handling mixed subcomponents)
-    fn get_value_impl<'ctx, 'val>(
+    /// CPS is necessary for handling mixed subcomponents since the actual MLIR types of the values
+    /// returned could diverge. The continuation is represented by the [`Continuation`] trait, that
+    /// is implemented by all function types that match the continuation's signature.
+    pub fn get_value<'decls, 'ctx, 'blk, 'val, 'cont, R, C>(
         &self,
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
-        block_gen: &mut BlockGenContext<'_, 'ctx, '_, 'val>,
+        block_gen: &mut C,
         subcmp_info: &dyn SubcmpInfo<'ctx>,
         location: Location<'ctx>,
         ov: Option<&dyn OverrideVar>,
-        cont: &impl Fn(
-            Value<'ctx, 'val>,
-            &mut BlockGenContext<'_, 'ctx, '_, 'val>,
-        ) -> Result<Value<'ctx, 'val>>,
-    ) -> Result<Value<'ctx, 'val>> {
+        cont: &'cont dyn Continuation<'ctx, 'val, R, C>,
+    ) -> Result<R>
+    where
+        R: Combine<'ctx, 'val>,
+        C: AsMut<BlockGenContext<'decls, 'ctx, 'blk, 'val>>,
+        'ctx: 'cont + 'blk + 'decls,
+        'val: 'cont,
+        'blk: 'val,
+    {
         macro_rules! var_name {
             ($ov:ident, $var:ident, $op:expr) => {
                 $ov.override_var(*$var, $op)
@@ -412,20 +364,21 @@ impl<'ast> Lvalue<'ast> {
         match self {
             Lvalue::Root { var, op: Root::Signal } => {
                 let root_signal =
-                    self.get_root_signal(var_name!(ov, var, Root::Signal), block_gen)?;
-                cont(root_signal, block_gen)
+                    self.get_root_signal(var_name!(ov, var, Root::Signal), block_gen.as_mut())?;
+                cont.cont(root_signal, block_gen)
             }
             Lvalue::Root { var, op: Root::Var } => {
-                let root_value = self.get_root_value(var_name!(ov, var, Root::Var), block_gen)?;
-                cont(root_value, block_gen)
+                let root_value =
+                    self.get_root_value(var_name!(ov, var, Root::Var), block_gen.as_mut())?;
+                cont.cont(root_value, block_gen)
             }
-            Lvalue::Array { indices, prev } => prev.get_value_impl(
+            Lvalue::Array { indices, prev } => prev.get_value(
                 codegen,
                 block_gen,
                 subcmp_info,
                 location,
                 ov,
-                &|prev, block_gen| {
+                &|prev: Value<'ctx, 'val>, block_gen: &mut C| {
                     self.get_array_value(
                         indices,
                         prev,
@@ -462,19 +415,19 @@ impl<'ast> Lvalue<'ast> {
                 let is_input = info.signal_is_input(signal_name);
                 let ovii = OverrideIfInput { do_override: is_input };
 
-                prev.get_value_impl(
+                prev.get_value(
                     codegen,
                     block_gen,
                     subcmp_info,
                     location,
                     ov.or(Some(&ovii)),
-                    &|subcmp_value, block_gen| {
+                    &|subcmp_value: Value<'ctx, 'val>, block_gen: &mut C| {
                         let subcmp_member_value = if is_input {
                             self.get_subcmp_input(
                                 signal_name,
                                 subcmp_value,
                                 codegen,
-                                block_gen,
+                                block_gen.as_mut(),
                                 location,
                             )
                         } else {
@@ -482,11 +435,11 @@ impl<'ast> Lvalue<'ast> {
                                 signal_name,
                                 subcmp_value,
                                 codegen,
-                                block_gen,
+                                block_gen.as_mut(),
                                 location,
                             )
                         }?;
-                        cont(subcmp_member_value, block_gen)
+                        cont.cont(subcmp_member_value, block_gen)
                     },
                 )
             }
@@ -731,10 +684,317 @@ fn emit_condition<'ctx, 'val>(
 
     let eqs = std::iter::zip(indices, entry_indices_values)
         .map(|(lhs, rhs)| {
-            block_gen.append_op_unnamed_result(llzk::dialect::bool::eq(location, *lhs, rhs)?)
+            block_gen.append_op_unnamed_result(arith::cmpi(
+                codegen.context,
+                arith::CmpiPredicate::Eq,
+                *lhs,
+                rhs,
+                location,
+            ))
         })
         .collect::<Result<Vec<_>>>()?;
     eqs.into_iter().try_fold(true_value, |acc, cmp| {
         block_gen.append_op_unnamed_result(llzk::dialect::bool::and(location, acc, cmp)?)
     })
+}
+
+mod sealed {
+    pub trait CombineSealed {}
+}
+
+/// Helper struct aggregating the data required by the `Combine` trait.
+pub struct CombineEntry<'ctx, 'blk, 'val, C> {
+    /// Boolean condition for the if-then-else blocks.
+    condition: Value<'ctx, 'val>,
+    /// Payload that needs to be combined.
+    data: C,
+    /// Information about the region containing the emitted IR for the entry.
+    info: NestedBlockInfo<'ctx, 'blk, 'val>,
+}
+
+impl<'ctx, 'blk, 'val, C> CombineEntry<'ctx, 'blk, 'val, C> {
+    fn new(condition: Value<'ctx, 'val>, data: C, info: NestedBlockInfo<'ctx, 'blk, 'val>) -> Self {
+        Self { condition, data, info }
+    }
+}
+
+/// This trait is used for combining the output of multiple continuation results
+/// when dealing with mixed subcomponents.
+///
+/// Only two implementations are included, one for `Value` and another for `()`.
+/// Both create the if-then-else chain with the difference that the former returns the value and
+/// the latter doesn't.
+pub trait Combine<'ctx, 'val>: sealed::CombineSealed + Sized + Copy {
+    fn make_tail<'blk>(
+        entries: &[CombineEntry<'ctx, 'blk, 'val, Self>],
+        block_gen: &mut BlockGenContext<'_, 'ctx, 'blk, 'val>,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+        location: Location<'ctx>,
+    ) -> Result<(NestedBlockInfo<'ctx, 'blk, 'val>, Self)>;
+
+    fn data_as_value(self) -> Option<Value<'ctx, 'val>>;
+
+    fn from_value(value: Option<Value<'ctx, 'val>>) -> Self;
+
+    fn combine<'blk>(
+        entries: Vec<CombineEntry<'ctx, 'blk, 'val, Self>>,
+        block_gen: &mut BlockGenContext<'_, 'ctx, 'blk, 'val>,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+        location: Location<'ctx>,
+    ) -> Result<Self> {
+        let (tail, tail_data) = Self::make_tail(&entries, block_gen, codegen, location)?;
+
+        let (mut info, _, (values, overwrites_offset, vars)) = entries.into_iter().try_fold(
+            (tail, tail_data, Default::default()),
+            |(mut tail, tail_data, _), CombineEntry { condition, data, mut info }| -> Result<_> {
+                let mut overwrites = combine_overwrites(info.var_overwrites, tail.var_overwrites);
+                if codegen.config.stabilize {
+                    // Sort by circom variable names to ensure a stable order.
+                    overwrites.sort_by(|lhs, rhs| lhs.var().cmp(rhs.var()));
+                }
+                // Reset the overwrites
+                info.var_overwrites = OverwriteMap::new();
+                tail.var_overwrites = OverwriteMap::new();
+                fill_missing_overwrites(
+                    &mut info,
+                    &mut tail,
+                    &mut overwrites,
+                    block_gen,
+                    location,
+                )?;
+
+                let mut vars = Vec::with_capacity(overwrites.len());
+                let mut then_values = Vec::with_capacity(overwrites.len() + 1);
+                let mut else_values = Vec::with_capacity(overwrites.len() + 1);
+
+                let overwrites_offset: usize =
+                    match (tail_data.data_as_value(), data.data_as_value()) {
+                        (None, None) => 0,
+                        (Some(tail), Some(data)) => {
+                            else_values.push(tail);
+                            then_values.push(data);
+                            1
+                        }
+                        _ => unreachable!(),
+                    };
+                for overwrite in overwrites {
+                    let Overwrite::Both { var, then, r#else } = overwrite else {
+                        unreachable!();
+                    };
+                    vars.push(var);
+                    then_values.push(then);
+                    else_values.push(r#else);
+                }
+
+                // Create the yield ops for the branches
+                info.enter_scope(block_gen, |block_gen| {
+                    block_gen.append_op_no_result(scf::r#yield(&then_values, location))
+                })?;
+                tail.enter_scope(block_gen, |block_gen| {
+                    block_gen.append_op_no_result(scf::r#yield(&else_values, location))
+                })?;
+
+                let then_region = info.region;
+                let else_region = tail.region;
+                let (mut new_info, values) = NestedBlockInfo::with_scope(block_gen, |block_gen| {
+                    block_gen.gen_safe_scf_multivalued_if(
+                        codegen,
+                        location,
+                        condition,
+                        (then_region, &then_values),
+                        (else_region, &else_values),
+                        None,
+                    )
+                })?;
+                let overwrites = &values[overwrites_offset..];
+                assert_eq!(vars.len(), overwrites.len());
+                new_info.var_overwrites = OverwriteMap::from_iter(
+                    std::iter::zip(&vars, overwrites).map(|(var, value)| (var.clone(), *value)),
+                );
+
+                Ok((
+                    new_info,
+                    Self::from_value(values.get(0).copied()),
+                    (values, overwrites_offset, vars),
+                ))
+            },
+        )?;
+
+        // Wrap the region in a `scf.execute_region`. It's easier to add ops than to steal the ops
+        // inside the region and the canonicalizer will get rid of it.
+        // Create an empty scf.yield op to satisfy scf.execute_region's requirements.
+        info.enter_scope(block_gen, |block_gen| {
+            block_gen.append_op_no_result(scf::r#yield(&values, location))
+        })?;
+        let types = values.iter().map(|v| v.r#type()).collect::<Vec<_>>();
+        let op = scf::execute_region(&types, info.region, location);
+
+        let results = if !values.is_empty() {
+            block_gen.append_op_many_unnamed_results(op)?
+        } else {
+            block_gen.append_op_no_result(op)?;
+            vec![]
+        };
+        // Update the overwriten variables with the values emitted by the `scf.execute_region` op.
+        std::iter::zip(vars, &results[overwrites_offset..])
+            .into_iter()
+            .try_for_each(|(var, value)| block_gen.block_ctx.set_named_value(var, *value))?;
+
+        Ok(Self::from_value(results.get(0).copied()))
+    }
+}
+
+impl sealed::CombineSealed for () {}
+impl sealed::CombineSealed for Value<'_, '_> {}
+
+type OverwriteMap<'ctx, 'val> = HashMap<String, Value<'ctx, 'val>>;
+
+/// Cases for combining overwrites between two if-then-else branches.
+enum Overwrite<'ctx, 'val> {
+    /// Both cases have the variable
+    Both { var: String, then: Value<'ctx, 'val>, r#else: Value<'ctx, 'val> },
+    /// Only the then branch has this variable
+    Then { var: String, value: Value<'ctx, 'val> },
+    /// Only the else branch has this variable
+    Else { var: String, value: Value<'ctx, 'val> },
+}
+
+impl Overwrite<'_, '_> {
+    fn var(&self) -> &str {
+        match self {
+            Overwrite::Both { var, .. }
+            | Overwrite::Then { var, .. }
+            | Overwrite::Else { var, .. } => var,
+        }
+    }
+}
+
+/// Combines the overwrite maps into a list of [`Overwrite`].
+fn combine_overwrites<'ctx, 'val>(
+    then_map: OverwriteMap<'ctx, 'val>,
+    else_map: OverwriteMap<'ctx, 'val>,
+) -> Vec<Overwrite<'ctx, 'val>> {
+    std::iter::chain(then_map.keys(), else_map.keys())
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .map(|var| {
+            let then = then_map.get(var).copied();
+            let r#else = else_map.get(var).copied();
+
+            match (then, r#else) {
+                (Some(then), Some(r#else)) => Overwrite::Both { var: var.clone(), then, r#else },
+                (Some(value), None) => Overwrite::Then { var: var.clone(), value },
+                (None, Some(value)) => Overwrite::Else { var: var.clone(), value },
+                (None, None) => unreachable!(),
+            }
+        })
+        .collect()
+}
+
+/// Creates `nondet` ops for the overwrites that are missing.
+fn fill_missing_overwrites<'ctx, 'blk, 'val>(
+    then_info: &mut NestedBlockInfo<'ctx, 'blk, 'val>,
+    else_info: &mut NestedBlockInfo<'ctx, 'blk, 'val>,
+    overwrites: &mut [Overwrite<'ctx, 'val>],
+    block_gen: &mut BlockGenContext<'_, 'ctx, 'blk, 'val>,
+    location: Location<'ctx>,
+) -> Result<()> {
+    let (mut missing_in_then, mut missing_in_else): (Vec<_>, Vec<_>) = overwrites
+        .iter_mut()
+        .filter(|o| !matches!(o, Overwrite::Both { .. }))
+        .partition(|o| matches!(o, Overwrite::Else { .. }));
+
+    then_info.enter_scope(block_gen, |block_gen| {
+        for overwrite in &mut missing_in_then {
+            match overwrite {
+                Overwrite::Else { var, value } => {
+                    let other =
+                        block_gen.append_op_unnamed_result(nondet(location, value.r#type()))?;
+                    **overwrite = Overwrite::Both { var: var.clone(), then: other, r#else: *value };
+                }
+                _ => unreachable!(),
+            }
+        }
+        Ok(())
+    })?;
+
+    else_info.enter_scope(block_gen, |block_gen| {
+        for overwrite in &mut missing_in_else {
+            match overwrite {
+                Overwrite::Then { var, value } => {
+                    let other =
+                        block_gen.append_op_unnamed_result(nondet(location, value.r#type()))?;
+                    **overwrite = Overwrite::Both { var: var.clone(), r#else: other, then: *value };
+                }
+                _ => unreachable!(),
+            }
+        }
+        Ok(())
+    })
+}
+
+impl<'ctx, 'val> Combine<'ctx, 'val> for () {
+    fn make_tail<'blk>(
+        _: &[CombineEntry<'ctx, 'blk, 'val, Self>],
+        _: &mut BlockGenContext<'_, 'ctx, 'blk, 'val>,
+        _: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+        _: Location<'ctx>,
+    ) -> Result<(NestedBlockInfo<'ctx, 'blk, 'val>, Self)> {
+        Ok((NestedBlockInfo::new(), ()))
+    }
+
+    fn data_as_value(self) -> Option<Value<'ctx, 'val>> {
+        None
+    }
+
+    fn from_value(_: Option<Value<'ctx, 'val>>) -> Self {
+        ()
+    }
+}
+
+impl<'ctx, 'val> Combine<'ctx, 'val> for Value<'ctx, 'val> {
+    fn make_tail<'blk>(
+        entries: &[CombineEntry<'ctx, 'blk, 'val, Self>],
+        block_gen: &mut BlockGenContext<'_, 'ctx, 'blk, 'val>,
+        _: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+        location: Location<'ctx>,
+    ) -> Result<(NestedBlockInfo<'ctx, 'blk, 'val>, Self)> {
+        NestedBlockInfo::with_scope(block_gen, |block_gen| {
+            block_gen.append_op_unnamed_result(nondet(location, entries[0].data.r#type()))
+        })
+    }
+
+    fn data_as_value(self) -> Option<Value<'ctx, 'val>> {
+        Some(self)
+    }
+
+    fn from_value(value: Option<Value<'ctx, 'val>>) -> Self {
+        value.unwrap()
+    }
+}
+
+/// Trait used for the continuation. Is implemented for all matching function types.
+///
+/// `impl Fn(...)` causes the rust compiler to enter an infinite loop of instantiations.
+/// Using this trait as a `dyn` trait fixes the problem.
+pub trait Continuation<'ctx, 'val, R, C> {
+    fn cont<'decls, 'blk>(&self, value: Value<'ctx, 'val>, block_gen: &mut C) -> Result<R>
+    where
+        C: AsMut<BlockGenContext<'decls, 'ctx, 'blk, 'val>>,
+        'ctx: 'blk + 'decls,
+        'blk: 'val;
+}
+
+impl<'ctx, 'val, F, R, C> Continuation<'ctx, 'val, R, C> for F
+where
+    F: Fn(Value<'ctx, 'val>, &mut C) -> Result<R>,
+{
+    fn cont<'decls, 'blk>(&self, value: Value<'ctx, 'val>, block_gen: &mut C) -> Result<R>
+    where
+        C: AsMut<BlockGenContext<'decls, 'ctx, 'blk, 'val>>,
+        'ctx: 'blk + 'decls,
+        'blk: 'val,
+    {
+        self(value, block_gen)
+    }
 }

--- a/llzk_backend/src/lvalue.rs
+++ b/llzk_backend/src/lvalue.rs
@@ -905,7 +905,9 @@ fn combine_overwrites<'ctx, 'val>(
     then_map: OverwriteMap<'ctx, 'val>,
     else_map: OverwriteMap<'ctx, 'val>,
 ) -> Vec<Overwrite<'ctx, 'val>> {
-    std::iter::chain(then_map.keys(), else_map.keys())
+    then_map
+        .keys()
+        .chain(else_map.keys())
         .collect::<HashSet<_>>()
         .into_iter()
         .map(|var| {

--- a/llzk_backend/src/lvalue.rs
+++ b/llzk_backend/src/lvalue.rs
@@ -8,13 +8,21 @@ use crate::shared::LlzkCodegen;
 use crate::subcmp::names::COMP;
 use crate::subcmp::SubcmpInfo;
 use anyhow::Result;
+use llzk::dialect::llzk::nondet;
 use llzk::dialect::pod;
 use llzk::dialect::r#struct;
+use llzk::prelude::IntegerAttribute;
 use llzk::prelude::Location;
 use llzk::prelude::PodType;
 use llzk::prelude::StructType;
 use llzk::prelude::Value;
 use llzk::prelude::ValueLike as _;
+use melior::dialect::arith;
+use melior::dialect::ods::scf;
+use melior::ir::Block;
+use melior::ir::BlockLike;
+use melior::ir::Region;
+use melior::ir::RegionLike;
 use num_traits::ToPrimitive;
 use program_structure::ast::Access;
 use program_structure::ast::AssignOp;
@@ -127,6 +135,11 @@ impl<'ast> Lvalue<'ast> {
     }
 
     /// Handle [Lvalue::Array] case of [`Lvalue::get_value`].
+    ///
+    /// The value read from the array is returned via the continuation.
+    /// If the array is an actual LLZK array then the continuation is called only once.
+    /// However, if the array is actual an array of mixed subcomponents, the continuation is
+    /// called for each branch of the dispatch table.
     fn get_array_value<'ctx, 'val>(
         &self,
         indices: &[&Expression],
@@ -134,30 +147,162 @@ impl<'ast> Lvalue<'ast> {
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
         block_gen: &mut BlockGenContext<'_, 'ctx, '_, 'val>,
         location: Location<'ctx>,
-        info: InfoProviders<'_>,
+        info: InfoProviders<'_, 'ctx>,
+        cont: &impl Fn(
+            Value<'ctx, 'val>,
+            &mut BlockGenContext<'_, 'ctx, '_, 'val>,
+        ) -> Result<Value<'ctx, 'val>>,
     ) -> Result<Value<'ctx, 'val>> {
-        if let Ok(prev_pod_type) = PodType::try_from(prev.r#type()) {
-            if let Some(indices) = concrete_indices(indices) {
-                if let Some(record_name) =
-                    info.subcmp_info.mixed_subcmp_record_for_indices(self.root_var(), &indices)
-                {
-                    let record_type =
-                        prev_pod_type.get_type_of_record(record_name).ok_or_else(|| {
-                            anyhow::anyhow!(
-                                "record {record_name} not found in mixed subcomponent pod: {prev}"
-                            )
-                        })?;
-                    return block_gen.append_op_unnamed_result(pod::read(
-                        location,
-                        prev,
-                        codegen.flat_sym(record_name),
-                        record_type,
-                    ));
-                }
-            }
-        }
         let indices = block_gen.gen_index_ops(indices.iter().copied(), codegen, location, info)?;
-        block_gen.append_array_read(prev, &indices, location, None)
+        // Whatever I do on `WriteChain::write_array` I need to do a similar thing here for reading
+        // the "arrays".
+        let Ok(prev_pod_type) = PodType::try_from(prev.r#type()) else {
+            let value = block_gen.append_array_read(prev, &indices, location, None)?;
+            return cont(value, block_gen);
+        };
+        // Constant true used as starting point for concatenating the conditions for a particular
+        // index set together with a fold.
+        let true_value = {
+            let attr = IntegerAttribute::new(codegen.bool_type().into(), 1);
+            block_gen.append_op_unnamed_result(arith::constant(
+                codegen.context,
+                attr.into(),
+                location,
+            ))
+        }?;
+
+        // I need the dimensions of the array. I need to know the number of dimensions and the size
+        // of each dimension. Since this stuff happens in `--concrete` I don't need to worry about
+        // arrays having a size that is unknown at compile time.
+        let mixed_subcmp_layout = info.subcmp_info.mixed_subcmp_info(self.root_var())?;
+
+        let entries = mixed_subcmp_layout
+            .indices()
+            .into_iter()
+            .map(|entry_indices| {
+                let cond = emit_condition(
+                    entry_indices,
+                    codegen,
+                    block_gen,
+                    location,
+                    true_value,
+                    &indices,
+                )?;
+
+                let (region, yield_value) = self.emit_mixed_subcmp_if_body(
+                    prev,
+                    entry_indices,
+                    codegen,
+                    block_gen,
+                    location,
+                    prev_pod_type,
+                    info,
+                    cont,
+                )?;
+
+                Ok((cond, region, yield_value))
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        if entries.is_empty() {
+            anyhow::bail!("No indices for mixed subcomponent array '{}'", self.root_var());
+        }
+
+        let fallthrough_type = entries[0].2.r#type();
+        let tail = {
+            let region = Region::new();
+            let body = region.append_block(Block::new(&[]));
+            block_gen.block_ctx.push(body);
+
+            let value = block_gen.append_op_unnamed_result(nondet(location, fallthrough_type))?;
+
+            let overwrites = block_gen.block_ctx.pop();
+            assert!(overwrites.is_empty());
+
+            (region, value)
+        };
+
+        let (region, yield_value) = entries.into_iter().try_fold(
+            tail,
+            |(tail_region, tail_value),
+             (condition, region, yield_value)|
+             -> Result<(Region<'ctx>, Value<'ctx, 'val>)> {
+                let new_region = Region::new();
+                let body = new_region.append_block(Block::new(&[]));
+
+                block_gen.block_ctx.push(body);
+                let yield_value = block_gen.gen_safe_scf_if(
+                    codegen,
+                    location,
+                    condition,
+                    (region, yield_value),
+                    (tail_region, tail_value),
+                    None,
+                )?;
+
+                let overwrites = block_gen.block_ctx.pop();
+                assert!(overwrites.is_empty());
+
+                Ok((new_region, yield_value))
+            },
+        )?;
+
+        // Wrap the region in a scf.execute_region. It's easier to add ops than to steal the ops
+        // inside the region and the canonicalizer will get rid of it.
+        {
+            // Pass the yield_value to a scf.yield op to satisfy scf.execute_region's requirements.
+            let yield_op = scf::r#yield(codegen.context, &[yield_value], location);
+            let fst = region.first_block().unwrap(); // We just created it!
+            assert!(fst.next_in_region().is_none(), "should create only one block!");
+            fst.append_operation(yield_op.into());
+        }
+        block_gen
+            .append_op_unnamed_result(scf::execute_region(codegen.context, region, location).into())
+    }
+
+    /// Emits the IR for a conditional check for array indices in a mixed subcomponent.
+    fn emit_mixed_subcmp_if_body<'ctx, 'val>(
+        &self,
+        prev: Value<'ctx, 'val>,
+        entry_indices: &[usize],
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+        block_gen: &mut BlockGenContext<'_, 'ctx, '_, 'val>,
+        location: Location<'ctx>,
+        prev_pod_type: PodType<'ctx>,
+        info: InfoProviders<'_, 'ctx>,
+        cont: &impl Fn(
+            Value<'ctx, 'val>,
+            &mut BlockGenContext<'_, 'ctx, '_, 'val>,
+        ) -> Result<Value<'ctx, 'val>>,
+    ) -> Result<(Region<'ctx>, Value<'ctx, 'val>)> {
+        let region = Region::new();
+        let body = region.append_block(Block::new(&[]));
+        block_gen.block_ctx.push(body);
+
+        let record_name = info
+            .subcmp_info
+            .mixed_subcmp_record_for_indices(self.root_var(), entry_indices)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Mixed subcomponent entry for '{}'{entry_indices:?} not found",
+                    self.root_var()
+                )
+            })?;
+        let record_type = prev_pod_type.get_type_of_record(record_name).ok_or_else(|| {
+            anyhow::anyhow!("record {record_name} not found in mixed subcomponent pod: {prev}")
+        })?;
+        let read_value = block_gen.append_op_unnamed_result(pod::read(
+            location,
+            prev,
+            codegen.flat_sym(record_name),
+            record_type,
+        ))?;
+
+        let yield_value = cont(read_value, block_gen)?;
+
+        let overwrites = block_gen.block_ctx.pop();
+        assert!(overwrites.is_empty());
+        Ok((region, yield_value))
     }
 
     /// Handle [Lvalue::Subcmp]  in [`Lvalue::get_value`] when the signal is an output of the
@@ -232,9 +377,28 @@ impl<'ast> Lvalue<'ast> {
         &self,
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
         block_gen: &mut BlockGenContext<'_, 'ctx, '_, 'val>,
-        subcmp_info: &dyn SubcmpInfo,
+        subcmp_info: &dyn SubcmpInfo<'ctx>,
         location: Location<'ctx>,
         ov: Option<&dyn OverrideVar>,
+    ) -> Result<Value<'ctx, 'val>> {
+        self.get_value_impl(codegen, block_gen, subcmp_info, location, ov, &|value, _| Ok(value))
+    }
+
+    /// Internal implementation of `get_value`.
+    ///
+    /// Uses continuation passing style for handling recursivity. This allows for replaying a leaf
+    /// branch multiple times by a parent (for example, for handling mixed subcomponents)
+    fn get_value_impl<'ctx, 'val>(
+        &self,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+        block_gen: &mut BlockGenContext<'_, 'ctx, '_, 'val>,
+        subcmp_info: &dyn SubcmpInfo<'ctx>,
+        location: Location<'ctx>,
+        ov: Option<&dyn OverrideVar>,
+        cont: &impl Fn(
+            Value<'ctx, 'val>,
+            &mut BlockGenContext<'_, 'ctx, '_, 'val>,
+        ) -> Result<Value<'ctx, 'val>>,
     ) -> Result<Value<'ctx, 'val>> {
         macro_rules! var_name {
             ($ov:ident, $var:ident, $op:expr) => {
@@ -247,18 +411,31 @@ impl<'ast> Lvalue<'ast> {
 
         match self {
             Lvalue::Root { var, op: Root::Signal } => {
-                self.get_root_signal(var_name!(ov, var, Root::Signal), block_gen)
+                let root_signal =
+                    self.get_root_signal(var_name!(ov, var, Root::Signal), block_gen)?;
+                cont(root_signal, block_gen)
             }
             Lvalue::Root { var, op: Root::Var } => {
-                self.get_root_value(var_name!(ov, var, Root::Var), block_gen)
+                let root_value = self.get_root_value(var_name!(ov, var, Root::Var), block_gen)?;
+                cont(root_value, block_gen)
             }
-            Lvalue::Array { indices, prev } => self.get_array_value(
-                indices,
-                prev.get_value(codegen, block_gen, subcmp_info, location, ov)?,
+            Lvalue::Array { indices, prev } => prev.get_value_impl(
                 codegen,
                 block_gen,
+                subcmp_info,
                 location,
-                InfoProviders { subcmp_info, ..Default::default() },
+                ov,
+                &|prev, block_gen| {
+                    self.get_array_value(
+                        indices,
+                        prev,
+                        codegen,
+                        block_gen,
+                        location,
+                        InfoProviders { subcmp_info, ..Default::default() },
+                        cont,
+                    )
+                },
             ),
             Lvalue::Subcmp { name: signal_name, prev } => {
                 let root = prev.root_var();
@@ -285,14 +462,33 @@ impl<'ast> Lvalue<'ast> {
                 let is_input = info.signal_is_input(signal_name);
                 let ovii = OverrideIfInput { do_override: is_input };
 
-                let subcmp_value =
-                    prev.get_value(codegen, block_gen, subcmp_info, location, ov.or(Some(&ovii)))?;
-
-                if is_input {
-                    self.get_subcmp_input(signal_name, subcmp_value, codegen, block_gen, location)
-                } else {
-                    self.get_subcmp_output(signal_name, subcmp_value, codegen, block_gen, location)
-                }
+                prev.get_value_impl(
+                    codegen,
+                    block_gen,
+                    subcmp_info,
+                    location,
+                    ov.or(Some(&ovii)),
+                    &|subcmp_value, block_gen| {
+                        let subcmp_member_value = if is_input {
+                            self.get_subcmp_input(
+                                signal_name,
+                                subcmp_value,
+                                codegen,
+                                block_gen,
+                                location,
+                            )
+                        } else {
+                            self.get_subcmp_output(
+                                signal_name,
+                                subcmp_value,
+                                codegen,
+                                block_gen,
+                                location,
+                            )
+                        }?;
+                        cont(subcmp_member_value, block_gen)
+                    },
+                )
             }
         }
     }
@@ -503,4 +699,42 @@ impl fmt::Display for Lvalue<'_> {
             }
         }
     }
+}
+
+/// Emits the IR for a conditional check for array indices in a mixed subcomponent.
+fn emit_condition<'ctx, 'val>(
+    entry_indices: &[usize],
+    codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
+    block_gen: &mut BlockGenContext<'_, 'ctx, '_, 'val>,
+    location: Location<'ctx>,
+    true_value: Value<'ctx, 'val>,
+    indices: &[Value<'ctx, 'val>],
+) -> Result<Value<'ctx, 'val>> {
+    let entry_indices_values = entry_indices
+        .iter()
+        .map(|idx| {
+            let attr = IntegerAttribute::new(codegen.index_type(), *idx as i64);
+            block_gen.append_op_unnamed_result(arith::constant(
+                codegen.context,
+                attr.into(),
+                location,
+            ))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    if entry_indices_values.len() != indices.len() {
+        anyhow::bail!(
+            "Array indices and mixed subcomponent indices len do not match: {} != {}",
+            entry_indices_values.len(),
+            indices.len()
+        );
+    }
+
+    let eqs = std::iter::zip(indices, entry_indices_values)
+        .map(|(lhs, rhs)| {
+            block_gen.append_op_unnamed_result(llzk::dialect::bool::eq(location, *lhs, rhs)?)
+        })
+        .collect::<Result<Vec<_>>>()?;
+    eqs.into_iter().try_fold(true_value, |acc, cmp| {
+        block_gen.append_op_unnamed_result(llzk::dialect::bool::and(location, acc, cmp)?)
+    })
 }

--- a/llzk_backend/src/subcmp.rs
+++ b/llzk_backend/src/subcmp.rs
@@ -20,7 +20,6 @@ use llzk::prelude::PodType;
 use llzk::prelude::StructType;
 use llzk::prelude::Type;
 use llzk::prelude::TypeLike as _;
-use std::cell::OnceCell;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::convert::TryFrom;

--- a/llzk_backend/src/subcmp.rs
+++ b/llzk_backend/src/subcmp.rs
@@ -293,7 +293,8 @@ impl<'ctx> MixedSubcmpLayout<'ctx> {
         Self { component_type, memory_type, inputs_type, entries }
     }
 
-    pub fn indices<'a>(&'a self) -> impl IntoIterator<Item = &'a [usize]> {
+    /// Returns the indices the entries are indexed with.
+    pub fn indices(&self) -> impl IntoIterator<Item = &[usize]> {
         self.entries.iter().map(MixedSubcmpEntry::indexed_with)
     }
 

--- a/llzk_backend/src/subcmp.rs
+++ b/llzk_backend/src/subcmp.rs
@@ -20,6 +20,7 @@ use llzk::prelude::PodType;
 use llzk::prelude::StructType;
 use llzk::prelude::Type;
 use llzk::prelude::TypeLike as _;
+use std::cell::OnceCell;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::convert::TryFrom;
@@ -43,7 +44,7 @@ pub mod names {
 }
 
 /// Gives information about subcomponents.
-pub trait SubcmpInfo: std::fmt::Debug {
+pub trait SubcmpInfo<'ctx>: std::fmt::Debug {
     /// Returns true if the given variable name is a subcomponent.
     fn is_subcmp(&self, var: &str) -> bool;
 
@@ -55,6 +56,9 @@ pub trait SubcmpInfo: std::fmt::Debug {
     ) -> Option<&'a str> {
         None
     }
+
+    /// Returns information about a mixed subcomponent pod.
+    fn mixed_subcmp_info(&self, var: &str) -> Result<&MixedSubcmpLayout<'ctx>>;
 
     /// Returns the template information for the given subcomponent.
     fn subcmp_info<'i>(
@@ -68,7 +72,7 @@ pub trait SubcmpInfo: std::fmt::Debug {
 #[derive(Debug)]
 pub struct NoSubcmps;
 
-impl SubcmpInfo for NoSubcmps {
+impl<'ctx> SubcmpInfo<'ctx> for NoSubcmps {
     fn is_subcmp(&self, _var: &str) -> bool {
         false
     }
@@ -78,6 +82,10 @@ impl SubcmpInfo for NoSubcmps {
         _var: &str,
         _info: &'i dyn ProgramInfo,
     ) -> Result<&'i dyn SignalDeclarations> {
+        unreachable!()
+    }
+
+    fn mixed_subcmp_info(&self, _: &str) -> Result<&MixedSubcmpLayout<'ctx>> {
         unreachable!()
     }
 }
@@ -284,6 +292,10 @@ impl<'ctx> MixedSubcmpLayout<'ctx> {
         entries: Vec<MixedSubcmpEntry<'ctx>>,
     ) -> Self {
         Self { component_type, memory_type, inputs_type, entries }
+    }
+
+    pub fn indices<'a>(&'a self) -> impl IntoIterator<Item = &'a [usize]> {
+        self.entries.iter().map(MixedSubcmpEntry::indexed_with)
     }
 
     /// Returns the owner struct member type containing computed component instances.

--- a/llzk_backend/src/template.rs
+++ b/llzk_backend/src/template.rs
@@ -1348,11 +1348,11 @@ where
                                     let location = codegen.location_from_meta(meta);
                                     Lvalue::new(var, Root::Signal, access)
                                         .get_value(
-                                            codegen, 
-                                            fc, 
-                                            template, 
-                                            location, 
-                                            None, 
+                                            codegen,
+                                            fc,
+                                            template,
+                                            location,
+                                            None,
                                             &|lhv: Value<'ctx,'val>, fc: &mut FunctionContext<'_, 'ctx,'_,'_,'val>| {
                                             fc.append_op_no_result(constrain::eq(location, lhv, rhv).into())
                                         })

--- a/llzk_backend/src/template.rs
+++ b/llzk_backend/src/template.rs
@@ -1346,9 +1346,16 @@ where
                                 },
                                 |fc, rhv| {
                                     let location = codegen.location_from_meta(meta);
-                                    let lhv = Lvalue::new(var, Root::Signal, access)
-                                        .get_value(codegen, fc, template, location, None)?;
-                                    fc.append_op_no_result(constrain::eq(location, lhv, rhv).into())
+                                    Lvalue::new(var, Root::Signal, access)
+                                        .get_value(
+                                            codegen, 
+                                            fc, 
+                                            template, 
+                                            location, 
+                                            None, 
+                                            &|lhv: Value<'ctx,'val>, fc: &mut FunctionContext<'_, 'ctx,'_,'_,'val>| {
+                                            fc.append_op_no_result(constrain::eq(location, lhv, rhv).into())
+                                        })
                                 },
                             ),
                         }

--- a/llzk_backend/src/template.rs
+++ b/llzk_backend/src/template.rs
@@ -30,6 +30,7 @@ use crate::shared::TypeSizeExpr;
 use crate::subcmp::names::COMP;
 use crate::subcmp::names::COUNT;
 use crate::subcmp::names::PARAMS;
+use crate::subcmp::MixedSubcmpLayout;
 use crate::subcmp::SubcmpBinding;
 use crate::subcmp::SubcmpInfo;
 use crate::subcmp::SubcmpLayout;
@@ -450,7 +451,7 @@ impl<'decls, 'ctx, 'str, 'func, 'blk, 'val> TemplateContext<'decls, 'ctx, 'str, 
     }
 }
 
-impl SubcmpInfo for TemplateContext<'_, '_, '_, '_, '_, '_> {
+impl<'ctx> SubcmpInfo<'ctx> for TemplateContext<'_, 'ctx, '_, '_, '_, '_> {
     fn is_subcmp(&self, var: &str) -> bool {
         self.subcmps.contains_key(var)
     }
@@ -478,6 +479,17 @@ impl SubcmpInfo for TemplateContext<'_, '_, '_, '_, '_, '_> {
         let binding =
             self.subcmps.get(var).ok_or_else(|| anyhow!("subcomponent '{var}' not found"))?;
         info.find_template(binding.template_name())
+    }
+
+    fn mixed_subcmp_info(&self, var: &str) -> Result<&MixedSubcmpLayout<'ctx>> {
+        let binding = self
+            .subcmps
+            .get(var)
+            .ok_or_else(|| anyhow::anyhow!("subcomponent '{var}' not found"))?;
+        let SubcmpLayout::Mixed(layout) = binding.layout() else {
+            anyhow::bail!("subcomponent '{var}' is not a mixed subcomponent");
+        };
+        Ok(layout)
     }
 }
 

--- a/llzk_backend/src/template_ext.rs
+++ b/llzk_backend/src/template_ext.rs
@@ -238,9 +238,10 @@ impl TemplateLike for TemplateInstance {
         // Get the types for the declarations
         for cluster in &self.clusters {
             if let Some(subcmp_decl) = subcmp_decls.get_mut(&cluster.cmp_name) {
-                match &cluster.xtype {
+                match dbg!(&cluster.xtype) {
                     ClusterType::Mixed { .. } => {
-                        for trigger in &self.triggers[cluster.slice.clone()] {
+                        for trigger in &self.triggers[dbg!(cluster.slice.clone())] {
+                            dbg!(trigger);
                             subcmp_decl.mixed_instances_mut().push(MixedSubcmpInstance::new(
                                 mixed_record_name(&trigger.indexed_with),
                                 trigger.indexed_with.clone(),

--- a/llzk_backend/src/template_ext.rs
+++ b/llzk_backend/src/template_ext.rs
@@ -238,10 +238,9 @@ impl TemplateLike for TemplateInstance {
         // Get the types for the declarations
         for cluster in &self.clusters {
             if let Some(subcmp_decl) = subcmp_decls.get_mut(&cluster.cmp_name) {
-                match dbg!(&cluster.xtype) {
+                match &cluster.xtype {
                     ClusterType::Mixed { .. } => {
-                        for trigger in &self.triggers[dbg!(cluster.slice.clone())] {
-                            dbg!(trigger);
+                        for trigger in &self.triggers[cluster.slice.clone()] {
                             subcmp_decl.mixed_instances_mut().push(MixedSubcmpInstance::new(
                                 mixed_record_name(&trigger.indexed_with),
                                 trigger.indexed_with.clone(),

--- a/llzk_backend/src/write_chain.rs
+++ b/llzk_backend/src/write_chain.rs
@@ -145,17 +145,14 @@ impl<'ast> WriteChain<'ast> {
             location,
             Some(&prev.ov(subcmp_info)),
             &|arr_ref: Value<'ctx, 'val>, fc: &mut FunctionContext<'_, 'ctx, '_, '_, 'val>| {
-                let indices_ast = indices.clone();
-                let indices = fc.gen_index_ops(
-                    indices.clone(),
-                    codegen,
-                    location,
-                    InfoProviders { subcmp_info, signal_write_info },
-                )?;
-
                 let Ok(pod_type) = PodType::try_from(arr_ref.r#type()) else {
-                    fc.append_array_write(codegen, arr_ref, &indices, location, val, None)?;
-
+                    let index_vals = fc.gen_index_ops(
+                        indices.clone(),
+                        codegen,
+                        location,
+                        InfoProviders { subcmp_info, signal_write_info },
+                    )?;
+                    fc.append_array_write(codegen, arr_ref, &index_vals, location, val, None)?;
                     return prev.clone().write(
                         arr_ref,
                         target,
@@ -172,7 +169,7 @@ impl<'ast> WriteChain<'ast> {
                 // it to values (that is done below with `fc.gen_index_ops`), and then check with a
                 // massive if then else for each possible index. The optimizer should be able to
                 // remove the dead branches on literal cases...
-                if let Some(indices) = concrete_indices(&indices_ast) {
+                if let Some(indices) = concrete_indices(&indices) {
                     // Using `root_var` here is somewhat safe since this representation can only be
                     // done on subcomponents (unless we can do it on buses as well but I'm not sure)
                     // and subcomponents are always top level variables.

--- a/llzk_backend/src/write_chain.rs
+++ b/llzk_backend/src/write_chain.rs
@@ -145,7 +145,6 @@ impl<'ast> WriteChain<'ast> {
             location,
             Some(&prev.ov(subcmp_info)),
             &|arr_ref: Value<'ctx, 'val>, fc: &mut FunctionContext<'_, 'ctx, '_, '_, 'val>| {
-                // TEMP
                 let indices_ast = indices.clone();
                 let indices = fc.gen_index_ops(
                     indices.clone(),
@@ -169,14 +168,14 @@ impl<'ast> WriteChain<'ast> {
                 };
 
                 // The problem here is that concrete_indices expects that the indices are always
-                // literal, which is not always the case.
-                // We need to take each expression, convert it to values (that is done below with
-                // `fc.gen_index_ops`), and then check with a massive if then else for each possible
-                // index. The optimizer should be able to remove the dead branches on literal cases...
+                // literal, which is not always the case. We need to take each expression, convert
+                // it to values (that is done below with `fc.gen_index_ops`), and then check with a
+                // massive if then else for each possible index. The optimizer should be able to
+                // remove the dead branches on literal cases...
                 if let Some(indices) = concrete_indices(&indices_ast) {
-                    // Using `root_var` here is somewhat safe since this representation can only be done on
-                    // subcomponents (unless we can do it on buses as well but I'm not sure) and
-                    // subcomponents are always top level variables.
+                    // Using `root_var` here is somewhat safe since this representation can only be
+                    // done on subcomponents (unless we can do it on buses as well but I'm not sure)
+                    // and subcomponents are always top level variables.
                     if let Some(record_name) = subcmp_info
                         .mixed_subcmp_record_for_indices(prev.lvalue.root_var(), &indices)
                     {

--- a/llzk_backend/src/write_chain.rs
+++ b/llzk_backend/src/write_chain.rs
@@ -86,14 +86,14 @@ impl WriteTarget {
 
 /// Overrides a subcomponent's variable name.
 #[derive(Clone, Copy)]
-struct Override<'info> {
+struct Override<'info, 'ctx> {
     /// If true, means that the write chain is storing the result of a call to compute.
     compute_result: bool,
     /// Reference to a subcomponent information provider.
-    subcmp_info: &'info dyn SubcmpInfo,
+    subcmp_info: &'info dyn SubcmpInfo<'ctx>,
 }
 
-impl OverrideVar for Override<'_> {
+impl OverrideVar for Override<'_, '_> {
     fn override_var(&self, var: &str, op: Root) -> Option<String> {
         (!self.compute_result && self.subcmp_info.is_subcmp(var) && op == Root::Signal)
             .then(|| crate::subcmp::names::inputs(var))
@@ -136,7 +136,7 @@ impl<'ast> WriteChain<'ast> {
         fc: &mut FunctionContext<'_, 'ctx, '_, '_, 'val>,
         location: Location<'ctx>,
         signal_write_info: &dyn SignalWriteInfo,
-        subcmp_info: &dyn SubcmpInfo,
+        subcmp_info: &dyn SubcmpInfo<'ctx>,
     ) -> Result<()> {
         let arr_ref = prev.lvalue.get_value(
             codegen,
@@ -145,44 +145,65 @@ impl<'ast> WriteChain<'ast> {
             location,
             Some(&prev.ov(subcmp_info)),
         )?;
-        if let Ok(pod_type) = PodType::try_from(arr_ref.r#type()) {
-            if let Some(indices) = concrete_indices(&indices) {
-                if let Some(record_name) =
-                    subcmp_info.mixed_subcmp_record_for_indices(prev.lvalue.root_var(), &indices)
-                {
-                    let record_type =
-                        pod_type.get_type_of_record(record_name).ok_or_else(|| {
-                            anyhow::anyhow!(
-                            "record {record_name} not found in mixed subcomponent pod: {arr_ref}"
-                        )
-                        })?;
-                    let val =
-                        fc.cast_to_expected_type_if_needed(codegen, location, val, record_type)?;
-                    fc.append_op_no_result(codegen.new_pod_write_op(
-                        location,
-                        arr_ref,
-                        record_name,
-                        val,
-                    ))?;
-                    return prev.write(
-                        arr_ref,
-                        target,
-                        codegen,
-                        fc,
-                        location,
-                        signal_write_info,
-                        subcmp_info,
-                    );
-                }
-            }
-        }
+        // TEMP
+        let indices_ast = indices.clone();
         let indices = fc.gen_index_ops(
             indices,
             codegen,
             location,
             InfoProviders { subcmp_info, signal_write_info },
         )?;
-        fc.append_array_write(codegen, arr_ref, &indices, location, val, None)?;
+
+        let Ok(pod_type) = PodType::try_from(arr_ref.r#type()) else {
+            fc.append_array_write(codegen, arr_ref, &indices, location, val, None)?;
+
+            return prev.write(
+                arr_ref,
+                target,
+                codegen,
+                fc,
+                location,
+                signal_write_info,
+                subcmp_info,
+            );
+        };
+
+        // The problem here is that concrete_indices expects that the indices are always
+        // literal, which is not always the case.
+        // We need to take each expression, convert it to values (that is done below with
+        // `fc.gen_index_ops`), and then check with a massive if then else for each possible
+        // index. The optimizer should be able to remove the dead branches on literal cases...
+        if let Some(indices) = concrete_indices(&indices_ast) {
+            // Using `root_var` here is somewhat safe since this representation can only be done on
+            // subcomponents (unless we can do it on buses as well but I'm not sure) and
+            // subcomponents are always top level variables.
+            if let Some(record_name) =
+                subcmp_info.mixed_subcmp_record_for_indices(prev.lvalue.root_var(), &indices)
+            {
+                let record_type = pod_type.get_type_of_record(record_name).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "record {record_name} not found in mixed subcomponent pod: {arr_ref}"
+                    )
+                })?;
+                let val =
+                    fc.cast_to_expected_type_if_needed(codegen, location, val, record_type)?;
+                fc.append_op_no_result(codegen.new_pod_write_op(
+                    location,
+                    arr_ref,
+                    record_name,
+                    val,
+                ))?;
+                return prev.write(
+                    arr_ref,
+                    target,
+                    codegen,
+                    fc,
+                    location,
+                    signal_write_info,
+                    subcmp_info,
+                );
+            }
+        }
         prev.write(arr_ref, target, codegen, fc, location, signal_write_info, subcmp_info)
     }
 
@@ -197,7 +218,7 @@ impl<'ast> WriteChain<'ast> {
         fc: &mut FunctionContext<'_, 'ctx, '_, '_, 'val>,
         location: Location<'ctx>,
         signal_write_info: &dyn SignalWriteInfo,
-        subcmp_info: &dyn SubcmpInfo,
+        subcmp_info: &dyn SubcmpInfo<'ctx>,
     ) -> Result<()> {
         let subcmp_value_inputs = prev.lvalue.get_value(
             codegen,
@@ -265,7 +286,7 @@ impl<'ast> WriteChain<'ast> {
         fc: &mut FunctionContext<'_, 'ctx, '_, '_, 'val>,
         location: Location<'ctx>,
         signal_write_info: &dyn SignalWriteInfo,
-        subcmp_info: &dyn SubcmpInfo,
+        subcmp_info: &dyn SubcmpInfo<'ctx>,
     ) -> Result<()> {
         /// Handle [Lvalue::Root] with [Root::Signal] case.
         fn write_root_signal<'ctx, 'val>(
@@ -350,7 +371,7 @@ impl<'ast> WriteChain<'ast> {
 
     /// Creates an override configuration for the given template and the internal `compute_result`
     /// state.
-    fn ov<'info>(&self, template: &'info dyn SubcmpInfo) -> Override<'info> {
+    fn ov<'info, 'ctx>(&self, template: &'info dyn SubcmpInfo<'ctx>) -> Override<'info, 'ctx> {
         Override { compute_result: self.compute_result, subcmp_info: template }
     }
 }

--- a/llzk_backend/src/write_chain.rs
+++ b/llzk_backend/src/write_chain.rs
@@ -101,7 +101,7 @@ impl OverrideVar for Override<'_, '_> {
 }
 
 /// Helper type that defines a chain of write operations.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct WriteChain<'ast> {
     /// Location value this write action takes place on.
     lvalue: Lvalue<'ast>,
@@ -138,62 +138,78 @@ impl<'ast> WriteChain<'ast> {
         signal_write_info: &dyn SignalWriteInfo,
         subcmp_info: &dyn SubcmpInfo<'ctx>,
     ) -> Result<()> {
-        let arr_ref = prev.lvalue.get_value(
+        prev.lvalue.get_value(
             codegen,
             fc,
             subcmp_info,
             location,
             Some(&prev.ov(subcmp_info)),
-        )?;
-        // TEMP
-        let indices_ast = indices.clone();
-        let indices = fc.gen_index_ops(
-            indices,
-            codegen,
-            location,
-            InfoProviders { subcmp_info, signal_write_info },
-        )?;
+            &|arr_ref: Value<'ctx, 'val>, fc: &mut FunctionContext<'_, 'ctx, '_, '_, 'val>| {
+                // TEMP
+                let indices_ast = indices.clone();
+                let indices = fc.gen_index_ops(
+                    indices.clone(),
+                    codegen,
+                    location,
+                    InfoProviders { subcmp_info, signal_write_info },
+                )?;
 
-        let Ok(pod_type) = PodType::try_from(arr_ref.r#type()) else {
-            fc.append_array_write(codegen, arr_ref, &indices, location, val, None)?;
+                let Ok(pod_type) = PodType::try_from(arr_ref.r#type()) else {
+                    fc.append_array_write(codegen, arr_ref, &indices, location, val, None)?;
 
-            return prev.write(
-                arr_ref,
-                target,
-                codegen,
-                fc,
-                location,
-                signal_write_info,
-                subcmp_info,
-            );
-        };
+                    return prev.clone().write(
+                        arr_ref,
+                        target,
+                        codegen,
+                        fc,
+                        location,
+                        signal_write_info,
+                        subcmp_info,
+                    );
+                };
 
-        // The problem here is that concrete_indices expects that the indices are always
-        // literal, which is not always the case.
-        // We need to take each expression, convert it to values (that is done below with
-        // `fc.gen_index_ops`), and then check with a massive if then else for each possible
-        // index. The optimizer should be able to remove the dead branches on literal cases...
-        if let Some(indices) = concrete_indices(&indices_ast) {
-            // Using `root_var` here is somewhat safe since this representation can only be done on
-            // subcomponents (unless we can do it on buses as well but I'm not sure) and
-            // subcomponents are always top level variables.
-            if let Some(record_name) =
-                subcmp_info.mixed_subcmp_record_for_indices(prev.lvalue.root_var(), &indices)
-            {
-                let record_type = pod_type.get_type_of_record(record_name).ok_or_else(|| {
-                    anyhow::anyhow!(
+                // The problem here is that concrete_indices expects that the indices are always
+                // literal, which is not always the case.
+                // We need to take each expression, convert it to values (that is done below with
+                // `fc.gen_index_ops`), and then check with a massive if then else for each possible
+                // index. The optimizer should be able to remove the dead branches on literal cases...
+                if let Some(indices) = concrete_indices(&indices_ast) {
+                    // Using `root_var` here is somewhat safe since this representation can only be done on
+                    // subcomponents (unless we can do it on buses as well but I'm not sure) and
+                    // subcomponents are always top level variables.
+                    if let Some(record_name) = subcmp_info
+                        .mixed_subcmp_record_for_indices(prev.lvalue.root_var(), &indices)
+                    {
+                        let record_type =
+                            pod_type.get_type_of_record(record_name).ok_or_else(|| {
+                                anyhow::anyhow!(
                         "record {record_name} not found in mixed subcomponent pod: {arr_ref}"
                     )
-                })?;
-                let val =
-                    fc.cast_to_expected_type_if_needed(codegen, location, val, record_type)?;
-                fc.append_op_no_result(codegen.new_pod_write_op(
-                    location,
-                    arr_ref,
-                    record_name,
-                    val,
-                ))?;
-                return prev.write(
+                            })?;
+                        let val = fc.cast_to_expected_type_if_needed(
+                            codegen,
+                            location,
+                            val,
+                            record_type,
+                        )?;
+                        fc.append_op_no_result(codegen.new_pod_write_op(
+                            location,
+                            arr_ref,
+                            record_name,
+                            val,
+                        ))?;
+                        return prev.clone().write(
+                            arr_ref,
+                            target,
+                            codegen,
+                            fc,
+                            location,
+                            signal_write_info,
+                            subcmp_info,
+                        );
+                    }
+                }
+                prev.clone().write(
                     arr_ref,
                     target,
                     codegen,
@@ -201,10 +217,9 @@ impl<'ast> WriteChain<'ast> {
                     location,
                     signal_write_info,
                     subcmp_info,
-                );
-            }
-        }
-        prev.write(arr_ref, target, codegen, fc, location, signal_write_info, subcmp_info)
+                )
+            },
+        )
     }
 
     /// Handle [Lvalue::Subcmp] case of [`WriteChain::write`].
@@ -220,60 +235,93 @@ impl<'ast> WriteChain<'ast> {
         signal_write_info: &dyn SignalWriteInfo,
         subcmp_info: &dyn SubcmpInfo<'ctx>,
     ) -> Result<()> {
-        let subcmp_value_inputs = prev.lvalue.get_value(
-            codegen,
-            fc,
-            subcmp_info,
-            location,
-            Some(&prev.ov(subcmp_info)),
-        )?;
-        fc.append_op_no_result(codegen.new_pod_write_op(location, subcmp_value_inputs, name, val))?;
         let prev_for_compute = prev.clone_for_compute_result();
-        prev.write(
-            subcmp_value_inputs,
-            target,
+        let ov = prev.ov(subcmp_info);
+        prev.lvalue.get_value::<(), _>(
             codegen,
             fc,
-            location,
-            signal_write_info,
             subcmp_info,
+            location,
+            Some(&ov),
+            &|subcmp_value_inputs: Value<'ctx, 'val>,
+              fc: &mut FunctionContext<'_, 'ctx, '_, '_, 'val>|
+             -> Result<()> {
+                fc.append_op_no_result(codegen.new_pod_write_op(
+                    location,
+                    subcmp_value_inputs,
+                    name,
+                    val,
+                ))?;
+                prev.clone().write(
+                    subcmp_value_inputs,
+                    target,
+                    codegen,
+                    fc,
+                    location,
+                    signal_write_info,
+                    subcmp_info,
+                )
+            },
         )?;
         // Read the subcomponent's memory, which should be the memory pod.
-        let subcmp_value = prev_for_compute.lvalue.get_value(
+        prev_for_compute.lvalue.get_value(
             codegen,
             fc,
             subcmp_info,
             location,
             Some(&prev_for_compute.ov(subcmp_info)),
-        )?;
+            &|subcmp_value: Value<'ctx, 'val>, fc: &mut FunctionContext<'_, 'ctx, '_, '_, 'val>| {
+                let subcmp_value_inputs = prev_for_compute.lvalue.get_value(
+                    codegen,
+                    fc,
+                    subcmp_info,
+                    location,
+                    Some(&ov),
+                    &|subcmp_value_inputs: Value<'ctx, 'val>,
+                      _: &mut FunctionContext<'_, 'ctx, '_, '_, 'val>| {
+                        Ok(subcmp_value_inputs)
+                    },
+                )?;
+                let counter = fc.gen_subcmp_decrease_counter(codegen, location, subcmp_value, 1)?;
+                fc.gen_scf_if_is_zero(
+                    counter,
+                    location,
+                    codegen,
+                    |fc: &mut FunctionContext<'_, 'ctx, '_, '_, 'val>| {
+                        let params = fc.append_op_unnamed_result(codegen.new_pod_read_op(
+                            subcmp_value,
+                            PARAMS,
+                            location,
+                        )?)?;
+                        let struct_type =
+                            comp_type(subcmp_value.r#type().try_into()?)?.try_into()?;
 
-        let counter = fc.gen_subcmp_decrease_counter(codegen, location, subcmp_value, 1)?;
-        fc.gen_scf_if_is_zero(counter, location, codegen, |fc| {
-            let params = fc.append_op_unnamed_result(codegen.new_pod_read_op(
-                subcmp_value,
-                PARAMS,
-                location,
-            )?)?;
-            let struct_type = comp_type(subcmp_value.r#type().try_into()?)?.try_into()?;
-
-            let subcmp_instance =
-                fc.gen_compute_call(struct_type, subcmp_value_inputs, params, location, codegen)?;
-            fc.append_op_no_result(codegen.new_pod_write_op(
-                location,
-                subcmp_value,
-                COMP,
-                subcmp_instance,
-            ))?;
-            prev_for_compute.write(
-                subcmp_value,
-                target,
-                codegen,
-                fc,
-                location,
-                signal_write_info,
-                subcmp_info,
-            )
-        })
+                        let subcmp_instance = fc.gen_compute_call(
+                            struct_type,
+                            subcmp_value_inputs,
+                            params,
+                            location,
+                            codegen,
+                        )?;
+                        fc.append_op_no_result(codegen.new_pod_write_op(
+                            location,
+                            subcmp_value,
+                            COMP,
+                            subcmp_instance,
+                        ))?;
+                        prev_for_compute.clone().write(
+                            subcmp_value,
+                            target,
+                            codegen,
+                            fc,
+                            location,
+                            signal_write_info,
+                            subcmp_info,
+                        )
+                    },
+                )
+            },
+        )
     }
 
     #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
Needs to be merged after #381!

Main changes so far:
- The logic that handles an _array read_ in LValue now considers any possible index set. It does this by creating an if-then-else chain that checks if the indices are any of the known indices for the subcomponent array. The leaf of the array read (aka, the expression that uses whatever was returned by the array read) is emitted N times, one for each branch. This should help avoid type conflicts more than just passing the returned value from the mixed subcomponent array.
- Changed LValue to work using continuation passing style, which allows emitting several times read ops for a leaf (as seen above)

This idea has the main limitation that it won't handle (and will crash) a partial array read. Handling such a thing will probably require some crazy shenanigans like closures or something...