### PR TITLE
visit nested declarations to collect them all

### DIFF
--- a/circom/tests/arrays/array_dimensions_13.circom
+++ b/circom/tests/arrays/array_dimensions_13.circom
@@ -21,121 +21,149 @@ template EvilArrayDims(N, M) {
 
 component main = EvilArrayDims(7, 2);
 
-// CHECK: #[[$ATTR_0:[0-9a-zA-Z_\.]+]] = affine_map<()[s0] -> (s0)>
-//
 // CHECK-LABEL: module attributes {llzk.lang, llzk.main = !struct.type<@EvilArrayDims::@EvilArrayDims<[7, 2]>>} {
 // CHECK-NEXT:    poly.template @EvilArrayDims {
 // CHECK-NEXT:      poly.param @N
 // CHECK-NEXT:      poly.param @M
+// CHECK-NEXT:      poly.expr @"D@333" {
+// CHECK-NEXT:        %[[VAL_0:[0-9a-zA-Z_\.]+]] = felt.const  99 : <"bn128">
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = poly.read_const @M : !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = bool.cmp gt(%[[VAL_2]], %[[VAL_0]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_3]] -> (!felt.type<"bn128">) {
+// CHECK-NEXT:          %[[VAL_5:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_2]], %[[VAL_1]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          scf.yield %[[VAL_5]] : !felt.type<"bn128">
+// CHECK-NEXT:        } else {
+// CHECK-NEXT:          %[[VAL_6:[0-9a-zA-Z_\.]+]] = llzk.nondet : !felt.type<"bn128">
+// CHECK-NEXT:          scf.yield %[[VAL_6]] : !felt.type<"bn128">
+// CHECK-NEXT:        }
+// CHECK-NEXT:        poly.yield %[[VAL_4]] : !felt.type<"bn128">
+// CHECK-NEXT:      }
+// CHECK-NEXT:      poly.expr @"D@438" {
+// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = felt.const  99 : <"bn128">
+// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:        %[[VAL_9:[0-9a-zA-Z_\.]+]] = poly.read_const @M : !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]] = bool.cmp gt(%[[VAL_10]], %[[VAL_7]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_12:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_11]] -> (!felt.type<"bn128">) {
+// CHECK-NEXT:          %[[VAL_13:[0-9a-zA-Z_\.]+]] = llzk.nondet : !felt.type<"bn128">
+// CHECK-NEXT:          scf.yield %[[VAL_13]] : !felt.type<"bn128">
+// CHECK-NEXT:        } else {
+// CHECK-NEXT:          %[[VAL_14:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_10]], %[[VAL_9]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_15:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_14]], %[[VAL_8]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          scf.yield %[[VAL_15]] : !felt.type<"bn128">
+// CHECK-NEXT:        }
+// CHECK-NEXT:        poly.yield %[[VAL_12]] : !felt.type<"bn128">
+// CHECK-NEXT:      }
 // CHECK-NEXT:      struct.def @EvilArrayDims {
 // CHECK-NEXT:        function.def @compute() -> !struct.type<@EvilArrayDims::@EvilArrayDims<[@N, @M]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
-// CHECK-NEXT:          %[[VAL_0:[0-9a-zA-Z_\.]+]] = struct.new : <@EvilArrayDims::@EvilArrayDims<[@N, @M]>>
-// CHECK-NEXT:          %[[VAL_1:[0-9a-zA-Z_\.]+]] = poly.read_const @M : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_2:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_3:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:          %[[VAL_4:[0-9a-zA-Z_\.]+]] = felt.const  99 : <"bn128">
-// CHECK-NEXT:          %[[VAL_5:[0-9a-zA-Z_\.]+]] = bool.cmp gt(%[[VAL_2]], %[[VAL_4]]) : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_6:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_5]] -> (!felt.type<"bn128">) {
-// CHECK-NEXT:            %[[VAL_7:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_2]], %[[VAL_1]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_8:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:            %[[VAL_9:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_7]] : !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_10:[0-9a-zA-Z_\.]+]] = array.new{(){{\[}}%[[VAL_9]]]} : <#[[$ATTR_0]] x !felt.type<"bn128">>
-// CHECK-NEXT:            %[[VAL_11:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:            %[[VAL_12:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_10]], %[[VAL_11]] : <#[[$ATTR_0]] x !felt.type<"bn128">>
-// CHECK-NEXT:            %[[VAL_13:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:            %[[VAL_14:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:            scf.for %[[VAL_15:[0-9a-zA-Z_\.]+]] = %[[VAL_13]] to %[[VAL_12]] step %[[VAL_14]] {
-// CHECK-NEXT:              array.write %[[VAL_10]]{{\[}}%[[VAL_15]]] = %[[VAL_8]] : <#[[$ATTR_0]] x !felt.type<"bn128">>, !felt.type<"bn128">
-// CHECK-NEXT:            }
-// CHECK-NEXT:            %[[VAL_16:[0-9a-zA-Z_\.]+]] = felt.const  99 : <"bn128">
-// CHECK-NEXT:            %[[VAL_17:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_18:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_7]], %[[VAL_17]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_19:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_18]] : !felt.type<"bn128">
-// CHECK-NEXT:            array.write %[[VAL_10]]{{\[}}%[[VAL_19]]] = %[[VAL_16]] : <#[[$ATTR_0]] x !felt.type<"bn128">>, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_20:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_21:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_7]], %[[VAL_20]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_22:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_21]] : !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_23:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_10]]{{\[}}%[[VAL_22]]] : <#[[$ATTR_0]] x !felt.type<"bn128">>, !felt.type<"bn128">
-// CHECK-NEXT:            scf.yield %[[VAL_23]] : !felt.type<"bn128">
-// CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[VAL_24:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_2]], %[[VAL_1]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_25:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_26:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_24]], %[[VAL_25]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_27:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:            %[[VAL_28:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_26]] : !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_29:[0-9a-zA-Z_\.]+]] = array.new{(){{\[}}%[[VAL_28]]]} : <#[[$ATTR_0]] x !felt.type<"bn128">>
+// CHECK-NEXT:          %[[VAL_16:[0-9a-zA-Z_\.]+]] = struct.new : <@EvilArrayDims::@EvilArrayDims<[@N, @M]>>
+// CHECK-NEXT:          %[[VAL_17:[0-9a-zA-Z_\.]+]] = poly.read_const @"D@333" : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_18:[0-9a-zA-Z_\.]+]] = poly.read_const @"D@438" : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_19:[0-9a-zA-Z_\.]+]] = poly.read_const @M : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_20:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_21:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_22:[0-9a-zA-Z_\.]+]] = felt.const  99 : <"bn128">
+// CHECK-NEXT:          %[[VAL_23:[0-9a-zA-Z_\.]+]] = bool.cmp gt(%[[VAL_20]], %[[VAL_22]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_24:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_23]] -> (!felt.type<"bn128">) {
+// CHECK-NEXT:            %[[VAL_25:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_20]], %[[VAL_19]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_26:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:            %[[VAL_27:[0-9a-zA-Z_\.]+]] = array.new  : <@"D@333" x !felt.type<"bn128">>
+// CHECK-NEXT:            %[[VAL_28:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:            %[[VAL_29:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_27]], %[[VAL_28]] : <@"D@333" x !felt.type<"bn128">>
 // CHECK-NEXT:            %[[VAL_30:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:            %[[VAL_31:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_29]], %[[VAL_30]] : <#[[$ATTR_0]] x !felt.type<"bn128">>
-// CHECK-NEXT:            %[[VAL_32:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:            %[[VAL_33:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:            scf.for %[[VAL_34:[0-9a-zA-Z_\.]+]] = %[[VAL_32]] to %[[VAL_31]] step %[[VAL_33]] {
-// CHECK-NEXT:              array.write %[[VAL_29]]{{\[}}%[[VAL_34]]] = %[[VAL_27]] : <#[[$ATTR_0]] x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_31:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:            scf.for %[[VAL_32:[0-9a-zA-Z_\.]+]] = %[[VAL_30]] to %[[VAL_29]] step %[[VAL_31]] {
+// CHECK-NEXT:              array.write %[[VAL_27]]{{\[}}%[[VAL_32]]] = %[[VAL_26]] : <@"D@333" x !felt.type<"bn128">>, !felt.type<"bn128">
 // CHECK-NEXT:            }
-// CHECK-NEXT:            %[[VAL_35:[0-9a-zA-Z_\.]+]] = felt.const  77 : <"bn128">
-// CHECK-NEXT:            %[[VAL_36:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_37:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_26]], %[[VAL_36]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_38:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_37]] : !felt.type<"bn128">
-// CHECK-NEXT:            array.write %[[VAL_29]]{{\[}}%[[VAL_38]]] = %[[VAL_35]] : <#[[$ATTR_0]] x !felt.type<"bn128">>, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_39:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_40:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_26]], %[[VAL_39]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_41:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_40]] : !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_42:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_29]]{{\[}}%[[VAL_41]]] : <#[[$ATTR_0]] x !felt.type<"bn128">>, !felt.type<"bn128">
-// CHECK-NEXT:            scf.yield %[[VAL_42]] : !felt.type<"bn128">
-// CHECK-NEXT:          }
-// CHECK-NEXT:          function.return %[[VAL_0]] : !struct.type<@EvilArrayDims::@EvilArrayDims<[@N, @M]>>
-// CHECK-NEXT:        }
-// CHECK-NEXT:        function.def @constrain(%[[VAL_43:[0-9a-zA-Z_\.]+]]: !struct.type<@EvilArrayDims::@EvilArrayDims<[@N, @M]>>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:          %[[VAL_44:[0-9a-zA-Z_\.]+]] = poly.read_const @M : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_45:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_46:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:          %[[VAL_47:[0-9a-zA-Z_\.]+]] = felt.const  99 : <"bn128">
-// CHECK-NEXT:          %[[VAL_48:[0-9a-zA-Z_\.]+]] = bool.cmp gt(%[[VAL_45]], %[[VAL_47]]) : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_49:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_48]] -> (!felt.type<"bn128">) {
-// CHECK-NEXT:            %[[VAL_50:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_45]], %[[VAL_44]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_51:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:            %[[VAL_52:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_50]] : !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_53:[0-9a-zA-Z_\.]+]] = array.new{(){{\[}}%[[VAL_52]]]} : <#[[$ATTR_0]] x !felt.type<"bn128">>
-// CHECK-NEXT:            %[[VAL_54:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:            %[[VAL_55:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_53]], %[[VAL_54]] : <#[[$ATTR_0]] x !felt.type<"bn128">>
-// CHECK-NEXT:            %[[VAL_56:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:            %[[VAL_57:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:            scf.for %[[VAL_58:[0-9a-zA-Z_\.]+]] = %[[VAL_56]] to %[[VAL_55]] step %[[VAL_57]] {
-// CHECK-NEXT:              array.write %[[VAL_53]]{{\[}}%[[VAL_58]]] = %[[VAL_51]] : <#[[$ATTR_0]] x !felt.type<"bn128">>, !felt.type<"bn128">
-// CHECK-NEXT:            }
-// CHECK-NEXT:            %[[VAL_59:[0-9a-zA-Z_\.]+]] = felt.const  99 : <"bn128">
-// CHECK-NEXT:            %[[VAL_60:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_61:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_50]], %[[VAL_60]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_62:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_61]] : !felt.type<"bn128">
-// CHECK-NEXT:            array.write %[[VAL_53]]{{\[}}%[[VAL_62]]] = %[[VAL_59]] : <#[[$ATTR_0]] x !felt.type<"bn128">>, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_63:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_64:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_50]], %[[VAL_63]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_65:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_64]] : !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_66:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_53]]{{\[}}%[[VAL_65]]] : <#[[$ATTR_0]] x !felt.type<"bn128">>, !felt.type<"bn128">
-// CHECK-NEXT:            scf.yield %[[VAL_66]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_33:[0-9a-zA-Z_\.]+]] = felt.const  99 : <"bn128">
+// CHECK-NEXT:            %[[VAL_34:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_35:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_25]], %[[VAL_34]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_36:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_35]] : !felt.type<"bn128">
+// CHECK-NEXT:            array.write %[[VAL_27]]{{\[}}%[[VAL_36]]] = %[[VAL_33]] : <@"D@333" x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_37:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_38:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_25]], %[[VAL_37]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_39:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_38]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_40:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_27]]{{\[}}%[[VAL_39]]] : <@"D@333" x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_40]] : !felt.type<"bn128">
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[VAL_67:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_45]], %[[VAL_44]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_68:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_69:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_67]], %[[VAL_68]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_70:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:            %[[VAL_71:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_69]] : !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_72:[0-9a-zA-Z_\.]+]] = array.new{(){{\[}}%[[VAL_71]]]} : <#[[$ATTR_0]] x !felt.type<"bn128">>
-// CHECK-NEXT:            %[[VAL_73:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:            %[[VAL_74:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_72]], %[[VAL_73]] : <#[[$ATTR_0]] x !felt.type<"bn128">>
-// CHECK-NEXT:            %[[VAL_75:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:            %[[VAL_76:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:            scf.for %[[VAL_77:[0-9a-zA-Z_\.]+]] = %[[VAL_75]] to %[[VAL_74]] step %[[VAL_76]] {
-// CHECK-NEXT:              array.write %[[VAL_72]]{{\[}}%[[VAL_77]]] = %[[VAL_70]] : <#[[$ATTR_0]] x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_41:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_20]], %[[VAL_19]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_42:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_43:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_41]], %[[VAL_42]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_44:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:            %[[VAL_45:[0-9a-zA-Z_\.]+]] = array.new  : <@"D@438" x !felt.type<"bn128">>
+// CHECK-NEXT:            %[[VAL_46:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:            %[[VAL_47:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_45]], %[[VAL_46]] : <@"D@438" x !felt.type<"bn128">>
+// CHECK-NEXT:            %[[VAL_48:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:            %[[VAL_49:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:            scf.for %[[VAL_50:[0-9a-zA-Z_\.]+]] = %[[VAL_48]] to %[[VAL_47]] step %[[VAL_49]] {
+// CHECK-NEXT:              array.write %[[VAL_45]]{{\[}}%[[VAL_50]]] = %[[VAL_44]] : <@"D@438" x !felt.type<"bn128">>, !felt.type<"bn128">
 // CHECK-NEXT:            }
-// CHECK-NEXT:            %[[VAL_78:[0-9a-zA-Z_\.]+]] = felt.const  77 : <"bn128">
-// CHECK-NEXT:            %[[VAL_79:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_80:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_69]], %[[VAL_79]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_81:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_80]] : !felt.type<"bn128">
-// CHECK-NEXT:            array.write %[[VAL_72]]{{\[}}%[[VAL_81]]] = %[[VAL_78]] : <#[[$ATTR_0]] x !felt.type<"bn128">>, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_82:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:            %[[VAL_83:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_69]], %[[VAL_82]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_84:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_83]] : !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_85:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_72]]{{\[}}%[[VAL_84]]] : <#[[$ATTR_0]] x !felt.type<"bn128">>, !felt.type<"bn128">
-// CHECK-NEXT:            scf.yield %[[VAL_85]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_51:[0-9a-zA-Z_\.]+]] = felt.const  77 : <"bn128">
+// CHECK-NEXT:            %[[VAL_52:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_53:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_43]], %[[VAL_52]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_54:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_53]] : !felt.type<"bn128">
+// CHECK-NEXT:            array.write %[[VAL_45]]{{\[}}%[[VAL_54]]] = %[[VAL_51]] : <@"D@438" x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_55:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_56:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_43]], %[[VAL_55]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_57:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_56]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_58:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_45]]{{\[}}%[[VAL_57]]] : <@"D@438" x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_58]] : !felt.type<"bn128">
+// CHECK-NEXT:          }
+// CHECK-NEXT:          function.return %[[VAL_16]] : !struct.type<@EvilArrayDims::@EvilArrayDims<[@N, @M]>>
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.def @constrain(%[[VAL_59:[0-9a-zA-Z_\.]+]]: !struct.type<@EvilArrayDims::@EvilArrayDims<[@N, @M]>>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_60:[0-9a-zA-Z_\.]+]] = poly.read_const @"D@333" : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_61:[0-9a-zA-Z_\.]+]] = poly.read_const @"D@438" : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_62:[0-9a-zA-Z_\.]+]] = poly.read_const @M : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_63:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_64:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_65:[0-9a-zA-Z_\.]+]] = felt.const  99 : <"bn128">
+// CHECK-NEXT:          %[[VAL_66:[0-9a-zA-Z_\.]+]] = bool.cmp gt(%[[VAL_63]], %[[VAL_65]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_67:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_66]] -> (!felt.type<"bn128">) {
+// CHECK-NEXT:            %[[VAL_68:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_63]], %[[VAL_62]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_69:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:            %[[VAL_70:[0-9a-zA-Z_\.]+]] = array.new  : <@"D@333" x !felt.type<"bn128">>
+// CHECK-NEXT:            %[[VAL_71:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:            %[[VAL_72:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_70]], %[[VAL_71]] : <@"D@333" x !felt.type<"bn128">>
+// CHECK-NEXT:            %[[VAL_73:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:            %[[VAL_74:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:            scf.for %[[VAL_75:[0-9a-zA-Z_\.]+]] = %[[VAL_73]] to %[[VAL_72]] step %[[VAL_74]] {
+// CHECK-NEXT:              array.write %[[VAL_70]]{{\[}}%[[VAL_75]]] = %[[VAL_69]] : <@"D@333" x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            }
+// CHECK-NEXT:            %[[VAL_76:[0-9a-zA-Z_\.]+]] = felt.const  99 : <"bn128">
+// CHECK-NEXT:            %[[VAL_77:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_78:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_68]], %[[VAL_77]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_79:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_78]] : !felt.type<"bn128">
+// CHECK-NEXT:            array.write %[[VAL_70]]{{\[}}%[[VAL_79]]] = %[[VAL_76]] : <@"D@333" x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_80:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_81:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_68]], %[[VAL_80]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_82:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_81]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_83:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_70]]{{\[}}%[[VAL_82]]] : <@"D@333" x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_83]] : !felt.type<"bn128">
+// CHECK-NEXT:          } else {
+// CHECK-NEXT:            %[[VAL_84:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_63]], %[[VAL_62]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_85:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_86:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_84]], %[[VAL_85]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_87:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:            %[[VAL_88:[0-9a-zA-Z_\.]+]] = array.new  : <@"D@438" x !felt.type<"bn128">>
+// CHECK-NEXT:            %[[VAL_89:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:            %[[VAL_90:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_88]], %[[VAL_89]] : <@"D@438" x !felt.type<"bn128">>
+// CHECK-NEXT:            %[[VAL_91:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:            %[[VAL_92:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:            scf.for %[[VAL_93:[0-9a-zA-Z_\.]+]] = %[[VAL_91]] to %[[VAL_90]] step %[[VAL_92]] {
+// CHECK-NEXT:              array.write %[[VAL_88]]{{\[}}%[[VAL_93]]] = %[[VAL_87]] : <@"D@438" x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            }
+// CHECK-NEXT:            %[[VAL_94:[0-9a-zA-Z_\.]+]] = felt.const  77 : <"bn128">
+// CHECK-NEXT:            %[[VAL_95:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_96:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_86]], %[[VAL_95]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_97:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_96]] : !felt.type<"bn128">
+// CHECK-NEXT:            array.write %[[VAL_88]]{{\[}}%[[VAL_97]]] = %[[VAL_94]] : <@"D@438" x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_98:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_99:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_86]], %[[VAL_98]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_100:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_99]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_101:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_88]]{{\[}}%[[VAL_100]]] : <@"D@438" x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_101]] : !felt.type<"bn128">
 // CHECK-NEXT:          }
 // CHECK-NEXT:          function.return
 // CHECK-NEXT:        }

--- a/circom/tests/arrays/array_dimensions_14.circom
+++ b/circom/tests/arrays/array_dimensions_14.circom
@@ -1,0 +1,224 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --stabilize --llzk --llzk_plaintext -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
+
+pragma circom 2.0.0;
+
+template EvilArrayDims(N, M) {
+    var arr = M;
+    var x;
+    if (N > 99) {
+        var D = N + M;
+        var arr[D][D];
+        arr[D-1][D-1] = 99;
+        x = arr[D-1][D-1];
+    } else {
+        var D = N * M + 1;
+        var arr[D];
+        arr[D-1] = 77;
+        x = arr[D-1];
+    }
+    signal output out <== x + arr;
+}
+
+component main = EvilArrayDims(7, 2);
+
+// CHECK-LABEL: module attributes {llzk.lang, llzk.main = !struct.type<@EvilArrayDims::@EvilArrayDims<[7, 2]>>} {
+// CHECK-NEXT:    poly.template @EvilArrayDims {
+// CHECK-NEXT:      poly.param @N
+// CHECK-NEXT:      poly.param @M
+// CHECK-NEXT:      poly.expr @"D@350" {
+// CHECK-NEXT:        %[[VAL_0:[0-9a-zA-Z_\.]+]] = felt.const  99 : <"bn128">
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = poly.read_const @M : !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = bool.cmp gt(%[[VAL_2]], %[[VAL_0]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_3]] -> (!felt.type<"bn128">) {
+// CHECK-NEXT:          %[[VAL_5:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_2]], %[[VAL_1]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          scf.yield %[[VAL_5]] : !felt.type<"bn128">
+// CHECK-NEXT:        } else {
+// CHECK-NEXT:          %[[VAL_6:[0-9a-zA-Z_\.]+]] = llzk.nondet : !felt.type<"bn128">
+// CHECK-NEXT:          scf.yield %[[VAL_6]] : !felt.type<"bn128">
+// CHECK-NEXT:        }
+// CHECK-NEXT:        poly.yield %[[VAL_4]] : !felt.type<"bn128">
+// CHECK-NEXT:      }
+// CHECK-NEXT:      poly.expr @"D@353" {
+// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = felt.const  99 : <"bn128">
+// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = poly.read_const @M : !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_9:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = bool.cmp gt(%[[VAL_9]], %[[VAL_7]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_10]] -> (!felt.type<"bn128">) {
+// CHECK-NEXT:          %[[VAL_12:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_9]], %[[VAL_8]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          scf.yield %[[VAL_12]] : !felt.type<"bn128">
+// CHECK-NEXT:        } else {
+// CHECK-NEXT:          %[[VAL_13:[0-9a-zA-Z_\.]+]] = llzk.nondet : !felt.type<"bn128">
+// CHECK-NEXT:          scf.yield %[[VAL_13]] : !felt.type<"bn128">
+// CHECK-NEXT:        }
+// CHECK-NEXT:        poly.yield %[[VAL_11]] : !felt.type<"bn128">
+// CHECK-NEXT:      }
+// CHECK-NEXT:      poly.expr @"D@468" {
+// CHECK-NEXT:        %[[VAL_14:[0-9a-zA-Z_\.]+]] = felt.const  99 : <"bn128">
+// CHECK-NEXT:        %[[VAL_15:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:        %[[VAL_16:[0-9a-zA-Z_\.]+]] = poly.read_const @M : !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_17:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_18:[0-9a-zA-Z_\.]+]] = bool.cmp gt(%[[VAL_17]], %[[VAL_14]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_19:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_18]] -> (!felt.type<"bn128">) {
+// CHECK-NEXT:          %[[VAL_20:[0-9a-zA-Z_\.]+]] = llzk.nondet : !felt.type<"bn128">
+// CHECK-NEXT:          scf.yield %[[VAL_20]] : !felt.type<"bn128">
+// CHECK-NEXT:        } else {
+// CHECK-NEXT:          %[[VAL_21:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_17]], %[[VAL_16]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_22:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_21]], %[[VAL_15]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          scf.yield %[[VAL_22]] : !felt.type<"bn128">
+// CHECK-NEXT:        }
+// CHECK-NEXT:        poly.yield %[[VAL_19]] : !felt.type<"bn128">
+// CHECK-NEXT:      }
+// CHECK-NEXT:      struct.def @EvilArrayDims {
+// CHECK-NEXT:        struct.member @out : !felt.type<"bn128"> {llzk.pub}
+// CHECK-NEXT:        function.def @compute() -> !struct.type<@EvilArrayDims::@EvilArrayDims<[@N, @M]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
+// CHECK-NEXT:          %[[VAL_23:[0-9a-zA-Z_\.]+]] = struct.new : <@EvilArrayDims::@EvilArrayDims<[@N, @M]>>
+// CHECK-NEXT:          %[[VAL_24:[0-9a-zA-Z_\.]+]] = poly.read_const @"D@350" : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_25:[0-9a-zA-Z_\.]+]] = poly.read_const @"D@353" : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_26:[0-9a-zA-Z_\.]+]] = poly.read_const @"D@468" : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_27:[0-9a-zA-Z_\.]+]] = poly.read_const @M : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_28:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_29:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_30:[0-9a-zA-Z_\.]+]] = felt.const  99 : <"bn128">
+// CHECK-NEXT:          %[[VAL_31:[0-9a-zA-Z_\.]+]] = bool.cmp gt(%[[VAL_28]], %[[VAL_30]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_32:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_31]] -> (!felt.type<"bn128">) {
+// CHECK-NEXT:            %[[VAL_33:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_28]], %[[VAL_27]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_34:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:            %[[VAL_35:[0-9a-zA-Z_\.]+]] = array.new  : <@"D@353" x !felt.type<"bn128">>
+// CHECK-NEXT:            %[[VAL_36:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:            %[[VAL_37:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_35]], %[[VAL_36]] : <@"D@353" x !felt.type<"bn128">>
+// CHECK-NEXT:            %[[VAL_38:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:            %[[VAL_39:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:            scf.for %[[VAL_40:[0-9a-zA-Z_\.]+]] = %[[VAL_38]] to %[[VAL_37]] step %[[VAL_39]] {
+// CHECK-NEXT:              array.write %[[VAL_35]]{{\[}}%[[VAL_40]]] = %[[VAL_34]] : <@"D@353" x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            }
+// CHECK-NEXT:            %[[VAL_41:[0-9a-zA-Z_\.]+]] = array.new  : <@"D@350",@"D@353" x !felt.type<"bn128">>
+// CHECK-NEXT:            %[[VAL_42:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:            %[[VAL_43:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_41]], %[[VAL_42]] : <@"D@350",@"D@353" x !felt.type<"bn128">>
+// CHECK-NEXT:            %[[VAL_44:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:            %[[VAL_45:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:            scf.for %[[VAL_46:[0-9a-zA-Z_\.]+]] = %[[VAL_44]] to %[[VAL_43]] step %[[VAL_45]] {
+// CHECK-NEXT:              array.insert %[[VAL_41]]{{\[}}%[[VAL_46]]] = %[[VAL_35]] : <@"D@350",@"D@353" x !felt.type<"bn128">>, <@"D@353" x !felt.type<"bn128">>
+// CHECK-NEXT:            }
+// CHECK-NEXT:            %[[VAL_47:[0-9a-zA-Z_\.]+]] = felt.const  99 : <"bn128">
+// CHECK-NEXT:            %[[VAL_48:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_49:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_33]], %[[VAL_48]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_50:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_49]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_51:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_52:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_33]], %[[VAL_51]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_53:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_52]] : !felt.type<"bn128">
+// CHECK-NEXT:            array.write %[[VAL_41]]{{\[}}%[[VAL_50]], %[[VAL_53]]] = %[[VAL_47]] : <@"D@350",@"D@353" x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_54:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_55:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_33]], %[[VAL_54]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_56:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_55]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_57:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_58:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_33]], %[[VAL_57]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_59:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_58]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_60:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_41]]{{\[}}%[[VAL_56]], %[[VAL_59]]] : <@"D@350",@"D@353" x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_60]] : !felt.type<"bn128">
+// CHECK-NEXT:          } else {
+// CHECK-NEXT:            %[[VAL_61:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_28]], %[[VAL_27]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_62:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_63:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_61]], %[[VAL_62]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_64:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:            %[[VAL_65:[0-9a-zA-Z_\.]+]] = array.new  : <@"D@468" x !felt.type<"bn128">>
+// CHECK-NEXT:            %[[VAL_66:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:            %[[VAL_67:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_65]], %[[VAL_66]] : <@"D@468" x !felt.type<"bn128">>
+// CHECK-NEXT:            %[[VAL_68:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:            %[[VAL_69:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:            scf.for %[[VAL_70:[0-9a-zA-Z_\.]+]] = %[[VAL_68]] to %[[VAL_67]] step %[[VAL_69]] {
+// CHECK-NEXT:              array.write %[[VAL_65]]{{\[}}%[[VAL_70]]] = %[[VAL_64]] : <@"D@468" x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            }
+// CHECK-NEXT:            %[[VAL_71:[0-9a-zA-Z_\.]+]] = felt.const  77 : <"bn128">
+// CHECK-NEXT:            %[[VAL_72:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_73:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_63]], %[[VAL_72]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_74:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_73]] : !felt.type<"bn128">
+// CHECK-NEXT:            array.write %[[VAL_65]]{{\[}}%[[VAL_74]]] = %[[VAL_71]] : <@"D@468" x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_75:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_76:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_63]], %[[VAL_75]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_77:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_76]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_78:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_65]]{{\[}}%[[VAL_77]]] : <@"D@468" x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_78]] : !felt.type<"bn128">
+// CHECK-NEXT:          }
+// CHECK-NEXT:          %[[VAL_79:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_32]], %[[VAL_27]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          struct.writem %[[VAL_23]][@out] = %[[VAL_79]] : <@EvilArrayDims::@EvilArrayDims<[@N, @M]>>, !felt.type<"bn128">
+// CHECK-NEXT:          function.return %[[VAL_23]] : !struct.type<@EvilArrayDims::@EvilArrayDims<[@N, @M]>>
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.def @constrain(%[[VAL_80:[0-9a-zA-Z_\.]+]]: !struct.type<@EvilArrayDims::@EvilArrayDims<[@N, @M]>>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_81:[0-9a-zA-Z_\.]+]] = poly.read_const @"D@350" : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_82:[0-9a-zA-Z_\.]+]] = poly.read_const @"D@353" : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_83:[0-9a-zA-Z_\.]+]] = poly.read_const @"D@468" : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_84:[0-9a-zA-Z_\.]+]] = poly.read_const @M : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_85:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_86:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_80]][@out] : <@EvilArrayDims::@EvilArrayDims<[@N, @M]>>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_87:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_88:[0-9a-zA-Z_\.]+]] = felt.const  99 : <"bn128">
+// CHECK-NEXT:          %[[VAL_89:[0-9a-zA-Z_\.]+]] = bool.cmp gt(%[[VAL_85]], %[[VAL_88]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_90:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_89]] -> (!felt.type<"bn128">) {
+// CHECK-NEXT:            %[[VAL_91:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_85]], %[[VAL_84]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_92:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:            %[[VAL_93:[0-9a-zA-Z_\.]+]] = array.new  : <@"D@353" x !felt.type<"bn128">>
+// CHECK-NEXT:            %[[VAL_94:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:            %[[VAL_95:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_93]], %[[VAL_94]] : <@"D@353" x !felt.type<"bn128">>
+// CHECK-NEXT:            %[[VAL_96:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:            %[[VAL_97:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:            scf.for %[[VAL_98:[0-9a-zA-Z_\.]+]] = %[[VAL_96]] to %[[VAL_95]] step %[[VAL_97]] {
+// CHECK-NEXT:              array.write %[[VAL_93]]{{\[}}%[[VAL_98]]] = %[[VAL_92]] : <@"D@353" x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            }
+// CHECK-NEXT:            %[[VAL_99:[0-9a-zA-Z_\.]+]] = array.new  : <@"D@350",@"D@353" x !felt.type<"bn128">>
+// CHECK-NEXT:            %[[VAL_100:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:            %[[VAL_101:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_99]], %[[VAL_100]] : <@"D@350",@"D@353" x !felt.type<"bn128">>
+// CHECK-NEXT:            %[[VAL_102:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:            %[[VAL_103:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:            scf.for %[[VAL_104:[0-9a-zA-Z_\.]+]] = %[[VAL_102]] to %[[VAL_101]] step %[[VAL_103]] {
+// CHECK-NEXT:              array.insert %[[VAL_99]]{{\[}}%[[VAL_104]]] = %[[VAL_93]] : <@"D@350",@"D@353" x !felt.type<"bn128">>, <@"D@353" x !felt.type<"bn128">>
+// CHECK-NEXT:            }
+// CHECK-NEXT:            %[[VAL_105:[0-9a-zA-Z_\.]+]] = felt.const  99 : <"bn128">
+// CHECK-NEXT:            %[[VAL_106:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_107:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_91]], %[[VAL_106]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_108:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_107]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_109:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_110:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_91]], %[[VAL_109]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_111:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_110]] : !felt.type<"bn128">
+// CHECK-NEXT:            array.write %[[VAL_99]]{{\[}}%[[VAL_108]], %[[VAL_111]]] = %[[VAL_105]] : <@"D@350",@"D@353" x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_112:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_113:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_91]], %[[VAL_112]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_114:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_113]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_115:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_116:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_91]], %[[VAL_115]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_117:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_116]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_118:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_99]]{{\[}}%[[VAL_114]], %[[VAL_117]]] : <@"D@350",@"D@353" x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_118]] : !felt.type<"bn128">
+// CHECK-NEXT:          } else {
+// CHECK-NEXT:            %[[VAL_119:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_85]], %[[VAL_84]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_120:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_121:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_119]], %[[VAL_120]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_122:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:            %[[VAL_123:[0-9a-zA-Z_\.]+]] = array.new  : <@"D@468" x !felt.type<"bn128">>
+// CHECK-NEXT:            %[[VAL_124:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:            %[[VAL_125:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_123]], %[[VAL_124]] : <@"D@468" x !felt.type<"bn128">>
+// CHECK-NEXT:            %[[VAL_126:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:            %[[VAL_127:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:            scf.for %[[VAL_128:[0-9a-zA-Z_\.]+]] = %[[VAL_126]] to %[[VAL_125]] step %[[VAL_127]] {
+// CHECK-NEXT:              array.write %[[VAL_123]]{{\[}}%[[VAL_128]]] = %[[VAL_122]] : <@"D@468" x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            }
+// CHECK-NEXT:            %[[VAL_129:[0-9a-zA-Z_\.]+]] = felt.const  77 : <"bn128">
+// CHECK-NEXT:            %[[VAL_130:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_131:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_121]], %[[VAL_130]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_132:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_131]] : !felt.type<"bn128">
+// CHECK-NEXT:            array.write %[[VAL_123]]{{\[}}%[[VAL_132]]] = %[[VAL_129]] : <@"D@468" x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_133:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:            %[[VAL_134:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_121]], %[[VAL_133]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_135:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_134]] : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_136:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_123]]{{\[}}%[[VAL_135]]] : <@"D@468" x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_136]] : !felt.type<"bn128">
+// CHECK-NEXT:          }
+// CHECK-NEXT:          %[[VAL_137:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_90]], %[[VAL_84]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          constrain.eq %[[VAL_86]], %[[VAL_137]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          function.return
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/circom_doc_examples/17.circom
+++ b/circom/tests/circom_doc_examples/17.circom
@@ -1,8 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --stabilize --llzk --llzk_plaintext -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL:.*
-// COM: failure related to the "TODO" on `DeclarationInfo::visit`
 
 pragma circom 2.1.5;
 
@@ -19,4 +17,44 @@ template A(n){
 
 component main = A(5);
 
-// CHECK-LABEL: module attributes {
+// CHECK-LABEL: module attributes {llzk.lang, llzk.main = !struct.type<@A::@A<[5]>>} {
+// CHECK-NEXT:    poly.template @A {
+// CHECK-NEXT:      poly.param @n
+// CHECK-NEXT:      struct.def @A {
+// CHECK-NEXT:        struct.member @outA : !felt.type<"bn128"> {llzk.pub}
+// CHECK-NEXT:        struct.member @out : !felt.type<"bn128">
+// CHECK-NEXT:        function.def @compute(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) -> !struct.type<@A::@A<[@n]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
+// CHECK-NEXT:          %[[VAL_1:[0-9a-zA-Z_\.]+]] = struct.new : <@A::@A<[@n]>>
+// CHECK-NEXT:          %[[VAL_2:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_3:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_4:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_3]], %[[VAL_2]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_5:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_4]] -> (!felt.type<"bn128">) {
+// CHECK-NEXT:            %[[VAL_6:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
+// CHECK-NEXT:            struct.writem %[[VAL_1]][@out] = %[[VAL_6]] : <@A::@A<[@n]>>, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_6]] : !felt.type<"bn128">
+// CHECK-NEXT:          } else {
+// CHECK-NEXT:            scf.yield %[[VAL_3]] : !felt.type<"bn128">
+// CHECK-NEXT:          }
+// CHECK-NEXT:          struct.writem %[[VAL_1]][@outA] = %[[VAL_5]] : <@A::@A<[@n]>>, !felt.type<"bn128">
+// CHECK-NEXT:          function.return %[[VAL_1]] : !struct.type<@A::@A<[@n]>>
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.def @constrain(%[[VAL_7:[0-9a-zA-Z_\.]+]]: !struct.type<@A::@A<[@n]>>, %[[VAL_8:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_9:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_10:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_7]][@outA] : <@A::@A<[@n]>>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_11:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_7]][@out] : <@A::@A<[@n]>>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_12:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:          %[[VAL_13:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_12]], %[[VAL_9]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_14:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_13]] -> (!felt.type<"bn128">) {
+// CHECK-NEXT:            %[[VAL_15:[0-9a-zA-Z_\.]+]] = llzk.nondet : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_16:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
+// CHECK-NEXT:            constrain.eq %[[VAL_15]], %[[VAL_16]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_15]] : !felt.type<"bn128">
+// CHECK-NEXT:          } else {
+// CHECK-NEXT:            scf.yield %[[VAL_12]] : !felt.type<"bn128">
+// CHECK-NEXT:          }
+// CHECK-NEXT:          constrain.eq %[[VAL_10]], %[[VAL_14]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          function.return
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/circom_doc_examples/39C.circom
+++ b/circom/tests/circom_doc_examples/39C.circom
@@ -1,7 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --stabilize --llzk --llzk_plaintext -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL:.*
 
 pragma circom 2.1.5;
 
@@ -24,4 +23,99 @@ template A(n) {
 
 component main = A(3);
 
-// CHECK-LABEL: module attributes {
+// CHECK-LABEL: module attributes {llzk.lang, llzk.main = !struct.type<@A::@A<[3]>>} {
+// CHECK-NEXT:    poly.template @A {
+// CHECK-NEXT:      poly.param @n
+// CHECK-NEXT:      struct.def @A {
+// CHECK-NEXT:        struct.member @out : !felt.type<"bn128">
+// CHECK-NEXT:        struct.member @aux : !felt.type<"bn128">
+// CHECK-NEXT:        struct.member @B_18_478 : !struct.type<@B::@B<[]>>
+// CHECK-NEXT:        struct.member @B_18_478$inputs : !pod.type<[@in: !felt.type<"bn128">]>
+// CHECK-NEXT:        function.def @compute() -> !struct.type<@A::@A<[@n]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
+// CHECK-NEXT:          %[[VAL_0:[0-9a-zA-Z_\.]+]] = struct.new : <@A::@A<[@n]>>
+// CHECK-NEXT:          %[[VAL_1:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_2:[0-9a-zA-Z_\.]+]] = llzk.nondet : !pod.type<[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:          %[[VAL_3:[0-9a-zA-Z_\.]+]] = pod.new : <[@in: !felt.type<"bn128">]>
+// CHECK-NEXT:          %[[VAL_4:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
+// CHECK-NEXT:          %[[VAL_5:[0-9a-zA-Z_\.]+]] = bool.cmp eq(%[[VAL_1]], %[[VAL_4]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_6:[0-9a-zA-Z_\.]+]]:3 = scf.if %[[VAL_5]] -> (!pod.type<[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>, !pod.type<[@in: !felt.type<"bn128">]>, !felt.type<"bn128">) {
+// CHECK-NEXT:            %[[VAL_7:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
+// CHECK-NEXT:            struct.writem %[[VAL_0]][@aux] = %[[VAL_7]] : <@A::@A<[@n]>>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_8:[0-9a-zA-Z_\.]+]] = pod.new : <[]>
+// CHECK-NEXT:            %[[VAL_9:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:            %[[VAL_10:[0-9a-zA-Z_\.]+]] = pod.new { @count = %[[VAL_9]], @params = %[[VAL_8]] }  : <[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:            pod.write %[[VAL_3]][@in] = %[[VAL_7]] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_11:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_10]][@count] : <[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:            %[[VAL_12:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:            %[[VAL_13:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_11]], %[[VAL_12]] : index
+// CHECK-NEXT:            pod.write %[[VAL_10]][@count] = %[[VAL_13]] : <[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>, index
+// CHECK-NEXT:            %[[VAL_14:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:            %[[VAL_15:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_13]], %[[VAL_14]] : index
+// CHECK-NEXT:            scf.if %[[VAL_15]] {
+// CHECK-NEXT:              %[[VAL_16:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_10]][@params] : <[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>, !pod.type<[]>
+// CHECK-NEXT:              %[[VAL_17:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_3]][@in] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:              %[[VAL_18:[0-9a-zA-Z_\.]+]] = function.call @B::@B::@compute(%[[VAL_17]]) : (!felt.type<"bn128">) -> !struct.type<@B::@B<[]>>
+// CHECK-NEXT:              pod.write %[[VAL_10]][@comp] = %[[VAL_18]] : <[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>, !struct.type<@B::@B<[]>>
+// CHECK-NEXT:            }
+// CHECK-NEXT:            %[[VAL_19:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_10]][@comp] : <[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>, !struct.type<@B::@B<[]>>
+// CHECK-NEXT:            %[[VAL_20:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_19]][@out] : <@B::@B<[]>>, !felt.type<"bn128">
+// CHECK-NEXT:            struct.writem %[[VAL_0]][@out] = %[[VAL_20]] : <@A::@A<[@n]>>, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_10]], %[[VAL_3]], %[[VAL_20]] : !pod.type<[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>, !pod.type<[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:          } else {
+// CHECK-NEXT:            %[[VAL_21:[0-9a-zA-Z_\.]+]] = felt.const  5 : <"bn128">
+// CHECK-NEXT:            struct.writem %[[VAL_0]][@out] = %[[VAL_21]] : <@A::@A<[@n]>>, !felt.type<"bn128">
+// CHECK-NEXT:            scf.yield %[[VAL_2]], %[[VAL_3]], %[[VAL_21]] : !pod.type<[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>, !pod.type<[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:          }
+// CHECK-NEXT:          struct.writem %[[VAL_0]][@B_18_478$inputs] = %[[VAL_6]]#1 : <@A::@A<[@n]>>, !pod.type<[@in: !felt.type<"bn128">]>
+// CHECK-NEXT:          %[[VAL_22:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_6]]#0[@comp] : <[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>, !struct.type<@B::@B<[]>>
+// CHECK-NEXT:          struct.writem %[[VAL_0]][@B_18_478] = %[[VAL_22]] : <@A::@A<[@n]>>, !struct.type<@B::@B<[]>>
+// CHECK-NEXT:          function.return %[[VAL_0]] : !struct.type<@A::@A<[@n]>>
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.def @constrain(%[[VAL_23:[0-9a-zA-Z_\.]+]]: !struct.type<@A::@A<[@n]>>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_24:[0-9a-zA-Z_\.]+]] = poly.read_const @n : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_25:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_23]][@out] : <@A::@A<[@n]>>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_26:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_23]][@aux] : <@A::@A<[@n]>>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_27:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_23]][@B_18_478] : <@A::@A<[@n]>>, !struct.type<@B::@B<[]>>
+// CHECK-NEXT:          %[[VAL_28:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_23]][@B_18_478$inputs] : <@A::@A<[@n]>>, !pod.type<[@in: !felt.type<"bn128">]>
+// CHECK-NEXT:          %[[VAL_29:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
+// CHECK-NEXT:          %[[VAL_30:[0-9a-zA-Z_\.]+]] = bool.cmp eq(%[[VAL_24]], %[[VAL_29]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          scf.if %[[VAL_30]] {
+// CHECK-NEXT:            %[[VAL_31:[0-9a-zA-Z_\.]+]] = llzk.nondet : !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_32:[0-9a-zA-Z_\.]+]] = felt.const  2 : <"bn128">
+// CHECK-NEXT:            constrain.eq %[[VAL_31]], %[[VAL_32]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_33:[0-9a-zA-Z_\.]+]] = pod.new : <[]>
+// CHECK-NEXT:            %[[VAL_34:[0-9a-zA-Z_\.]+]] = pod.new : <[@count: index, @comp: !struct.type<@B::@B<[]>>, @params: !pod.type<[]>]>
+// CHECK-NEXT:            %[[VAL_35:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_28]][@in] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:            constrain.eq %[[VAL_35]], %[[VAL_31]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_36:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_27]][@out] : <@B::@B<[]>>, !felt.type<"bn128">
+// CHECK-NEXT:            constrain.eq %[[VAL_25]], %[[VAL_36]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          } else {
+// CHECK-NEXT:            %[[VAL_37:[0-9a-zA-Z_\.]+]] = felt.const  5 : <"bn128">
+// CHECK-NEXT:            constrain.eq %[[VAL_25]], %[[VAL_37]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          }
+// CHECK-NEXT:          %[[VAL_38:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_28]][@in] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:          function.call @B::@B::@constrain(%[[VAL_27]], %[[VAL_38]]) : (!struct.type<@B::@B<[]>>, !felt.type<"bn128">) -> ()
+// CHECK-NEXT:          function.return
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    poly.template @B {
+// CHECK-NEXT:      struct.def @B {
+// CHECK-NEXT:        struct.member @out : !felt.type<"bn128"> {llzk.pub}
+// CHECK-NEXT:        function.def @compute(%[[VAL_39:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) -> !struct.type<@B::@B<[]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
+// CHECK-NEXT:          %[[VAL_40:[0-9a-zA-Z_\.]+]] = struct.new : <@B::@B<[]>>
+// CHECK-NEXT:          %[[VAL_41:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_42:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_39]], %[[VAL_41]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          struct.writem %[[VAL_40]][@out] = %[[VAL_42]] : <@B::@B<[]>>, !felt.type<"bn128">
+// CHECK-NEXT:          function.return %[[VAL_40]] : !struct.type<@B::@B<[]>>
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.def @constrain(%[[VAL_43:[0-9a-zA-Z_\.]+]]: !struct.type<@B::@B<[]>>, %[[VAL_44:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_45:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_43]][@out] : <@B::@B<[]>>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_46:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:          %[[VAL_47:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_44]], %[[VAL_46]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          constrain.eq %[[VAL_45]], %[[VAL_47]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          function.return
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/llzk_backend/src/module.rs
+++ b/llzk_backend/src/module.rs
@@ -115,7 +115,7 @@ pub struct DeclarationInfo<'ctx> {
     /// Map source-position-qualified key (`name@meta_start`) to its LLZK declaration Operation
     /// (usually `llzk.nondet` initially). Using a source-position-qualified key allows the same
     /// circom variable name to appear in multiple scopes without collision (e.g., an outer scope
-    /// followed by an inner scopeor both branches of an if/else).
+    /// followed by an inner scope or both branches of an if/else).
     decl_inits: HashMap<String, Operation<'ctx>>,
     /// Maps each qualified key in `decl_inits` back to the plain circom variable name, so that
     /// function contexts can declare the value under its original name.
@@ -132,7 +132,7 @@ pub struct DeclarationInfo<'ctx> {
     poly_exprs: RefCell<HashMap<String, TemplateExprOp<'ctx>>>,
     /// Pre-computed LLZK types for `var` declarations, keyed by the same source-position-qualified
     /// key (`name@meta_start`) used in `decl_inits` so that the same circom variable name in
-    /// different scopes maps to each distinct types. Used by `poly.expr` body generation.
+    /// different scopes will map to each distinct type. Used by `poly.expr` body generation.
     var_decl_types: HashMap<String, Type<'ctx>>,
 }
 

--- a/llzk_backend/src/module.rs
+++ b/llzk_backend/src/module.rs
@@ -112,8 +112,17 @@ pub struct DeclarationInfo<'ctx> {
     inputs: Vec<InputSignalInfo<'ctx>>,
     /// Output and Intermediate declarations to use as LLZK struct fields.
     struct_fields: Vec<MemberInfo<'ctx>>,
-    /// Map var/signal name to its LLZK declaration Operation (usually `llzk.nondet`).
+    /// Map source-position-qualified key (`name@meta_start`) to its LLZK declaration Operation
+    /// (usually `llzk.nondet` initially). Using a source-position-qualified key allows the same
+    /// circom variable name to appear in multiple scopes without collision (e.g., an outer scope
+    /// followed by an inner scopeor both branches of an if/else).
     decl_inits: HashMap<String, Operation<'ctx>>,
+    /// Maps each qualified key in `decl_inits` back to the plain circom variable name, so that
+    /// function contexts can declare the value under its original name.
+    decl_key_to_name: HashMap<String, String>,
+    /// Set of plain circom variable names that have at least one entry in `decl_inits`. Used for
+    /// O(1) plain-name containment checks without iterating `decl_inits`.
+    declared_var_names: HashSet<String>,
     /// Map `component` name to its declaration information.
     subcmp_decls: HashMap<String, SubcmpDeclInfo<'ctx>>,
     /// The template params that may be used to instantiate array dimensions.
@@ -121,8 +130,9 @@ pub struct DeclarationInfo<'ctx> {
     template_params: HashSet<String>,
     /// Dimension expressions mapped to generated `poly.expr` op to be inserted into the template.
     poly_exprs: RefCell<HashMap<String, TemplateExprOp<'ctx>>>,
-    /// Pre-computed LLZK types for `var` declarations, keyed by var name. Used by
-    /// `poly.expr` body generation to avoid recursive dimension-expression recomputation.
+    /// Pre-computed LLZK types for `var` declarations, keyed by the same source-position-qualified
+    /// key (`name@meta_start`) used in `decl_inits` so that the same circom variable name in
+    /// different scopes maps to each distinct types. Used by `poly.expr` body generation.
     var_decl_types: HashMap<String, Type<'ctx>>,
 }
 
@@ -227,9 +237,11 @@ impl<'ctx> DeclarationInfo<'ctx> {
 
     /// Visit a statement and populate this `DeclarationInfo` with any declarations found.
     ///
-    /// TODO: This currently visits only top-level statements within the template body. However,
-    /// since circom 2.1.5, signal declarations are allowed inside of blocks and known-condition if
-    /// statements. Those nested declarations are not currently processed here.
+    /// Recursively descends into all nested statements so that declarations inside `if/else`
+    /// branches and loops are discovered. The [`LlzkCodegen::statement_trace`] (pushed via
+    /// [`LlzkCodegen::trace_statement`] at the top of each call) records the nesting context so
+    /// that [`DimExprConverter::gen_template_poly_expr`] can correctly scope the dimension
+    /// expressions for those declarations.
     fn visit(
         &mut self,
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
@@ -255,6 +267,15 @@ impl<'ctx> DeclarationInfo<'ctx> {
                 }
                 Ok(())
             }
+            Statement::IfThenElse { if_case, else_case, .. } => {
+                // Collect `var` (and `signal` since circom 2.1.5) declarations from both branches.
+                self.visit(codegen, if_case.as_ref())?;
+                if let Some(else_case) = else_case.as_deref() {
+                    self.visit(codegen, else_case)?;
+                }
+                Ok(())
+            }
+            Statement::While { stmt, .. } => self.visit(codegen, stmt.as_ref()),
             Statement::Declaration { meta, name, xtype, dimensions, .. } => {
                 // The Signal and Bus types use SignalType to indicate if they are input, output, or
                 // intermediate. The others are all intermediate. Intermediates become SSA values
@@ -283,14 +304,24 @@ impl<'ctx> DeclarationInfo<'ctx> {
                         let dimensions = self.get_dim_exprs(codegen, dimensions)?;
                         let var_type =
                             dimensions.type_from_dimension_exprs(codegen.felt_type().into());
-                        self.var_decl_types.insert(name.clone(), var_type);
-                        self.decl_inits.insert(
-                            name.clone(),
+                        // Key by source position so the same name in different scopes
+                        // (e.g., both branches of an if/else) gets a distinct entry.
+                        let qualified_key = format!("{}@{}", name, meta.start);
+                        self.var_decl_types.insert(qualified_key.clone(), var_type);
+                        self.declared_var_names.insert(name.clone());
+                        let old = self.decl_inits.insert(
+                            qualified_key.clone(),
                             codegen.new_nondet_at_location(
                                 codegen.location_from_meta(meta),
                                 var_type,
                             )?,
                         );
+                        assert!(
+                            old.is_none(),
+                            "multiple declarations for qualified key {}",
+                            qualified_key
+                        );
+                        self.decl_key_to_name.insert(qualified_key, name.clone());
                         Ok(())
                     }
                     VariableType::Component => {
@@ -398,8 +429,13 @@ impl<'ctx> DeclarationInfo<'ctx> {
         }
         // Create `llzk.nondet` of the appropriate type. When the actual assignment
         // is processed later, this is replaced with the appropriate value.
+        // Signals are uniquely named within a template (the circom type checker enforces this),
+        // so use the plain name as the qualified key.
         codegen.new_nondet_at_location(location, decl_type).map(|op| {
-            self.decl_inits.insert(name.clone(), op);
+            self.declared_var_names.insert(name.clone());
+            let old = self.decl_inits.insert(name.clone(), op);
+            assert!(old.is_none(), "multiple declarations for {}", name);
+            self.decl_key_to_name.insert(name.clone(), name.clone());
         })
     }
 
@@ -499,14 +535,12 @@ where
                         // This is a `Statement::Declaration` with `VariableType::Var` that was
                         // previously encountered and converted into a `poly.expr`.
                         ArrayDimensionResult::new(codegen.flat_sym(name).into(), &[])
-                    } else if self.decl_inits.contains_key(name) {
+                    } else if self.declared_var_names.contains(name) {
                         // This is a `Statement::Declaration` with `VariableType::Var` that is
                         // encountered for the first time and must have a `poly.expr` generated.
                         self.gen_template_poly_expr(codegen, expr)
                     } else {
-                        // TODO: this happens in `circom/tests/circom_doc_examples/04.circom`
-                        // and I think it's related to the "TODO" on `DeclarationInfo::visit`.
-                        todo!("not a known circom template parameter or var declaration: {}", name)
+                        unreachable!("[DeclarationInfo::visit] traversed all statements")
                     }
                 }
                 // Variable case with non-empty `access`
@@ -696,11 +730,13 @@ fn gen_template_llzk<'ast, 'ctx, T: TemplateLike>(
 
     // Insert the Operations created from variable Declaration statements and map the circom
     // variable name to LLZK op result Value (do this in each function).
-    for (name, op) in decl_inits(declarations.decl_inits, codegen.config.stabilize) {
+    let decl_key_to_name = declarations.decl_key_to_name;
+    for (key, op) in decl_inits(declarations.decl_inits, codegen.config.stabilize) {
+        let name = decl_key_to_name.get(&key).expect("every decl_inits key has a name entry");
         // Insert (a clone of) the declaration into the compute function.
-        compute_ctx.block_ctx.declare_name_if_not_present(&name, || Ok(op.clone()))?;
+        compute_ctx.block_ctx.declare_name_if_not_present(name, || Ok(op.clone()))?;
         // Insert the declaration into the constrain function.
-        constrain_ctx.block_ctx.declare_name_if_not_present(&name, || Ok(op))?;
+        constrain_ctx.block_ctx.declare_name_if_not_present(name, || Ok(op))?;
     }
     let subcmp_decls = declarations.subcmp_decls;
     let subcmp_names = subcmps

--- a/llzk_backend/src/shared.rs
+++ b/llzk_backend/src/shared.rs
@@ -271,12 +271,14 @@ pub struct LlzkCodegen<'ast, 'ctx, P: ProgramLike> {
     template_decls: RefCell<HashMap<String, DeclInfo<'ctx>>>,
     /// Body of the function or template currently being processed.
     current_body: Cell<Option<&'ast [Statement]>>,
-    /// Current [Statement] (or stack thereof when within an `IfThenElse` or `While`) being visited
-    /// and/or translated. Used by [`DimExprConverter::gen_template_poly_expr`] to replicate the
-    /// body into the `poly.expr` initializer up to the current position so all variable
-    /// assignments that contribute to the target expression will be computed. Raw pointers are
-    /// used to avoid a lifetime issue from synthetic Statements created on-the-fly and translated.
-    /// They pointers must only be used for pointer equality comparisons to avoid unsafe behavior.
+    /// Current [`Statement`] (or stack thereof when within an `IfThenElse` or `While`) being
+    /// visited and/or translated. Used by [`DimExprConverter::gen_template_poly_expr`] to
+    /// replicate the body into the `poly.expr` initializer up to the current position so all
+    /// variable assignments that contribute to the target expression will be computed.
+    ///
+    /// Raw pointers are used to avoid a lifetime issue from synthetic Statements created
+    /// on-the-fly and translated. These pointers must only be used for pointer equality
+    /// comparisons to avoid unsafe behavior.
     statement_trace: RefCell<Vec<*const Statement>>,
     /// Operation builder
     builder: OpBuilder<'ctx>,
@@ -1789,7 +1791,8 @@ where
                         // Use the pre-computed type from DeclarationInfo (seeded into the
                         // BlockContextStack root) to avoid triggering recursive
                         // gen_template_poly_expr calls for non-constant dimension expressions.
-                        if let Some(ty) = gen_ctx.var_decl_types.get(name) {
+                        let qualified_key = format!("{}@{}", name, meta.start);
+                        if let Some(ty) = gen_ctx.var_decl_types.get(&qualified_key) {
                             let op = codegen
                                 .new_nondet_at_location(codegen.location_from_meta(meta), *ty)?;
                             gen_ctx.block_ctx.declare_name_ensure_not_present(name, op)?;

--- a/llzk_backend/src/shared.rs
+++ b/llzk_backend/src/shared.rs
@@ -210,7 +210,7 @@ macro_rules! type_switch {
 #[derive(Debug)]
 enum DeclInfo<'ctx> {
     /// Complete declaration info computed initially.
-    Full(DeclarationInfo<'ctx>),
+    Full(Box<DeclarationInfo<'ctx>>),
     /// Minimal information left behind after generating LLZK for a template.
     Remnant {
         /// Map of signal name to type for input signals.
@@ -621,7 +621,9 @@ impl<'ast, 'ctx, P: ProgramLike> LlzkCodegen<'ast, 'ctx, P> {
 
     /// Store the full [DeclarationInfo] for the template with the given name.
     pub fn put_template_decl(&self, name: &str, decl_info: DeclarationInfo<'ctx>) {
-        self.template_decls.borrow_mut().insert(name.to_string(), DeclInfo::Full(decl_info));
+        self.template_decls
+            .borrow_mut()
+            .insert(name.to_string(), DeclInfo::Full(Box::new(decl_info)));
     }
 
     /// Remove and return the full [DeclarationInfo] for the template with the given name and leave
@@ -629,6 +631,7 @@ impl<'ast, 'ctx, P: ProgramLike> LlzkCodegen<'ast, 'ctx, P> {
     pub fn take_template_decl(&self, name: &str) -> Result<DeclarationInfo<'ctx>> {
         let mut borrow = self.template_decls.borrow_mut();
         if let Some((name, DeclInfo::Full(decl_info))) = borrow.remove_entry(name) {
+            let decl_info = *decl_info;
             let inputs = decl_info.build_input_name_to_type_map();
             let outputs = decl_info.build_output_name_to_type_map();
             borrow.insert(name, DeclInfo::Remnant { inputs, outputs });


### PR DESCRIPTION
Resolves:
>  /// TODO: This currently visits only top-level statements within the template body. However,
>  /// since circom 2.1.5, signal declarations are allowed inside of blocks and known-condition if
>  /// statements. Those nested declarations are not currently processed here.

The comment did not point out that this was a shortcoming that affected some var declarations as well, hence the need to fix it now.