### PR TITLE
consistent identity affine_map

### DIFF
--- a/circom/tests/arrays/array_dimensions_13.circom
+++ b/circom/tests/arrays/array_dimensions_13.circom
@@ -21,7 +21,7 @@ template EvilArrayDims(N, M) {
 
 component main = EvilArrayDims(7, 2);
 
-// CHECK: #[[$ATTR_0:[0-9a-zA-Z_\.]+]] = affine_map<()[s0] -> (s0)>
+// CHECK: #[[$ATTR_0:[0-9a-zA-Z_\.]+]] = affine_map<(d0) -> (d0)>
 //
 // CHECK-LABEL: module attributes {llzk.lang, llzk.main = !struct.type<@EvilArrayDims::@EvilArrayDims<[7, 2]>>} {
 // CHECK-NEXT:    poly.template @EvilArrayDims {
@@ -39,7 +39,7 @@ component main = EvilArrayDims(7, 2);
 // CHECK-NEXT:            %[[VAL_7:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_2]], %[[VAL_1]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:            %[[VAL_8:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
 // CHECK-NEXT:            %[[VAL_9:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_7]] : !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_10:[0-9a-zA-Z_\.]+]] = array.new{(){{\[}}%[[VAL_9]]]} : <#[[$ATTR_0]] x !felt.type<"bn128">>
+// CHECK-NEXT:            %[[VAL_10:[0-9a-zA-Z_\.]+]] = array.new{(%[[VAL_9]])} : <#[[$ATTR_0]] x !felt.type<"bn128">>
 // CHECK-NEXT:            %[[VAL_11:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
 // CHECK-NEXT:            %[[VAL_12:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_10]], %[[VAL_11]] : <#[[$ATTR_0]] x !felt.type<"bn128">>
 // CHECK-NEXT:            %[[VAL_13:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
@@ -63,7 +63,7 @@ component main = EvilArrayDims(7, 2);
 // CHECK-NEXT:            %[[VAL_26:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_24]], %[[VAL_25]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:            %[[VAL_27:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
 // CHECK-NEXT:            %[[VAL_28:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_26]] : !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_29:[0-9a-zA-Z_\.]+]] = array.new{(){{\[}}%[[VAL_28]]]} : <#[[$ATTR_0]] x !felt.type<"bn128">>
+// CHECK-NEXT:            %[[VAL_29:[0-9a-zA-Z_\.]+]] = array.new{(%[[VAL_28]])} : <#[[$ATTR_0]] x !felt.type<"bn128">>
 // CHECK-NEXT:            %[[VAL_30:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
 // CHECK-NEXT:            %[[VAL_31:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_29]], %[[VAL_30]] : <#[[$ATTR_0]] x !felt.type<"bn128">>
 // CHECK-NEXT:            %[[VAL_32:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
@@ -94,7 +94,7 @@ component main = EvilArrayDims(7, 2);
 // CHECK-NEXT:            %[[VAL_50:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_45]], %[[VAL_44]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:            %[[VAL_51:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
 // CHECK-NEXT:            %[[VAL_52:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_50]] : !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_53:[0-9a-zA-Z_\.]+]] = array.new{(){{\[}}%[[VAL_52]]]} : <#[[$ATTR_0]] x !felt.type<"bn128">>
+// CHECK-NEXT:            %[[VAL_53:[0-9a-zA-Z_\.]+]] = array.new{(%[[VAL_52]])} : <#[[$ATTR_0]] x !felt.type<"bn128">>
 // CHECK-NEXT:            %[[VAL_54:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
 // CHECK-NEXT:            %[[VAL_55:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_53]], %[[VAL_54]] : <#[[$ATTR_0]] x !felt.type<"bn128">>
 // CHECK-NEXT:            %[[VAL_56:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
@@ -118,7 +118,7 @@ component main = EvilArrayDims(7, 2);
 // CHECK-NEXT:            %[[VAL_69:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_67]], %[[VAL_68]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:            %[[VAL_70:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
 // CHECK-NEXT:            %[[VAL_71:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_69]] : !felt.type<"bn128">
-// CHECK-NEXT:            %[[VAL_72:[0-9a-zA-Z_\.]+]] = array.new{(){{\[}}%[[VAL_71]]]} : <#[[$ATTR_0]] x !felt.type<"bn128">>
+// CHECK-NEXT:            %[[VAL_72:[0-9a-zA-Z_\.]+]] = array.new{(%[[VAL_71]])} : <#[[$ATTR_0]] x !felt.type<"bn128">>
 // CHECK-NEXT:            %[[VAL_73:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
 // CHECK-NEXT:            %[[VAL_74:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_72]], %[[VAL_73]] : <#[[$ATTR_0]] x !felt.type<"bn128">>
 // CHECK-NEXT:            %[[VAL_75:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index

--- a/llzk_backend/src/gen_context.rs
+++ b/llzk_backend/src/gen_context.rs
@@ -1,5 +1,6 @@
 //! Handles circom var scoping and LLZK blocks stack management.
 
+use crate::affine_map::AffineMapAttribute;
 use crate::function::InfoProviders;
 use crate::function_ext::FunctionLike as _;
 use crate::lvalue::Lvalue;
@@ -1850,7 +1851,7 @@ where
             // so we instead create the array empty and use array.insert to insert values.
             let ctor = if let Some(symbols) = dimension.value_range()? {
                 symbols_sto.push(symbols);
-                ArrayCtor::MapDimSlice(&symbols_sto, &[0])
+                ArrayCtor::MapDimSlice(&symbols_sto, &[1])
             } else {
                 ArrayCtor::Empty
             };
@@ -1893,7 +1894,7 @@ where
                 let mut v_sto = vec![];
                 let ctor = if let Ok(Some(v)) = dimension.value_range() {
                     v_sto.push(v);
-                    ArrayCtor::MapDimSlice(&v_sto, &[0])
+                    ArrayCtor::MapDimSlice(&v_sto, &[1])
                 } else {
                     ArrayCtor::Empty
                 };
@@ -2114,7 +2115,10 @@ where
                         if self.poly_template_binding_names.contains_key(&expr_name) {
                             ArrayDimensionResult::new(codegen.flat_sym(expr_name).into(), &[])
                         } else if let Ok(v) = self.block_ctx.get_named_value(name) {
-                            ArrayDimensionResult::new(codegen.identity_affine_map_attr()?, &[*v])
+                            ArrayDimensionResult::new(
+                                AffineMapAttribute::identity(codegen.context, 1).into(),
+                                &[*v],
+                            )
                         } else {
                             todo!("Handle dimension Variable expression in BlockGenContext")
                         }

--- a/llzk_backend/src/gen_context.rs
+++ b/llzk_backend/src/gen_context.rs
@@ -1851,7 +1851,7 @@ where
             // so we instead create the array empty and use array.insert to insert values.
             let ctor = if let Some(dim_operands) = dimension.value_range()? {
                 dim_operands_sto.push(dim_operands);
-                ArrayCtor::MapDimSlice(&dim_operands_sto, &[1])
+                ArrayCtor::MapDimSlice(&dim_operands_sto, &[i32::try_from(dim_operands.len())?])
             } else {
                 ArrayCtor::Empty
             };
@@ -1894,7 +1894,8 @@ where
                 let mut v_sto = vec![];
                 let ctor = if let Ok(Some(v)) = dimension.value_range() {
                     v_sto.push(v);
-                    ArrayCtor::MapDimSlice(&v_sto, &[1])
+
+                    ArrayCtor::MapDimSlice(&v_sto, &[i32::try_from(v.len())?])
                 } else {
                     ArrayCtor::Empty
                 };

--- a/llzk_backend/src/gen_context.rs
+++ b/llzk_backend/src/gen_context.rs
@@ -1846,12 +1846,12 @@ where
         let const_dim = IntegerAttribute::try_from(dimension);
         if let Ok(subarr_ty) = ArrayType::try_from(value.r#type()) {
             let arr_ty = dimension.new_array_type(&subarr_ty.into());
-            let mut symbols_sto = vec![];
+            let mut dim_operands_sto = vec![];
             // The array.new constructor doesn't accept arrays as initializer values,
             // so we instead create the array empty and use array.insert to insert values.
-            let ctor = if let Some(symbols) = dimension.value_range()? {
-                symbols_sto.push(symbols);
-                ArrayCtor::MapDimSlice(&symbols_sto, &[1])
+            let ctor = if let Some(dim_operands) = dimension.value_range()? {
+                dim_operands_sto.push(dim_operands);
+                ArrayCtor::MapDimSlice(&dim_operands_sto, &[1])
             } else {
                 ArrayCtor::Empty
             };

--- a/llzk_backend/src/module.rs
+++ b/llzk_backend/src/module.rs
@@ -752,17 +752,8 @@ where
     'val: 'blk,
 {
     subcmps.into_iter().try_for_each(|subcmp| {
-        subcmp.generate_constraint_func_prologue(
-            constrain_ctx,
-            codegen.op_builder(),
-            subcmp_decls,
-        )?;
-        subcmp.generate_compute_func_prologue(
-            compute_ctx,
-            codegen.op_builder(),
-            codegen,
-            subcmp_decls,
-        )
+        subcmp.generate_constraint_func_prologue(constrain_ctx, codegen, subcmp_decls)?;
+        subcmp.generate_compute_func_prologue(compute_ctx, codegen, subcmp_decls)
     })
 }
 

--- a/llzk_backend/src/shared.rs
+++ b/llzk_backend/src/shared.rs
@@ -28,6 +28,7 @@ use llzk::dialect::pod;
 use llzk::dialect::poly;
 use llzk::prelude::is_felt_type;
 use llzk::prelude::melior_dialects::arith;
+use llzk::prelude::replace_uses_of_with;
 use llzk::prelude::verify_operation_with_diags;
 use llzk::prelude::ArrayType;
 use llzk::prelude::Attribute;
@@ -70,7 +71,6 @@ use llzk::prelude::Type;
 use llzk::prelude::TypeLike as _;
 use llzk::prelude::Value;
 use llzk::prelude::ValueLike;
-use llzk::prelude::replace_uses_of_with;
 use llzk::value_ext::OwningValueRange;
 use llzk::value_ext::ValueRange;
 use melior::utility;
@@ -821,12 +821,6 @@ impl<'ast, 'ctx, P: ProgramLike> LlzkCodegen<'ast, 'ctx, P> {
             .ok_or_else(|| anyhow!("could not parse affine_map definition"))
     }
 
-    /// Create an identity affine_map attribute.
-    #[inline]
-    pub fn identity_affine_map_attr(&self) -> Result<Attribute<'ctx>> {
-        self.affine_map_attr("affine_map<()[i] -> (i)>")
-    }
-
     /// Creates a [`FlatSymbolRefAttribute`] from the given string.
     #[inline]
     pub fn flat_sym(&self, sym: impl AsRef<str>) -> FlatSymbolRefAttribute<'ctx> {
@@ -889,7 +883,7 @@ impl<'ast, 'ctx, P: ProgramLike> LlzkCodegen<'ast, 'ctx, P> {
         arith::constant(self.context, self.index_attr(val).into(), location)
     }
 
-    /// Create an LLZK `array.new` operation with the given element type and dimensions.
+    /// Create an LLZK `array.new` operation with the given type and constructor info.
     #[inline]
     pub fn new_array_new_op(
         &self,

--- a/llzk_backend/src/subcmp.rs
+++ b/llzk_backend/src/subcmp.rs
@@ -8,8 +8,6 @@ use crate::shared::LlzkCodegen;
 use crate::template_ext::SignalDeclarations;
 use crate::template_ext::TemplateLike as _;
 use anyhow::Result;
-use llzk::builder::OpBuilder;
-use llzk::dialect::array;
 use llzk::dialect::array::ArrayCtor;
 use llzk::dialect::llzk::nondet;
 use llzk::dialect::pod;
@@ -278,14 +276,14 @@ impl<'ctx> SubcmpPrologueData<'ctx> {
     pub fn generate_constraint_func_prologue(
         &self,
         constrain_ctx: &mut FunctionContext<'_, 'ctx, '_, '_, '_>,
-        op_builder: &OpBuilder<'ctx>,
+        codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
         subcmp_decls: &HashMap<String, SubcmpDeclInfo<'ctx>>,
     ) -> Result<()> {
         let decl = &subcmp_decls[self.name()];
         let self_ref = constrain_ctx.func.self_value_of_constrain()?;
         constrain_ctx.block_ctx.declare_name_if_not_present(self.name(), || {
             Ok(r#struct::readm(
-                op_builder,
+                codegen.op_builder(),
                 decl.location(),
                 self.subcmp.r#type(),
                 self_ref,
@@ -294,7 +292,7 @@ impl<'ctx> SubcmpPrologueData<'ctx> {
         })?;
         constrain_ctx.block_ctx.declare_name_if_not_present(self.name_inputs(), || {
             Ok(r#struct::readm(
-                op_builder,
+                codegen.op_builder(),
                 decl.location(),
                 self.inputs,
                 self_ref,
@@ -313,7 +311,6 @@ impl<'ctx> SubcmpPrologueData<'ctx> {
     pub fn generate_compute_func_prologue<'func, 'blk, 'val>(
         &self,
         compute_ctx: &mut FunctionContext<'_, 'ctx, 'func, 'blk, 'val>,
-        op_builder: &OpBuilder<'ctx>,
         codegen: &LlzkCodegen<'_, 'ctx, impl ProgramLike>,
         subcmp_decls: &HashMap<String, SubcmpDeclInfo<'ctx>>,
     ) -> Result<()>
@@ -325,15 +322,17 @@ impl<'ctx> SubcmpPrologueData<'ctx> {
         compute_ctx.block_ctx.declare_name_ensure_not_present(
             self.name(),
             match ArrayType::try_from(comp_pod) {
-                Ok(comp_pod) => array::new(op_builder, decl.location(), comp_pod, ArrayCtor::Empty),
+                Ok(ty) => codegen.new_array_new_op(decl.location(), ty, ArrayCtor::Empty),
                 Err(_) => nondet(decl.location(), comp_pod),
             },
         )?;
         compute_ctx.block_ctx.declare_name_ensure_not_present(
             self.name_inputs(),
             match self.inputs_as::<ArrayType>() {
-                Ok(inputs) => array::new(op_builder, decl.location(), inputs, ArrayCtor::Empty),
-                Err(_) => pod::new(op_builder, decl.location(), &[], Some(self.inputs_as()?)),
+                Ok(ty) => codegen.new_array_new_op(decl.location(), ty, ArrayCtor::Empty),
+                Err(_) => {
+                    pod::new(codegen.op_builder(), decl.location(), &[], Some(self.inputs_as()?))
+                }
             },
         )
     }


### PR DESCRIPTION
There were 2 different ways of creating an `affine_map` (`AffineMapAttribute::identity` and `identity_affine_map_attr`) but one used "dimensions" and the other "symbols". They now consistently use dimensions via `AffineMapAttribute::identity`.