### PR TITLE
Update LLZK dependency

### DIFF
--- a/.github/workflows/ci-llzk.yml
+++ b/.github/workflows/ci-llzk.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: cachix/install-nix-action@9280e7aca88deada44c930f1e2c78e21c3ae3edd # v31.7.0
+      - uses: cachix/install-nix-action@v31.11.0
         with:
           install_url: https://releases.nixos.org/nix/nix-2.31.2/install
           github_access_token: "${{ secrets.GITHUB_TOKEN }}"
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: cachix/install-nix-action@9280e7aca88deada44c930f1e2c78e21c3ae3edd # v31.7.0
+      - uses: cachix/install-nix-action@v31.11.0
         with:
           install_url: https://releases.nixos.org/nix/nix-2.31.2/install
           github_access_token: "${{ secrets.GITHUB_TOKEN }}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,7 +798,7 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 [[package]]
 name = "llzk"
 version = "0.6.0"
-source = "git+https://github.com/project-llzk/llzk-rs#2d741d34c870353559bf600aa93f68596039a068"
+source = "git+https://github.com/project-llzk/llzk-rs#cf501f89b3a3915e36fefbee84afb7d9ca8aca81"
 dependencies = [
  "llzk-macro",
  "llzk-sys",
@@ -811,7 +811,7 @@ dependencies = [
 [[package]]
 name = "llzk-macro"
 version = "0.3.0"
-source = "git+https://github.com/project-llzk/llzk-rs#2d741d34c870353559bf600aa93f68596039a068"
+source = "git+https://github.com/project-llzk/llzk-rs#cf501f89b3a3915e36fefbee84afb7d9ca8aca81"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -823,7 +823,7 @@ dependencies = [
 [[package]]
 name = "llzk-sys"
 version = "30.1.0"
-source = "git+https://github.com/project-llzk/llzk-rs#2d741d34c870353559bf600aa93f68596039a068"
+source = "git+https://github.com/project-llzk/llzk-rs#cf501f89b3a3915e36fefbee84afb7d9ca8aca81"
 dependencies = [
  "anyhow",
  "llzk-sys-build-support",
@@ -833,7 +833,7 @@ dependencies = [
 [[package]]
 name = "llzk-sys-build-support"
 version = "1.0.1"
-source = "git+https://github.com/project-llzk/llzk-rs#2d741d34c870353559bf600aa93f68596039a068"
+source = "git+https://github.com/project-llzk/llzk-rs#cf501f89b3a3915e36fefbee84afb7d9ca8aca81"
 dependencies = [
  "anyhow",
  "bindgen 0.71.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,7 +798,7 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 [[package]]
 name = "llzk"
 version = "0.6.0"
-source = "git+https://github.com/project-llzk/llzk-rs#cf501f89b3a3915e36fefbee84afb7d9ca8aca81"
+source = "git+https://github.com/project-llzk/llzk-rs#2b9834ab0bdb3fe42bf06cb5343c88756f647306"
 dependencies = [
  "llzk-macro",
  "llzk-sys",
@@ -811,7 +811,7 @@ dependencies = [
 [[package]]
 name = "llzk-macro"
 version = "0.3.0"
-source = "git+https://github.com/project-llzk/llzk-rs#cf501f89b3a3915e36fefbee84afb7d9ca8aca81"
+source = "git+https://github.com/project-llzk/llzk-rs#2b9834ab0bdb3fe42bf06cb5343c88756f647306"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -823,7 +823,7 @@ dependencies = [
 [[package]]
 name = "llzk-sys"
 version = "30.1.0"
-source = "git+https://github.com/project-llzk/llzk-rs#cf501f89b3a3915e36fefbee84afb7d9ca8aca81"
+source = "git+https://github.com/project-llzk/llzk-rs#2b9834ab0bdb3fe42bf06cb5343c88756f647306"
 dependencies = [
  "anyhow",
  "llzk-sys-build-support",
@@ -833,7 +833,7 @@ dependencies = [
 [[package]]
 name = "llzk-sys-build-support"
 version = "1.0.1"
-source = "git+https://github.com/project-llzk/llzk-rs#cf501f89b3a3915e36fefbee84afb7d9ca8aca81"
+source = "git+https://github.com/project-llzk/llzk-rs#2b9834ab0bdb3fe42bf06cb5343c88756f647306"
 dependencies = [
  "anyhow",
  "bindgen 0.71.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,7 +798,7 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 [[package]]
 name = "llzk"
 version = "0.6.0"
-source = "git+https://github.com/project-llzk/llzk-rs#2b9834ab0bdb3fe42bf06cb5343c88756f647306"
+source = "git+https://github.com/project-llzk/llzk-rs#829e420fc342987a40b6c920e9ce34d0fbddc382"
 dependencies = [
  "llzk-macro",
  "llzk-sys",
@@ -811,7 +811,7 @@ dependencies = [
 [[package]]
 name = "llzk-macro"
 version = "0.3.0"
-source = "git+https://github.com/project-llzk/llzk-rs#2b9834ab0bdb3fe42bf06cb5343c88756f647306"
+source = "git+https://github.com/project-llzk/llzk-rs#829e420fc342987a40b6c920e9ce34d0fbddc382"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -823,7 +823,7 @@ dependencies = [
 [[package]]
 name = "llzk-sys"
 version = "30.1.0"
-source = "git+https://github.com/project-llzk/llzk-rs#2b9834ab0bdb3fe42bf06cb5343c88756f647306"
+source = "git+https://github.com/project-llzk/llzk-rs#829e420fc342987a40b6c920e9ce34d0fbddc382"
 dependencies = [
  "anyhow",
  "llzk-sys-build-support",
@@ -833,7 +833,7 @@ dependencies = [
 [[package]]
 name = "llzk-sys-build-support"
 version = "1.0.1"
-source = "git+https://github.com/project-llzk/llzk-rs#2b9834ab0bdb3fe42bf06cb5343c88756f647306"
+source = "git+https://github.com/project-llzk/llzk-rs#829e420fc342987a40b6c920e9ce34d0fbddc382"
 dependencies = [
  "anyhow",
  "bindgen 0.71.1",

--- a/flake.lock
+++ b/flake.lock
@@ -35,11 +35,11 @@
         "release-helpers": "release-helpers"
       },
       "locked": {
-        "lastModified": 1784323621,
-        "narHash": "sha256-bX5yn4bwZNqsdb0X0V6ssB8zcjjSeaCcO/6NRR7Xi3Y=",
+        "lastModified": 1784546219,
+        "narHash": "sha256-AiNnk1ILy7MzXzxFiSiK4PL8Q8gUnYZt4h+9kDGdHsc=",
         "owner": "project-llzk",
         "repo": "llzk-lib",
-        "rev": "759d76f904da63719f98cef6d2064f3d0a44330b",
+        "rev": "9f5ff93c97baca5e11fffb4e382edebcc4eb1254",
         "type": "github"
       },
       "original": {
@@ -89,11 +89,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1784323799,
-        "narHash": "sha256-rpPk+A0RJZJbBLgTWkGSVma8+MJKpydjPcvVcLbUZRI=",
+        "lastModified": 1784573308,
+        "narHash": "sha256-n9jLKdgqX9TVyWTH6ttVKVNqXe3Emt3ynyTAppi4Udk=",
         "ref": "refs/heads/main",
-        "rev": "cf501f89b3a3915e36fefbee84afb7d9ca8aca81",
-        "revCount": 525,
+        "rev": "2b9834ab0bdb3fe42bf06cb5343c88756f647306",
+        "revCount": 528,
         "type": "git",
         "url": "https://github.com/project-llzk/llzk-rs"
       },

--- a/flake.lock
+++ b/flake.lock
@@ -89,11 +89,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1784573308,
-        "narHash": "sha256-n9jLKdgqX9TVyWTH6ttVKVNqXe3Emt3ynyTAppi4Udk=",
+        "lastModified": 1784660294,
+        "narHash": "sha256-1AV4i4MsHXPm5VYH/fbdElhojdYtjODEvlMu1lfFHPg=",
         "ref": "refs/heads/main",
-        "rev": "2b9834ab0bdb3fe42bf06cb5343c88756f647306",
-        "revCount": 528,
+        "rev": "829e420fc342987a40b6c920e9ce34d0fbddc382",
+        "revCount": 529,
         "type": "git",
         "url": "https://github.com/project-llzk/llzk-rs"
       },

--- a/flake.lock
+++ b/flake.lock
@@ -35,11 +35,11 @@
         "release-helpers": "release-helpers"
       },
       "locked": {
-        "lastModified": 1784128226,
-        "narHash": "sha256-mZ+mQiSt/yD6zqlhrdWc8MlbOu9YT4ud+WI+RsDNtXg=",
+        "lastModified": 1784323621,
+        "narHash": "sha256-bX5yn4bwZNqsdb0X0V6ssB8zcjjSeaCcO/6NRR7Xi3Y=",
         "owner": "project-llzk",
         "repo": "llzk-lib",
-        "rev": "0fab8754a75fdcafe2c4a102a83b9715f590c476",
+        "rev": "759d76f904da63719f98cef6d2064f3d0a44330b",
         "type": "github"
       },
       "original": {
@@ -89,11 +89,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1784130923,
-        "narHash": "sha256-CgllW2VYnKCRXgumn5kfSxbFpufto3CqWrmroWECW1E=",
+        "lastModified": 1784323799,
+        "narHash": "sha256-rpPk+A0RJZJbBLgTWkGSVma8+MJKpydjPcvVcLbUZRI=",
         "ref": "refs/heads/main",
-        "rev": "2d741d34c870353559bf600aa93f68596039a068",
-        "revCount": 519,
+        "rev": "cf501f89b3a3915e36fefbee84afb7d9ca8aca81",
+        "revCount": 525,
         "type": "git",
         "url": "https://github.com/project-llzk/llzk-rs"
       },

--- a/llzk_backend/src/cleanup_return_tvar.rs
+++ b/llzk_backend/src/cleanup_return_tvar.rs
@@ -17,6 +17,7 @@ use llzk::builder::EntryPoint;
 use llzk::builder::OpBuilder;
 use llzk::dialect::function;
 use llzk::dialect::poly;
+use llzk::operation::build_owned_operation;
 use llzk::prelude::BlockLike as _;
 use llzk::prelude::CallOpLike as _;
 use llzk::prelude::CallOpRef;
@@ -128,7 +129,7 @@ fn wrap_call_in_synthetic_template<'ctx>(
     let mut inner_call = None;
 
     // Build owned/detached poly.template @synthetic { poly.param; function.def }.
-    let template_op = shared::build_owned_operation(codegen.context, |builder| {
+    let template_op = build_owned_operation(codegen.context, |builder| {
         poly::template(builder, location, UNUSED_CALL_RESULT_WRAPPER_NAME, |builder| {
             poly::param(
                 builder,

--- a/llzk_backend/src/cleanup_return_tvar.rs
+++ b/llzk_backend/src/cleanup_return_tvar.rs
@@ -17,7 +17,6 @@ use llzk::builder::EntryPoint;
 use llzk::builder::OpBuilder;
 use llzk::dialect::function;
 use llzk::dialect::poly;
-use llzk::operation::build_owned_operation;
 use llzk::prelude::BlockLike as _;
 use llzk::prelude::CallOpLike as _;
 use llzk::prelude::CallOpRef;
@@ -129,7 +128,7 @@ fn wrap_call_in_synthetic_template<'ctx>(
     let mut inner_call = None;
 
     // Build owned/detached poly.template @synthetic { poly.param; function.def }.
-    let template_op = build_owned_operation(codegen.context, |builder| {
+    let template_op = shared::build_owned_operation(codegen.context, |builder| {
         poly::template(builder, location, UNUSED_CALL_RESULT_WRAPPER_NAME, |builder| {
             poly::param(
                 builder,

--- a/llzk_backend/src/cleanup_return_tvar.rs
+++ b/llzk_backend/src/cleanup_return_tvar.rs
@@ -283,7 +283,7 @@ pub(crate) fn specialize_tvar_function_calls<'ctx>(
     walk_from_block(
         codegen.module.body(),
         WalkCallbacks::for_ops(|op| {
-            if function::is_func_call(&op) {
+            if function::is_call_op(&op) {
                 calls.push(op.to_raw());
             }
         }),

--- a/llzk_backend/src/cleanup_return_tvar.rs
+++ b/llzk_backend/src/cleanup_return_tvar.rs
@@ -17,7 +17,7 @@ use llzk::builder::EntryPoint;
 use llzk::builder::OpBuilder;
 use llzk::dialect::function;
 use llzk::dialect::poly;
-use llzk::prelude::Block;
+use llzk::operation::build_owned_operation;
 use llzk::prelude::BlockLike as _;
 use llzk::prelude::CallOpLike as _;
 use llzk::prelude::CallOpRef;
@@ -126,15 +126,11 @@ fn wrap_call_in_synthetic_template<'ctx>(
 
     let func_type = FunctionType::new(codegen.context, &operand_types, &[]);
 
-    // Use a temporary block to build the synthetic template because it will be detached and
-    // re-inserted to avoid naming collisions.
-    let scratch = Block::new(&[]);
-    let builder = OpBuilder::at_block_end(codegen.context, &scratch);
     let mut inner_call = None;
 
-    // Build poly.template @synthetic { poly.param; function.def }.
-    let template_op =
-        poly::template(&builder, location, UNUSED_CALL_RESULT_WRAPPER_NAME, |builder| {
+    // Build owned/detached poly.template @synthetic { poly.param; function.def }.
+    let template_op = build_owned_operation(codegen.context, |builder| {
+        poly::template(builder, location, UNUSED_CALL_RESULT_WRAPPER_NAME, |builder| {
             poly::param(
                 builder,
                 location,
@@ -172,11 +168,12 @@ fn wrap_call_in_synthetic_template<'ctx>(
             function::r#return(&inner_builder, location, &[]);
             inner_call = Some(call.to_raw());
             Ok(())
-        })?;
+        })
+        .map(Into::into)
+    })?;
     let inner_call = inner_call.expect("synthetic template callback must create inner call");
 
-    // Detach and re-insert the template into the module to unique the name and avoid collisions.
-    let template_op = shared::detach_owned_operation(&template_op);
+    // Insert the template into the module, uniquing the name to avoid collisions.
     let op_ref = shared::insert_unique_symbol_op(&codegen.module.as_operation(), template_op);
     let template_name = shared::get_sym_name_attr(&op_ref)
         .expect("`poly.template` must have `sym_name` attribute per ODS");

--- a/llzk_backend/src/cleanup_return_tvar.rs
+++ b/llzk_backend/src/cleanup_return_tvar.rs
@@ -13,15 +13,17 @@ use crate::traversal::WalkCallbacks;
 use anyhow::bail;
 use anyhow::Result;
 use llzk::attributes::array::ArrayAttribute;
+use llzk::builder::EntryPoint;
 use llzk::builder::OpBuilder;
 use llzk::dialect::function;
 use llzk::dialect::poly;
 use llzk::prelude::Block;
 use llzk::prelude::BlockLike as _;
-use llzk::prelude::CallOpLike;
+use llzk::prelude::CallOpLike as _;
 use llzk::prelude::CallOpRef;
 use llzk::prelude::FuncDefOpLike as _;
 use llzk::prelude::FunctionType;
+use llzk::prelude::LlzkError;
 use llzk::prelude::OperationLike;
 use llzk::prelude::OperationRefMut;
 use llzk::prelude::OperationResult;
@@ -33,7 +35,7 @@ use llzk::prelude::TemplateParamOpRefMut;
 use llzk::prelude::TemplateSymbolBindingOpLike as _;
 use llzk::prelude::Type;
 use llzk::prelude::Value;
-use llzk::prelude::ValueLike;
+use llzk::prelude::ValueLike as _;
 use llzk::symbol_ref::SymbolRefAttribute;
 use llzk::value_ext::replace_all_uses;
 use llzk::value_ext::users_of;
@@ -122,36 +124,15 @@ fn wrap_call_in_synthetic_template<'ctx>(
     // The tvar type that lives inside the synthetic template, referencing its own @T_return param.
     let synthetic_tvar_type = codegen.tvar_type(function_return_type_param());
 
-    // Build the synthetic function.def with a body block taking the call's operands as args.
     let func_type = FunctionType::new(codegen.context, &operand_types, &[]);
-    let func_def = function::def(location, UNUSED_CALL_RESULT_WRAPPER_NAME, func_type, &[], None)?;
-    func_def.set_allow_non_native_field_ops_attr(true);
-    let inner_call = {
-        let arg_locs: Vec<_> = operand_types.iter().map(|&t| (t, location)).collect();
-        let block = func_def.region(0)?.append_block(Block::new(&arg_locs));
-        let block_args = (0..operand_types.len())
-            .map(|i| block.argument(i).map(Value::from).map_err(Into::into))
-            .collect::<Result<Vec<_>>>()?;
 
-        // Rebuild the original call inside the synthetic function using the block args as operands.
-        // The result type references the synthetic template's own @T_return param.
-        let inner_call = function::call(
-            codegen.op_builder(),
-            location,
-            call_op.callee()?,
-            &block_args,
-            &[synthetic_tvar_type],
-        )?;
-        let inner_call = block.append_operation(inner_call.into());
-
-        // The result of the inner call is discarded; return void.
-        block.append_operation(function::r#return(location, &[]));
-        inner_call.to_raw()
-    }; // block and block_args dropped here, releasing the borrow on func_def
-
-    // Build poly.template @synthetic { poly.param; function.def }.
+    // Use a temporary block to build the synthetic template because it will be detached and
+    // re-inserted to avoid naming collisions.
     let scratch = Block::new(&[]);
     let builder = OpBuilder::at_block_end(codegen.context, &scratch);
+    let mut inner_call = None;
+
+    // Build poly.template @synthetic { poly.param; function.def }.
     let template_op =
         poly::template(&builder, location, UNUSED_CALL_RESULT_WRAPPER_NAME, |builder| {
             poly::param(
@@ -160,11 +141,41 @@ fn wrap_call_in_synthetic_template<'ctx>(
                 function_return_type_param(),
                 Some(synthetic_tvar_type),
             )?;
+            let func_def = function::def(
+                builder,
+                location,
+                UNUSED_CALL_RESULT_WRAPPER_NAME,
+                func_type,
+                &[],
+                None,
+                llzk::dialect::empty_region,
+            )?;
+            func_def.set_allow_non_native_field_ops_attr(true);
+
+            let block = func_def.body()?.first_block().expect("synthetic function body is empty");
+            let inner_builder = OpBuilder::at_block_end(codegen.context, block);
+
+            // Rebuild the original call inside the synthetic function using the block args as
+            // operands. The result type references the synthetic template's own @T_return param.
+            let block_args = (0..operand_types.len())
+                .map(|i| block.argument(i).map(Value::from).map_err(LlzkError::from))
+                .collect::<std::result::Result<Vec<_>, LlzkError>>()?;
+            let call = function::call(
+                &inner_builder,
+                location,
+                call_op.callee()?,
+                &block_args,
+                &[synthetic_tvar_type],
+            )?;
+
+            // The result of the inner call is discarded; return void.
+            function::r#return(&inner_builder, location, &[]);
+            inner_call = Some(call.to_raw());
             Ok(())
         })?;
-    template_op.body().append_operation(func_def.into());
+    let inner_call = inner_call.expect("synthetic template callback must create inner call");
 
-    // Insert the template into the module, uniquing the name to avoid collisions.
+    // Detach and re-insert the template into the module to unique the name and avoid collisions.
     let template_op = shared::detach_owned_operation(&template_op);
     let op_ref = shared::insert_unique_symbol_op(&codegen.module.as_operation(), template_op);
     let template_name = shared::get_sym_name_attr(&op_ref)
@@ -178,8 +189,9 @@ fn wrap_call_in_synthetic_template<'ctx>(
     // The replacement call passes the original operands and uses wildcard attribute for the
     // template params (i.e. the unused return `tvar` of the call op).
     let original_operands: Vec<_> = call_op.operands().collect();
-    let replacement = function::call_with_template_params(
-        codegen.op_builder(),
+    let replacement_builder = OpBuilder::new(codegen.context, EntryPoint::Before(call_op.into()));
+    function::call_with_template_params(
+        &replacement_builder,
         location,
         callee,
         &original_operands,
@@ -187,12 +199,6 @@ fn wrap_call_in_synthetic_template<'ctx>(
         &[] as &[Type<'ctx>],
         &[codegen.wildcard_attr()],
     )?;
-
-    // Insert the replacement before the original call, then remove the original.
-    let call_block = call_op
-        .block()
-        .ok_or_else(|| anyhow::anyhow!("function.call at {location} has no parent block"))?;
-    call_block.insert_operation_before(call_op.into(), replacement.into());
     Ok(inner_call)
 }
 
@@ -210,13 +216,8 @@ fn specialize_call_result_type<'ctx>(
     let callee = call_op.callee()?;
     let operands: Vec<_> = call_op.operands().collect();
     let location = call_op.location();
-    let block = call_op
-        .block()
-        .ok_or_else(|| anyhow::anyhow!("function.call at {location} has no parent block"))?;
-    let new_call = block.insert_operation_before(
-        call_op.into(),
-        function::call(codegen.op_builder(), location, callee, &operands, &[use_type])?.into(),
-    );
+    let builder = OpBuilder::new(codegen.context, EntryPoint::Before(call_op.into()));
+    let new_call = function::call(&builder, location, callee, &operands, &[use_type])?;
     let new_call_raw = new_call.to_raw();
     let new_result = Value::from(new_call.result(0)?);
     replace_all_uses(Value::from(old_result), new_result);

--- a/llzk_backend/src/function.rs
+++ b/llzk_backend/src/function.rs
@@ -43,8 +43,8 @@ use llzk::operation::WalkOperationMutLike as _;
 use llzk::prelude::is_type_variable;
 use llzk::prelude::melior_dialects::arith;
 use llzk::prelude::melior_dialects::scf;
-use llzk::prelude::melior_dialects::scf::is_scf_if;
-use llzk::prelude::melior_dialects::scf::is_scf_yield;
+use llzk::prelude::melior_dialects::scf::is_if_op;
+use llzk::prelude::melior_dialects::scf::is_yield_op;
 use llzk::prelude::ArrayType;
 use llzk::prelude::Attribute;
 use llzk::prelude::BlockLike as _;
@@ -359,7 +359,7 @@ where
             // Remove any `llzk.nondet` ops from the function whose result value is unused. These
             // were added, for example, when visiting [Statement::Declaration] but their uses were
             // later replaced with actual values when visiting [Statement::Substitution], etc.
-            if dialect::llzk::is_nondet(&op) && !has_uses(single_result_as_value(op).unwrap()) {
+            if dialect::llzk::is_nondet_op(&op) && !has_uses(single_result_as_value(op).unwrap()) {
                 OperationMutLike::remove_from_parent(op.deref_mut());
                 return WalkResult::Skip;
             }
@@ -372,9 +372,9 @@ where
         self.func.walk_rev_mut(WalkOrder::PostOrder, |mut op| {
             if op.has_attribute(CIRCOM_RETURN_MARKER_ATTR) {
                 // Perform replacement of "if(..) return" pattern.
-                if function::is_func_return(&op) {
+                if function::is_return_op(&op) {
                     if let Some(parent) = parent_operation_mut(&op) {
-                        if is_scf_if(&parent) {
+                        if is_if_op(&parent) {
                             // Cannot directly do the refactor here because it will invalidate the
                             // walk iterator. Instead, collect the pairs to process after the walk.
                             // But, must use raw objects since `op` is invalid outside this closure.
@@ -413,8 +413,8 @@ where
         ret_op: OperationRefMut<'ctx, '_>,
         mut parent_if_op: OperationRefMut<'ctx, '_>,
     ) -> Result<()> {
-        assert!(function::is_func_return(&ret_op)); // precondition
-        assert!(is_scf_if(&parent_if_op)); // precondition
+        assert!(function::is_return_op(&ret_op)); // precondition
+        assert!(is_if_op(&parent_if_op)); // precondition
 
         // Move all ops after the `scf.if` into a new block for "else" branch of new `scf.if`.
         let (new_else_region, new_else_block) = new_region_and_block(&[]);
@@ -433,14 +433,14 @@ where
             }
             // Special handling for the tail op: yield is just added, return is converted to yield.
             let tail = remove_from_parent(&mut tail);
-            if is_scf_yield(&tail) {
+            if is_yield_op(&tail) {
                 let result_types = tail.operands().map(|v| v.r#type()).collect();
                 let names = tail
                     .attribute(OPERAND_VAL_NAMES)
                     .expect("multi-value yield op must have names");
                 new_else_result_info = RefactoringBlockResultType::Multiple(result_types, names);
                 no_results(new_else_block.append_operation(tail))?;
-            } else if function::is_func_return(&tail) {
+            } else if function::is_return_op(&tail) {
                 assert_eq!(tail.operand_count(), 1, "circom functions must return a single value");
                 let ret_val = tail.operand(0).unwrap();
                 new_else_result_info = RefactoringBlockResultType::Single(ret_val.r#type());
@@ -515,7 +515,7 @@ where
 
         // Replace `parent_if_op` with the new `scf.if` and then append a return/yield with the new
         // `scf.if` results. If the destination block is the function body use return, else yield.
-        if blk.parent_operation().is_some_and(|r| function::is_func_def(&r)) {
+        if blk.parent_operation().is_some_and(|r| function::is_def_op(&r)) {
             let builder = OpBuilder::at_block_end(codegen.context, blk);
             no_results(function::r#return(&builder, parent_if_op.location(), &result_values))?;
         } else {
@@ -718,7 +718,7 @@ where
         if term.has_attribute(CIRCOM_RETURN_MARKER_ATTR) {
             // ASSERT: This must be a `yield` not a `return` since it's generated
             // within a nested block of an `if` or `while` statement.
-            assert!(is_scf_yield(&term));
+            assert!(is_yield_op(&term));
             // ASSERT: Per `append_circom_return()` it has exactly one operand.
             assert_eq!(term.operand_count(), 1);
             let result = term.operand(0).unwrap();

--- a/llzk_backend/src/function.rs
+++ b/llzk_backend/src/function.rs
@@ -734,7 +734,6 @@ where
 
 /// Helper for [gen_if_then_else] to mangage the special return-related variables needed
 /// when a circom [Statement::IfThenElse] contains a return statement.
-#[allow(clippy::too_many_arguments)]
 fn handle_unbalanced_return<'ctx, 'func, 'blk, 'val>(
     codegen: &LlzkCodegen<'_, 'ctx, '_, impl ProgramLike>,
     function: &mut FunctionContext<'_, 'ctx, 'func, 'blk, 'val>,

--- a/llzk_backend/src/function.rs
+++ b/llzk_backend/src/function.rs
@@ -31,6 +31,7 @@ use crate::write_chain::NoSignalsInfo;
 use crate::write_chain::SignalWriteInfo;
 use anyhow::Context as _;
 use anyhow::Result;
+use llzk::builder::OpBuilder;
 use llzk::dialect;
 use llzk::dialect::array;
 use llzk::dialect::array::ArrayCtor;
@@ -51,6 +52,7 @@ use llzk::prelude::BlockRef;
 use llzk::prelude::FuncDefOpLike as _;
 use llzk::prelude::FuncDefOpRefMut;
 use llzk::prelude::IntegerAttribute;
+use llzk::prelude::LlzkContext;
 use llzk::prelude::Location;
 use llzk::prelude::LoopBoundsAttribute;
 use llzk::prelude::Operation;
@@ -244,16 +246,31 @@ where
         let mut block_ctx = BlockContextStack::from_function(func.deref(), param_name_to_value)?;
         if FREE_FUNC {
             // Ensure the specially-named values are declared in free functions.
-            block_ctx.declare_name_if_not_present(VAR_NAME_RETURN_VAL, || {
-                // Get the result type from the free function. It supports exactly 1.
-                let ty = func.function_type()?;
-                assert_eq!(ty.result_count(), 1);
-                codegen.new_nondet_at_location(codegen.location_unknown(), ty.result(0)?)
-            })?;
-            block_ctx.declare_name_if_not_present(VAR_NAME_HAD_RETURN, || {
-                codegen
-                    .new_nondet_at_location(codegen.location_unknown(), codegen.bool_type().into())
-            })?;
+            block_ctx.declare_value_if_not_present(
+                VAR_NAME_RETURN_VAL,
+                |builder| {
+                    // Get the result type from the free function. It supports exactly 1.
+                    let ty = func.function_type()?;
+                    assert_eq!(ty.result_count(), 1);
+                    single_result_as_value(codegen.new_nondet_at_location(
+                        builder,
+                        codegen.location_unknown(),
+                        ty.result(0)?,
+                    ))
+                },
+                codegen.context,
+            )?;
+            block_ctx.declare_value_if_not_present(
+                VAR_NAME_HAD_RETURN,
+                |builder| {
+                    single_result_as_value(codegen.new_nondet_at_location(
+                        builder,
+                        codegen.location_unknown(),
+                        codegen.bool_type().into(),
+                    ))
+                },
+                codegen.context,
+            )?;
         }
         Ok(Self {
             func,
@@ -280,14 +297,18 @@ where
         location: Location<'ctx>,
         value: Value<'ctx, 'val>,
     ) -> Result<()> {
-        let mut op = if self.block_ctx.is_only_root() {
+        if self.block_ctx.is_only_root() {
             let value = self.cast_to_return_type_if_needed(codegen, location, value)?;
-            function::r#return(location, &[value])
+            let builder = self.builder_at_current_insertion_point(codegen.context);
+            let op = function::r#return(&builder, location, &[value]);
+            unsafe { OperationRefMut::from_raw(op.to_raw()) }
+                .set_attribute(CIRCOM_RETURN_MARKER_ATTR, Attribute::unit(codegen.context));
+            no_results(op)
         } else {
-            scf::r#yield(&[value], location)
-        };
-        op.set_attribute(CIRCOM_RETURN_MARKER_ATTR, Attribute::unit(codegen.context));
-        self.append_op_no_result(op)
+            let mut op = scf::r#yield(&[value], location);
+            op.set_attribute(CIRCOM_RETURN_MARKER_ATTR, Attribute::unit(codegen.context));
+            self.append_op_no_result(op)
+        }
     }
 
     /// Create an op to cast `val` to match the return type of the function.
@@ -323,7 +344,7 @@ where
         self.block_ctx.push(then_block);
         body(self)?;
         self.append_op_no_result(scf::r#yield(&[], location))?;
-        self.block_ctx.pop();
+        self.block_ctx.pop(codegen.context)?;
 
         // No need to use `gen_safe_scf_if()` here since there's no result value.
         self.append_op_no_result(scf::r#if(cmp, &[], then_region, new_region_empty(), location))
@@ -461,10 +482,9 @@ where
                         } else {
                             assert!(i <= result_types.len(), "more names than result types");
                             // Fill other positions with `llzk.nondet` values of the expected type.
+                            let builder = OpBuilder::at_block_end(codegen.context, new_then_block);
                             yield_values.push(single_result_as_value(
-                                new_then_block.append_operation(
-                                    codegen.new_nondet_at_location(location, result_types[i])?,
-                                ),
+                                codegen.new_nondet_at_location(&builder, location, result_types[i]),
                             )?);
                         }
                     }
@@ -495,12 +515,14 @@ where
 
         // Replace `parent_if_op` with the new `scf.if` and then append a return/yield with the new
         // `scf.if` results. If the destination block is the function body use return, else yield.
-        let op = if blk.parent_operation().is_some_and(|r| function::is_func_def(&r)) {
-            function::r#return(parent_if_op.location(), &result_values)
+        if blk.parent_operation().is_some_and(|r| function::is_func_def(&r)) {
+            let builder = OpBuilder::at_block_end(codegen.context, blk);
+            no_results(function::r#return(&builder, parent_if_op.location(), &result_values))?;
         } else {
-            new_else_result_info.gen_yield(&result_values, parent_if_op.location())
-        };
-        no_results(blk.append_operation(op))?;
+            no_results(blk.append_operation(
+                new_else_result_info.gen_yield(&result_values, parent_if_op.location()),
+            ))?;
+        }
 
         // Finally, remove and drop the original `parent_if_op`.
         let _drop = remove_from_parent(&mut parent_if_op);
@@ -530,6 +552,7 @@ where
 
     fn stack_pop<H>(
         &mut self,
+        context: &'ctx LlzkContext,
         overwrite_handler: H,
         overwrite_data: &mut Self::HandlerDataType,
     ) -> Result<()>
@@ -540,7 +563,7 @@ where
             HashMap<String, Value<'ctx, 'val>>,
         ) -> Result<()>,
     {
-        let popped = self.block_ctx.pop();
+        let popped = self.block_ctx.pop(context)?;
         overwrite_handler(&mut self.base, overwrite_data, popped)
     }
 }
@@ -631,11 +654,13 @@ where
     );
 
     // Allocate a new uninitialized array of the destination type.
-    let dst = single_result_as_value(block.append_operation(codegen.new_array_new_op(
+    let builder = OpBuilder::at_block_end(codegen.context, block);
+    let dst = single_result_as_value(codegen.new_array_new_op(
+        &builder,
         location,
         dst_ty,
         ArrayCtor::Empty,
-    )))?;
+    ))?;
 
     // Copy elements within the min bounds of each dimension pair.
     let min_dims: Vec<i64> = src_dims.iter().zip(&dst_dims).map(|(s, d)| *s.min(d)).collect();
@@ -648,13 +673,10 @@ where
                 )
             })
             .collect::<Result<_>>()?;
-        let elem = single_result_as_value(block.append_operation(array::read(
-            location,
-            src_ty.element_type(),
-            src,
-            &idx_vals,
-        )))?;
-        block.append_operation(array::write(location, dst, &idx_vals, elem));
+        let read = array::read(&builder, location, src_ty.element_type(), src, &idx_vals);
+        let elem = single_result_as_value(read)?;
+        let write = array::write(&builder, location, dst, &idx_vals, elem);
+        no_results(write)?;
     }
 
     Ok(dst)
@@ -663,6 +685,7 @@ where
 /// Append a `poly.unifiable_cast` to cast `value` to `target_ty` directly on `block` if the
 /// types differ. Returns `value` unchanged if the types are already equal.
 fn cast_to_type_in_block<'ctx, 'blk, 'val>(
+    codegen: &LlzkCodegen<'_, 'ctx, '_, impl ProgramLike>,
     location: Location<'ctx>,
     block: BlockRef<'ctx, 'blk>,
     value: Value<'ctx, 'val>,
@@ -675,7 +698,9 @@ where
     if value.r#type() == target_ty {
         return Ok(value);
     }
-    single_result_as_value(block.append_operation(poly::unifiable_cast(location, value, target_ty)))
+    let builder = OpBuilder::at_block_end(codegen.context, block);
+    let cast = poly::unifiable_cast(&builder, location, value, target_ty);
+    single_result_as_value(cast)
 }
 
 /// Within a nested (i.e. non-root) block, get the Value wrapped within an `scf.yield` op that was
@@ -745,11 +770,12 @@ where
     nonreturning_block_overwrites.insert(
         VAR_NAME_RETURN_VAL.to_string(),
         function.block_ctx.get_named_value(VAR_NAME_RETURN_VAL).cloned().or_else(|_| {
-            single_result_as_value(
-                nonreturning_block.append_operation(
-                    codegen.new_nondet_at_location(location, return_val.r#type())?,
-                ),
-            )
+            let builder = OpBuilder::at_block_end(codegen.context, nonreturning_block);
+            single_result_as_value(codegen.new_nondet_at_location(
+                &builder,
+                location,
+                return_val.r#type(),
+            ))
         })?,
     );
     Ok(())
@@ -773,13 +799,19 @@ where
     'blk: 'val,
 {
     let (then_region, then_block) = new_region_and_block(&[]);
-    function.gen_in_given_block_with_new_circom_scope_and_merge_overwrites(then_block, |fc| {
-        let ret_val = fc.block_ctx.get_named_value(VAR_NAME_RETURN_VAL)?;
-        let value = fc.cast_to_return_type_if_needed(codegen, location, *ret_val)?;
-        let mut op = function::r#return(location, &[value]);
-        op.set_attribute(CIRCOM_RETURN_MARKER_ATTR, Attribute::unit(codegen.context));
-        fc.append_op_no_result(op)
-    })?;
+    function.gen_in_given_block_with_new_circom_scope_and_merge_overwrites(
+        codegen.context,
+        then_block,
+        |fc| {
+            let ret_val = fc.block_ctx.get_named_value(VAR_NAME_RETURN_VAL)?;
+            let value = fc.cast_to_return_type_if_needed(codegen, location, *ret_val)?;
+            let builder = fc.builder_at_current_insertion_point(codegen.context);
+            let op = function::r#return(&builder, location, &[value]);
+            unsafe { OperationRefMut::from_raw(op.to_raw()) }
+                .set_attribute(CIRCOM_RETURN_MARKER_ATTR, Attribute::unit(codegen.context));
+            no_results(op)
+        },
+    )?;
 
     let condition = *function.block_ctx.get_named_value(VAR_NAME_HAD_RETURN)?;
     // No need to use `gen_safe_scf_if()` here since there's no result value.
@@ -811,6 +843,7 @@ where
     // Initially, generate the blocks for the 'then' and 'else' cases naively.
     let mut then_info = NestedBlockInfo::default();
     function.gen_in_given_block_with_new_circom_scope_and_cache_overwrites(
+        codegen.context,
         then_info.block,
         |function| if_case.gen_llzk_in_function(codegen, function, info),
         &mut then_info,
@@ -818,6 +851,7 @@ where
     let mut else_info = NestedBlockInfo::default();
     if let Some(else_case) = else_case {
         function.gen_in_given_block_with_new_circom_scope_and_cache_overwrites(
+            codegen.context,
             else_info.block,
             |function| else_case.gen_llzk_in_function(codegen, function, info),
             &mut else_info,
@@ -893,12 +927,14 @@ where
                         // use unifiable_cast to coerce each branch to the return type.
                         _ => (
                             cast_to_type_in_block(
+                                codegen,
                                 location,
                                 then_info.block,
                                 then_return,
                                 return_ty,
                             )?,
                             cast_to_type_in_block(
+                                codegen,
                                 location,
                                 else_info.block,
                                 else_return,
@@ -913,13 +949,25 @@ where
                     // unify_scf_branch_types.
                     (
                         then_return,
-                        cast_to_type_in_block(location, else_info.block, else_return, return_ty)?,
+                        cast_to_type_in_block(
+                            codegen,
+                            location,
+                            else_info.block,
+                            else_return,
+                            return_ty,
+                        )?,
                     )
                 } else if !then_is_tvar && else_is_tvar && else_ty == return_ty {
                     // Else branch already yields the function's T_return tvar; cast the
                     // concrete then branch to match for the same reason.
                     (
-                        cast_to_type_in_block(location, then_info.block, then_return, return_ty)?,
+                        cast_to_type_in_block(
+                            codegen,
+                            location,
+                            then_info.block,
+                            then_return,
+                            return_ty,
+                        )?,
                         else_return,
                     )
                 } else {
@@ -993,12 +1041,14 @@ where
     // Generate the loop condition (i.e. "before") and body (i.e. "after") blocks naively.
     let mut loop_cond_info = NestedBlockInfo::default();
     let cond_result = function.gen_in_given_block_with_new_circom_scope_and_cache_overwrites(
+        codegen.context,
         loop_cond_info.block,
         |fc| cond.gen_llzk_in_block(codegen, fc, info),
         &mut loop_cond_info,
     )?;
     let mut loop_body_info = NestedBlockInfo::default();
     function.gen_in_given_block_with_new_circom_scope_and_cache_overwrites(
+        codegen.context,
         loop_body_info.block,
         |fc| body_stmt.gen_llzk_in_function(codegen, fc, info),
         &mut loop_body_info,
@@ -1032,10 +1082,13 @@ where
         loop_body_info.var_overwrites.insert(VAR_NAME_RETURN_VAL.to_string(), early_return);
         // In the current block, ensure the return value variable is initialized, default to nondet.
         if function.block_ctx.get_named_value(VAR_NAME_RETURN_VAL).is_err() {
-            function.append_op_named_result(
-                codegen.new_nondet_at_location(location, early_return.r#type())?,
-                VAR_NAME_RETURN_VAL.to_string(),
-            )?;
+            let builder = function.builder_at_current_insertion_point(codegen.context);
+            let value = function.append_op_ref_unnamed_result(codegen.new_nondet_at_location(
+                &builder,
+                location,
+                early_return.r#type(),
+            ))?;
+            function.block_ctx.set_named_value(VAR_NAME_RETURN_VAL.to_string(), value)?;
         }
     }
 
@@ -1109,6 +1162,7 @@ where
             }
             Statement::Block { meta, stmts } => {
                 function.gen_in_current_block_with_new_circom_scope_and_merge_overwrites(
+                    codegen.context,
                     |function| {
                         try_for_loop_heuristic!(codegen, function, meta, stmts, info);
                         // Fallback to standard block handling.

--- a/llzk_backend/src/gen_context.rs
+++ b/llzk_backend/src/gen_context.rs
@@ -1845,7 +1845,7 @@ where
                     .terminator()
                     .with_context(|| format!("scf.if {branch_name} region has no terminator"))?;
                 ensure!(
-                    scf::is_scf_yield(&terminator),
+                    scf::is_yield_op(&terminator),
                     "scf.if {branch_name} block has terminator other than scf.yield"
                 );
                 Ok(terminator.operands().collect())

--- a/llzk_backend/src/gen_context.rs
+++ b/llzk_backend/src/gen_context.rs
@@ -25,6 +25,7 @@ use anyhow::ensure;
 use anyhow::Context as _;
 use anyhow::Result;
 use llzk::attributes::array::AffineMapAttribute;
+use llzk::builder::EntryPoint;
 use llzk::builder::OpBuilder;
 use llzk::dialect::array;
 use llzk::dialect::array::ArrayCtor;
@@ -35,6 +36,7 @@ use llzk::dialect::felt;
 use llzk::dialect::function;
 use llzk::dialect::pod;
 use llzk::dialect::poly;
+use llzk::dialect::r#struct;
 use llzk::map_operands::MapOperandsBuilder;
 use llzk::prelude::is_felt_type;
 use llzk::prelude::is_type_variable;
@@ -50,10 +52,11 @@ use llzk::prelude::BlockRef;
 use llzk::prelude::FlatSymbolRefAttribute;
 use llzk::prelude::FuncDefOp;
 use llzk::prelude::IntegerAttribute;
+use llzk::prelude::LlzkContext;
 use llzk::prelude::Location;
 use llzk::prelude::LoopBoundsAttribute;
 use llzk::prelude::Operation;
-use llzk::prelude::OperationLike as _;
+use llzk::prelude::OperationLike;
 use llzk::prelude::OperationMutLike as _;
 use llzk::prelude::OperationRef;
 use llzk::prelude::PodType;
@@ -64,9 +67,9 @@ use llzk::prelude::StringRef;
 use llzk::prelude::StructType;
 use llzk::prelude::TVarType;
 use llzk::prelude::TemplateParamOp;
-use llzk::prelude::TemplateParamOpLike;
+use llzk::prelude::TemplateParamOpLike as _;
 use llzk::prelude::TemplateSymbolBindingOp;
-use llzk::prelude::TemplateSymbolBindingOpLike;
+use llzk::prelude::TemplateSymbolBindingOpLike as _;
 use llzk::prelude::TemplateSymbolBindingOpRef;
 use llzk::prelude::Type;
 use llzk::prelude::Value;
@@ -178,8 +181,17 @@ where
     /// Value stored for that variable. These are preserved when the block is popped because they
     /// overwrite the value of existing variables in outer scopes.
     overwriting_name_to_value: HashMap<String, Value<'ctx, 'val>>,
-    /// Queue of operations that need to be appended before the context goes out of scope.
-    op_queue: Vec<Operation<'ctx>>,
+    /// Queue of writes that need to be emitted before the context goes out of scope.
+    write_queue: Vec<QueuedStructWrite<'ctx, 'val>>,
+}
+
+/// Information needed to create a delayed `struct.writem` directly at its final insertion point.
+#[derive(Debug)]
+struct QueuedStructWrite<'ctx, 'val> {
+    location: Location<'ctx>,
+    target: Value<'ctx, 'val>,
+    field: String,
+    value: Value<'ctx, 'val>,
 }
 
 impl<'ctx, 'blk, 'val> BlockContext<'ctx, 'blk, 'val>
@@ -193,7 +205,7 @@ where
             block,
             scope_local_name_to_value: Default::default(),
             overwriting_name_to_value: Default::default(),
-            op_queue: Default::default(),
+            write_queue: Default::default(),
         }
     }
 
@@ -314,19 +326,31 @@ where
         }
     }
 
-    /// Queues an operation to the given block that will get appended before it goes out of scope.
+    /// Create an operation builder positioned at the current block insertion point.
+    pub fn builder_at_current_insertion_point(
+        &self,
+        context: &'ctx LlzkContext,
+    ) -> OpBuilder<'ctx, 'static> {
+        OpBuilder::at_block_end(context, *self.top_block())
+    }
+
+    /// Queues a `struct.writem` to the given block that will be created directly before the block
+    /// goes out of scope.
     ///
     /// If the block is scoped in multiple contexts picks the deepest one.
     ///
     /// Fails if the block is not part of the stack.
-    pub fn enqueue_in_block(
+    pub fn enqueue_struct_write_in_block(
         &mut self,
-        operation: Operation<'ctx>,
         block: BlockRef<'ctx, 'blk>,
+        location: Location<'ctx>,
+        target: Value<'ctx, 'val>,
+        field: String,
+        value: Value<'ctx, 'val>,
     ) -> Result<()> {
         let mut blocks = self.blocks_iter_mut_rev();
         let bc = blocks.find(|bc| bc.block == block).ok_or_else(|| block_not_in_stack(block))?;
-        bc.op_queue.push(operation);
+        bc.write_queue.push(QueuedStructWrite { location, target, field, value });
         Ok(())
     }
 
@@ -352,6 +376,18 @@ where
         Ok(())
     }
 
+    /// Ensure the given name is not already declared in the current scope, then bind it to a value
+    /// produced directly in the current block.
+    pub fn declare_value_ensure_not_present(
+        &mut self,
+        name: &str,
+        value: Value<'ctx, 'val>,
+    ) -> Result<()> {
+        ensure!(!self.is_name_present(name), format!("name {name} is already present"));
+        self.top_mut().scope_local_name_to_value.insert(name.to_string(), value);
+        Ok(())
+    }
+
     /// If the given name is not already declared in the current scope, declare it by producing an
     /// [Operation] via the callback, inserting that into the current block, and using its result.
     /// The only scenario where a declaration would already be present is when the same Declaration
@@ -366,6 +402,22 @@ where
         if !self.is_name_present(name) {
             let op = uninit_value()?;
             let value = single_result_as_value(self.append_current_block(op))?;
+            self.top_mut().scope_local_name_to_value.insert(name.to_string(), value);
+        }
+        Ok(())
+    }
+
+    /// If the given name is not already declared in the current scope, declare it from a value
+    /// produced directly in the current block.
+    pub fn declare_value_if_not_present(
+        &mut self,
+        name: &str,
+        uninit_value: impl FnOnce(&OpBuilder<'ctx, 'static>) -> Result<Value<'ctx, 'val>>,
+        context: &'ctx LlzkContext,
+    ) -> Result<()> {
+        if !self.is_name_present(name) {
+            let builder = self.builder_at_current_insertion_point(context);
+            let value = uninit_value(&builder)?;
             self.top_mut().scope_local_name_to_value.insert(name.to_string(), value);
         }
         Ok(())
@@ -447,17 +499,32 @@ where
 
     /// Pop the current block off the stack to return to the previous block. The vars declared in
     /// the popped frame are dropped and those which are overwrites are returned.
-    pub fn pop(&mut self) -> HashMap<String, Value<'ctx, 'val>> {
-        self.append_queue();
-        self.other_blocks.pop().expect("There is no block to pop!").overwriting_name_to_value
+    pub fn pop(
+        &mut self,
+        context: &'ctx LlzkContext,
+    ) -> Result<HashMap<String, Value<'ctx, 'val>>> {
+        self.append_queue(context)?;
+        Ok(self.other_blocks.pop().expect("There is no block to pop!").overwriting_name_to_value)
     }
 
-    /// Appends the queued operations in the top of the stack.
-    pub fn append_queue(&mut self) {
-        let queue = std::mem::take(&mut self.top_mut().op_queue);
-        for op in queue {
-            self.append_current_block(op);
+    /// Emits the queued writes in the top of the stack.
+    pub fn append_queue(&mut self, context: &'ctx LlzkContext) -> Result<()> {
+        let block = *self.top_block();
+        let queue = std::mem::take(&mut self.top_mut().write_queue);
+        for write in queue {
+            let builder = match block.terminator() {
+                Some(terminator) => OpBuilder::new(context, EntryPoint::Before(terminator)),
+                None => OpBuilder::at_block_end(context, block),
+            };
+            no_results(r#struct::writem(
+                &builder,
+                write.location,
+                write.target,
+                &write.field,
+                write.value,
+            )?)?;
         }
+        Ok(())
     }
 }
 
@@ -502,6 +569,7 @@ where
     /// Creates a new instance using the common pattern of pushing the block into the stack,
     /// emitting some IR, and then popping the block.
     pub fn with_scope<'decls, R, C>(
+        context: &'ctx LlzkContext,
         block_gen: &mut C,
         cb: impl FnOnce(&mut C) -> Result<R>,
     ) -> Result<(Self, R)>
@@ -510,7 +578,7 @@ where
         'ctx: 'decls,
     {
         let mut info = Self::new();
-        let r = info.enter_scope(block_gen, cb)?;
+        let r = info.enter_scope(context, block_gen, cb)?;
         Ok((info, r))
     }
 
@@ -520,6 +588,7 @@ where
     /// Handling the overwrites follows the rules of [`add_overwrites`].
     pub fn enter_scope<'decls, R, C>(
         &mut self,
+        context: &'ctx LlzkContext,
         block_gen: &mut C,
         cb: impl FnOnce(&mut C) -> Result<R>,
     ) -> Result<R>
@@ -529,7 +598,7 @@ where
     {
         block_gen.as_mut().block_ctx.push(self.block);
         let r = cb(block_gen)?;
-        let overwrites = block_gen.as_mut().block_ctx.pop();
+        let overwrites = block_gen.as_mut().block_ctx.pop(context)?;
         self.add_overwrites(&overwrites, block_gen.as_mut())?;
         Ok(r)
     }
@@ -588,6 +657,7 @@ where
     /// Pop the top `BlockType` from the [BlockContextStack].
     fn stack_pop<H>(
         &mut self,
+        context: &'ctx LlzkContext,
         overwrite_handler: H,
         overwrite_data: &mut Self::HandlerDataType,
     ) -> Result<()>
@@ -604,6 +674,7 @@ where
     /// variables that already exist prior to this new scope are passed to the overwrite handler.
     fn gen_in_given_block_with_new_circom_scope<H, R>(
         &mut self,
+        context: &'ctx LlzkContext,
         block: Self::BlockType,
         generator: impl FnOnce(&mut Self) -> Result<R>,
         overwrite_handler: H,
@@ -618,7 +689,7 @@ where
     {
         self.stack_push(block);
         let res = generator(self);
-        self.stack_pop(overwrite_handler, overwrite_data)?;
+        self.stack_pop(context, overwrite_handler, overwrite_data)?;
         res
     }
 
@@ -630,11 +701,13 @@ where
     #[inline]
     fn gen_in_given_block_with_new_circom_scope_and_cache_overwrites<R>(
         &mut self,
+        context: &'ctx LlzkContext,
         block: Self::BlockType,
         generator: impl FnOnce(&mut Self) -> Result<R>,
         overwrite_data: &mut Self::HandlerDataType,
     ) -> Result<R> {
         self.gen_in_given_block_with_new_circom_scope(
+            context,
             block,
             generator,
             |_, block_info, overwrites| {
@@ -653,10 +726,12 @@ where
     #[inline]
     fn gen_in_given_block_with_new_circom_scope_and_merge_overwrites<R>(
         &mut self,
+        context: &'ctx LlzkContext,
         block: Self::BlockType,
         generator: impl FnOnce(&mut Self) -> Result<R>,
     ) -> Result<R> {
         self.gen_in_given_block_with_new_circom_scope(
+            context,
             block,
             generator,
             |fc, _, overwrites| fc.block_ctx.set_named_values(overwrites),
@@ -672,9 +747,11 @@ where
     #[inline]
     fn gen_in_current_block_with_new_circom_scope_and_merge_overwrites<R>(
         &mut self,
+        context: &'ctx LlzkContext,
         generator: impl FnOnce(&mut Self) -> Result<R>,
     ) -> Result<R> {
         self.gen_in_given_block_with_new_circom_scope_and_merge_overwrites(
+            context,
             self.stack_top(),
             generator,
         )
@@ -756,17 +833,14 @@ where
         for (name, ty) in sorted {
             // If there is no type restriction use `felt` since it's circom's basic type.
             let ty = (*ty).unwrap_or_else(|| codegen.felt_type().into());
-            let value = single_result_as_value(
-                self.block_ctx.append_current_block(poly::read_const(location, name, ty)),
-            )?;
+            let builder = self.builder_at_current_insertion_point(codegen.context);
+            let read = poly::read_const(&builder, location, name, ty);
+            let value = single_result_as_value(read)?;
             // Array-dimension `poly.expr`s yield index values, while Circom template parameters
             // and expressions otherwise behave as field elements inside generated functions.
             let value = if is_index(ty) {
-                single_result_as_value(self.block_ctx.append_current_block(cast::tofelt(
-                    location,
-                    value,
-                    Some(codegen.felt_type()),
-                )))?
+                let cast = cast::tofelt(&builder, location, value, Some(codegen.felt_type()));
+                single_result_as_value(cast)?
             } else {
                 value
             };
@@ -782,9 +856,22 @@ where
         self.block_ctx.append_current_block(op)
     }
 
+    /// Create an operation builder positioned at this context's current insertion point.
+    pub fn builder_at_current_insertion_point(
+        &self,
+        context: &'ctx LlzkContext,
+    ) -> OpBuilder<'ctx, 'static> {
+        self.block_ctx.builder_at_current_insertion_point(context)
+    }
+
     /// Append an operation that must produce no results.
     pub fn append_op_no_result(&mut self, op: Operation<'ctx>) -> Result<()> {
         no_results(self.append_op(op))
+    }
+
+    /// Append a builder-created operation reference that must produce no results.
+    pub fn append_op_ref_no_result(&mut self, op: impl OperationLike<'ctx, 'val>) -> Result<()> {
+        no_results(op)
     }
 
     /// Append an operation that must produce a single result and is NOT associated with a variable
@@ -793,10 +880,19 @@ where
         single_result_as_value(self.append_op(op))
     }
 
+    /// Append a builder-created operation reference that must produce a single unnamed result.
+    pub fn append_op_ref_unnamed_result(
+        &mut self,
+        op: impl OperationLike<'ctx, 'val>,
+    ) -> Result<Value<'ctx, 'val>> {
+        single_result_as_value(op)
+    }
+
     /// Read a visible `poly.param` or `poly.expr` using its declared type restriction.
     /// Unrestricted bindings are read using `fallback_type`.
     pub(crate) fn read_poly_template_binding(
         &mut self,
+        codegen: &LlzkCodegen<'_, 'ctx, '_, impl ProgramLike>,
         location: Location<'ctx>,
         name: &str,
         fallback_type: Type<'ctx>,
@@ -808,7 +904,9 @@ where
             .copied()
             .ok_or_else(|| anyhow!("unknown polymorphic binding '{name}'"))?;
         let ty = type_restriction.unwrap_or(fallback_type);
-        self.append_op_unnamed_result(poly::read_const(location, name, ty))
+        let builder = self.builder_at_current_insertion_point(codegen.context);
+        let read = poly::read_const(&builder, location, name, ty);
+        self.append_op_ref_unnamed_result(read)
     }
 
     /// Append an operation that must produce one or more results and is NOT associated with a
@@ -876,7 +974,9 @@ where
         rhs: Value<'ctx, 'val>,
     ) -> Result<()> {
         let (lhs, rhs) = self.unify_constrain_eq_types(codegen, location, lhs, rhs)?;
-        self.append_op_no_result(constrain::eq(location, lhs, rhs).into())
+        let builder = self.builder_at_current_insertion_point(codegen.context);
+        let op = constrain::eq(&builder, location, lhs, rhs);
+        self.append_op_ref_no_result(op)
     }
 
     /// Generate an `array.write` or `array.insert` operation appropriate for the number of indices
@@ -895,6 +995,7 @@ where
             format!("Conflicting types to write {v} at {location}")
         })?;
         let arr_ty_dims = arr_ty.dims();
+        let builder = self.builder_at_current_insertion_point(codegen.context);
         let write_op = match indices.len().cmp(&arr_ty_dims.len()) {
             std::cmp::Ordering::Equal => {
                 // Indexing all dimensions requires an `array.write`
@@ -904,18 +1005,18 @@ where
                     rvalue,
                     arr_ty.element_type(),
                 )?;
-                array::write(location, arr_ref, indices, rvalue)
+                array::write(&builder, location, arr_ref, indices, rvalue)
             }
             std::cmp::Ordering::Less => {
                 // Indexing a subset of dimensions requires an `array.insert`
-                array::insert(location, arr_ref, indices, rvalue)
+                array::insert(&builder, location, arr_ref, indices, rvalue)
             }
             std::cmp::Ordering::Greater => {
                 let v = var_name.map_or(String::from("array"), |s| format!("'{s}'"));
                 anyhow::bail!("Too many indices to write {v} at {location}");
             }
         };
-        self.append_op_no_result(write_op)
+        self.append_op_ref_no_result(write_op)
     }
 
     /// Generate an `array.read` or `array.extract` operation appropriate for the number of indices
@@ -937,13 +1038,10 @@ where
             let elem_ty_pname = self.add_new_tvar_poly_param(codegen, location, "$e")?;
             let arr_elem_ty = TVarType::new(codegen.context, StringRef::new(elem_ty_pname.value()));
             let arr_ty = ArrayType::new(arr_elem_ty.into(), &dims);
-            let arr_ref = self.unifiable_cast(location, arr_ref, arr_ty.into())?;
-            return self.append_op_unnamed_result(array::read(
-                location,
-                arr_elem_ty.into(),
-                arr_ref,
-                indices,
-            ));
+            let arr_ref = self.unifiable_cast(codegen, location, arr_ref, arr_ty.into())?;
+            let builder = self.builder_at_current_insertion_point(codegen.context);
+            let read = array::read(&builder, location, arr_elem_ty.into(), arr_ref, indices);
+            return self.append_op_ref_unnamed_result(read);
         }
         // Normal case
         let arr_ty = ArrayType::try_from(arr_ref.r#type()).with_context(|| {
@@ -951,24 +1049,25 @@ where
             format!("Conflicting types to read {v} at {location}")
         })?;
         let arr_ty_dims = arr_ty.dims();
+        let builder = self.builder_at_current_insertion_point(codegen.context);
         let array_get_op = match indices.len().cmp(&arr_ty_dims.len()) {
             std::cmp::Ordering::Equal => {
                 // Indexing all dimensions requires an `array.read`
-                array::read(location, arr_ty.element_type(), arr_ref, indices)
+                array::read(&builder, location, arr_ty.element_type(), arr_ref, indices)
             }
             std::cmp::Ordering::Less => {
                 // Indexing a subset of dimensions requires an `array.extract`
                 let reduced_dims: Vec<_> =
                     arr_ty_dims.iter().skip(indices.len()).copied().collect();
                 let reduced_type = ArrayType::new(arr_ty.element_type().into(), &reduced_dims);
-                array::extract(location, reduced_type.into(), arr_ref, indices)
+                array::extract(&builder, location, reduced_type.into(), arr_ref, indices)
             }
             std::cmp::Ordering::Greater => {
                 let v = var_name.map_or(String::from("array"), |s| format!("'{s}'"));
                 anyhow::bail!("Too many indices to read {v} at {location}");
             }
         };
-        self.append_op_unnamed_result(array_get_op)
+        self.append_op_ref_unnamed_result(array_get_op)
     }
 
     /// Cast `val` to bool and emit a `bool.assert` op.
@@ -980,7 +1079,9 @@ where
     ) -> Result<()> {
         let cond = self.cast_to_bool_if_needed(codegen, location, val)?;
         let msg = Some("assertion failed");
-        self.append_op_no_result(bool::assert(location, cond, msg)?.into())
+        let builder = self.builder_at_current_insertion_point(codegen.context);
+        let op = bool::assert(&builder, location, cond, msg)?;
+        self.append_op_ref_no_result(op)
     }
 
     /// Append a `unifiable_cast` operation to cast `val` to the `expected` type, unless it already
@@ -988,6 +1089,7 @@ where
     #[inline]
     pub fn unifiable_cast(
         &mut self,
+        codegen: &LlzkCodegen<'_, 'ctx, '_, impl ProgramLike>,
         location: Location<'ctx>,
         val: Value<'ctx, 'val>,
         expected: Type<'ctx>,
@@ -996,7 +1098,9 @@ where
         if current_type == expected {
             Ok(val)
         } else if types_unify(current_type, expected) {
-            self.append_op_unnamed_result(poly::unifiable_cast(location, val, expected))
+            let builder = self.builder_at_current_insertion_point(codegen.context);
+            let op = poly::unifiable_cast(&builder, location, val, expected);
+            self.append_op_ref_unnamed_result(op)
         } else {
             anyhow::bail!("Unsupported cast to '{expected}' from value type '{}'", current_type)
         }
@@ -1011,9 +1115,11 @@ where
         val: Value<'ctx, 'val>,
     ) -> Result<Value<'ctx, 'val>> {
         if is_type_variable(val.r#type()) {
-            self.unifiable_cast(location, val, codegen.felt_type().into())
+            self.unifiable_cast(codegen, location, val, codegen.felt_type().into())
         } else {
-            self.append_op_unnamed_result(cast::tofelt(location, val, Some(codegen.felt_type())))
+            let builder = self.builder_at_current_insertion_point(codegen.context);
+            let op = cast::tofelt(&builder, location, val, Some(codegen.felt_type()));
+            self.append_op_ref_unnamed_result(op)
         }
     }
 
@@ -1041,9 +1147,11 @@ where
         val: Value<'ctx, 'val>,
     ) -> Result<Value<'ctx, 'val>> {
         if is_type_variable(val.r#type()) {
-            self.unifiable_cast(location, val, codegen.index_type())
+            self.unifiable_cast(codegen, location, val, codegen.index_type())
         } else {
-            self.append_op_unnamed_result(cast::toindex(location, val).into())
+            let builder = self.builder_at_current_insertion_point(codegen.context);
+            let op = cast::toindex(&builder, location, val, None);
+            self.append_op_ref_unnamed_result(op)
         }
     }
 
@@ -1074,9 +1182,15 @@ where
         // `normalize()` in `modular_arithmetic.rs`.
         let val_type = val.r#type();
         if is_felt_type(val_type) {
-            let zero = self
-                .append_op_unnamed_result(codegen.new_felt_const_op(&BigInt::zero(), location)?)?;
-            self.append_op_unnamed_result(bool::ne(location, val, zero)?)
+            let builder = self.builder_at_current_insertion_point(codegen.context);
+            let zero = self.append_op_ref_unnamed_result(codegen.new_felt_const_op(
+                &builder,
+                &BigInt::zero(),
+                location,
+            )?)?;
+            let builder = self.builder_at_current_insertion_point(codegen.context);
+            let op = bool::ne(&builder, location, val, zero)?;
+            self.append_op_ref_unnamed_result(op)
         } else if is_index(val_type) {
             let zero = self.append_op_unnamed_result(codegen.new_index_const_op(0, location))?;
             self.append_op_unnamed_result(index::cmp(
@@ -1091,7 +1205,7 @@ where
             if val_type == bool_type {
                 Ok(val)
             } else {
-                self.unifiable_cast(location, val, bool_type)
+                self.unifiable_cast(codegen, location, val, bool_type)
             }
         }
     }
@@ -1108,7 +1222,7 @@ where
         if expected == val.r#type() {
             Ok(val)
         } else if types_unify(expected, val.r#type()) {
-            self.unifiable_cast(location, val, expected)
+            self.unifiable_cast(codegen, location, val, expected)
         } else if is_felt_type(expected) {
             self.cast_to_felt_if_needed(codegen, location, val)
         } else if is_index(expected) {
@@ -1193,12 +1307,15 @@ where
 
         let element_types_not_equal = src_elem_ty != dst_elem_ty;
         self.gen_loop_nest(codegen, location, &bounds, move |fc, indices| {
-            let mut val =
-                fc.append_op_unnamed_result(array::read(location, src_elem_ty, src, indices))?;
+            let builder = fc.builder_at_current_insertion_point(codegen.context);
+            let read = array::read(&builder, location, src_elem_ty, src, indices);
+            let mut val = fc.append_op_ref_unnamed_result(read)?;
             if element_types_not_equal {
-                val = fc.unifiable_cast(location, val, dst_elem_ty)?;
+                val = fc.unifiable_cast(codegen, location, val, dst_elem_ty)?;
             }
-            fc.append_op_no_result(array::write(location, dst, indices, val))
+            let builder = fc.builder_at_current_insertion_point(codegen.context);
+            let write = array::write(&builder, location, dst, indices, val);
+            fc.append_op_ref_no_result(write)
         })
     }
 
@@ -1253,7 +1370,7 @@ where
         }
         if types_unify(existing.r#type(), rvalue.r#type()) {
             let location = codegen.location_from_meta(meta);
-            let rvalue = self.unifiable_cast(location, rvalue, existing.r#type())?;
+            let rvalue = self.unifiable_cast(codegen, location, rvalue, existing.r#type())?;
             return self.block_ctx.set_named_value(var.clone(), rvalue);
         }
         anyhow::bail!(
@@ -1350,11 +1467,15 @@ where
                 }
                 // Otherwise, cast to felt and use felt negation.
                 let rhs_felt = self.cast_to_felt_if_needed(codegen, loc, rhs)?;
-                return self.append_op_unnamed_result(felt::neg(loc, rhs_felt)?);
+                let builder = self.builder_at_current_insertion_point(codegen.context);
+                let op = felt::neg(&builder, loc, rhs_felt)?;
+                self.append_op_ref_unnamed_result(op)
             }
             ExpressionPrefixOpcode::BoolNot => {
                 let rhs_bool = self.cast_to_bool_if_needed(codegen, loc, rhs)?;
-                return self.append_op_unnamed_result(bool::not(loc, rhs_bool)?);
+                let builder = self.builder_at_current_insertion_point(codegen.context);
+                let op = bool::not(&builder, loc, rhs_bool)?;
+                self.append_op_ref_unnamed_result(op)
             }
             ExpressionPrefixOpcode::Complement => {
                 // For index negation, we need to subtract one from the negative
@@ -1370,7 +1491,9 @@ where
                 }
                 // Otherwise, cast to felt and use felt bitwise NOT.
                 let rhs_felt = self.cast_to_felt_if_needed(codegen, loc, rhs)?;
-                return self.append_op_unnamed_result(felt::bit_not(loc, rhs_felt)?);
+                let builder = self.builder_at_current_insertion_point(codegen.context);
+                let op = felt::bit_not(&builder, loc, rhs_felt)?;
+                self.append_op_ref_unnamed_result(op)
             }
         }
     }
@@ -1384,11 +1507,10 @@ where
         rhs_type_filter: impl FnOnce(Type) -> bool,
         lhs: Value<'ctx, 'val>,
         rhs: Value<'ctx, 'val>,
-        op_gen_fn: impl FnOnce(&mut Self) -> Result<Operation<'ctx>>,
+        op_gen_fn: impl FnOnce(&mut Self) -> Result<Value<'ctx, 'val>>,
     ) -> Result<Option<Value<'ctx, 'val>>> {
         if lhs_type_filter(lhs.r#type()) && rhs_type_filter(rhs.r#type()) {
-            let op_res = op_gen_fn(self)?;
-            self.append_op_unnamed_result(op_res).map(Option::Some)
+            op_gen_fn(self).map(Option::Some)
         } else {
             Ok(None)
         }
@@ -1416,9 +1538,11 @@ where
 
         macro_rules! generic_op_callback {
             ($op_path:path) => {{
-                |_| {
+                |block_gen: &mut Self| {
                     let loc = codegen.location_from_meta(meta);
-                    $op_path(loc, lhs, rhs).map_err(Into::into)
+                    let builder = block_gen.builder_at_current_insertion_point(codegen.context);
+                    let op = $op_path(&builder, loc, lhs, rhs)?;
+                    block_gen.append_op_ref_unnamed_result(op)
                 }
             }};
         }
@@ -1434,7 +1558,9 @@ where
                 let loc = codegen.location_from_meta(meta);
                 let lhs = self.cast_to_bool_if_needed(codegen, loc, lhs)?;
                 let rhs = self.cast_to_bool_if_needed(codegen, loc, rhs)?;
-                return self.append_op_unnamed_result($op_path(loc, lhs, rhs)?);
+                let builder = self.builder_at_current_insertion_point(codegen.context);
+                let op = $op_path(&builder, loc, lhs, rhs)?;
+                return self.append_op_ref_unnamed_result(op);
             }};
         }
 
@@ -1445,26 +1571,33 @@ where
             ($op_path:path) => {{
                 let loc = codegen.location_from_meta(meta);
                 let felt_ty = codegen.felt_type().into();
-                let lhs = self.unifiable_cast(loc, lhs, felt_ty)?;
-                let rhs = self.unifiable_cast(loc, rhs, felt_ty)?;
-                return self.append_op_unnamed_result($op_path(loc, lhs, rhs)?);
+                let lhs = self.unifiable_cast(codegen, loc, lhs, felt_ty)?;
+                let rhs = self.unifiable_cast(codegen, loc, rhs, felt_ty)?;
+                let builder = self.builder_at_current_insertion_point(codegen.context);
+                let op = $op_path(&builder, loc, lhs, rhs)?;
+                return self.append_op_ref_unnamed_result(op);
             }};
         }
 
         macro_rules! try_index_op {
             ($op_path:path) => {{
-                try_callback_for_type!(shared::is_index, |_| {
+                try_callback_for_type!(shared::is_index, |block_gen: &mut Self| {
                     let loc = codegen.location_from_meta(meta);
-                    Ok($op_path(lhs, rhs, loc))
+                    block_gen.append_op_unnamed_result($op_path(lhs, rhs, loc))
                 });
             }};
         }
 
         macro_rules! try_math_op {
             ($op_path:path) => {{
-                try_callback_for_type!(shared::is_index, |_| {
+                try_callback_for_type!(shared::is_index, |block_gen: &mut Self| {
                     let loc = codegen.location_from_meta(meta);
-                    Ok(Operation::from($op_path(codegen.context, lhs, rhs, loc)))
+                    block_gen.append_op_unnamed_result(Operation::from($op_path(
+                        codegen.context,
+                        lhs,
+                        rhs,
+                        loc,
+                    )))
                 });
             }};
         }
@@ -1492,9 +1625,15 @@ where
         macro_rules! try_bool_cmp_op {
             ($bool_op:path, $cmp:ident) => {{
                 try_felt_op!($bool_op);
-                try_callback_for_type!(shared::is_index, |_| {
+                try_callback_for_type!(shared::is_index, |block_gen: &mut Self| {
                     let loc = codegen.location_from_meta(meta);
-                    Ok(index::cmp(codegen.context, arith::CmpiPredicate::$cmp, lhs, rhs, loc))
+                    block_gen.append_op_unnamed_result(index::cmp(
+                        codegen.context,
+                        arith::CmpiPredicate::$cmp,
+                        lhs,
+                        rhs,
+                        loc,
+                    ))
                 });
                 try_unifiable_felt_op!($bool_op);
             }};
@@ -1600,10 +1739,10 @@ where
         }
 
         if is_type_variable(else_ty) {
-            Self::insert_cast_before_yield(else_region, location, else_value, then_ty)
+            Self::insert_cast_before_yield(codegen, else_region, location, else_value, then_ty)
                 .map(|_| then_ty)
         } else {
-            Self::insert_cast_before_yield(then_region, location, then_value, else_ty)
+            Self::insert_cast_before_yield(codegen, then_region, location, then_value, else_ty)
                 .map(|_| else_ty)
         }
         .inspect_err(|_| {
@@ -1622,6 +1761,7 @@ where
     /// `value` to `target_ty` immediately before the single `scf.yield` terminator of
     /// `region`'s first block, and replace the yield's use of `value` with the cast result.
     fn insert_cast_before_yield(
+        codegen: &LlzkCodegen<'_, 'ctx, '_, impl ProgramLike>,
         region: &Region<'ctx>,
         location: Location<'ctx>,
         value: Value<'ctx, 'val>,
@@ -1638,10 +1778,8 @@ where
             let block = region.first_block().expect("region has a block");
             ensure!(block.next_in_region().is_none(), "region has more than one block");
             let terminator = block.terminator().expect("block has a terminator");
-            let new_cast = block.insert_operation_before(
-                terminator,
-                poly::unifiable_cast(location, value, target_ty),
-            );
+            let builder = OpBuilder::new(codegen.context, EntryPoint::Before(terminator));
+            let new_cast = poly::unifiable_cast(&builder, location, value, target_ty);
             replace_uses_of_with(&terminator, value, Value::from(new_cast.result(0)?));
         }
         Ok(())
@@ -1853,6 +1991,7 @@ where
     /// The `value_gen` function is called to generate the value to be yielded from the arm.
     pub fn gen_scf_if_arm_no_var_overwrites<F, Y>(
         &mut self,
+        context: &'ctx LlzkContext,
         location: Location<'ctx>,
         value_gen: F,
     ) -> Result<(Region<'ctx>, Y)>
@@ -1863,7 +2002,7 @@ where
         let (region, block) = new_region_and_block(&[]);
         self.block_ctx.push(block);
         let arm_val = value_gen(self)?;
-        let overwrites = self.block_ctx.pop();
+        let overwrites = self.block_ctx.pop(context)?;
         assert!(overwrites.is_empty(), "expected no variable overwrites");
         let yield_vals = arm_val.to_yield_values();
         no_results(block.append_operation(scf::r#yield(yield_vals.as_ref(), location)))?;
@@ -1885,8 +2024,10 @@ where
         F1: FnOnce(&mut Self) -> Result<Value<'ctx, 'val>>,
         F2: FnOnce(&mut Self) -> Result<Value<'ctx, 'val>>,
     {
-        let then_info = self.gen_scf_if_arm_no_var_overwrites(location, then_value_gen)?;
-        let else_info = self.gen_scf_if_arm_no_var_overwrites(location, else_value_gen)?;
+        let then_info =
+            self.gen_scf_if_arm_no_var_overwrites(codegen.context, location, then_value_gen)?;
+        let else_info =
+            self.gen_scf_if_arm_no_var_overwrites(codegen.context, location, else_value_gen)?;
         self.gen_safe_scf_if(codegen, location, condition, then_info, else_info, None)
     }
 
@@ -1934,14 +2075,18 @@ where
         subcmp_memory: Value<'ctx, 'val>,
         amount: u32,
     ) -> Result<Value<'ctx, 'val>> {
-        let counter = self.append_op_unnamed_result(codegen.new_pod_read_op(
+        let builder = self.builder_at_current_insertion_point(codegen.context);
+        let counter = self.append_op_ref_unnamed_result(codegen.new_pod_read_op(
+            &builder,
             subcmp_memory,
             COUNT,
             location,
         )?)?;
         let one = self.append_op_unnamed_result(codegen.new_index_const_op(amount, location))?;
         let counter = self.append_op_unnamed_result(arith::subi(counter, one, location))?;
-        self.append_op_no_result(codegen.new_pod_write_op(
+        let builder = self.builder_at_current_insertion_point(codegen.context);
+        self.append_op_ref_no_result(codegen.new_pod_write_op(
+            &builder,
             location,
             subcmp_memory,
             COUNT,
@@ -1953,19 +2098,23 @@ where
     /// Decomposes the given value of [`PodType`] into a sequence of values in declaration order.
     pub fn gen_decompose_pod(
         &mut self,
+        codegen: &LlzkCodegen<'_, 'ctx, '_, impl ProgramLike>,
         pod: Value<'ctx, 'val>,
         location: Location<'ctx>,
     ) -> Result<Vec<Value<'ctx, 'val>>> {
+        let builder = self.builder_at_current_insertion_point(codegen.context);
         PodType::try_from(pod.r#type())?
             .records()
             .into_iter()
             .map(|record| {
-                self.append_op_unnamed_result(pod::read(
+                let read = pod::read(
+                    &builder,
                     location,
                     pod,
                     record.name().as_string_ref().as_str()?,
                     record.r#type(),
-                ))
+                );
+                self.append_op_ref_unnamed_result(read)
             })
             .collect()
     }
@@ -1994,7 +2143,9 @@ where
             .map(|idx| {
                 let record_name = params[idx].name();
                 let record_name = record_name.as_string_ref();
-                let value = self.append_op_unnamed_result(codegen.new_pod_read_op(
+                let builder = self.builder_at_current_insertion_point(codegen.context);
+                let value = self.append_op_ref_unnamed_result(codegen.new_pod_read_op(
+                    &builder,
                     params_value,
                     record_name.as_str()?,
                     location,
@@ -2018,22 +2169,21 @@ where
         location: Location<'ctx>,
         codegen: &LlzkCodegen<'_, 'ctx, '_, impl ProgramLike>,
     ) -> Result<Value<'ctx, 'val>> {
-        let input_values = self.gen_decompose_pod(inputs, location)?;
+        let input_values = self.gen_decompose_pod(codegen, inputs, location)?;
         let func_name = append_tail(&struct_type.name(), FUNC_NAME_COMPUTE.as_ref());
         let params = self.read_required_params(struct_type, params, codegen, location)?;
         let mut map_operands = MapOperandsBuilder::new();
         fill_map_operands_for_subcmp_call(&params, &mut map_operands)?;
-        self.append_op_unnamed_result(
-            function::call_with_map_operands(
-                codegen.op_builder(),
-                location,
-                func_name,
-                &input_values,
-                &[struct_type],
-                map_operands,
-            )?
-            .into(),
-        )
+        let builder = self.builder_at_current_insertion_point(codegen.context);
+        let call = function::call_with_map_operands(
+            &builder,
+            location,
+            func_name,
+            &input_values,
+            &[struct_type],
+            map_operands,
+        )?;
+        self.append_op_ref_unnamed_result(call)
     }
 
     /// Generates a call to `@constrain` for the given struct type.
@@ -2048,16 +2198,15 @@ where
         codegen: &LlzkCodegen<'_, 'ctx, '_, impl ProgramLike>,
     ) -> Result<()> {
         let mut call_args = vec![subcmp];
-        call_args.extend(self.gen_decompose_pod(inputs, location)?);
+        call_args.extend(self.gen_decompose_pod(codegen, inputs, location)?);
         let func_name = append_tail(
             &StructType::try_from(subcmp.r#type())?.name(),
             FUNC_NAME_CONSTRAIN.as_ref(),
         );
         let return_types: [Type; 0] = [];
-        self.append_op_no_result(
-            function::call(codegen.op_builder(), location, func_name, &call_args, &return_types)?
-                .into(),
-        )
+        let builder = self.builder_at_current_insertion_point(codegen.context);
+        let call = function::call(&builder, location, func_name, &call_args, &return_types)?;
+        self.append_op_ref_no_result(call)
     }
 
     /// Convert a dimension [Attribute] from an [ArrayType] into a [`Value`] of index type,
@@ -2080,7 +2229,7 @@ where
         if let Ok(sym_ref) = FlatSymbolRefAttribute::try_from(dim) {
             let sym_name = sym_ref.value();
             let value =
-                self.read_poly_template_binding(location, sym_name, codegen.index_type())?;
+                self.read_poly_template_binding(codegen, location, sym_name, codegen.index_type())?;
             return self.cast_to_index_if_needed(codegen, location, value);
         }
         unreachable!("Unhandled attribute in array dimensions {}", dim)
@@ -2154,7 +2303,7 @@ where
         // to the right block.
         self.block_ctx.push(block);
         body(self, &loop_vars)?;
-        self.block_ctx.pop();
+        self.block_ctx.pop(codegen.context)?;
 
         // Traverse the stack of blocks until we reach the block where we inserted the whole nest.
         // For each block traversed this way add the scf terminator op.
@@ -2194,26 +2343,27 @@ where
             } else {
                 ArrayCtor::Empty
             };
-            let new_arr =
-                self.append_op_unnamed_result(codegen.new_array_new_op(location, arr_ty, ctor))?;
+            let builder = self.builder_at_current_insertion_point(codegen.context);
+            let new_arr = self.append_op_ref_unnamed_result(
+                codegen.new_array_new_op(&builder, location, arr_ty, ctor),
+            )?;
             if let Ok(const_dim) = const_dim {
                 for idx in 0..const_dim.value() {
                     let idx_val =
                         self.append_op_unnamed_result(codegen.new_index_const_op(idx, location))?;
-                    self.append_op_no_result(array::insert(location, new_arr, &[idx_val], value))?;
+                    let builder = self.builder_at_current_insertion_point(codegen.context);
+                    let insert = array::insert(&builder, location, new_arr, &[idx_val], value);
+                    self.append_op_ref_no_result(insert)?;
                 }
             } else {
                 let dim = self.append_op_unnamed_result(codegen.new_index_const_op(0, location))?;
-                let array_len =
-                    self.append_op_unnamed_result(array::len(location, new_arr, dim))?;
+                let builder = self.builder_at_current_insertion_point(codegen.context);
+                let len = array::len(&builder, location, new_arr, dim);
+                let array_len = self.append_op_ref_unnamed_result(len)?;
                 self.gen_normalized_scf_for(codegen, location, array_len, |b| {
                     let induction_var = b.argument(0)?;
-                    b.append_operation(array::insert(
-                        location,
-                        new_arr,
-                        &[induction_var.into()],
-                        value,
-                    ));
+                    let builder = OpBuilder::at_block_end(codegen.context, b);
+                    array::insert(&builder, location, new_arr, &[induction_var.into()], value);
                     b.append_operation(scf::r#yield(&[], location));
                     Ok(())
                 })?;
@@ -2224,7 +2374,9 @@ where
             let arr_ty = dimension.new_array_type(&value.r#type());
             if let Ok(const_dim) = const_dim {
                 let values = vec![value; usize::try_from(const_dim.value())?];
-                self.append_op_unnamed_result(codegen.new_array_new_op(
+                let builder = self.builder_at_current_insertion_point(codegen.context);
+                self.append_op_ref_unnamed_result(codegen.new_array_new_op(
+                    &builder,
                     location,
                     arr_ty,
                     ArrayCtor::Values(&values),
@@ -2238,19 +2390,18 @@ where
                 } else {
                     ArrayCtor::Empty
                 };
-                let array_ref = self
-                    .append_op_unnamed_result(codegen.new_array_new_op(location, arr_ty, ctor))?;
+                let builder = self.builder_at_current_insertion_point(codegen.context);
+                let array_ref = self.append_op_ref_unnamed_result(
+                    codegen.new_array_new_op(&builder, location, arr_ty, ctor),
+                )?;
                 let dim = self.append_op_unnamed_result(codegen.new_index_const_op(0, location))?;
-                let array_len =
-                    self.append_op_unnamed_result(array::len(location, array_ref, dim))?;
+                let builder = self.builder_at_current_insertion_point(codegen.context);
+                let len = array::len(&builder, location, array_ref, dim);
+                let array_len = self.append_op_ref_unnamed_result(len)?;
                 self.gen_normalized_scf_for(codegen, location, array_len, |b| {
                     let induction_var = b.argument(0)?;
-                    b.append_operation(array::write(
-                        location,
-                        array_ref,
-                        &[induction_var.into()],
-                        value,
-                    ));
+                    let builder = OpBuilder::at_block_end(codegen.context, b);
+                    array::write(&builder, location, array_ref, &[induction_var.into()], value);
                     b.append_operation(scf::r#yield(&[], location));
                     Ok(())
                 })?;
@@ -2312,10 +2463,8 @@ where
                 body_yield_values.iter().copied().zip(loop_carried_types.iter().copied())
             {
                 if val.r#type() != expected_ty && types_unify(val.r#type(), expected_ty) {
-                    let cast_op = loop_body_info.block.insert_operation_before(
-                        terminator,
-                        poly::unifiable_cast(location, val, expected_ty),
-                    );
+                    let builder = OpBuilder::new(codegen.context, EntryPoint::Before(terminator));
+                    let cast_op = poly::unifiable_cast(&builder, location, val, expected_ty);
                     replace_uses_of_with(&terminator, val, Value::from(cast_op.result(0)?));
                 }
             }
@@ -2343,13 +2492,11 @@ where
             // If there is a return within the loop, add prefix "!<VAR_NAME_HAD_RETURN> &&" to the
             // loop condition to ensure the loop terminates when the return occurs.
             if let Some(flag) = return_flag {
-                let not_return_flag = single_result_as_value(
-                    loop_cond_info.block.append_operation(bool::r#not(location, flag)?.into()),
-                )?;
-                condition =
-                    single_result_as_value(loop_cond_info.block.append_operation(
-                        bool::and(location, not_return_flag, condition)?.into(),
-                    ))?;
+                let builder = OpBuilder::at_block_end(codegen.context, loop_cond_info.block);
+                let not_return_flag =
+                    single_result_as_value(bool::r#not(&builder, location, flag)?)?;
+                let and = bool::and(&builder, location, not_return_flag, condition)?;
+                condition = single_result_as_value(and)?;
             }
             // Pass the block arguments as the initial values to the condition op.
             let block_arg_values = (0..loop_cond_info.block.argument_count())
@@ -2429,8 +2576,10 @@ where
         if codegen.config.verbose {
             println!("Declaring variable '{name}' with dimensions {dims:?}");
         }
-        let op = dims.new_nondet_felt_of_dimensions(codegen, meta)?;
-        self.block_ctx.declare_name_ensure_not_present(name, op)
+        let builder = self.builder_at_current_insertion_point(codegen.context);
+        let value =
+            single_result_as_value(dims.new_nondet_felt_of_dimensions(codegen, &builder, meta))?;
+        self.block_ctx.declare_value_ensure_not_present(name, value)
     }
 
     /// Add a new polymorphic parameter with `poly.tvar` type via
@@ -2573,6 +2722,7 @@ where
 
     fn stack_pop<H>(
         &mut self,
+        context: &'ctx LlzkContext,
         overwrite_handler: H,
         overwrite_data: &mut Self::HandlerDataType,
     ) -> Result<()>
@@ -2583,7 +2733,7 @@ where
             HashMap<String, Value<'ctx, 'val>>,
         ) -> Result<()>,
     {
-        let popped = self.block_ctx.pop();
+        let popped = self.block_ctx.pop(context)?;
         overwrite_handler(self, overwrite_data, popped)
     }
 }
@@ -2629,8 +2779,10 @@ where
             Expression::Number(meta, big_int) => {
                 // Convert the BigInt to an LLZK `felt.const` op. The user of the Expression is
                 // responsible for converting this `felt.type` value to another type if needed.
-                block_gen.append_op_unnamed_result(
-                    codegen.new_felt_const_op(big_int, codegen.location_from_meta(meta))?,
+                let location = codegen.location_from_meta(meta);
+                let builder = block_gen.builder_at_current_insertion_point(codegen.context);
+                block_gen.append_op_ref_unnamed_result(
+                    codegen.new_felt_const_op(&builder, big_int, location)?,
                 )
             }
             Expression::Variable { meta, name, access } => {
@@ -2664,12 +2816,14 @@ where
                 let condition = block_gen.cast_to_bool_if_needed(codegen, location, cond_val)?;
 
                 // Generate branch arms nested blocks so `gen_llzk_in_block` can use `block_gen`
-                let then_info = block_gen.gen_scf_if_arm_no_var_overwrites(location, |g| {
-                    if_true.gen_llzk_in_block(codegen, g, info)
-                })?;
-                let else_info = block_gen.gen_scf_if_arm_no_var_overwrites(location, |g| {
-                    if_false.gen_llzk_in_block(codegen, g, info)
-                })?;
+                let then_info =
+                    block_gen.gen_scf_if_arm_no_var_overwrites(codegen.context, location, |g| {
+                        if_true.gen_llzk_in_block(codegen, g, info)
+                    })?;
+                let else_info =
+                    block_gen.gen_scf_if_arm_no_var_overwrites(codegen.context, location, |g| {
+                        if_false.gen_llzk_in_block(codegen, g, info)
+                    })?;
                 block_gen.gen_safe_scf_if(codegen, location, condition, then_info, else_info, None)
             }
             Expression::ArrayInLine { meta, values } => {
@@ -2689,21 +2843,17 @@ where
                     // For subarrays, we need to create a new array then insert the values
                     let dim = codegen.index_attr(i64::try_from(values.len())?);
                     let arr_ty = new_array_type(dim.into(), &subarr_ty);
-                    let new_arr = block_gen.append_op_unnamed_result(codegen.new_array_new_op(
-                        location,
-                        arr_ty,
-                        ArrayCtor::Empty,
-                    ))?;
+                    let builder = block_gen.builder_at_current_insertion_point(codegen.context);
+                    let new_arr = block_gen.append_op_ref_unnamed_result(
+                        codegen.new_array_new_op(&builder, location, arr_ty, ArrayCtor::Empty),
+                    )?;
                     for (idx, val) in values.iter().enumerate() {
                         let idx_val = block_gen.append_op_unnamed_result(
                             codegen.new_index_const_op(i64::try_from(idx)?, location),
                         )?;
-                        block_gen.append_op_no_result(array::insert(
-                            location,
-                            new_arr,
-                            &[idx_val],
-                            *val,
-                        ))?;
+                        let builder = block_gen.builder_at_current_insertion_point(codegen.context);
+                        let insert = array::insert(&builder, location, new_arr, &[idx_val], *val);
+                        block_gen.append_op_ref_no_result(insert)?;
                     }
 
                     // Output value is still the newly created array
@@ -2711,7 +2861,9 @@ where
                 } else {
                     let dim = codegen.index_attr(i64::try_from(values.len())?);
                     let arr_ty = ArrayType::new(value_ty.into(), &[dim.into()]);
-                    block_gen.append_op_unnamed_result(codegen.new_array_new_op(
+                    let builder = block_gen.builder_at_current_insertion_point(codegen.context);
+                    block_gen.append_op_ref_unnamed_result(codegen.new_array_new_op(
+                        &builder,
                         location,
                         arr_ty,
                         ArrayCtor::Values(&values),
@@ -2765,16 +2917,14 @@ where
                 } else {
                     return_type
                 };
-                block_gen.append_op_unnamed_result(
-                    function::call(
-                        codegen.op_builder(),
-                        location,
-                        codegen.double_ref_sym(id),
-                        &call_operands,
-                        &[return_type],
-                    )?
-                    .into(),
-                )
+                let call = function::call(
+                    &block_gen.builder_at_current_insertion_point(codegen.context),
+                    location,
+                    codegen.double_ref_sym(id),
+                    &call_operands,
+                    &[return_type],
+                )?;
+                block_gen.append_op_ref_unnamed_result(call)
             }
             #[allow(unused_variables)] // TODO: TEMP
             Expression::BusCall { meta, id, args } => {

--- a/llzk_backend/src/gen_context.rs
+++ b/llzk_backend/src/gen_context.rs
@@ -38,6 +38,7 @@ use llzk::dialect::pod;
 use llzk::dialect::poly;
 use llzk::dialect::r#struct;
 use llzk::map_operands::MapOperandsBuilder;
+use llzk::operation::build_owned_operation;
 use llzk::prelude::is_felt_type;
 use llzk::prelude::is_type_variable;
 use llzk::prelude::melior_dialects::arith;
@@ -2591,7 +2592,7 @@ where
         location: Location<'ctx>,
         name: &str,
     ) -> Result<StringAttribute<'ctx>> {
-        shared::build_owned_operation(codegen.context, |builder| {
+        build_owned_operation(codegen.context, |builder| {
             poly::param(builder, location, name, None).map(Into::into)
         })
         .and_then(TemplateParamOp::try_from)

--- a/llzk_backend/src/gen_context.rs
+++ b/llzk_backend/src/gen_context.rs
@@ -1382,7 +1382,6 @@ where
 
     /// Handle [program_structure::ast::Statement::Substitution] when the operator is not a signal
     /// operator. Note: Do not use directly from `GenerateLLZKInTemplate`.
-    #[allow(clippy::too_many_arguments)]
     pub fn handle_substitution_stmt_nonsignal<'info>(
         &mut self,
         codegen: &LlzkCodegen<'_, 'ctx, '_, impl ProgramLike>,
@@ -1826,7 +1825,6 @@ where
     ///
     /// Each [Region] is assumed to contain a single block with an `scf.yield` terminator. If
     /// `then_values` or `else_values` is None, the Values are retrieved from the block terminator.
-    #[allow(clippy::too_many_arguments)]
     pub fn gen_safe_scf_if_multi(
         &mut self,
         codegen: &LlzkCodegen<'_, 'ctx, '_, impl ProgramLike>,

--- a/llzk_backend/src/gen_context.rs
+++ b/llzk_backend/src/gen_context.rs
@@ -331,7 +331,11 @@ where
         &self,
         context: &'ctx LlzkContext,
     ) -> OpBuilder<'ctx, 'static> {
-        OpBuilder::at_block_end(context, *self.top_block())
+        let current = *self.top_block();
+        match current.terminator() {
+            Some(terminator) => OpBuilder::new(context, EntryPoint::Before(terminator)),
+            None => OpBuilder::at_block_end(context, current),
+        }
     }
 
     /// Queues a `struct.writem` to the given block that will be created directly before the block

--- a/llzk_backend/src/gen_context.rs
+++ b/llzk_backend/src/gen_context.rs
@@ -38,7 +38,6 @@ use llzk::dialect::pod;
 use llzk::dialect::poly;
 use llzk::dialect::r#struct;
 use llzk::map_operands::MapOperandsBuilder;
-use llzk::operation::build_owned_operation;
 use llzk::prelude::is_felt_type;
 use llzk::prelude::is_type_variable;
 use llzk::prelude::melior_dialects::arith;
@@ -2592,7 +2591,7 @@ where
         location: Location<'ctx>,
         name: &str,
     ) -> Result<StringAttribute<'ctx>> {
-        build_owned_operation(codegen.context, |builder| {
+        shared::build_owned_operation(codegen.context, |builder| {
             poly::param(builder, location, name, None).map(Into::into)
         })
         .and_then(TemplateParamOp::try_from)

--- a/llzk_backend/src/gen_context.rs
+++ b/llzk_backend/src/gen_context.rs
@@ -826,7 +826,7 @@ where
         let map = self.poly_template_binding_names.borrow();
         let mut sorted: Vec<_> = map.iter().collect();
         if codegen.config.stabilize {
-            sorted.sort_by(|(a, _), (b, _)| a.cmp(b));
+            sorted.sort_by_key(|(a, _)| *a);
         }
         // Keep the binding map borrowed so sorting can use references; only the disjoint block
         // context is mutated below. Names are copied only when inserted into its owning map.

--- a/llzk_backend/src/gen_context.rs
+++ b/llzk_backend/src/gen_context.rs
@@ -38,6 +38,7 @@ use llzk::dialect::pod;
 use llzk::dialect::poly;
 use llzk::dialect::r#struct;
 use llzk::map_operands::MapOperandsBuilder;
+use llzk::operation::build_owned_operation;
 use llzk::prelude::is_felt_type;
 use llzk::prelude::is_type_variable;
 use llzk::prelude::melior_dialects::arith;
@@ -46,7 +47,6 @@ use llzk::prelude::melior_dialects::scf;
 use llzk::prelude::replace_uses_of_with;
 use llzk::prelude::ArrayType;
 use llzk::prelude::Attribute;
-use llzk::prelude::Block;
 use llzk::prelude::BlockLike as _;
 use llzk::prelude::BlockRef;
 use llzk::prelude::FlatSymbolRefAttribute;
@@ -2588,21 +2588,21 @@ where
         location: Location<'ctx>,
         name: &str,
     ) -> Result<StringAttribute<'ctx>> {
-        let scratch = Block::new(&[]);
-        let builder = OpBuilder::at_block_end(codegen.context, &scratch);
-        poly::param(&builder, location, name, None)
-            .and_then(|op| TemplateParamOp::try_from(shared::detach_owned_operation(&op)))
-            .map(|op| {
-                self.record_new_sym_binding(codegen, op.into(), &|op_ref| match op_ref {
-                    TemplateSymbolBindingOpRef::Param(op_ref) => {
-                        // Once the final unique symbol name is known, update the
-                        // `poly.param` op with the correct type restriction.
-                        op_ref.set_type_restriction(Some(codegen.tvar_type(op_ref.sym_name())));
-                    }
-                    TemplateSymbolBindingOpRef::Expr(_) => unreachable!("just created poly::param"),
-                })
+        build_owned_operation(codegen.context, |builder| {
+            poly::param(builder, location, name, None).map(Into::into)
+        })
+        .and_then(TemplateParamOp::try_from)
+        .map(|op| {
+            self.record_new_sym_binding(codegen, op.into(), &|op_ref| match op_ref {
+                TemplateSymbolBindingOpRef::Param(op_ref) => {
+                    // Once the final unique symbol name is known, update the
+                    // `poly.param` op with the correct type restriction.
+                    op_ref.set_type_restriction(Some(codegen.tvar_type(op_ref.sym_name())));
+                }
+                TemplateSymbolBindingOpRef::Expr(_) => unreachable!("just created poly::param"),
             })
-            .map_err(Into::into)
+        })
+        .map_err(Into::into)
     }
 }
 

--- a/llzk_backend/src/lib.rs
+++ b/llzk_backend/src/lib.rs
@@ -7,6 +7,7 @@
 #![deny(unused_must_use)]
 #![warn(redundant_imports)]
 #![warn(clippy::cast_lossless)]
+#![allow(clippy::too_many_arguments)]
 #![allow(clippy::useless_conversion)]
 
 mod cleanup_return_tvar;

--- a/llzk_backend/src/lvalue.rs
+++ b/llzk_backend/src/lvalue.rs
@@ -9,7 +9,6 @@ use crate::shared::LlzkCodegen;
 use crate::subcmp::names::COMP;
 use crate::subcmp::SubcmpInfo;
 use anyhow::Result;
-use llzk::dialect::llzk::nondet;
 use llzk::dialect::pod;
 use llzk::dialect::r#struct;
 use llzk::prelude::Location;
@@ -188,12 +187,12 @@ impl<'ast> Lvalue<'ast> {
                         prev
                     )
                 })?;
-                let read_value = block_gen.as_mut().append_op_unnamed_result(pod::read(
-                    location,
-                    prev,
-                    record_name,
-                    record_type,
-                ))?;
+                let read_value = {
+                    let block_gen = block_gen.as_mut();
+                    let builder = block_gen.builder_at_current_insertion_point(codegen.context);
+                    let read = pod::read(&builder, location, prev, record_name, record_type);
+                    block_gen.append_op_ref_unnamed_result(read)?
+                };
                 return cont.cont(read_value, block_gen);
             }
         }
@@ -223,6 +222,7 @@ impl<'ast> Lvalue<'ast> {
                     prev,
                     entry_indices,
                     block_gen,
+                    codegen,
                     location,
                     prev_pod_type,
                     info,
@@ -247,6 +247,7 @@ impl<'ast> Lvalue<'ast> {
         prev: Value<'ctx, 'val>,
         entry_indices: &[usize],
         block_gen: &mut C,
+        codegen: &LlzkCodegen<'_, 'ctx, '_, impl ProgramLike>,
         location: Location<'ctx>,
         prev_pod_type: PodType<'ctx>,
         info: InfoProviders<'_, 'ctx>,
@@ -258,7 +259,7 @@ impl<'ast> Lvalue<'ast> {
         'val: 'cont,
         'blk: 'val,
     {
-        NestedBlockInfo::with_scope(block_gen, |block_gen| {
+        NestedBlockInfo::with_scope(codegen.context, block_gen, |block_gen| {
             let record_name = info
                 .subcmp_info
                 .mixed_subcmp_record_for_indices(self.root_var(), entry_indices)
@@ -271,12 +272,12 @@ impl<'ast> Lvalue<'ast> {
             let record_type = prev_pod_type.record_type(record_name).ok_or_else(|| {
                 anyhow::anyhow!("record {record_name} not found in mixed subcomponent pod: {prev}")
             })?;
-            let read_value = block_gen.as_mut().append_op_unnamed_result(pod::read(
-                location,
-                prev,
-                record_name,
-                record_type,
-            ))?;
+            let read_value = {
+                let block_gen = block_gen.as_mut();
+                let builder = block_gen.builder_at_current_insertion_point(codegen.context);
+                let read = pod::read(&builder, location, prev, record_name, record_type);
+                block_gen.append_op_ref_unnamed_result(read)?
+            };
 
             cont.cont(read_value, block_gen)
         })
@@ -294,7 +295,9 @@ impl<'ast> Lvalue<'ast> {
     ) -> Result<Value<'ctx, 'val>> {
         let comp_value = type_switch! { let ty = subcmp_value.r#type();
             PodType => {
-                block_gen.append_op_unnamed_result(pod::read(
+                let builder = block_gen.builder_at_current_insertion_point(codegen.context);
+                let read = pod::read(
+                    &builder,
                     location,
                     subcmp_value,
                     COMP,
@@ -305,7 +308,8 @@ impl<'ast> Lvalue<'ast> {
                                 "record {COMP} not found in subcomponent memory pod: {subcmp_value}"
                             )
                         })?,
-                ))?
+                );
+                block_gen.append_op_ref_unnamed_result(read)?
             }
             StructType as _ => subcmp_value,
         };
@@ -313,13 +317,9 @@ impl<'ast> Lvalue<'ast> {
         let field_ty = codegen
             .get_output_signal_type(shared::get_name_tail(&comp_value_type)?, signal_name)?;
 
-        block_gen.append_op_unnamed_result(r#struct::readm(
-            codegen.op_builder(),
-            location,
-            field_ty,
-            comp_value,
-            signal_name,
-        )?)
+        let builder = block_gen.builder_at_current_insertion_point(codegen.context);
+        let read = r#struct::readm(&builder, location, field_ty, comp_value, signal_name)?;
+        block_gen.append_op_ref_unnamed_result(read)
     }
 
     /// Handle [Lvalue::Subcmp]  in [`Lvalue::get_value`] when the signal is an input of the
@@ -328,10 +328,13 @@ impl<'ast> Lvalue<'ast> {
         &self,
         signal_name: &str,
         subcmp_value: Value<'ctx, 'val>,
+        codegen: &LlzkCodegen<'_, 'ctx, '_, impl ProgramLike>,
         block_gen: &mut BlockGenContext<'_, 'ctx, '_, 'val>,
         location: Location<'ctx>,
     ) -> Result<Value<'ctx, 'val>> {
-        block_gen.append_op_unnamed_result(pod::read(
+        let builder = block_gen.builder_at_current_insertion_point(codegen.context);
+        let read = pod::read(
+            &builder,
             location,
             subcmp_value,
             signal_name,
@@ -343,7 +346,8 @@ impl<'ast> Lvalue<'ast> {
                         "subcomponent input signal {signal_name} not found: {subcmp_value}"
                     )
                 })?,
-        ))
+        );
+        block_gen.append_op_ref_unnamed_result(read)
     }
 
     /// Returns the SSA [`Value`] representing the op.
@@ -443,6 +447,7 @@ impl<'ast> Lvalue<'ast> {
                             self.get_subcmp_input(
                                 signal_name,
                                 subcmp_value,
+                                codegen,
                                 block_gen.as_mut(),
                                 location,
                             )
@@ -706,7 +711,9 @@ pub(crate) fn emit_condition<'ctx, 'val>(
         })
         .collect::<Result<Vec<_>>>()?;
     eqs.into_iter().try_fold(true_value, |acc, cmp| {
-        block_gen.append_op_unnamed_result(llzk::dialect::bool::and(location, acc, cmp)?)
+        let builder = block_gen.builder_at_current_insertion_point(codegen.context);
+        let op = llzk::dialect::bool::and(&builder, location, acc, cmp)?;
+        block_gen.append_op_ref_unnamed_result(op)
     })
 }
 
@@ -791,6 +798,7 @@ pub trait Combine<'ctx, 'val>: sealed::CombineSealed + Sized + Copy {
                     &mut tail,
                     &mut overwrites,
                     block_gen,
+                    codegen,
                     location,
                 )?;
 
@@ -818,27 +826,28 @@ pub trait Combine<'ctx, 'val>: sealed::CombineSealed + Sized + Copy {
                 }
 
                 // Create the yield ops for the branches
-                info.enter_scope(block_gen, |block_gen| {
+                info.enter_scope(codegen.context, block_gen, |block_gen| {
                     block_gen.append_op_no_result(scf::r#yield(&then_values, location))
                 })?;
-                tail.enter_scope(block_gen, |block_gen| {
+                tail.enter_scope(codegen.context, block_gen, |block_gen| {
                     block_gen.append_op_no_result(scf::r#yield(&else_values, location))
                 })?;
 
                 let then_region = info.region;
                 let else_region = tail.region;
-                let (mut new_info, values) = NestedBlockInfo::with_scope(block_gen, |block_gen| {
-                    block_gen.gen_safe_scf_if_multi(
-                        codegen,
-                        location,
-                        condition,
-                        then_region,
-                        Some(&then_values),
-                        else_region,
-                        Some(&else_values),
-                        None,
-                    )
-                })?;
+                let (mut new_info, values) =
+                    NestedBlockInfo::with_scope(codegen.context, block_gen, |block_gen| {
+                        block_gen.gen_safe_scf_if_multi(
+                            codegen,
+                            location,
+                            condition,
+                            then_region,
+                            Some(&then_values),
+                            else_region,
+                            Some(&else_values),
+                            None,
+                        )
+                    })?;
                 let overwrites = &values[overwrites_offset..];
                 assert_eq!(vars.len(), overwrites.len());
                 new_info.var_overwrites = OverwriteMap::from_iter(
@@ -856,7 +865,7 @@ pub trait Combine<'ctx, 'val>: sealed::CombineSealed + Sized + Copy {
         // Wrap the region in a `scf.execute_region`. It's easier to add ops than to steal the ops
         // inside the region and the canonicalizer will get rid of it.
         // Create an empty scf.yield op to satisfy scf.execute_region's requirements.
-        info.enter_scope(block_gen, |block_gen| {
+        info.enter_scope(codegen.context, block_gen, |block_gen| {
             block_gen.append_op_no_result(scf::r#yield(&values, location))
         })?;
         let types = values.iter().map(|v| v.r#type()).collect::<Vec<_>>();
@@ -951,6 +960,7 @@ fn fill_missing_overwrites<'ctx, 'blk, 'val>(
     else_info: &mut NestedBlockInfo<'ctx, 'blk, 'val>,
     overwrites: &mut [Overwrite<'ctx, 'val>],
     block_gen: &mut BlockGenContext<'_, 'ctx, 'blk, 'val>,
+    codegen: &LlzkCodegen<'_, 'ctx, '_, impl ProgramLike>,
     location: Location<'ctx>,
 ) -> Result<()> {
     let (mut missing_in_then, mut missing_in_else): (Vec<_>, Vec<_>) = overwrites
@@ -958,12 +968,14 @@ fn fill_missing_overwrites<'ctx, 'blk, 'val>(
         .filter(|o| !matches!(o, Overwrite::Both { .. }))
         .partition(|o| matches!(o, Overwrite::Else { .. }));
 
-    then_info.enter_scope(block_gen, |block_gen| {
+    then_info.enter_scope(codegen.context, block_gen, |block_gen| {
         for overwrite in &mut missing_in_then {
             match overwrite {
                 Overwrite::Else { var, value } => {
-                    let other =
-                        block_gen.append_op_unnamed_result(nondet(location, value.r#type()))?;
+                    let builder = block_gen.builder_at_current_insertion_point(codegen.context);
+                    let other = block_gen.append_op_ref_unnamed_result(
+                        codegen.new_nondet_at_location(&builder, location, value.r#type()),
+                    )?;
                     **overwrite = Overwrite::Both { var: var.clone(), then: other, r#else: *value };
                 }
                 _ => unreachable!(),
@@ -972,12 +984,14 @@ fn fill_missing_overwrites<'ctx, 'blk, 'val>(
         Ok(())
     })?;
 
-    else_info.enter_scope(block_gen, |block_gen| {
+    else_info.enter_scope(codegen.context, block_gen, |block_gen| {
         for overwrite in &mut missing_in_else {
             match overwrite {
                 Overwrite::Then { var, value } => {
-                    let other =
-                        block_gen.append_op_unnamed_result(nondet(location, value.r#type()))?;
+                    let builder = block_gen.builder_at_current_insertion_point(codegen.context);
+                    let other = block_gen.append_op_ref_unnamed_result(
+                        codegen.new_nondet_at_location(&builder, location, value.r#type()),
+                    )?;
                     **overwrite = Overwrite::Both { var: var.clone(), r#else: other, then: *value };
                 }
                 _ => unreachable!(),
@@ -1008,11 +1022,16 @@ impl<'ctx, 'val> Combine<'ctx, 'val> for Value<'ctx, 'val> {
     fn make_tail<'blk>(
         entries: &[CombineEntry<'ctx, 'blk, 'val, Self>],
         block_gen: &mut BlockGenContext<'_, 'ctx, 'blk, 'val>,
-        _: &LlzkCodegen<'_, 'ctx, '_, impl ProgramLike>,
+        codegen: &LlzkCodegen<'_, 'ctx, '_, impl ProgramLike>,
         location: Location<'ctx>,
     ) -> Result<(NestedBlockInfo<'ctx, 'blk, 'val>, Self)> {
-        NestedBlockInfo::with_scope(block_gen, |block_gen| {
-            block_gen.append_op_unnamed_result(nondet(location, entries[0].data.r#type()))
+        NestedBlockInfo::with_scope(codegen.context, block_gen, |block_gen| {
+            let builder = block_gen.builder_at_current_insertion_point(codegen.context);
+            block_gen.append_op_ref_unnamed_result(codegen.new_nondet_at_location(
+                &builder,
+                location,
+                entries[0].data.r#type(),
+            ))
         })
     }
 

--- a/llzk_backend/src/lvalue.rs
+++ b/llzk_backend/src/lvalue.rs
@@ -138,7 +138,6 @@ impl<'ast> Lvalue<'ast> {
     /// actual LLZK array then the continuation is called only once. However, if the array
     /// is actually an array of mixed subcomponents, the continuation is called for each
     /// branch of the dispatch table.
-    #[allow(clippy::too_many_arguments)]
     fn get_array_value<'decls, 'ctx, 'blk, 'val, 'cont, R, C>(
         &self,
         indices: &[&Expression],
@@ -241,7 +240,6 @@ impl<'ast> Lvalue<'ast> {
     }
 
     /// Emits the IR for a conditional check for array indices in a mixed subcomponent.
-    #[allow(clippy::too_many_arguments)]
     fn emit_mixed_subcmp_if_body<'decls, 'ctx, 'blk, 'val, 'cont, R, C>(
         &self,
         prev: Value<'ctx, 'val>,

--- a/llzk_backend/src/module.rs
+++ b/llzk_backend/src/module.rs
@@ -31,9 +31,7 @@ use llzk::dialect::function;
 use llzk::dialect::r#struct;
 use llzk::dialect::r#struct::helpers::compute_fn;
 use llzk::dialect::r#struct::helpers::constrain_fn;
-use llzk::error::Error;
 use llzk::prelude::ArrayType;
-use llzk::prelude::Block;
 use llzk::prelude::BlockLike as _;
 use llzk::prelude::FeltType;
 use llzk::prelude::FlatSymbolRefAttribute;
@@ -43,17 +41,14 @@ use llzk::prelude::FuncDefOpRefMut;
 use llzk::prelude::FunctionType;
 use llzk::prelude::Location;
 use llzk::prelude::MemberDefOpLike as _;
-use llzk::prelude::Operation;
-use llzk::prelude::OperationLike as _;
 use llzk::prelude::PodRecordAttribute;
 use llzk::prelude::PodType;
 use llzk::prelude::PublicAttribute;
-use llzk::prelude::RegionLike as _;
 use llzk::prelude::StructDefOpLike as _;
 use llzk::prelude::StructDefOpRef;
 use llzk::prelude::StructType;
-use llzk::prelude::TemplateOpLike;
-use llzk::prelude::TemplateSymbolBindingOpLike;
+use llzk::prelude::TemplateOpLike as _;
+use llzk::prelude::TemplateSymbolBindingOpLike as _;
 use llzk::prelude::Type;
 use melior::ir::Attribute;
 use melior::ir::AttributeLike as _;
@@ -98,22 +93,6 @@ struct MemberInfo<'ctx> {
     signal: bool,
 }
 
-impl<'ctx> TryFrom<MemberInfo<'ctx>> for Operation<'ctx> {
-    type Error = Error;
-
-    fn try_from(value: MemberInfo<'ctx>) -> std::result::Result<Self, Self::Error> {
-        r#struct::member(
-            value.location,
-            &value.name,
-            value.decl_type,
-            value.signal,
-            false,
-            value.public,
-        )
-        .map(Into::into)
-    }
-}
-
 /// Information collected from Declaration statements within a template that is used to setup LLZK
 /// struct fields and parameters to the functions with the struct.
 ///
@@ -124,11 +103,11 @@ pub struct DeclarationInfo<'ctx> {
     inputs: Vec<InputSignalInfo<'ctx>>,
     /// Output and Intermediate declarations to use as LLZK struct fields.
     struct_fields: Vec<MemberInfo<'ctx>>,
-    /// Map source-position-qualified key (`name@meta_start`) to its LLZK declaration Operation
-    /// (usually `llzk.nondet` initially). Using a source-position-qualified key allows the same
-    /// circom variable name to appear in multiple scopes without collision (e.g., an outer scope
-    /// followed by an inner scope or both branches of an if/else).
-    decl_inits: HashMap<String, Operation<'ctx>>,
+    /// Map source-position-qualified key (`name@meta_start`) to its LLZK declaration type. Using
+    /// a source-position-qualified key allows the same circom variable name to appear in multiple
+    /// scopes without collision (e.g., an outer scope followed by an inner scope or both branches
+    /// of an if/else).
+    decl_inits: HashMap<String, Type<'ctx>>,
     /// Maps each qualified key in `decl_inits` back to the plain circom variable name, so that
     /// function contexts can declare the value under its original name.
     decl_key_to_name: HashMap<String, String>,
@@ -415,13 +394,7 @@ impl<'ctx> DeclarationInfo<'ctx> {
                         let qualified_key = format!("{}@{}", name, meta.start);
                         self.var_decl_types.insert(qualified_key.clone(), var_type);
                         self.declared_var_names.insert(name.clone());
-                        let old = self.decl_inits.insert(
-                            qualified_key.clone(),
-                            codegen.new_nondet_at_location(
-                                codegen.location_from_meta(meta),
-                                var_type,
-                            )?,
-                        );
+                        let old = self.decl_inits.insert(qualified_key.clone(), var_type);
                         assert!(
                             old.is_none(),
                             "multiple declarations for qualified key {}",
@@ -556,16 +529,15 @@ impl<'ctx> DeclarationInfo<'ctx> {
                 signal: is_signal,
             });
         }
-        // Create `llzk.nondet` of the appropriate type. When the actual assignment
-        // is processed later, this is replaced with the appropriate value.
+        // Record the type for the `llzk.nondet` initializer. When the actual assignment is
+        // processed later, this is replaced with the appropriate value.
         // Signals are uniquely named within a template (the circom type checker enforces this),
         // so use the plain name as the qualified key.
-        codegen.new_nondet_at_location(location, decl_type).map(|op| {
-            self.declared_var_names.insert(name.clone());
-            let old = self.decl_inits.insert(name.clone(), op);
-            assert!(old.is_none(), "multiple declarations for {}", name);
-            self.decl_key_to_name.insert(name.clone(), name.clone());
-        })
+        self.declared_var_names.insert(name.clone());
+        let old = self.decl_inits.insert(name.clone(), decl_type);
+        assert!(old.is_none(), "multiple declarations for {}", name);
+        self.decl_key_to_name.insert(name.clone(), name.clone());
+        Ok(())
     }
 
     /// Traverses the AST looking for assigments of subcomponents and collects the instances used
@@ -694,15 +666,6 @@ where
         .collect::<Vec<_>>();
     let result = func_like.get_type_of_return(codegen);
     let func_type = FunctionType::new(codegen.context, &inputs, &[result]);
-    let func_def = function::def(location, func_like.get_name(), func_type, &[], Some(&arg_attrs))
-        .and_then(|f| {
-            let arguments: Vec<(Type, Location)> =
-                inputs.into_iter().map(|t| (t, location)).collect();
-            f.region(0)?.append_block(Block::new(&arguments));
-            Ok(f)
-        })?;
-    func_def.set_allow_non_native_field_ops_attr(true);
-
     let template_params = func_like
         .initial_poly_param_names()
         .map(|name| {
@@ -714,9 +677,19 @@ where
         codegen.create_and_set_current_template(location, func_like.get_name(), template_params)?;
 
     // Store function inside the `poly.template` so its type variables can resolve to the params.
-    let func = FuncDefOpRefMut::from(FuncDefOpRef::try_from(
-        new_template.body().append_operation(func_def.into()),
-    )?);
+    let template_builder =
+        llzk::builder::OpBuilder::at_block_end(codegen.context, new_template.body());
+    let func_def = function::def(
+        &template_builder,
+        location,
+        func_like.get_name(),
+        func_type,
+        &[],
+        Some(&arg_attrs),
+        llzk::dialect::empty_region,
+    )?;
+    func_def.set_allow_non_native_field_ops_attr(true);
+    let func = FuncDefOpRefMut::from(FuncDefOpRef::try_from(func_def)?);
 
     // Generate mapping from parameter names to SSA Values.
     let name_to_value = map_name_to_arg_value(func, func_like.get_name_of_params())?;
@@ -786,16 +759,25 @@ where
     }
 
     // Add the struct definition, prepopulated with fields, to the template body.
-    let new_struct = StructDefOpRef::try_from(
-        new_template.body().append_operation(
-            r#struct::def(
-                location,
-                template_like.get_name(),
-                declarations.struct_fields.into_iter().map(MemberInfo::try_into),
-            )?
-            .into(),
-        ),
-    )?;
+    let struct_fields = declarations.struct_fields;
+    let template_builder =
+        llzk::builder::OpBuilder::at_block_end(codegen.context, new_template.body());
+    let new_struct_ref =
+        r#struct::def(&template_builder, location, template_like.get_name(), |builder| {
+            for field in struct_fields {
+                r#struct::member(
+                    builder,
+                    field.location,
+                    &field.name,
+                    field.decl_type,
+                    field.signal,
+                    false,
+                    field.public,
+                )?;
+            }
+            Ok(())
+        })?;
+    let new_struct = StructDefOpRef::try_from(new_struct_ref)?;
 
     // Consume and separate 'declarations.inputs' (to avoid cloning 'attrs' and 'name').
     let (inputs, arg_attrs, arg_names) = declarations.inputs.into_iter().fold(
@@ -810,13 +792,22 @@ where
     // Generate the compute and constrain functions.
     let new_struct_type = new_struct.r#type();
     let struct_body = new_struct.body();
-    let compute_func = FuncDefOpRef::try_from(struct_body.append_operation(
-        compute_fn(location, new_struct_type, &inputs, Some(&arg_attrs))?.into(),
-    ))?
+    let struct_builder = llzk::builder::OpBuilder::at_block_end(codegen.context, struct_body);
+    let compute_func = FuncDefOpRef::try_from(compute_fn(
+        &struct_builder,
+        location,
+        new_struct_type,
+        &inputs,
+        Some(&arg_attrs),
+    )?)?
     .into();
-    let constrain_func = FuncDefOpRef::try_from(struct_body.append_operation(
-        constrain_fn(location, new_struct_type, &inputs, Some(&arg_attrs))?.into(),
-    ))?
+    let constrain_func = FuncDefOpRef::try_from(constrain_fn(
+        &struct_builder,
+        location,
+        new_struct_type,
+        &inputs,
+        Some(&arg_attrs),
+    )?)?
     .into();
 
     // Map parameter Values of each LLZK function to the corresponding circom variable names and
@@ -848,22 +839,25 @@ where
     // Insert read operations for struct fields into constrain functions.
     for member in new_struct.member_defs() {
         let member_name = member.member_name();
-        constrain_ctx.block_ctx.declare_name_if_not_present(member_name, || {
-            r#struct::readm(
-                codegen.op_builder(),
-                location,
-                member.member_type(),
-                constrain_func.self_value_of_constrain()?,
-                member_name,
-            )
-            .map_err(Into::into)
-        })?;
+        constrain_ctx.block_ctx.declare_value_if_not_present(
+            member_name,
+            |builder| {
+                shared::single_result_as_value(r#struct::readm(
+                    builder,
+                    location,
+                    member.member_type(),
+                    constrain_func.self_value_of_constrain()?,
+                    member_name,
+                )?)
+            },
+            codegen.context,
+        )?;
     }
 
     fn decl_inits<'ctx>(
-        decl_inits: HashMap<String, Operation<'ctx>>,
+        decl_inits: HashMap<String, Type<'ctx>>,
         sort: bool,
-    ) -> Vec<(String, Operation<'ctx>)> {
+    ) -> Vec<(String, Type<'ctx>)> {
         let mut v: Vec<_> = decl_inits.into_iter().collect();
         if sort {
             v.sort_by(|(lhs, _), (rhs, _)| lhs.cmp(rhs));
@@ -871,15 +865,35 @@ where
         v
     }
 
-    // Insert the Operations created from variable Declaration statements and map the circom
-    // variable name to LLZK op result Value (do this in each function).
+    // Insert initializers for variable Declaration statements and map the circom variable name to
+    // LLZK op result Value (do this in each function).
     let decl_key_to_name = declarations.decl_key_to_name;
-    for (key, op) in decl_inits(declarations.decl_inits, codegen.config.stabilize) {
+    for (key, ty) in decl_inits(declarations.decl_inits, codegen.config.stabilize) {
         let name = decl_key_to_name.get(&key).expect("every decl_inits key has a name entry");
-        // Insert (a clone of) the declaration into the compute function.
-        compute_ctx.block_ctx.declare_name_if_not_present(name, || Ok(op.clone()))?;
+        // Insert the declaration into the compute function.
+        compute_ctx.block_ctx.declare_value_if_not_present(
+            name,
+            |builder| {
+                shared::single_result_as_value(codegen.new_nondet_at_location(
+                    builder,
+                    codegen.location_unknown(),
+                    ty,
+                ))
+            },
+            codegen.context,
+        )?;
         // Insert the declaration into the constrain function.
-        constrain_ctx.block_ctx.declare_name_if_not_present(name, || Ok(op))?;
+        constrain_ctx.block_ctx.declare_value_if_not_present(
+            name,
+            |builder| {
+                shared::single_result_as_value(codegen.new_nondet_at_location(
+                    builder,
+                    codegen.location_unknown(),
+                    ty,
+                ))
+            },
+            codegen.context,
+        )?;
     }
     let subcmp_decls = declarations.subcmp_decls;
     let subcmp_names = subcmps

--- a/llzk_backend/src/shared.rs
+++ b/llzk_backend/src/shared.rs
@@ -32,6 +32,7 @@ use llzk::dialect::felt;
 use llzk::dialect::global;
 use llzk::dialect::pod;
 use llzk::dialect::poly;
+use llzk::operation::build_owned_operation;
 use llzk::prelude::is_felt_type;
 use llzk::prelude::melior_dialects::arith;
 use llzk::prelude::replace_uses_of_with;
@@ -114,28 +115,6 @@ use std::io::Write;
 use std::ops::Deref;
 use std::os::raw::c_void;
 use std::path::Path;
-
-/// Build an owned operation that is not attached to any block.
-///
-/// This mirrors `llzk::operation::build_owned_operation`, but does not tie the returned
-/// `OperationRef` lifetime to the callback's builder borrow. The upstream helper does that with a
-/// higher-ranked callback lifetime, while the LLZK dialect builders return refs with an independent
-/// inferred lifetime.
-pub fn build_owned_operation<'ctx: 'a, 'a, E>(
-    context: &'ctx LlzkContext,
-    build: impl FnOnce(&OpBuilder<'ctx, '_>) -> std::result::Result<OperationRef<'ctx, 'a>, E>,
-) -> std::result::Result<Operation<'ctx>, E> {
-    let scratch = Block::new(&[]);
-    let builder = OpBuilder::at_block_end(context, &scratch);
-    let raw = build(&builder)?.to_raw();
-    // SAFETY: `raw` is the operation inserted into the scratch block.
-    // Removing it transfers ownership to the returned `Operation`.
-    unsafe {
-        let mut op_ref = llzk::prelude::OperationRefMut::from_raw(raw);
-        op_ref.remove_from_parent();
-        Ok(Operation::from_raw(raw))
-    }
-}
 
 /// This macro allows writing type switches with a syntax similar to match expressions.
 #[macro_export]

--- a/llzk_backend/src/shared.rs
+++ b/llzk_backend/src/shared.rs
@@ -27,10 +27,12 @@ use llzk::builder::OpBuilderLike;
 use llzk::dialect;
 use llzk::dialect::array;
 use llzk::dialect::array::ArrayCtor;
+use llzk::dialect::empty_region;
 use llzk::dialect::felt;
 use llzk::dialect::global;
 use llzk::dialect::pod;
 use llzk::dialect::poly;
+use llzk::operation::build_owned_operation;
 use llzk::prelude::is_felt_type;
 use llzk::prelude::melior_dialects::arith;
 use llzk::prelude::replace_uses_of_with;
@@ -58,7 +60,6 @@ use llzk::prelude::Operation;
 use llzk::prelude::OperationLike;
 use llzk::prelude::OperationMutLike;
 use llzk::prelude::OperationRef;
-use llzk::prelude::OperationRefMut;
 use llzk::prelude::PassManager;
 use llzk::prelude::PodType;
 use llzk::prelude::RecordValue;
@@ -2623,23 +2624,58 @@ where
         // Generate `poly.expr` and fill its initializer region.
         let name = K::expr_name(target_expr);
         let location = codegen.location_from_meta(target_expr.get_meta());
-        let scratch = Block::new(&[]);
-        let scratch_builder = OpBuilder::at_block_end(codegen.context, &scratch);
-        let expr_op = poly::expr(&scratch_builder, location, &name, |_| Ok(()))?;
-        let mut expr_gen_ctx = BlockGenContext::new(
-            BlockContextStack::new(
+        let mut incomplete_poly_expr = false;
+        let expr_op = build_owned_operation(codegen.context, |builder| {
+            let expr_op = poly::expr(builder, location, &name, empty_region)?;
+            let mut expr_gen_ctx = BlockGenContext::new(
+                BlockContextStack::new(
+                    expr_op
+                        .initializer_region()
+                        .first_block()
+                        .expect("block should have been added"),
+                ),
+                self.get_var_decl_types(),
+                self.poly_template_binding_names(),
+            )
+            .with_poly_template_binding_locals(codegen, location)?;
+            let body_opt = codegen.current_body();
+            assert!(body_opt.is_some(), "should have been set at top level");
+            let trace = codegen.snapshot_statement_trace();
+            let Some(val) = gen_up_to_target(
+                codegen,
+                &mut expr_gen_ctx,
+                target_expr,
+                body_opt.unwrap(),
+                &trace,
+            )?
+            else {
+                incomplete_poly_expr = true;
+                return Ok::<OperationRef<'_, '_>, anyhow::Error>(expr_op.into());
+            };
+            let val = K::finalize_poly_expr_value(&mut expr_gen_ctx, codegen, location, val)?;
+            let yield_builder = OpBuilder::at_block_end(
+                codegen.context,
                 expr_op.initializer_region().first_block().expect("block should have been added"),
-            ),
-            self.get_var_decl_types(),
-            self.poly_template_binding_names(),
-        )
-        .with_poly_template_binding_locals(codegen, location)?;
-        let body_opt = codegen.current_body();
-        assert!(body_opt.is_some(), "should have been set at top level");
-        let trace = codegen.snapshot_statement_trace();
-        let Some(val) =
-            gen_up_to_target(codegen, &mut expr_gen_ctx, target_expr, body_opt.unwrap(), &trace)?
-        else {
+            );
+            poly::r#yield(&yield_builder, location, val)?;
+
+            // Run cleanup passes to simplify and normalize the generated code a bit:
+            // - remove-dead-values: drop ops whose results are not used
+            // - sccp: constant fold and propagate values
+            // - canonicalize: mainly to remove unused `llzk.nondet` (which `remove-dead-values`
+            //   cannot remove due to memory effects) but also folds felt constants, etc.
+            // This cleanup is not simply an optimization. In some cases, an `llzk.nondet` may be
+            // generated that references a symbol defined by a different `poly.expr` due to the way
+            // array declaration and initialization are split up in the circom AST. This is illegal
+            // in LLZK but that `llzk.nondet` result value is unused so it can be removed.
+            codegen.run_pass_pipeline_on(
+                "any(composite-fixed-point-pass{pipeline=\"canonicalize,sccp,remove-dead-values\"})",
+                &expr_op,
+            )?;
+
+            Ok(expr_op.into())
+        })?;
+        if incomplete_poly_expr {
             // If `gen_up_to_target` returns `None` that means that we don't have enough
             // information for creating the poly expression, so we give up here by returning an
             // identity affine map.
@@ -2647,29 +2683,8 @@ where
                 AffineMapAttribute::identity(codegen.context, 1).into(),
                 &[],
             );
-        };
-        let val = K::finalize_poly_expr_value(&mut expr_gen_ctx, codegen, location, val)?;
-        let yield_builder = OpBuilder::at_block_end(
-            codegen.context,
-            expr_op.initializer_region().first_block().expect("block should have been added"),
-        );
-        poly::r#yield(&yield_builder, location, val)?;
-
-        // Run cleanup passes to simplify and normalize the generated code a bit:
-        // - remove-dead-values: drop ops whose results are not used
-        // - sccp: constant fold and propagate values
-        // - canonicalize: mainly to remove unused `llzk.nondet` (which `remove-dead-values` cannot
-        //   remove due to memory effects) but also folds felt constants, etc.
-        // This cleanup is not simply an optimization. In some cases, an `llzk.nondet` may be
-        // generated that references a symbol defined by a different `poly.expr` due to the way
-        // array declaration and initialization are split up in the circom AST. This is illegal
-        // in LLZK but that `llzk.nondet` result value is unused so it can be removed.
-        codegen.run_pass_pipeline_on(
-            "any(composite-fixed-point-pass{pipeline=\"canonicalize,sccp,remove-dead-values\"})",
-            &expr_op,
-        )?;
-
-        let expr_op = TemplateExprOp::try_from(detach_owned_operation(&expr_op))?;
+        }
+        let expr_op = TemplateExprOp::try_from(expr_op)?;
         let uniqued_name = self.record_new_sym_binding(codegen, expr_op.into(), &|_| {});
 
         if codegen.config.verbose {
@@ -2778,20 +2793,6 @@ pub fn insert_unique_symbol_op<'c: 'a, 'a>(
     new_symbol_op: impl Into<Operation<'c>>,
 ) -> OperationRef<'c, 'a> {
     symbol_table::insert(sym_table_op, new_symbol_op.into())
-}
-
-/// Detach a builder-created operation from its temporary block and return ownership of it.
-///
-/// TODO: move to `llzk-rs`
-pub fn detach_owned_operation<'c: 'a, 'a>(op: &impl OperationLike<'c, 'a>) -> Operation<'c> {
-    let raw = op.to_raw();
-    // SAFETY: `raw` is a valid operation inserted in a scratch block. Removing it transfers
-    // responsibility for destroying it to the owned `Operation` constructed below.
-    unsafe {
-        let mut op_ref = OperationRefMut::from_raw(raw);
-        op_ref.remove_from_parent();
-        Operation::from_raw(raw)
-    }
 }
 
 /// Wraps the given pod record tuples into instances of [`RecordValue`].

--- a/llzk_backend/src/shared.rs
+++ b/llzk_backend/src/shared.rs
@@ -2625,7 +2625,7 @@ where
         let name = K::expr_name(target_expr);
         let location = codegen.location_from_meta(target_expr.get_meta());
         let mut incomplete_poly_expr = false;
-        let expr_op = build_owned_operation(codegen.context, |builder| {
+        let expr_op = build_owned_operation(codegen.context, |builder| -> Result<_> {
             let expr_op = poly::expr(builder, location, &name, empty_region)?;
             let mut expr_gen_ctx = BlockGenContext::new(
                 BlockContextStack::new(
@@ -2650,7 +2650,7 @@ where
             )?
             else {
                 incomplete_poly_expr = true;
-                return Ok::<OperationRef<'_, '_>, anyhow::Error>(expr_op.into());
+                return Ok(expr_op.into());
             };
             let val = K::finalize_poly_expr_value(&mut expr_gen_ctx, codegen, location, val)?;
             let yield_builder = OpBuilder::at_block_end(

--- a/llzk_backend/src/shared.rs
+++ b/llzk_backend/src/shared.rs
@@ -1673,7 +1673,6 @@ pub fn next_in_block_mut<'c: 'a, 'a>(
 ///
 /// This function provides an API fix that is added in a newer release of melior via
 /// [mlir-sys/melior#802](https://github.com/mlir-rs/melior/pull/802).
-#[allow(clippy::too_many_arguments)]
 pub fn enable_ir_printing(
     _self: &melior::pass::PassManager,
     before_all: bool,
@@ -2471,7 +2470,6 @@ where
         /// Generate the `scf.if` for a [Statement::IfThenElse] boundary encountered while
         /// walking toward `target_expr`. The branch containing the target recursively calls
         /// `gen_up_to_target`; the other branch yields a `nondet` placeholder of the same type.
-        #[allow(clippy::too_many_arguments)]
         fn gen_if_then_else_up_to_target<'ctx, 'blk, 'val>(
             codegen: &LlzkCodegen<'_, 'ctx, '_, impl ProgramLike>,
             gen_ctx: &mut BlockGenContext<'_, 'ctx, 'blk, 'val>,

--- a/llzk_backend/src/shared.rs
+++ b/llzk_backend/src/shared.rs
@@ -32,7 +32,6 @@ use llzk::dialect::felt;
 use llzk::dialect::global;
 use llzk::dialect::pod;
 use llzk::dialect::poly;
-use llzk::operation::build_owned_operation;
 use llzk::prelude::is_felt_type;
 use llzk::prelude::melior_dialects::arith;
 use llzk::prelude::replace_uses_of_with;
@@ -115,6 +114,28 @@ use std::io::Write;
 use std::ops::Deref;
 use std::os::raw::c_void;
 use std::path::Path;
+
+/// Build an owned operation that is not attached to any block.
+///
+/// This mirrors `llzk::operation::build_owned_operation`, but does not tie the returned
+/// `OperationRef` lifetime to the callback's builder borrow. The upstream helper does that with a
+/// higher-ranked callback lifetime, while the LLZK dialect builders return refs with an independent
+/// inferred lifetime.
+pub fn build_owned_operation<'ctx: 'a, 'a, E>(
+    context: &'ctx LlzkContext,
+    build: impl FnOnce(&OpBuilder<'ctx, '_>) -> std::result::Result<OperationRef<'ctx, 'a>, E>,
+) -> std::result::Result<Operation<'ctx>, E> {
+    let scratch = Block::new(&[]);
+    let builder = OpBuilder::at_block_end(context, &scratch);
+    let raw = build(&builder)?.to_raw();
+    // SAFETY: `raw` is the operation inserted into the scratch block.
+    // Removing it transfers ownership to the returned `Operation`.
+    unsafe {
+        let mut op_ref = llzk::prelude::OperationRefMut::from_raw(raw);
+        op_ref.remove_from_parent();
+        Ok(Operation::from_raw(raw))
+    }
+}
 
 /// This macro allows writing type switches with a syntax similar to match expressions.
 #[macro_export]

--- a/llzk_backend/src/shared.rs
+++ b/llzk_backend/src/shared.rs
@@ -23,6 +23,7 @@ use anyhow::Result;
 use llzk::attributes::array::AffineMapAttribute;
 use llzk::attributes::array::ArrayAttribute;
 use llzk::builder::OpBuilder;
+use llzk::builder::OpBuilderLike;
 use llzk::dialect;
 use llzk::dialect::array;
 use llzk::dialect::array::ArrayCtor;
@@ -38,7 +39,7 @@ use llzk::prelude::ArrayType;
 use llzk::prelude::Attribute;
 use llzk::prelude::AttributeLike as _;
 use llzk::prelude::Block;
-use llzk::prelude::BlockLike;
+use llzk::prelude::BlockLike as _;
 use llzk::prelude::BlockRef;
 use llzk::prelude::BoolAttribute;
 use llzk::prelude::FeltType;
@@ -62,22 +63,22 @@ use llzk::prelude::PassManager;
 use llzk::prelude::PodType;
 use llzk::prelude::RecordValue;
 use llzk::prelude::Region;
-use llzk::prelude::RegionLike;
+use llzk::prelude::RegionLike as _;
 use llzk::prelude::StringAttribute;
 use llzk::prelude::StringRef;
 use llzk::prelude::StructType;
 use llzk::prelude::SymbolRefAttribute;
 use llzk::prelude::TemplateExprOp;
-use llzk::prelude::TemplateExprOpLike;
-use llzk::prelude::TemplateOpLike;
+use llzk::prelude::TemplateExprOpLike as _;
+use llzk::prelude::TemplateOpLike as _;
 use llzk::prelude::TemplateOpRefMut;
 use llzk::prelude::TemplateSymbolBindingOp;
-use llzk::prelude::TemplateSymbolBindingOpLike;
+use llzk::prelude::TemplateSymbolBindingOpLike as _;
 use llzk::prelude::TemplateSymbolBindingOpRef;
 use llzk::prelude::Type;
 use llzk::prelude::TypeLike as _;
 use llzk::prelude::Value;
-use llzk::prelude::ValueLike;
+use llzk::prelude::ValueLike as _;
 use llzk::symbol_table;
 use llzk::value_ext::OwningValueRange;
 use llzk::value_ext::ValueRange;
@@ -692,9 +693,8 @@ impl<'ast: 'r, 'ctx: 'r, 'r, P: ProgramLike> LlzkCodegen<'ast, 'ctx, 'r, P> {
         let name = format!("vcp_array_const_{}", self.vcp_array_const_globals.borrow().len());
         let initial_value = self.build_vcp_array_const_attr(values);
 
-        self.module.body().append_operation(
-            global::def(location, &name, array_type, true, Some(initial_value)).into(),
-        );
+        let builder = OpBuilder::at_block_end(self.context, self.module.body());
+        global::def(&builder, location, &name, array_type, true, Some(initial_value));
         self.vcp_array_const_globals.borrow_mut().insert(key, name.clone());
         Ok((name, array_type))
     }
@@ -973,12 +973,13 @@ impl<'ast: 'r, 'ctx: 'r, 'r, P: ProgramLike> LlzkCodegen<'ast, 'ctx, 'r, P> {
     }
 
     /// Create an LLZK operation that produces a nondeterministic value of the given type.
-    pub fn new_nondet_at_location(
+    pub fn new_nondet_at_location<'a>(
         &self,
+        builder: &impl OpBuilderLike<'ctx>,
         location: Location<'ctx>,
         result_type: Type<'ctx>,
-    ) -> Result<Operation<'ctx>> {
-        Ok(dialect::llzk::nondet(location, result_type))
+    ) -> OperationRef<'ctx, 'a> {
+        dialect::llzk::nondet(builder, location, result_type)
     }
 
     /// Get the boolean type (`i1`).
@@ -1060,30 +1061,32 @@ impl<'ast: 'r, 'ctx: 'r, 'r, P: ProgramLike> LlzkCodegen<'ast, 'ctx, 'r, P> {
     ///
     /// Fails if the type of the value is not [`PodType`] or if the given name does not correspond
     /// with a record in the pod.
-    pub fn new_pod_read_op(
+    pub fn new_pod_read_op<'a>(
         &self,
+        builder: &impl OpBuilderLike<'ctx>,
         pod: Value<'ctx, '_>,
         name: impl AsRef<str>,
         location: Location<'ctx>,
-    ) -> Result<Operation<'ctx>> {
+    ) -> Result<OperationRef<'ctx, 'a>> {
         let name = name.as_ref();
         let pod_type = PodType::try_from(pod.r#type())?;
         let record_type = pod_type
             .record_type(name)
             .ok_or_else(|| anyhow!("record '{}' not found for pod {pod_type}", name))?;
-        Ok(pod::read(location, pod, name, record_type))
+        Ok(pod::read(builder, location, pod, name, record_type))
     }
 
     /// Creates a `pod.write` operation.
     #[inline]
-    pub fn new_pod_write_op(
+    pub fn new_pod_write_op<'a>(
         &self,
+        builder: &impl OpBuilderLike<'ctx>,
         location: Location<'ctx>,
         pod: Value<'ctx, '_>,
         name: impl AsRef<str>,
         src: Value<'ctx, '_>,
-    ) -> Operation<'ctx> {
-        pod::write(location, pod, name.as_ref(), src)
+    ) -> OperationRef<'ctx, 'a> {
+        pod::write(builder, location, pod, name.as_ref(), src)
     }
 
     /// Create an LLZK operation that produces a boolean constant value.
@@ -1103,29 +1106,31 @@ impl<'ast: 'r, 'ctx: 'r, 'r, P: ProgramLike> LlzkCodegen<'ast, 'ctx, 'r, P> {
 
     /// Create an LLZK `array.new` operation with the given type and constructor info.
     #[inline]
-    pub fn new_array_new_op(
+    pub fn new_array_new_op<'a>(
         &self,
+        builder: &impl OpBuilderLike<'ctx>,
         location: Location<'ctx>,
         r#type: ArrayType<'ctx>,
         ctor: ArrayCtor<'ctx, '_, '_, '_>,
-    ) -> Operation<'ctx> {
-        array::new(&self.builder, location, r#type, ctor)
+    ) -> OperationRef<'ctx, 'a> {
+        array::new(builder, location, r#type, ctor)
     }
 
     /// Generate a `felt.const` operation from a BigInt. Returns an `Err` result if unsuccessful
     /// or if the number of bits required to represent the BigInt does not fit in 32 bits.
-    pub fn new_felt_const_op(
+    pub fn new_felt_const_op<'a>(
         &self,
+        builder: &impl OpBuilderLike<'ctx>,
         val: &BigInt,
         location: Location<'ctx>,
-    ) -> Result<Operation<'ctx>> {
+    ) -> Result<OperationRef<'ctx, 'a>> {
         // ASSERT: The circom parser always produces non-negative constants. These can be negated
         // via PrefixOp but negative BigInt constants are never created directly.
         assert_ne!(val.sign(), num_bigint_dig::Sign::Minus, "Felt constants must be non-negative");
         // Increase by one to ensure the value is kept unsigned.
         let bitlen = val.bits() + 1;
         let attr = self.context.felt_attr_from_str(bitlen.try_into().unwrap(), val.to_string());
-        felt::constant(location, attr).map_err(Into::into)
+        felt::constant(builder, location, attr).map_err(Into::into)
     }
 
     /// Run the given pass pipeline on the given operation.
@@ -1905,12 +1910,14 @@ impl<'ctx, 'val> ArrayDimensions<'ctx, 'val> {
     /// Create an LLZK operation that produces a nondeterministic `felt.type` value of the given
     /// `dimensions` (non-array scalar if empty).
     #[inline]
-    pub fn new_nondet_felt_of_dimensions_at_location(
+    pub fn new_nondet_felt_of_dimensions_at_location<'a>(
         &self,
         codegen: &LlzkCodegen<'_, 'ctx, '_, impl ProgramLike>,
+        builder: &impl OpBuilderLike<'ctx>,
         location: Location<'ctx>,
-    ) -> Result<Operation<'ctx>> {
+    ) -> OperationRef<'ctx, 'a> {
         codegen.new_nondet_at_location(
+            builder,
             location,
             self.type_from_dimension_exprs(codegen.felt_type().into()),
         )
@@ -1919,12 +1926,17 @@ impl<'ctx, 'val> ArrayDimensions<'ctx, 'val> {
     /// Create an LLZK operation that produces a nondeterministic `felt.type` value of the given
     /// array `dimensions` (non-array scalar if empty).
     #[inline]
-    pub fn new_nondet_felt_of_dimensions(
+    pub fn new_nondet_felt_of_dimensions<'a>(
         &self,
         codegen: &LlzkCodegen<'_, 'ctx, '_, impl ProgramLike>,
+        builder: &impl OpBuilderLike<'ctx>,
         meta: &Meta,
-    ) -> Result<Operation<'ctx>> {
-        self.new_nondet_felt_of_dimensions_at_location(codegen, codegen.location_from_meta(meta))
+    ) -> OperationRef<'ctx, 'a> {
+        self.new_nondet_felt_of_dimensions_at_location(
+            codegen,
+            builder,
+            codegen.location_from_meta(meta),
+        )
     }
 }
 
@@ -2312,6 +2324,7 @@ where
                     }
                     let top = *gen_ctx.block_ctx.top_block();
                     gen_ctx.gen_in_given_block_with_new_circom_scope_and_merge_overwrites(
+                        codegen.context,
                         top,
                         |gen_ctx| {
                             stmts.iter().try_for_each(|stmt| gen_stmt_fully(stmt, codegen, gen_ctx))
@@ -2345,15 +2358,20 @@ where
                         // gen_template_poly_expr calls for non-constant dimension expressions.
                         let qualified_key = format!("{}@{}", name, meta.start);
                         if let Some(ty) = gen_ctx.get_var_decl_types().get(&qualified_key) {
-                            let op = codegen
-                                .new_nondet_at_location(codegen.location_from_meta(meta), *ty)?;
+                            let builder =
+                                gen_ctx.builder_at_current_insertion_point(codegen.context);
+                            let value = single_result_as_value(codegen.new_nondet_at_location(
+                                &builder,
+                                codegen.location_from_meta(meta),
+                                *ty,
+                            ))?;
                             if codegen.config.verbose {
                                 println!(
                                     "Declaring '{name}' @ {}",
                                     codegen.location_from_meta(meta)
                                 );
                             }
-                            gen_ctx.block_ctx.declare_name_ensure_not_present(name, op)?;
+                            gen_ctx.block_ctx.declare_value_ensure_not_present(name, value)?;
                         } else {
                             gen_ctx.gen_declaration(codegen, meta, name, dimensions)?;
                         }
@@ -2381,14 +2399,14 @@ where
                     let mut then_info = NestedBlockInfo::default();
                     gen_ctx.block_ctx.push(then_info.block);
                     gen_stmt_fully(if_case, codegen, gen_ctx)?;
-                    then_info.var_overwrites = gen_ctx.block_ctx.pop();
+                    then_info.var_overwrites = gen_ctx.block_ctx.pop(codegen.context)?;
                     // Build else-branch NestedBlockInfo.
                     let mut else_info = NestedBlockInfo::default();
                     gen_ctx.block_ctx.push(else_info.block);
                     if let Some(ec) = else_case {
                         gen_stmt_fully(ec, codegen, gen_ctx)?;
                     }
-                    else_info.var_overwrites = gen_ctx.block_ctx.pop();
+                    else_info.var_overwrites = gen_ctx.block_ctx.pop(codegen.context)?;
                     gen_ctx.gen_scf_if_with_var_overwrites(
                         codegen, location, cond_bool, then_info, else_info,
                     )?;
@@ -2402,11 +2420,12 @@ where
                         );
                     }
                     let location = codegen.location_from_meta(meta);
-                    let (cond_info, cond_bool) = NestedBlockInfo::with_scope(gen_ctx, |gen_ctx| {
-                        let cond_val =
-                            cond.gen_llzk_in_block(codegen, gen_ctx, Default::default())?;
-                        gen_ctx.cast_to_bool_if_needed(codegen, location, cond_val)
-                    })?;
+                    let (cond_info, cond_bool) =
+                        NestedBlockInfo::with_scope(codegen.context, gen_ctx, |gen_ctx| {
+                            let cond_val =
+                                cond.gen_llzk_in_block(codegen, gen_ctx, Default::default())?;
+                            gen_ctx.cast_to_bool_if_needed(codegen, location, cond_val)
+                        })?;
                     if codegen.config.verbose {
                         println!(
                             "[While] Popping cond scope @ {}",
@@ -2417,9 +2436,10 @@ where
                             codegen.location_from_meta(meta)
                         );
                     }
-                    let (body_info, _) = NestedBlockInfo::with_scope(gen_ctx, |gen_ctx| {
-                        gen_stmt_fully(stmt, codegen, gen_ctx)
-                    })?;
+                    let (body_info, _) =
+                        NestedBlockInfo::with_scope(codegen.context, gen_ctx, |gen_ctx| {
+                            gen_stmt_fully(stmt, codegen, gen_ctx)
+                        })?;
                     if codegen.config.verbose {
                         println!(
                             "[While] Popping body scope @ {}",
@@ -2492,23 +2512,30 @@ where
 
             // Generate the branch that contains the target, then a nondet placeholder for the
             // other branch (using the result type from the containing branch).
-            let containing_arm_info = gen_ctx.gen_scf_if_arm_no_var_overwrites(location, |gc| {
-                gen_up_to_target(
-                    codegen,
-                    gc,
-                    target_expr,
-                    std::slice::from_ref(containing_stmt),
-                    trace,
-                )
-            })?;
+            let containing_arm_info =
+                gen_ctx.gen_scf_if_arm_no_var_overwrites(codegen.context, location, |gc| {
+                    gen_up_to_target(
+                        codegen,
+                        gc,
+                        target_expr,
+                        std::slice::from_ref(containing_stmt),
+                        trace,
+                    )
+                })?;
             if containing_arm_info.1.is_none() {
                 return Ok(None);
             }
             let containing_arm_info = (containing_arm_info.0, containing_arm_info.1.unwrap());
             let result_type = containing_arm_info.1.r#type();
-            let other_arm_info = gen_ctx.gen_scf_if_arm_no_var_overwrites(location, |gc| {
-                gc.append_op_unnamed_result(codegen.new_nondet_at_location(location, result_type)?)
-            })?;
+            let other_arm_info =
+                gen_ctx.gen_scf_if_arm_no_var_overwrites(codegen.context, location, |gc| {
+                    let builder = gc.builder_at_current_insertion_point(codegen.context);
+                    gc.append_op_ref_unnamed_result(codegen.new_nondet_at_location(
+                        &builder,
+                        location,
+                        result_type,
+                    ))
+                })?;
 
             // Assemble the scf.if with regions in the correct order.
             let (then_arm_info, else_arm_info) = if target_in_then {
@@ -2757,9 +2784,7 @@ pub fn insert_unique_symbol_op<'c: 'a, 'a>(
 
 /// Detach a builder-created operation from its temporary block and return ownership of it.
 ///
-/// LLZK's builder APIs insert operations immediately. Declaration collection still needs to hold
-/// some symbol operations until their containing template is created, so those operations are
-/// initially built in a scratch block and transferred into owned form here.
+/// TODO: move to `llzk-rs`
 pub fn detach_owned_operation<'c: 'a, 'a>(op: &impl OperationLike<'c, 'a>) -> Operation<'c> {
     let raw = op.to_raw();
     // SAFETY: `raw` is a valid operation inserted in a scratch block. Removing it transfers

--- a/llzk_backend/src/subcmp.rs
+++ b/llzk_backend/src/subcmp.rs
@@ -13,7 +13,6 @@ use crate::template_ext::SignalDeclarations;
 use crate::template_ext::TemplateLike as _;
 use anyhow::Result;
 use llzk::dialect::array::ArrayCtor;
-use llzk::dialect::llzk::nondet;
 use llzk::dialect::pod;
 use llzk::dialect::r#struct;
 use llzk::prelude::ArrayType;
@@ -24,7 +23,6 @@ use llzk::prelude::PodType;
 use llzk::prelude::StructType;
 use llzk::prelude::Type;
 use llzk::prelude::TypeLike as _;
-use melior::ir::Operation;
 use melior::ir::Value;
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -325,14 +323,14 @@ impl<'ctx> MixedSubcmpLayout<'ctx> {
         &self.entries
     }
 
-    /// Generates the initialization operation for this mixed subcomponent.
-    fn generate_initialization_op<'val>(
+    /// Generates the initialization value for this mixed subcomponent.
+    fn generate_initialization_value<'val>(
         &self,
         empty_params: Value<'ctx, 'val>,
         block_gen: &mut BlockGenContext<'_, 'ctx, '_, 'val>,
         codegen: &LlzkCodegen<'_, 'ctx, '_, impl ProgramLike>,
         location: Location<'ctx>,
-    ) -> Result<Operation<'ctx>> {
+    ) -> Result<Value<'ctx, 'val>> {
         // Generate initialization ops for each entry as normal.
         // Then combine all of them into one `pod.new` operation passing all the entries.
         let entries = self
@@ -348,8 +346,9 @@ impl<'ctx> MixedSubcmpLayout<'ctx> {
                     location,
                     None,
                 )?;
-                let entry_init = block_gen.append_op_unnamed_result(pod::new(
-                    codegen.op_builder(),
+                let builder = block_gen.builder_at_current_insertion_point(codegen.context);
+                let entry_init = block_gen.append_op_ref_unnamed_result(pod::new(
+                    &builder,
                     location,
                     &wrap_pod_records(records),
                     Some(entry.memory_type),
@@ -358,8 +357,9 @@ impl<'ctx> MixedSubcmpLayout<'ctx> {
                 Ok((name, entry_init))
             })
             .collect::<Result<Vec<_>>>()?;
-        Ok(pod::new(
-            codegen.op_builder(),
+        let builder = block_gen.builder_at_current_insertion_point(codegen.context);
+        block_gen.append_op_ref_unnamed_result(pod::new(
+            &builder,
             location,
             &wrap_pod_records(entries),
             Some(self.memory_type),
@@ -576,8 +576,9 @@ impl<'ctx> SubcmpType<'ctx> {
         // If the count == 0 means that the subcomponent has no inputs. In that
         // case we call `@compute` here directly and store it into COMP.
         if count.is_const_zero() {
-            let empty_inputs = block_gen.append_op_unnamed_result(pod::new(
-                codegen.op_builder(),
+            let builder = block_gen.builder_at_current_insertion_point(codegen.context);
+            let empty_inputs = block_gen.append_op_ref_unnamed_result(pod::new(
+                &builder,
                 location,
                 &[],
                 Some(codegen.pod_type(&[])),
@@ -721,52 +722,65 @@ impl<'ctx> SubcmpPrologueData<'ctx> {
     ) -> Result<()> {
         let decl = &subcmp_decls[self.name()];
         let self_ref = constrain_ctx.func.self_value_of_constrain()?;
-        constrain_ctx.block_ctx.declare_name_if_not_present(self.name(), || {
-            Ok(r#struct::readm(
-                codegen.op_builder(),
-                decl.location(),
-                self.component_type,
-                self_ref,
-                self.name(),
-            )?)
-        })?;
-        constrain_ctx.block_ctx.declare_name_if_not_present(self.name_inputs(), || {
-            Ok(r#struct::readm(
-                codegen.op_builder(),
-                decl.location(),
-                self.inputs,
-                self_ref,
-                self.name_inputs(),
-            )?)
-        })?;
+        constrain_ctx.block_ctx.declare_value_if_not_present(
+            self.name(),
+            |builder| {
+                crate::shared::single_result_as_value(r#struct::readm(
+                    builder,
+                    decl.location(),
+                    self.component_type,
+                    self_ref,
+                    self.name(),
+                )?)
+            },
+            codegen.context,
+        )?;
+        constrain_ctx.block_ctx.declare_value_if_not_present(
+            self.name_inputs(),
+            |builder| {
+                crate::shared::single_result_as_value(r#struct::readm(
+                    builder,
+                    decl.location(),
+                    self.inputs,
+                    self_ref,
+                    self.name_inputs(),
+                )?)
+            },
+            codegen.context,
+        )?;
         Ok(())
     }
 
     /// Generates the operation that initializes a subcomponent.
-    fn generate_initialization_op<'func, 'blk, 'val>(
+    fn generate_initialization_value<'func, 'blk, 'val>(
         &self,
         compute_ctx: &mut FunctionContext<'_, 'ctx, 'func, 'blk, 'val>,
         codegen: &LlzkCodegen<'_, 'ctx, '_, impl ProgramLike>,
         decl: &SubcmpDeclInfo<'ctx>,
-    ) -> Result<Operation<'ctx>>
+    ) -> Result<Value<'ctx, 'val>>
     where
         'val: 'blk,
     {
         use SubcmpPrologueLayout::*;
         let memory_type = self.memory_type(codegen);
         if let Ok(comp_pod) = ArrayType::try_from(memory_type) {
-            let array = codegen.new_array_new_op(decl.location(), comp_pod, ArrayCtor::Empty);
-            return Ok(array);
+            let builder = compute_ctx.builder_at_current_insertion_point(codegen.context);
+            let array =
+                codegen.new_array_new_op(&builder, decl.location(), comp_pod, ArrayCtor::Empty);
+            return compute_ctx.append_op_ref_unnamed_result(array);
         }
 
         if !self.layout.is_very_concrete() {
             // If the subcomponent has parameters we defer initialization to
             // the constructor call.
-            return Ok(nondet(decl.location(), memory_type));
+            let builder = compute_ctx.builder_at_current_insertion_point(codegen.context);
+            let nondet = codegen.new_nondet_at_location(&builder, decl.location(), memory_type);
+            return compute_ctx.append_op_ref_unnamed_result(nondet);
         }
 
-        let empty_params = compute_ctx.append_op_unnamed_result(pod::new(
-            codegen.op_builder(),
+        let builder = compute_ctx.builder_at_current_insertion_point(codegen.context);
+        let empty_params = compute_ctx.append_op_ref_unnamed_result(pod::new(
+            &builder,
             decl.location(),
             &[],
             Some(codegen.pod_type(&[])),
@@ -775,14 +789,14 @@ impl<'ctx> SubcmpPrologueData<'ctx> {
         // initialized twice, once here and another in the constructor callsite.
         // In concrete mode the initialization should happen only here.
         match &self.layout {
-            Uniform(subcmp_type) => self.generate_initialization_op_with_subcmp_type(
+            Uniform(subcmp_type) => self.generate_initialization_value_with_subcmp_type(
                 subcmp_type,
                 empty_params,
                 compute_ctx,
                 codegen,
                 decl.location(),
             ),
-            Mixed(mixed_subcmp_layout) => mixed_subcmp_layout.generate_initialization_op(
+            Mixed(mixed_subcmp_layout) => mixed_subcmp_layout.generate_initialization_value(
                 empty_params,
                 compute_ctx,
                 codegen,
@@ -792,14 +806,14 @@ impl<'ctx> SubcmpPrologueData<'ctx> {
     }
 
     /// Generates the initialization op of a subcomponent using the given [`SubcmpType`].
-    fn generate_initialization_op_with_subcmp_type<'blk, 'val>(
+    fn generate_initialization_value_with_subcmp_type<'blk, 'val>(
         &self,
         subcmp_type: &SubcmpType<'ctx>,
         empty_params: Value<'ctx, 'val>,
         block_gen: &mut BlockGenContext<'_, 'ctx, 'blk, 'val>,
         codegen: &LlzkCodegen<'_, 'ctx, '_, impl ProgramLike>,
         location: Location<'ctx>,
-    ) -> Result<Operation<'ctx>>
+    ) -> Result<Value<'ctx, 'val>>
     where
         'val: 'blk,
     {
@@ -811,8 +825,9 @@ impl<'ctx> SubcmpPrologueData<'ctx> {
             // We don't need template parameters in this case
             None,
         )?;
-        Ok(pod::new(
-            codegen.op_builder(),
+        let builder = block_gen.builder_at_current_insertion_point(codegen.context);
+        block_gen.append_op_ref_unnamed_result(pod::new(
+            &builder,
             location,
             &wrap_pod_records(records),
             Some(subcmp_type.comp_pod(codegen).try_into()?),
@@ -835,23 +850,38 @@ impl<'ctx> SubcmpPrologueData<'ctx> {
         'val: 'blk,
     {
         let decl = &subcmp_decls[self.name()];
-        let initialization_op = self.generate_initialization_op(compute_ctx, codegen, decl)?;
-        compute_ctx.block_ctx.declare_name_ensure_not_present(self.name(), initialization_op)?;
+        let initialization_value =
+            self.generate_initialization_value(compute_ctx, codegen, decl)?;
+        compute_ctx
+            .block_ctx
+            .declare_value_ensure_not_present(self.name(), initialization_value)?;
         self.initialize_subcmp_array(
             *compute_ctx.block_ctx.get_named_value(self.name())?,
             compute_ctx,
             codegen,
             decl.location(),
         )?;
-        compute_ctx.block_ctx.declare_name_ensure_not_present(
-            self.name_inputs(),
-            match self.inputs_as::<ArrayType>() {
-                Ok(ty) => codegen.new_array_new_op(decl.location(), ty, ArrayCtor::Empty),
-                Err(_) => {
-                    pod::new(codegen.op_builder(), decl.location(), &[], Some(self.inputs_as()?))
-                }
-            },
-        )
+        let inputs_value = match self.inputs_as::<ArrayType>() {
+            Ok(ty) => {
+                let builder = compute_ctx.builder_at_current_insertion_point(codegen.context);
+                compute_ctx.append_op_ref_unnamed_result(codegen.new_array_new_op(
+                    &builder,
+                    decl.location(),
+                    ty,
+                    ArrayCtor::Empty,
+                ))?
+            }
+            Err(_) => {
+                let builder = compute_ctx.builder_at_current_insertion_point(codegen.context);
+                compute_ctx.append_op_ref_unnamed_result(pod::new(
+                    &builder,
+                    decl.location(),
+                    &[],
+                    Some(self.inputs_as()?),
+                ))?
+            }
+        };
+        compute_ctx.block_ctx.declare_value_ensure_not_present(self.name_inputs(), inputs_value)
     }
 
     /// Generates a loop nest that initializes a subcomponent if it's an array and the layout is
@@ -874,8 +904,9 @@ impl<'ctx> SubcmpPrologueData<'ctx> {
             unreachable!("Mixed subcomponents cannot be represented with uniform array types")
         };
         let subcmp_type = subcmp_type.scoped_to_inner();
-        let empty_params = compute_ctx.append_op_unnamed_result(pod::new(
-            codegen.op_builder(),
+        let builder = compute_ctx.builder_at_current_insertion_point(codegen.context);
+        let empty_params = compute_ctx.append_op_ref_unnamed_result(pod::new(
+            &builder,
             location,
             &[],
             Some(codegen.pod_type(&[])),
@@ -886,14 +917,13 @@ impl<'ctx> SubcmpPrologueData<'ctx> {
             location,
             &comp_pod.dims(),
             |block_gen, indices| {
-                let init_op = self.generate_initialization_op_with_subcmp_type(
+                let comp_memory_pod = self.generate_initialization_value_with_subcmp_type(
                     &subcmp_type,
                     empty_params,
                     block_gen,
                     codegen,
                     location,
                 )?;
-                let comp_memory_pod = block_gen.append_op_unnamed_result(init_op)?;
                 block_gen.append_array_write(
                     codegen,
                     comp_memory,

--- a/llzk_backend/src/template.rs
+++ b/llzk_backend/src/template.rs
@@ -50,6 +50,7 @@ use llzk::prelude::BlockRef;
 use llzk::prelude::FlatSymbolRefAttribute;
 use llzk::prelude::FuncDefOpLike as _;
 use llzk::prelude::IntegerAttribute;
+use llzk::prelude::LlzkContext;
 use llzk::prelude::LoopBoundsAttribute;
 use llzk::prelude::MemberDefOpLike as _;
 use llzk::prelude::PodType;
@@ -58,9 +59,9 @@ use llzk::prelude::StringRef;
 use llzk::prelude::StructDefOpLike as _;
 use llzk::prelude::StructDefOpRefMut;
 use llzk::prelude::SymbolRefAttribute;
-use llzk::prelude::TemplateOpLike;
+use llzk::prelude::TemplateOpLike as _;
 use llzk::prelude::TemplateOpRefMut;
-use llzk::prelude::TemplateSymbolBindingOpLike;
+use llzk::prelude::TemplateSymbolBindingOpLike as _;
 use llzk::prelude::Type;
 use llzk::prelude::Value;
 use llzk::prelude::ValueLike as _;
@@ -228,14 +229,32 @@ impl<'decls, 'ctx, 'str, 'func, 'blk, 'val> TemplateContext<'decls, 'ctx, 'str, 
     ) -> Result<()> {
         let global_ref = || SymbolRefAttribute::new_from_str(codegen.context, global_name, &[]);
         if let Some(fc) = self.compute.as_ref() {
-            fc.borrow_mut().block_ctx.declare_name_if_not_present(name, || {
-                Ok(global::read(location, global_ref(), ty))
-            })?;
+            fc.borrow_mut().block_ctx.declare_value_if_not_present(
+                name,
+                |builder| {
+                    shared::single_result_as_value(global::read(
+                        builder,
+                        location,
+                        global_ref(),
+                        ty,
+                    ))
+                },
+                codegen.context,
+            )?;
         }
         if let Some(fc) = self.constrain.as_ref() {
-            fc.borrow_mut().block_ctx.declare_name_if_not_present(name, || {
-                Ok(global::read(location, global_ref(), ty))
-            })?;
+            fc.borrow_mut().block_ctx.declare_value_if_not_present(
+                name,
+                |builder| {
+                    shared::single_result_as_value(global::read(
+                        builder,
+                        location,
+                        global_ref(),
+                        ty,
+                    ))
+                },
+                codegen.context,
+            )?;
         }
         Ok(())
     }
@@ -251,12 +270,12 @@ impl<'decls, 'ctx, 'str, 'func, 'blk, 'val> TemplateContext<'decls, 'ctx, 'str, 
     }
 
     /// Part of the finalization procedure that emits the pending operations in the queue.
-    fn finalize_queue(self) -> Result<Self> {
+    fn finalize_queue(self, codegen: &LlzkCodegen<'_, 'ctx, '_, impl ProgramLike>) -> Result<Self> {
         self.and_then_same::<_, GenResultUnit>(|fc, _| {
             if !fc.block_ctx.is_only_root() {
                 anyhow::bail!("Template generation reached final step with more than one scope");
             }
-            fc.block_ctx.append_queue();
+            fc.block_ctx.append_queue(codegen.context)?;
             Ok(())
         })?;
         Ok(self)
@@ -287,12 +306,15 @@ impl<'decls, 'ctx, 'str, 'func, 'blk, 'val> TemplateContext<'decls, 'ctx, 'str, 
                     // Write the inputs of the subcomponent.
                     let name_inputs = crate::subcmp::names::inputs(name);
                     let name_inputs_val = *fc.block_ctx.get_named_value(&name_inputs)?;
-                    fc.append_op_no_result(r#struct::writem(
+                    let builder = fc.builder_at_current_insertion_point(codegen.context);
+                    let write = r#struct::writem(
+                        &builder,
                         location,
                         self_value,
                         &name_inputs,
                         name_inputs_val,
-                    )?)?;
+                    )?;
+                    fc.append_op_ref_no_result(write)?;
 
                     // This value is the memory SSA value. We need to extract the component from
                     // it.
@@ -303,7 +325,9 @@ impl<'decls, 'ctx, 'str, 'func, 'blk, 'val> TemplateContext<'decls, 'ctx, 'str, 
                                 // Copy the components into an array of the same dimensions.
                                 let struct_type = comp_type(ty.element_type().try_into()?)?;
 
-                                let comp_array = fc.append_op_unnamed_result(codegen.new_array_new_op(
+                                let builder = fc.builder_at_current_insertion_point(codegen.context);
+                                let comp_array = fc.append_op_ref_unnamed_result(codegen.new_array_new_op(
+                                    &builder,
                                     location,
                                     map_array_inner_type(ty.into(), struct_type).try_into()?,
                                     ArrayCtor::Empty
@@ -317,12 +341,15 @@ impl<'decls, 'ctx, 'str, 'func, 'blk, 'val> TemplateContext<'decls, 'ctx, 'str, 
                                         location,
                                         None
                                     )?;
-                                    let comp_instance = fc.append_op_unnamed_result(pod::read(
+                                    let builder = fc.builder_at_current_insertion_point(codegen.context);
+                                    let read = pod::read(
+                                        &builder,
                                         location,
                                         comp_memory,
                                         COMP,
                                         struct_type
-                                    ))?;
+                                    );
+                                    let comp_instance = fc.append_op_ref_unnamed_result(read)?;
                                     fc.append_array_write(
                                         codegen,
                                         comp_array,
@@ -336,35 +363,45 @@ impl<'decls, 'ctx, 'str, 'func, 'blk, 'val> TemplateContext<'decls, 'ctx, 'str, 
                                 comp_array
                             }
                             PodType => {
-                                fc.append_op_unnamed_result(pod::read(
+                                let builder = fc.builder_at_current_insertion_point(codegen.context);
+                                let read = pod::read(
+                                    &builder,
                                     location,
                                     mem,
                                     COMP,
                                     comp_type(ty)?
-                                ))?
+                                );
+                                fc.append_op_ref_unnamed_result(read)?
                             }
                         },
                         SubcmpLayout::Mixed(layout) => {
                             let records = layout.entries().iter().map(|entry| {
-                                let comp_memory = fc.append_op_unnamed_result(pod::read(
+                                let builder = fc.builder_at_current_insertion_point(codegen.context);
+                                let read = pod::read(
+                                    &builder,
                                     location,
                                     mem,
                                     entry.record_name(),
                                     entry.memory_type().into(),
-                                ))?;
-                                let comp_instance = fc.append_op_unnamed_result(pod::read(
+                                );
+                                let comp_memory = fc.append_op_ref_unnamed_result(read)?;
+                                let builder = fc.builder_at_current_insertion_point(codegen.context);
+                                let read = pod::read(
+                                    &builder,
                                     location,
                                     comp_memory,
                                     COMP,
                                     entry.struct_type().into(),
-                                ))?;
+                                );
+                                let comp_instance = fc.append_op_ref_unnamed_result(read)?;
                                 Ok(RecordValue::new(
                                     StringRef::new(entry.record_name()),
                                     comp_instance,
                                 ))
                             }).collect::<Result<Vec<_>>>()?;
-                            fc.append_op_unnamed_result(pod::new(
-                                codegen.op_builder(),
+                            let builder = fc.builder_at_current_insertion_point(codegen.context);
+                            fc.append_op_ref_unnamed_result(pod::new(
+                                &builder,
                                 location,
                                 &records,
                                 Some(layout.component_type()),
@@ -372,12 +409,15 @@ impl<'decls, 'ctx, 'str, 'func, 'blk, 'val> TemplateContext<'decls, 'ctx, 'str, 
                         }
                     };
 
-                    fc.append_op_no_result(r#struct::writem(
+                    let builder = fc.builder_at_current_insertion_point(codegen.context);
+                    let write = r#struct::writem(
+                        &builder,
                         location,
                         self_value,
                         name,
                         value,
-                    )?)
+                    )?;
+                    fc.append_op_ref_no_result(write)
 
                 })
 
@@ -425,18 +465,24 @@ impl<'decls, 'ctx, 'str, 'func, 'blk, 'val> TemplateContext<'decls, 'ctx, 'str, 
                         },
                         SubcmpLayout::Mixed(layout) => {
                             layout.entries().iter().try_for_each(|entry| {
-                                let subcmp_instance = fc.append_op_unnamed_result(pod::read(
+                                let builder = fc.builder_at_current_insertion_point(codegen.context);
+                                let read = pod::read(
+                                    &builder,
                                     location,
                                     subcmp,
                                     entry.record_name(),
                                     entry.struct_type().into(),
-                                ))?;
-                                let subcmp_inputs = fc.append_op_unnamed_result(pod::read(
+                                );
+                                let subcmp_instance = fc.append_op_ref_unnamed_result(read)?;
+                                let builder = fc.builder_at_current_insertion_point(codegen.context);
+                                let read = pod::read(
+                                    &builder,
                                     location,
                                     inputs,
                                     entry.record_name(),
                                     entry.inputs_type().into(),
-                                ))?;
+                                );
+                                let subcmp_inputs = fc.append_op_ref_unnamed_result(read)?;
                                 fc.gen_constrain_call(
                                     subcmp_instance,
                                     subcmp_inputs,
@@ -459,7 +505,7 @@ impl<'decls, 'ctx, 'str, 'func, 'blk, 'val> TemplateContext<'decls, 'ctx, 'str, 
         'val: 'blk,
     {
         self.finalize_subcmps(codegen)?
-            .finalize_queue()?
+            .finalize_queue(codegen)?
             .and_then_same(|fc, _| fc.finalize(codegen))
     }
 
@@ -554,6 +600,7 @@ where
 
     fn stack_pop<H>(
         &mut self,
+        context: &'ctx LlzkContext,
         overwrite_handler: H,
         overwrite_data: &mut Self::HandlerDataType,
     ) -> Result<()>
@@ -570,7 +617,7 @@ where
         // `NestedBlockInfo` passed to it so just insert a default `NestedBlockInfo`.
         if let Some(rc) = self.compute.as_ref() {
             let mut fc = rc.borrow_mut();
-            let popped = fc.block_ctx.pop();
+            let popped = fc.block_ctx.pop(context)?;
             overwrite_handler(
                 &mut fc,
                 overwrite_data.compute.get_or_insert_with(NestedBlockInfo::default),
@@ -579,7 +626,7 @@ where
         }
         if let Some(rc) = self.constrain.as_ref() {
             let mut fc = rc.borrow_mut();
-            let popped = fc.block_ctx.pop();
+            let popped = fc.block_ctx.pop(context)?;
             overwrite_handler(
                 &mut fc,
                 overwrite_data.constrain.get_or_insert_with(NestedBlockInfo::default),
@@ -1054,6 +1101,7 @@ where
     // Initially, generate the blocks for the 'then' and 'else' cases naively.
     let mut then_info = TemplateFuncPair::new(template);
     template.gen_in_given_block_with_new_circom_scope_and_cache_overwrites(
+        codegen.context,
         then_info.block(),
         |template| if_case.gen_llzk_in_template(codegen, template),
         &mut then_info,
@@ -1061,6 +1109,7 @@ where
     let mut else_info = TemplateFuncPair::new(template);
     if let Some(else_case) = else_case {
         template.gen_in_given_block_with_new_circom_scope_and_cache_overwrites(
+            codegen.context,
             else_info.block(),
             |template| else_case.gen_llzk_in_template(codegen, template),
             &mut else_info,
@@ -1120,12 +1169,14 @@ where
     // Generate the loop condition (i.e. "before") and body (i.e. "after") blocks naively.
     let mut loop_cond_info = TemplateFuncPair::new(template);
     let cond_result = template.gen_in_given_block_with_new_circom_scope_and_cache_overwrites(
+        codegen.context,
         loop_cond_info.block(),
         |template| cond.gen_llzk_in_template(codegen, template),
         &mut loop_cond_info,
     )?;
     let mut loop_body_info = TemplateFuncPair::new(template);
     template.gen_in_given_block_with_new_circom_scope_and_cache_overwrites(
+        codegen.context,
         loop_body_info.block(),
         |template| body_stmt.gen_llzk_in_template(codegen, template),
         &mut loop_body_info,
@@ -1223,6 +1274,7 @@ where
             Statement::Block { meta, stmts } => {
                 let mut template = template; // satisfy the &mut in `GenWithCircomScopeHandling`
                 template.gen_in_current_block_with_new_circom_scope_and_merge_overwrites(
+                    codegen.context,
                     |template| {
                         try_for_loop_heuristic!(codegen, template, meta, stmts);
                         // Fallback to standard block handling.
@@ -1244,6 +1296,7 @@ where
 
                                         if val.r#type() != subcmp_type {
                                             val = fc.unifiable_cast(
+                                                codegen,
                                                 codegen.location_from_meta(meta),
                                                 val,
                                                 template.get_subcmp_type(var)?,
@@ -1311,10 +1364,12 @@ where
                                         )?;
                                         // Write value to field of "self" struct.
                                         let self_val = fc.func.self_value_of_compute()?;
-                                        fc.append_op_no_result(
-                                            r#struct::writem(location, self_val, var, value)?
-                                                .into(),
+                                        let builder =
+                                            fc.builder_at_current_insertion_point(codegen.context);
+                                        let write = r#struct::writem(
+                                            &builder, location, self_val, var, value,
                                         )?;
+                                        fc.append_op_ref_no_result(write)?;
                                         fc.block_ctx.set_named_value(var.clone(), value)
                                     })
                             }
@@ -1349,10 +1404,16 @@ where
                                         )?;
                                         // Write value to field of "self" struct.
                                         let self_val = fc.func.self_value_of_compute()?;
-                                        fc.append_op_no_result(
-                                            r#struct::writem(location, self_val, var, value)?
-                                                .into(),
+                                        let builder =
+                                            fc.builder_at_current_insertion_point(codegen.context);
+                                        let write = r#struct::writem(
+                                            &builder,
+                                            location,
+                                            self_val,
+                                            var,
+                                            value,
                                         )?;
+                                        fc.append_op_ref_no_result(write)?;
                                         fc.block_ctx.set_named_value(var.clone(), value)
                                     },
                                     |fc, val| {
@@ -1591,12 +1652,16 @@ impl<'ast, 'ctx, 'val, 'info> CtorCallScope<'ast, 'ctx, 'info> {
     ) -> Result<Value<'ctx, 'val>> {
         type_switch! { attr,
             IntegerAttribute as int => {
-                fc.append_op_unnamed_result(
-                    codegen.new_felt_const_op(&BigInt::from(int.value()), self.location)?
-                )
+                let builder = fc.builder_at_current_insertion_point(codegen.context);
+                fc.append_op_ref_unnamed_result(codegen.new_felt_const_op(
+                    &builder,
+                    &BigInt::from(int.value()),
+                    self.location,
+                )?)
             }
             FlatSymbolRefAttribute as sym => {
                 let value = fc.read_poly_template_binding(
+                    codegen,
                     self.location,
                     sym.value(),
                     self.subcmp_type.param_type(codegen),
@@ -1646,8 +1711,9 @@ impl<'ast, 'ctx, 'val, 'info> CtorCallScope<'ast, 'ctx, 'info> {
     {
         let mut map_operands_values = vec![];
         let params = self.emit_params(codegen, fc, &mut map_operands_values)?;
-        let params_pod = fc.append_op_unnamed_result(pod::new(
-            codegen.op_builder(),
+        let builder = fc.builder_at_current_insertion_point(codegen.context);
+        let params_pod = fc.append_op_ref_unnamed_result(pod::new(
+            &builder,
             self.location,
             &params,
             Some(self.subcmp_type.params_pod_type(codegen)),
@@ -1659,8 +1725,9 @@ impl<'ast, 'ctx, 'val, 'info> CtorCallScope<'ast, 'ctx, 'info> {
             map_operands.append_operands_with_dim_count(ValueRange::try_from(value_range)?, 1);
         }
 
-        fc.append_op_unnamed_result(pod::new_with_affine_init(
-            codegen.op_builder(),
+        let builder = fc.builder_at_current_insertion_point(codegen.context);
+        fc.append_op_ref_unnamed_result(pod::new_with_affine_init(
+            &builder,
             self.location,
             &records,
             self.pod_type,

--- a/llzk_backend/src/write_chain.rs
+++ b/llzk_backend/src/write_chain.rs
@@ -18,7 +18,6 @@ use crate::subcmp::names::PARAMS;
 use crate::subcmp::SubcmpInfo;
 use crate::template::TemplateContext;
 use anyhow::Result;
-use llzk::dialect::r#struct;
 use llzk::prelude::FuncDefOpLike as _;
 use llzk::prelude::Location;
 use llzk::prelude::PodType;
@@ -181,7 +180,9 @@ impl<'ast> WriteChain<'ast> {
                 if !rest.is_empty() {
                     anyhow::bail!("unsupported nested access after subcomponent input array");
                 }
-                let field_value = fc.append_op_unnamed_result(codegen.new_pod_read_op(
+                let builder = fc.builder_at_current_insertion_point(codegen.context);
+                let field_value = fc.append_op_ref_unnamed_result(codegen.new_pod_read_op(
+                    &builder,
                     input_record,
                     signal_name,
                     location,
@@ -201,7 +202,9 @@ impl<'ast> WriteChain<'ast> {
             None => fc.cast_to_expected_type_if_needed(codegen, location, val, field_type)?,
         };
 
-        fc.append_op_no_result(codegen.new_pod_write_op(
+        let builder = fc.builder_at_current_insertion_point(codegen.context);
+        fc.append_op_ref_no_result(codegen.new_pod_write_op(
+            &builder,
             location,
             input_record,
             signal_name,
@@ -290,19 +293,25 @@ impl<'ast> WriteChain<'ast> {
                 &index_vals,
             )?;
 
-            let (info, ()) = NestedBlockInfo::with_scope(fc, |fc| {
+            let (info, ()) = NestedBlockInfo::with_scope(codegen.context, fc, |fc| {
                 if let Some(signal_name) = signal_name {
                     let inputs_value = inputs_value.expect("input value exists for signal writes");
-                    let memory_record = fc.append_op_unnamed_result(codegen.new_pod_read_op(
-                        memory_value,
-                        entry.record_name(),
-                        location,
-                    )?)?;
-                    let input_record = fc.append_op_unnamed_result(codegen.new_pod_read_op(
-                        inputs_value,
-                        entry.record_name(),
-                        location,
-                    )?)?;
+                    let builder = fc.builder_at_current_insertion_point(codegen.context);
+                    let memory_record =
+                        fc.append_op_ref_unnamed_result(codegen.new_pod_read_op(
+                            &builder,
+                            memory_value,
+                            entry.record_name(),
+                            location,
+                        )?)?;
+                    let builder = fc.builder_at_current_insertion_point(codegen.context);
+                    let input_record =
+                        fc.append_op_ref_unnamed_result(codegen.new_pod_read_op(
+                            &builder,
+                            inputs_value,
+                            entry.record_name(),
+                            location,
+                        )?)?;
                     Self::write_mixed_input_tail(
                         signal_name,
                         &tail[1..],
@@ -315,7 +324,9 @@ impl<'ast> WriteChain<'ast> {
                         signal_write_info,
                         subcmp_info,
                     )?;
-                    fc.append_op_no_result(codegen.new_pod_write_op(
+                    let builder = fc.builder_at_current_insertion_point(codegen.context);
+                    fc.append_op_ref_no_result(codegen.new_pod_write_op(
+                        &builder,
                         location,
                         inputs_value,
                         entry.record_name(),
@@ -330,11 +341,14 @@ impl<'ast> WriteChain<'ast> {
                         location,
                         codegen,
                         |fc: &mut FunctionContext<'_, 'ctx, '_, '_, 'val>| {
-                            let params = fc.append_op_unnamed_result(codegen.new_pod_read_op(
-                                memory_record,
-                                PARAMS,
-                                location,
-                            )?)?;
+                            let builder = fc.builder_at_current_insertion_point(codegen.context);
+                            let params =
+                                fc.append_op_ref_unnamed_result(codegen.new_pod_read_op(
+                                    &builder,
+                                    memory_record,
+                                    PARAMS,
+                                    location,
+                                )?)?;
                             let subcmp_instance = fc.gen_compute_call(
                                 entry.struct_type(),
                                 input_record,
@@ -342,7 +356,9 @@ impl<'ast> WriteChain<'ast> {
                                 location,
                                 codegen,
                             )?;
-                            fc.append_op_no_result(codegen.new_pod_write_op(
+                            let builder = fc.builder_at_current_insertion_point(codegen.context);
+                            fc.append_op_ref_no_result(codegen.new_pod_write_op(
+                                &builder,
                                 location,
                                 memory_record,
                                 COMP,
@@ -350,7 +366,9 @@ impl<'ast> WriteChain<'ast> {
                             ))
                         },
                     )?;
-                    fc.append_op_no_result(codegen.new_pod_write_op(
+                    let builder = fc.builder_at_current_insertion_point(codegen.context);
+                    fc.append_op_ref_no_result(codegen.new_pod_write_op(
+                        &builder,
                         location,
                         memory_value,
                         entry.record_name(),
@@ -367,7 +385,9 @@ impl<'ast> WriteChain<'ast> {
                         })?;
                     let val =
                         fc.cast_to_expected_type_if_needed(codegen, location, val, record_type)?;
-                    fc.append_op_no_result(codegen.new_pod_write_op(
+                    let builder = fc.builder_at_current_insertion_point(codegen.context);
+                    fc.append_op_ref_no_result(codegen.new_pod_write_op(
+                        &builder,
                         location,
                         memory_value,
                         entry.record_name(),
@@ -447,7 +467,9 @@ impl<'ast> WriteChain<'ast> {
                             val,
                             record_type,
                         )?;
-                        fc.append_op_no_result(codegen.new_pod_write_op(
+                        let builder = fc.builder_at_current_insertion_point(codegen.context);
+                        fc.append_op_ref_no_result(codegen.new_pod_write_op(
+                            &builder,
                             location,
                             arr_ref,
                             record_name,
@@ -501,7 +523,9 @@ impl<'ast> WriteChain<'ast> {
             &|subcmp_value_inputs: Value<'ctx, 'val>,
               fc: &mut FunctionContext<'_, 'ctx, '_, '_, 'val>|
              -> Result<()> {
-                fc.append_op_no_result(codegen.new_pod_write_op(
+                let builder = fc.builder_at_current_insertion_point(codegen.context);
+                fc.append_op_ref_no_result(codegen.new_pod_write_op(
+                    &builder,
                     location,
                     subcmp_value_inputs,
                     name,
@@ -543,7 +567,9 @@ impl<'ast> WriteChain<'ast> {
                     location,
                     codegen,
                     |fc: &mut FunctionContext<'_, 'ctx, '_, '_, 'val>| {
-                        let params = fc.append_op_unnamed_result(codegen.new_pod_read_op(
+                        let builder = fc.builder_at_current_insertion_point(codegen.context);
+                        let params = fc.append_op_ref_unnamed_result(codegen.new_pod_read_op(
+                            &builder,
                             subcmp_value,
                             PARAMS,
                             location,
@@ -558,7 +584,9 @@ impl<'ast> WriteChain<'ast> {
                             location,
                             codegen,
                         )?;
-                        fc.append_op_no_result(codegen.new_pod_write_op(
+                        let builder = fc.builder_at_current_insertion_point(codegen.context);
+                        fc.append_op_ref_no_result(codegen.new_pod_write_op(
+                            &builder,
                             location,
                             subcmp_value,
                             COMP,
@@ -605,9 +633,12 @@ impl<'ast> WriteChain<'ast> {
 
                 let self_value = fc.func.self_value_of_compute()?;
                 // Write value to field of "self" struct.
-                fc.block_ctx.enqueue_in_block(
-                    r#struct::writem(location, self_value, &var, val)?.into(),
+                fc.block_ctx.enqueue_struct_write_in_block(
                     block,
+                    location,
+                    self_value,
+                    var.clone(),
+                    val,
                 )?;
                 fc.block_ctx.set_named_value_at_declaration(var.clone(), val)?;
                 signal_write_info.mark_signal_as_written(var)

--- a/llzk_backend/src/write_chain.rs
+++ b/llzk_backend/src/write_chain.rs
@@ -158,7 +158,6 @@ impl<'ast> WriteChain<'ast> {
     }
 
     /// Writes a value into a field of a mixed subcomponent input pod.
-    #[allow(clippy::too_many_arguments)]
     fn write_mixed_input_tail<'ctx, 'val>(
         signal_name: &str,
         tail: &[AccessRef<'_, 'ast>],
@@ -217,7 +216,6 @@ impl<'ast> WriteChain<'ast> {
     /// The selected record has a concrete component type, but different records may have
     /// different input pod shapes. Keep those record-specific values inside the dispatch branch
     /// and only merge the uniform parent pods back into the surrounding block.
-    #[allow(clippy::too_many_arguments)]
     fn try_write_mixed_subcmp<'ctx, 'val>(
         &self,
         val: Value<'ctx, 'val>,
@@ -404,7 +402,6 @@ impl<'ast> WriteChain<'ast> {
     }
 
     /// Handle [Lvalue::Array] case of [`WriteChain::write`].
-    #[allow(clippy::too_many_arguments)]
     fn write_array<'ctx, 'val>(
         indices: Vec<&Expression>,
         prev: Self,
@@ -500,7 +497,6 @@ impl<'ast> WriteChain<'ast> {
     }
 
     /// Handle [Lvalue::Subcmp] case of [`WriteChain::write`].
-    #[allow(clippy::too_many_arguments)]
     fn write_subcmp<'ctx, 'val>(
         name: &str,
         prev: Self,
@@ -607,7 +603,6 @@ impl<'ast> WriteChain<'ast> {
         )
     }
 
-    #[allow(clippy::too_many_arguments)]
     /// Emits the write operations.
     pub fn write<'ctx, 'val>(
         self,


### PR DESCRIPTION
Updates to new `llzk-rs` dependency where op builders have been standardized to always do op insertion via the `OpBuilder` and return an `OperationRef` instead of an owned `Operation`.