### PR TITLE
Support large constants in poly expressions

### DIFF
--- a/circom/tests/misc/large_constant2.circom
+++ b/circom/tests/misc/large_constant2.circom
@@ -1,7 +1,6 @@
 // REQUIRES: circom
 // RUN: rm -rf %t && mkdir %t && %circom --stabilize --llzk --llzk_plaintext -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
 // END.
-// XFAIL:.*
 
 pragma circom 2.0.0;
 
@@ -26,4 +25,81 @@ template Sign() {
 
 component main = Sign();
 
-// CHECK-LABEL: module attributes {
+// CHECK-LABEL: module attributes {llzk.lang, llzk.main = !struct.type<@Sign::@Sign<[]>>} {
+// CHECK-NEXT:    poly.template @CompConstant {
+// CHECK-NEXT:      poly.param @ct
+// CHECK-NEXT:      struct.def @CompConstant {
+// CHECK-NEXT:        struct.member @out : !felt.type<"bn128"> {llzk.pub}
+// CHECK-NEXT:        function.def @compute(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) -> !struct.type<@CompConstant::@CompConstant<[@ct]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
+// CHECK-NEXT:          %[[VAL_1:[0-9a-zA-Z_\.]+]] = struct.new : <@CompConstant::@CompConstant<[@ct]>>
+// CHECK-NEXT:          %[[VAL_2:[0-9a-zA-Z_\.]+]] = poly.read_const @ct : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_3:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_2]], %[[VAL_0]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          struct.writem %[[VAL_1]][@out] = %[[VAL_3]] : <@CompConstant::@CompConstant<[@ct]>>, !felt.type<"bn128">
+// CHECK-NEXT:          function.return %[[VAL_1]] : !struct.type<@CompConstant::@CompConstant<[@ct]>>
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.def @constrain(%[[VAL_4:[0-9a-zA-Z_\.]+]]: !struct.type<@CompConstant::@CompConstant<[@ct]>>, %[[VAL_5:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_6:[0-9a-zA-Z_\.]+]] = poly.read_const @ct : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_7:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_4]][@out] : <@CompConstant::@CompConstant<[@ct]>>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_8:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_6]], %[[VAL_5]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          constrain.eq %[[VAL_7]], %[[VAL_8]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          function.return
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    poly.template @Sign {
+// CHECK-NEXT:      poly.expr @"10944121435919637611123202872628637544274182200208017171849102093287904247808@[[ID:[0-9]+]]" {
+// CHECK-NEXT:        %[[VAL_9:[0-9a-zA-Z_\.]+]] = felt.const  10944121435919637611123202872628637544274182200208017171849102093287904247808 : <"bn128">
+// CHECK-NEXT:        poly.yield %[[VAL_9]] : !felt.type<"bn128">
+// CHECK-NEXT:      }
+// CHECK-NEXT:      struct.def @Sign {
+// CHECK-NEXT:        struct.member @sign : !felt.type<"bn128"> {llzk.pub}
+// CHECK-NEXT:        struct.member @comp : !struct.type<@CompConstant::@CompConstant<[@"10944121435919637611123202872628637544274182200208017171849102093287904247808@[[ID]]"]>>
+// CHECK-NEXT:        struct.member @comp$inputs : !pod.type<[@in: !felt.type<"bn128">]>
+// CHECK-NEXT:        function.def @compute(%[[VAL_10:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) -> !struct.type<@Sign::@Sign<[]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
+// CHECK-NEXT:          %[[VAL_11:[0-9a-zA-Z_\.]+]] = struct.new : <@Sign::@Sign<[]>>
+// CHECK-NEXT:          %[[VAL_12:[0-9a-zA-Z_\.]+]] = poly.read_const @"10944121435919637611123202872628637544274182200208017171849102093287904247808@[[ID]]" : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_13:[0-9a-zA-Z_\.]+]] = pod.new : <[@in: !felt.type<"bn128">]>
+// CHECK-NEXT:          %[[VAL_14:[0-9a-zA-Z_\.]+]] = poly.read_const @"10944121435919637611123202872628637544274182200208017171849102093287904247808@[[ID]]" : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_15:[0-9a-zA-Z_\.]+]] = pod.new { @ct = %[[VAL_14]] }  : <[@ct: !felt.type<"bn128">]>
+// CHECK-NEXT:          %[[VAL_16:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          %[[VAL_17:[0-9a-zA-Z_\.]+]] = pod.new { @count = %[[VAL_16]], @params = %[[VAL_15]] }  : <[@count: index, @comp: !struct.type<@CompConstant::@CompConstant<[@"10944121435919637611123202872628637544274182200208017171849102093287904247808@[[ID]]"]>>, @params: !pod.type<[@ct: !felt.type<"bn128">]>]>
+// CHECK-NEXT:          pod.write %[[VAL_13]][@in] = %[[VAL_10]] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_18:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_17]][@count] : <[@count: index, @comp: !struct.type<@CompConstant::@CompConstant<[@"10944121435919637611123202872628637544274182200208017171849102093287904247808@[[ID]]"]>>, @params: !pod.type<[@ct: !felt.type<"bn128">]>]>, index
+// CHECK-NEXT:          %[[VAL_19:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:          %[[VAL_20:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_18]], %[[VAL_19]] : index
+// CHECK-NEXT:          pod.write %[[VAL_17]][@count] = %[[VAL_20]] : <[@count: index, @comp: !struct.type<@CompConstant::@CompConstant<[@"10944121435919637611123202872628637544274182200208017171849102093287904247808@[[ID]]"]>>, @params: !pod.type<[@ct: !felt.type<"bn128">]>]>, index
+// CHECK-NEXT:          %[[VAL_21:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[VAL_22:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_20]], %[[VAL_21]] : index
+// CHECK-NEXT:          scf.if %[[VAL_22]] {
+// CHECK-NEXT:            %[[VAL_23:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_17]][@params] : <[@count: index, @comp: !struct.type<@CompConstant::@CompConstant<[@"10944121435919637611123202872628637544274182200208017171849102093287904247808@[[ID]]"]>>, @params: !pod.type<[@ct: !felt.type<"bn128">]>]>, !pod.type<[@ct: !felt.type<"bn128">]>
+// CHECK-NEXT:            %[[VAL_24:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_13]][@in] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:            %[[VAL_25:[0-9a-zA-Z_\.]+]] = function.call @CompConstant::@CompConstant::@compute(%[[VAL_24]]) : (!felt.type<"bn128">) -> !struct.type<@CompConstant::@CompConstant<[@"10944121435919637611123202872628637544274182200208017171849102093287904247808@[[ID]]"]>>
+// CHECK-NEXT:            pod.write %[[VAL_17]][@comp] = %[[VAL_25]] : <[@count: index, @comp: !struct.type<@CompConstant::@CompConstant<[@"10944121435919637611123202872628637544274182200208017171849102093287904247808@[[ID]]"]>>, @params: !pod.type<[@ct: !felt.type<"bn128">]>]>, !struct.type<@CompConstant::@CompConstant<[@"10944121435919637611123202872628637544274182200208017171849102093287904247808@[[ID]]"]>>
+// CHECK-NEXT:          }
+// CHECK-NEXT:          %[[VAL_26:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_17]][@comp] : <[@count: index, @comp: !struct.type<@CompConstant::@CompConstant<[@"10944121435919637611123202872628637544274182200208017171849102093287904247808@[[ID]]"]>>, @params: !pod.type<[@ct: !felt.type<"bn128">]>]>, !struct.type<@CompConstant::@CompConstant<[@"10944121435919637611123202872628637544274182200208017171849102093287904247808@[[ID]]"]>>
+// CHECK-NEXT:          %[[VAL_27:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_26]][@out] : <@CompConstant::@CompConstant<[@"10944121435919637611123202872628637544274182200208017171849102093287904247808@[[ID]]"]>>, !felt.type<"bn128">
+// CHECK-NEXT:          struct.writem %[[VAL_11]][@sign] = %[[VAL_27]] : <@Sign::@Sign<[]>>, !felt.type<"bn128">
+// CHECK-NEXT:          struct.writem %[[VAL_11]][@comp$inputs] = %[[VAL_13]] : <@Sign::@Sign<[]>>, !pod.type<[@in: !felt.type<"bn128">]>
+// CHECK-NEXT:          %[[VAL_28:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_17]][@comp] : <[@count: index, @comp: !struct.type<@CompConstant::@CompConstant<[@"10944121435919637611123202872628637544274182200208017171849102093287904247808@[[ID]]"]>>, @params: !pod.type<[@ct: !felt.type<"bn128">]>]>, !struct.type<@CompConstant::@CompConstant<[@"10944121435919637611123202872628637544274182200208017171849102093287904247808@[[ID]]"]>>
+// CHECK-NEXT:          struct.writem %[[VAL_11]][@comp] = %[[VAL_28]] : <@Sign::@Sign<[]>>, !struct.type<@CompConstant::@CompConstant<[@"10944121435919637611123202872628637544274182200208017171849102093287904247808@[[ID]]"]>>
+// CHECK-NEXT:          function.return %[[VAL_11]] : !struct.type<@Sign::@Sign<[]>>
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.def @constrain(%[[VAL_29:[0-9a-zA-Z_\.]+]]: !struct.type<@Sign::@Sign<[]>>, %[[VAL_30:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_31:[0-9a-zA-Z_\.]+]] = poly.read_const @"10944121435919637611123202872628637544274182200208017171849102093287904247808@[[ID]]" : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_32:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_29]][@sign] : <@Sign::@Sign<[]>>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_33:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_29]][@comp] : <@Sign::@Sign<[]>>, !struct.type<@CompConstant::@CompConstant<[@"10944121435919637611123202872628637544274182200208017171849102093287904247808@[[ID]]"]>>
+// CHECK-NEXT:          %[[VAL_34:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_29]][@comp$inputs] : <@Sign::@Sign<[]>>, !pod.type<[@in: !felt.type<"bn128">]>
+// CHECK-NEXT:          %[[VAL_35:[0-9a-zA-Z_\.]+]] = poly.read_const @"10944121435919637611123202872628637544274182200208017171849102093287904247808@[[ID]]" : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_36:[0-9a-zA-Z_\.]+]] = pod.new { @ct = %[[VAL_35]] }  : <[@ct: !felt.type<"bn128">]>
+// CHECK-NEXT:          %[[VAL_37:[0-9a-zA-Z_\.]+]] = pod.new : <[@count: index, @comp: !struct.type<@CompConstant::@CompConstant<[@"10944121435919637611123202872628637544274182200208017171849102093287904247808@[[ID]]"]>>, @params: !pod.type<[@ct: !felt.type<"bn128">]>]>
+// CHECK-NEXT:          %[[VAL_38:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_34]][@in] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:          constrain.eq %[[VAL_38]], %[[VAL_30]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_39:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_33]][@out] : <@CompConstant::@CompConstant<[@"10944121435919637611123202872628637544274182200208017171849102093287904247808@[[ID]]"]>>, !felt.type<"bn128">
+// CHECK-NEXT:          constrain.eq %[[VAL_32]], %[[VAL_39]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_40:[0-9a-zA-Z_\.]+]] = pod.read %[[VAL_34]][@in] : <[@in: !felt.type<"bn128">]>, !felt.type<"bn128">
+// CHECK-NEXT:          function.call @CompConstant::@CompConstant::@constrain(%[[VAL_33]], %[[VAL_40]]) : (!struct.type<@CompConstant::@CompConstant<[@"10944121435919637611123202872628637544274182200208017171849102093287904247808@[[ID]]"]>>, !felt.type<"bn128">) -> ()
+// CHECK-NEXT:          function.return
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/circom/tests/misc/large_constant2.circom
+++ b/circom/tests/misc/large_constant2.circom
@@ -1,0 +1,29 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --stabilize --llzk --llzk_plaintext -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
+// XFAIL:.*
+
+pragma circom 2.0.0;
+
+template CompConstant(ct) {
+    signal input in;
+    signal output out;
+
+    out <== ct * in;
+}
+
+template Sign() {
+    signal input in;
+    signal output sign;
+
+    component comp = CompConstant(10944121435919637611123202872628637544274182200208017171849102093287904247808);
+
+    comp.in <== in;
+    sign <== comp.out;
+}
+
+
+
+component main = Sign();
+
+// CHECK-LABEL: module attributes {

--- a/circom/tests/misc/large_constant3.circom
+++ b/circom/tests/misc/large_constant3.circom
@@ -1,0 +1,37 @@
+// REQUIRES: circom
+// RUN: rm -rf %t && mkdir %t && %circom --stabilize --llzk --llzk_plaintext -o %t %s | sed -n 's/.*Written successfully:.* \(.*\)/\1/p' | xargs cat | FileCheck %s --enable-var-scope
+// END.
+
+pragma circom 2.0.0;
+
+template CompConstant(ct) {
+    signal input in;
+    signal output out;
+
+    out <== ct * in;
+}
+
+component main = CompConstant(10944121435919637611123202872628637544274182200208017171849102093287904247808);
+
+// CHECK-LABEL: module attributes {llzk.lang, llzk.main = !struct.type<@CompConstant::@CompConstant<[#felt<const 10944121435919637611123202872628637544274182200208017171849102093287904247808>]>>} {
+// CHECK-NEXT:    poly.template @CompConstant {
+// CHECK-NEXT:      poly.param @ct
+// CHECK-NEXT:      struct.def @CompConstant {
+// CHECK-NEXT:        struct.member @out : !felt.type<"bn128"> {llzk.pub}
+// CHECK-NEXT:        function.def @compute(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) -> !struct.type<@CompConstant::@CompConstant<[@ct]>> attributes {function.allow_non_native_field_ops, function.allow_witness} {
+// CHECK-NEXT:          %[[VAL_1:[0-9a-zA-Z_\.]+]] = struct.new : <@CompConstant::@CompConstant<[@ct]>>
+// CHECK-NEXT:          %[[VAL_2:[0-9a-zA-Z_\.]+]] = poly.read_const @ct : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_3:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_2]], %[[VAL_0]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          struct.writem %[[VAL_1]][@out] = %[[VAL_3]] : <@CompConstant::@CompConstant<[@ct]>>, !felt.type<"bn128">
+// CHECK-NEXT:          function.return %[[VAL_1]] : !struct.type<@CompConstant::@CompConstant<[@ct]>>
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.def @constrain(%[[VAL_4:[0-9a-zA-Z_\.]+]]: !struct.type<@CompConstant::@CompConstant<[@ct]>>, %[[VAL_5:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_6:[0-9a-zA-Z_\.]+]] = poly.read_const @ct : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_7:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_4]][@out] : <@CompConstant::@CompConstant<[@ct]>>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_8:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_6]], %[[VAL_5]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          constrain.eq %[[VAL_7]], %[[VAL_8]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          function.return
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/llzk_backend/src/codegen.rs
+++ b/llzk_backend/src/codegen.rs
@@ -1,5 +1,7 @@
 //! Entry point for LLZK code generation.
 
+use std::convert::TryInto as _;
+
 use crate::module::GenerateLLZKInModule;
 use crate::program_ext::ProgramLike;
 use crate::shared;
@@ -8,6 +10,7 @@ pub use crate::shared::LlzkConfig;
 use ansi_term::Color;
 use anyhow::anyhow;
 use anyhow::Result;
+use llzk::prelude::FeltConstAttribute;
 use llzk::prelude::IntegerAttribute;
 use llzk::prelude::LlzkContext;
 use llzk::prelude::Module;
@@ -16,7 +19,64 @@ use llzk::prelude::StructType;
 use llzk::prelude::Type;
 use llzk::prelude::TypeAttribute;
 use llzk::prelude::MAIN_ATTR_NAME;
+use melior::ir::Attribute;
 use num_bigint_dig::BigUint;
+use num_traits::ToPrimitive;
+use program_structure::ast::Expression;
+
+/// Converts the given big unsigned integer into parts of 64 bit long in least significant order.
+fn to_u64_digits(n: &BigUint) -> Vec<u64> {
+    let bytes = n.to_bytes_le();
+    bytes
+        .chunks(size_of::<u64>() / size_of::<u8>())
+        .map(|chunk| {
+            u64::from_le_bytes(chunk.try_into().unwrap_or_else(|_| {
+                let mut arr = [0u8; 8];
+                arr[..chunk.len()].copy_from_slice(chunk);
+                arr
+            }))
+        })
+        .collect()
+}
+
+/// Prepares the paremeters of the main component StructType.
+///
+/// TODO: This approach does not currently handle ArrayInLine or Call expressions that can be
+/// used as parameters to the main component. The Call case could be handled by finding the
+/// target function and evaluating it statically. The ArrayInLine (i.e. a literal array like
+/// `[9,3,1]`) however may require generating an additional wrapper struct that can construct
+/// the array and pass it to the main component. Alternatively, put the array in a global const
+/// and then generate the main component with one less template parameter and read the global.
+fn prepare_main_component_params<'ctx>(
+    params: impl IntoIterator<Item = Expression>,
+    prime: &BigUint,
+    context: &'ctx LlzkContext,
+) -> Result<Vec<Attribute<'ctx>>> {
+    params
+        .into_iter()
+        .enumerate()
+        .map(|(i, e)| -> Result<Attribute<'ctx>> {
+            let n = shared::try_compute_biguint(&e, prime).and_then(|n| {
+                n.ok_or_else(|| anyhow!("main component parameter {i} is not a positive constant"))
+            })?;
+            Ok(match n.to_i64() {
+                Some(n) => IntegerAttribute::new(Type::index(context), n).into(),
+                None => {
+                    // Increase by one to ensure the value is kept unsigned.
+                    let bitlen = n.bits() + 1;
+                    let parts = to_u64_digits(&n);
+                    FeltConstAttribute::from_parts(
+                        context,
+                        bitlen.try_into().unwrap(),
+                        &parts,
+                        None,
+                    )
+                    .into()
+                }
+            })
+        })
+        .collect()
+}
 
 /// Create a new, empty LLZK `Module` with Location "main" from the `ProgramArchive`.
 ///
@@ -27,25 +87,7 @@ fn new_llzk_module<'ctx>(
     prime: &BigUint,
 ) -> Result<Module<'ctx>> {
     let main_info = program.get_main_component_info();
-
-    // Compute constant parameters of the main component StructType.
-    // TODO: This approach does not currently handle ArrayInLine or Call expressions that can be
-    // used as parameters to the main component. The Call case could be handled by finding the
-    // target function and evaluating it statically. The ArrayInLine (i.e. a literal array like
-    // `[9,3,1]`) however may require generating an additional wrapper struct that can construct
-    // the array and pass it to the main component. Alternatively, put the array in a global const
-    // and then generate the main component with one less template parameter and read the global.
-    let params = main_info
-        .params
-        .into_iter()
-        .enumerate()
-        .map(|(i, e)| {
-            shared::try_compute_as_i64(&e, prime)?
-                .ok_or_else(|| anyhow!("main component parameter {i} is not a positive constant"))
-        })
-        .collect::<Result<Vec<_>>>()?;
-    let params: Vec<_> =
-        params.into_iter().map(|p| IntegerAttribute::new(Type::index(context), p).into()).collect();
+    let params = prepare_main_component_params(main_info.params, prime, context)?;
 
     // Create the LLZK module, using the location of the main component declaration expression.
     let location =

--- a/llzk_backend/src/gen_context.rs
+++ b/llzk_backend/src/gen_context.rs
@@ -2470,7 +2470,14 @@ where
         } else {
             match expr {
                 Expression::Number(_, _) => {
-                    unreachable!("handled by try_compute_as_i64")
+                    let expr_name = dim_expr_name(expr);
+                    if self.poly_template_binding_names.borrow().contains_key(&expr_name) {
+                        // Return the const expr representing the constant value.
+                        ArrayDimensionResult::new(codegen.flat_sym(expr_name).into(), &[])
+                    } else {
+                        // Generate it otherwise.
+                        self.gen_template_poly_expr(codegen, expr)
+                    }
                 }
                 Expression::Variable { meta, name, access } if access.is_empty() => {
                     // Grab the template symbol binding name if it exists (first try `poly.param`

--- a/llzk_backend/src/module.rs
+++ b/llzk_backend/src/module.rs
@@ -526,9 +526,9 @@ where
             ArrayDimensionResult::new(codegen.index_attr(integer).into(), &[])
         } else {
             match expr {
-                Expression::Number(_, _) => {
-                    unreachable!("handled by try_compute_as_i64")
-                }
+                //Expression::Number(_, _) => {
+                //    unreachable!("handled by try_compute_as_i64")
+                //}
                 Expression::Variable { name, access, .. } if access.is_empty() => {
                     if self.template_params.contains(name) {
                         ArrayDimensionResult::new(codegen.flat_sym(name).into(), &[])
@@ -546,6 +546,7 @@ where
                 }
                 // Variable case with non-empty `access`
                 Expression::Variable { .. }
+                | Expression::Number(_, _)
                 | Expression::InlineSwitchOp { .. }
                 | Expression::PrefixOp { .. }
                 | Expression::InfixOp { .. }

--- a/llzk_backend/src/module.rs
+++ b/llzk_backend/src/module.rs
@@ -526,9 +526,6 @@ where
             ArrayDimensionResult::new(codegen.index_attr(integer).into(), &[])
         } else {
             match expr {
-                //Expression::Number(_, _) => {
-                //    unreachable!("handled by try_compute_as_i64")
-                //}
                 Expression::Variable { name, access, .. } if access.is_empty() => {
                     if self.template_params.contains(name) {
                         ArrayDimensionResult::new(codegen.flat_sym(name).into(), &[])

--- a/llzk_backend/src/template.rs
+++ b/llzk_backend/src/template.rs
@@ -881,7 +881,14 @@ where
         } else {
             match expr {
                 Expression::Number(_, _) => {
-                    unreachable!("handled by try_compute_as_i64")
+                    let expr_name = dim_expr_name(expr);
+                    if self.template_def.has_const_expr_named(&expr_name) {
+                        // Return the const expr representing the constant value.
+                        ArrayDimensionResult::new(codegen.flat_sym(expr_name).into(), &[])
+                    } else {
+                        // Generate it otherwise.
+                        self.gen_template_poly_expr(codegen, expr)
+                    }
                 }
                 Expression::Variable { meta, name, access } if access.is_empty() => {
                     // Grab the template symbol binding name if it exists (first try `poly.param`


### PR DESCRIPTION
Handles constant values larger than what is possible to fit in a `i64`:

- When the constant is present inside the body of a template.
- For the template parameters of the main component.

Fixes #417
